### PR TITLE
Allow to dinamically configure the A2A server URL

### DIFF
--- a/docs/docs/tutorials/agents.md
+++ b/docs/docs/tutorials/agents.md
@@ -2969,6 +2969,27 @@ public interface DeclarativeA2AWithCustomizer {
 }
 ```
 
+### Configuring the A2A server URL dynamically
+
+By default, the `@A2AClientAgent` annotation requires the A2A server URL as a compile-time string literal via the `a2aServerUrl` attribute. For environments where the URL varies (e.g., dev, staging, production), a static method annotated with `@A2AServerUrlSupplier` can provide the URL dynamically at build time instead:
+
+```java
+public interface DeclarativeA2AWithUrlSupplier {
+
+    @A2AClientAgent(outputKey = "story")
+    String generateStory(@V("topic") String topic);
+
+    @A2AServerUrlSupplier
+    static String serverUrl() {
+        return System.getenv("A2A_SERVER_URL");
+    }
+}
+```
+
+The supplier method must be `static`, take no parameters, and return a `String`. It is invoked once when the agent is constructed — the URL does not change between invocations. Exactly one of `a2aServerUrl` in the annotation or an `@A2AServerUrlSupplier` method must be provided; specifying both (or neither) is an error.
+
+This pattern is consistent with how `@McpClientSupplier` provides the MCP client for `@McpClientAgent` declarative agents.
+
 ## MCP-based Tool Agents
 
 The additional `langchain4j-agentic-mcp` module allows wrapping a single [MCP](https://modelcontextprotocol.io/) tool as a non-AI agent in the agentic system. Unlike regular agents that use an LLM, an MCP tool agent simply executes the MCP tool directly and returns its result. This makes it possible to compose MCP tools with other agents in larger agentic systems, without involving an LLM for the tool execution itself.

--- a/langchain4j-agentic-a2a/pom.xml
+++ b/langchain4j-agentic-a2a/pom.xml
@@ -20,7 +20,7 @@
     </developers>
 
     <properties>
-        <a2a-java-sdk-version>1.0.0.Final</a2a-java-sdk-version>
+        <a2a-java-sdk-version>1.1.0.Final</a2a-java-sdk-version>
     </properties>
 
     <dependencyManagement>

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AAgentIT.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AAgentIT.java
@@ -10,6 +10,7 @@ import dev.langchain4j.agentic.a2a.Agents.CreativeWriter;
 import dev.langchain4j.agentic.a2a.Agents.DeclarativeA2ACreativeWriter;
 import dev.langchain4j.agentic.a2a.Agents.StoryCreatorWithCustomizedWriter;
 import dev.langchain4j.agentic.a2a.Agents.StoryCreatorWithReview;
+import dev.langchain4j.agentic.a2a.Agents.StoryCreatorWithUrlSupplier;
 import dev.langchain4j.agentic.a2a.Agents.StyleEditor;
 import dev.langchain4j.agentic.a2a.Agents.StyleReviewLoop;
 import dev.langchain4j.agentic.a2a.Agents.StyleScorer;
@@ -370,6 +371,23 @@ public class A2AAgentIT {
         System.out.println(story);
 
         AgenticScope agenticScope = result.agenticScope();
+        assertThat(story).isEqualTo(agenticScope.readState("story"));
+        assertThat(agenticScope.readState("score", 0.0)).isGreaterThanOrEqualTo(0.8);
+    }
+
+    @Test
+    @Disabled("Requires A2A server to be running")
+    void declarative_a2a_agent_with_url_supplier() {
+        StoryCreatorWithUrlSupplier storyCreator =
+                AgenticServices.createAgenticSystem(StoryCreatorWithUrlSupplier.class, baseModel());
+
+        ResultWithAgenticScope<String> result = storyCreator.write("dragons and wizards", "comedy");
+        String story = result.result();
+        assertThat(story).isNotBlank();
+
+        AgenticScope agenticScope = result.agenticScope();
+        assertThat(agenticScope.readState("topic")).isEqualTo("dragons and wizards");
+        assertThat(agenticScope.readState("style")).isEqualTo("comedy");
         assertThat(story).isEqualTo(agenticScope.readState("story"));
         assertThat(agenticScope.readState("score", 0.0)).isGreaterThanOrEqualTo(0.8);
     }

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AServerUrlResolutionTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AServerUrlResolutionTest.java
@@ -43,4 +43,42 @@ class A2AServerUrlResolutionTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("not both");
     }
+
+    public interface A2AWithSupplierTakingParameters {
+
+        @A2AClientAgent(outputKey = "story")
+        String generateStory(@V("topic") String topic);
+
+        @A2AServerUrlSupplier
+        static String serverUrl(String env) {
+            return "http://localhost:8080";
+        }
+    }
+
+    @Test
+    void should_fail_when_supplier_takes_parameters() {
+        assertThatThrownBy(() ->
+                AgenticServices.createAgenticSystem(A2AWithSupplierTakingParameters.class, (ChatModel) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("@A2AServerUrlSupplier");
+    }
+
+    public interface A2AWithNonStaticSupplier {
+
+        @A2AClientAgent(outputKey = "story")
+        String generateStory(@V("topic") String topic);
+
+        @A2AServerUrlSupplier
+        default String serverUrl() {
+            return "http://localhost:8080";
+        }
+    }
+
+    @Test
+    void should_fail_when_supplier_is_not_static() {
+        assertThatThrownBy(() ->
+                AgenticServices.createAgenticSystem(A2AWithNonStaticSupplier.class, (ChatModel) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("@A2AServerUrlSupplier");
+    }
 }

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AServerUrlResolutionTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AServerUrlResolutionTest.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.agentic.a2a;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.V;
+import org.junit.jupiter.api.Test;
+
+class A2AServerUrlResolutionTest {
+
+    public interface A2AWithNoUrl {
+
+        @A2AClientAgent(outputKey = "story")
+        String generateStory(@V("topic") String topic);
+    }
+
+    public interface A2AWithBothUrlAndSupplier {
+
+        @A2AClientAgent(a2aServerUrl = "http://localhost:8080", outputKey = "story")
+        String generateStory(@V("topic") String topic);
+
+        @A2AServerUrlSupplier
+        static String serverUrl() {
+            return "http://localhost:8080";
+        }
+    }
+
+    @Test
+    void should_fail_when_neither_url_nor_supplier_is_provided() {
+        assertThatThrownBy(() ->
+                AgenticServices.createAgenticSystem(A2AWithNoUrl.class, (ChatModel) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("@A2AServerUrlSupplier");
+    }
+
+    @Test
+    void should_fail_when_both_url_and_supplier_are_provided() {
+        assertThatThrownBy(() ->
+                AgenticServices.createAgenticSystem(A2AWithBothUrlAndSupplier.class, (ChatModel) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not both");
+    }
+}

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/Agents.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/Agents.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.agentic.a2a.A2AAgentIT.A2A_SERVER_URL;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
 import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
+import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
 import dev.langchain4j.agentic.declarative.ExitCondition;
 import dev.langchain4j.agentic.declarative.LoopAgent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
@@ -117,6 +118,26 @@ public class Agents {
         @SequenceAgent(
                 outputKey = "story",
                 subAgents = { DeclarativeA2AWithCustomizer.class, StyleReviewLoopAgent.class }
+        )
+        ResultWithAgenticScope<String> write(@V("topic") String topic, @V("style") String style);
+    }
+
+    public interface DeclarativeA2AWithUrlSupplier {
+
+        @A2AClientAgent(outputKey = "story")
+        String generateStory(@V("topic") String topic);
+
+        @A2AServerUrlSupplier
+        static String serverUrl() {
+            return A2A_SERVER_URL;
+        }
+    }
+
+    public interface StoryCreatorWithUrlSupplier {
+
+        @SequenceAgent(
+                outputKey = "story",
+                subAgents = { DeclarativeA2AWithUrlSupplier.class, StyleReviewLoopAgent.class }
         )
         ResultWithAgenticScope<String> write(@V("topic") String topic, @V("style") String style);
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
@@ -742,7 +742,8 @@ public class AgenticServices {
 
     private static String resolveA2AServerUrl(Class<?> agentServiceClass, A2AClientAgent a2aClient) {
         String annotationUrl = a2aClient.a2aServerUrl();
-        Optional<Method> supplierMethod = getAnnotatedMethodOnClass(agentServiceClass, A2AServerUrlSupplier.class);
+        Optional<Method> supplierMethod = selectMethod(agentServiceClass,
+                method -> method.isAnnotationPresent(A2AServerUrlSupplier.class) && method.getParameterCount() == 0);
 
         if (!isNullOrBlank(annotationUrl) && supplierMethod.isPresent()) {
             throw new IllegalArgumentException(

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
@@ -18,6 +18,7 @@ import dev.langchain4j.agentic.agent.AgentBuilder;
 import dev.langchain4j.agentic.agent.UntypedAgentBuilder;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
 import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
+import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
 import dev.langchain4j.agentic.declarative.ActivationCondition;
 import dev.langchain4j.agentic.declarative.AgentListenerSupplier;
 import dev.langchain4j.agentic.declarative.ChatModelSupplier;
@@ -715,7 +716,8 @@ public class AgenticServices {
 
     private static <T> T createA2AClient(Class<T> agentServiceClass, Method a2aMethod) {
         var a2aClient = a2aMethod.getAnnotation(A2AClientAgent.class);
-        var a2aClientBuilder = a2aBuilder(a2aClient.a2aServerUrl(), agentServiceClass)
+        String a2aServerUrl = resolveA2AServerUrl(agentServiceClass, a2aClient);
+        var a2aClientBuilder = a2aBuilder(a2aServerUrl, agentServiceClass)
                 .inputKeys(Stream.of(a2aMethod.getParameters())
                         .map(AgentInvoker::parameterName)
                         .toArray(String[]::new))
@@ -736,6 +738,28 @@ public class AgenticServices {
                 });
 
         return a2aClientBuilder.build();
+    }
+
+    private static String resolveA2AServerUrl(Class<?> agentServiceClass, A2AClientAgent a2aClient) {
+        String annotationUrl = a2aClient.a2aServerUrl();
+        Optional<Method> supplierMethod = getAnnotatedMethodOnClass(agentServiceClass, A2AServerUrlSupplier.class);
+
+        if (!isNullOrBlank(annotationUrl) && supplierMethod.isPresent()) {
+            throw new IllegalArgumentException(
+                    "Provide either a2aServerUrl in the @A2AClientAgent annotation or an @A2AServerUrlSupplier method, not both.");
+        }
+
+        if (supplierMethod.isPresent()) {
+            checkReturnType(supplierMethod.get(), String.class);
+            return invokeStatic(supplierMethod.get());
+        }
+
+        if (!isNullOrBlank(annotationUrl)) {
+            return annotationUrl;
+        }
+
+        throw new IllegalArgumentException(
+                "An A2A client agent requires either a2aServerUrl in the @A2AClientAgent annotation or a method annotated with @A2AServerUrlSupplier.");
     }
 
     private static AgentExecutor createMcpClientAgent(Class<?> agentServiceClass, Method mcpMethod) {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AClientAgent.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AClientAgent.java
@@ -17,10 +17,12 @@ public @interface A2AClientAgent {
 
     /**
      * URL of the A2A server to which the requests will be sent.
+     * If not provided, a method annotated with {@link A2AServerUrlSupplier} must be present
+     * on the same interface.
      *
      * @return URL of the A2A server.
      */
-    String a2aServerUrl();
+    String a2aServerUrl() default "";
 
     /**
      * Name of the agent. If not provided, method name will be used.

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AServerUrlSupplier.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AServerUrlSupplier.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.agentic.declarative;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a static method that returns the A2A server URL for declarative A2A client agents.
+ */
+@Retention(RUNTIME)
+@Target({METHOD})
+public @interface A2AServerUrlSupplier {
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #5760

## Change

The `@A2AClientAgent` annotation previously required `a2aServerUrl` as a compile-time string literal, making it impossible to configure the URL per environment (dev, staging, production).

This PR adds an `@A2AServerUrlSupplier` companion annotation — a static method that returns the URL at agent construction time — following the same supplier pattern already used by `@McpClientSupplier` for `@McpClientAgent`.

It also bumps the A2A client to the latest `1.1.0.Final` version.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
