### PR TITLE
Add crash-resilient Human-in-the-Loop suspension and resume for agentic systems

### DIFF
--- a/docs/docs/tutorials/agents.md
+++ b/docs/docs/tutorials/agents.md
@@ -2821,48 +2821,44 @@ The user can make this choice at the point where the response is created — in 
 
 It is advised to use `SuspendedResponse` for long-running interactions (hours/days) where crash resilience matters, and `PendingResponse` for short-lived in-process waits where a background thread will provide the answer shortly.
 
-If the method's return type is `ResultWithAgenticScope`, no exception is thrown on suspension; instead, the returned record has `suspended() == true` and `result() == null`:
+If the method's return type is `ResultWithAgenticScope`, no exception is thrown on suspension; instead, the result has `suspended() == true` and `result() == null`. You can then complete the pending response and resume execution in a single call:
 
 ```java
 ResultWithAgenticScope<String> result = workflow.processOrder("order-12345", "1000 widgets");
 if (result.suspended()) {
-    // Handle suspension — provide response and re-invoke later
+    result = result.completePendingResponse("APPROVED by manager");
+    // result.result() → "Order VALIDATED: 1000 widgets — APPROVED by manager"
 }
 ```
 
-To resume the agentic system, provide the human response and re-invoke the agent method with the same memory ID:
+This works naturally with multi-step workflows that have multiple sequential HITL gates — each `completePendingResponse` call returns a new `ResultWithAgenticScope` that may itself be suspended:
+
+```java
+ResultWithAgenticScope<String> result = workflow.processOrder("order-12345", "1000 widgets");
+
+result = result.completePendingResponse("Manager OK");   // resumes, suspends at legal gate
+result = result.completePendingResponse("Legal OK");      // resumes, completes
+// result.result() → final output
+```
+
+`ResultWithAgenticScope` is the recommended approach for handling suspension, as it avoids using exceptions for control flow.
+
+Conversely, If the method returns a plain type (e.g. `String`) instead of `ResultWithAgenticScope`, the system throws `AgenticSystemSuspendedException` on suspension. In that case, or when you need to resume through the scope directly (e.g. after a crash/restart), you can complete the response on the `AgenticScope` and re-invoke the agent method:
 
 ```java
 AgenticScope scope = workflow.getAgenticScope("order-12345");
 
-// Option 1: Complete the single deferred response (when there is exactly one)
+// Complete the single deferred response (when there is exactly one)
 scope.completePendingResponse("APPROVED by manager");
 
-// Option 2: Complete by explicit ID (useful when multiple responses are pending)
+// Or complete by explicit ID (useful when multiple responses are pending)
 scope.completePendingResponse("manager-approval", "APPROVED by manager");
 
-// Option 3: Replace the response value directly in state
-scope.writeState("approval", "APPROVED by manager");
-
-// Then re-invoke — the planner resumes from step 3
-String result = workflow.processOrder("order-12345", "1000 widgets");
-// → "Order VALIDATED: 1000 widgets — APPROVED by manager"
-```
-
-The `SequentialPlanner` restores its cursor from the checkpointed state and skips the already-completed steps (validate and approval gate), executing only the final shipping step.
-
-Note that `completePendingResponse` both completes the in-memory future (unblocking any waiting threads) and replaces the state map entry with the resolved value (so it survives serialization). The single-argument overload throws `IllegalStateException` if there is not exactly one deferred response. Similarly, `writeState` completes any `DeferredResponse` it replaces.
-
-The suspension mechanism naturally handles crash recovery. If the process crashes or restarts while waiting for human input, the scope can be recovered from the store:
-
-```java
-// After restart: load the persisted scope and provide the human response
-AgenticScope recovered = workflow.getAgenticScope("order-12345");
-recovered.completePendingResponse("APPROVED by manager");
-
-// Re-invoke — the planner resumes from the checkpoint
+// Then re-invoke — the planner resumes from the checkpoint
 String result = workflow.processOrder("order-12345", "1000 widgets");
 ```
+
+Note that `completePendingResponse` both completes the in-memory future (unblocking any waiting threads) and replaces the state map entry with the resolved value (so it survives serialization). The single-argument overload throws `IllegalStateException` if there is not exactly one deferred response.
 
 ## Agents Registry
 

--- a/docs/docs/tutorials/agents.md
+++ b/docs/docs/tutorials/agents.md
@@ -2732,7 +2732,7 @@ or using the standard Java Service Provider interface creating a file named `MET
 
 ### AgenticScope and agentic systems recoverability
 
-When an `AgenticScopeStore` is configured, the `langchain4j-agentic` module provides built-in recoverability support that allows agentic systems to resume execution from where they left off after a crash or process restart. This is especially valuable for long-running workflows that include human-in-the-loop steps, where the process may be intentionally stopped and restarted later.
+When an `AgenticScopeStore` is configured, the `langchain4j-agentic` module provides built-in recoverability support that allows agentic systems to resume execution from where they left off after a crash or process restart. This is especially valuable for long-running agentic systems that include human-in-the-loop steps, where the process may be intentionally stopped and restarted later.
 
 Recoverability is based on two mechanisms working together: **per-step checkpointing** and **planner execution state persistence**.
 
@@ -2748,7 +2748,7 @@ default Map<String, Object> executionState() { return Map.of(); }
 default void restoreExecutionState(Map<String, Object> state) { }
 ```
 
-For instance, stateful planners like the sequential and the loop ones implement these methods to save and restore their cursor position and iteration counters. Stateless planners (like `ParallelPlanner` or `ConditionalPlanner`) use the default no-op implementations. Custom `Planner` implementations can override these methods to participate in recoverability as well.
+For instance, stateful planners like the sequential and the loop ones implement these methods to save and restore their cursor position and iteration counters. Stateless planners (like `ParallelPlanner` or `ConditionalPlanner`) use the default no-op implementations. Custom `Planner` implementations can override these methods to participate in recoverability as well. The execution loop also tracks its own internal state (such as which agents have completed in a parallel block) alongside the planner state, so that on resume only the agents that haven't finished are re-dispatched.
 
 To give a practical example of how this works, consider an order processing workflow where a large order must be reviewed by a human before it is fulfilled. The workflow has three steps: validate the order, wait for human approval, and ship the order.
 
@@ -2768,11 +2768,11 @@ AgenticScopeAction validateOrder = AgenticServices.agentAction(scope -> {
     scope.writeState("validated_order", "VALIDATED: " + order);
 });
 
-// Step 2: Pause for human approval using PendingResponse
+// Step 2: Pause for human approval using SuspendedResponse
 HumanInTheLoop approvalGate = AgenticServices.humanInTheLoopBuilder()
         .description("Wait for manager approval on large orders")
         .outputKey("approval")
-        .responseProvider(scope -> new PendingResponse<>("manager-approval"))
+        .responseProvider(scope -> new SuspendedResponse<>("manager-approval"))
         .build();
 
 // Step 3: Finalize based on the approval decision
@@ -2788,35 +2788,81 @@ OrderWorkflow workflow = AgenticServices.sequenceBuilder(OrderWorkflow.class)
         .build();
 ```
 
-When this workflow runs, it validates the order, then blocks at the `HumanInTheLoop` step waiting for external input. At this point the full scope — including the validated order data, the planner's cursor position (step 2 completed), and the `PendingResponse` — is checkpointed to the store.
-
-The `PendingResponse` class is an implementation of the `DelayedResponse` that can be completed externally without spawning a background thread. Unlike `AsyncResponse`, which immediately starts executing on a thread pool, `PendingResponse` creates an initially incomplete future that must be explicitly completed via its `complete()` method. After serialization and deserialization, a new incomplete future is created, allowing an external system to reconnect and complete the response.
-
-If the process crashes or restarts, the scope can be recovered and the workflow resumed:
+When this workflow runs, it validates the order, then reaches the `HumanInTheLoop` step. Because the response provider returns a `SuspendedResponse`, the agentic system suspends its execution by throwing an `AgenticSystemSuspendedException`, instead of blocking the calling thread. The full scope — including the validated order data, the planner's cursor position (step 2 completed), and the `SuspendedResponse` — is checkpointed to the store (if one is configured), and an `AgenticSystemSuspendedException` is thrown to release the thread:
 
 ```java
-// After restart: load the persisted scope and provide the human response
-AgenticScope recovered = workflow.getAgenticScope("order-12345");
+try {
+    String result = workflow.processOrder("order-12345", "1000 widgets");
+    // Workflow completed normally
+} catch (AgenticSystemSuspendedException e) {
+    // Workflow suspended — waiting for human input
+    AgenticScope scope = e.scope();
+    Set<String> pendingIds = scope.pendingResponseIds(); // → ["manager-approval"]
+    // Store the scope/pendingIds for your UI / REST API to present to the human
+}
+```
 
-// Replace the PendingResponse with the actual human decision
-recovered.writeState("approval", "APPROVED by manager");
+In alternative to `SuspendedResponse`, the human-in-the-loop can return an instance of the `PendingResponse` class to block the calling thread until the human response is provided. In essence:
 
-// Re-invoke with the same order ID — the planner resumes from step 3
+| Response type | Behavior |
+|---|---|
+| `SuspendedResponse` | **Suspends** the agentic system: checkpoints the scope, throws `AgenticSystemSuspendedException`, and releases the calling thread. The system is resumed by completing the response and re-invoking the agent method. |
+| `PendingResponse` | **Blocks** the calling thread on the underlying `CompletableFuture` until `complete()` is called from another thread. No exception is thrown — the agentic system waits in place. |
+
+The user can make this choice at the point where the response is created — in the `responseProvider` lambda or the `@HumanInTheLoop` static method:
+
+```java
+// Suspension: the agentic system checkpoints and throws AgenticSystemSuspendedException
+.responseProvider(scope -> new SuspendedResponse<>("approval-id"))
+
+// Blocking: the calling thread waits until complete() is called from another thread
+.responseProvider(scope -> new PendingResponse<>("approval-id"))
+```
+
+It is advised to use `SuspendedResponse` for long-running interactions (hours/days) where crash resilience matters, and `PendingResponse` for short-lived in-process waits where a background thread will provide the answer shortly.
+
+If the method's return type is `ResultWithAgenticScope`, no exception is thrown on suspension; instead, the returned record has `suspended() == true` and `result() == null`:
+
+```java
+ResultWithAgenticScope<String> result = workflow.processOrder("order-12345", "1000 widgets");
+if (result.suspended()) {
+    // Handle suspension — provide response and re-invoke later
+}
+```
+
+To resume the agentic system, provide the human response and re-invoke the agent method with the same memory ID:
+
+```java
+AgenticScope scope = workflow.getAgenticScope("order-12345");
+
+// Option 1: Complete the single deferred response (when there is exactly one)
+scope.completePendingResponse("APPROVED by manager");
+
+// Option 2: Complete by explicit ID (useful when multiple responses are pending)
+scope.completePendingResponse("manager-approval", "APPROVED by manager");
+
+// Option 3: Replace the response value directly in state
+scope.writeState("approval", "APPROVED by manager");
+
+// Then re-invoke — the planner resumes from step 3
 String result = workflow.processOrder("order-12345", "1000 widgets");
 // → "Order VALIDATED: 1000 widgets — APPROVED by manager"
 ```
 
 The `SequentialPlanner` restores its cursor from the checkpointed state and skips the already-completed steps (validate and approval gate), executing only the final shipping step.
 
-Alternatively, if the process is still running and the workflow is simply waiting for human input, the `PendingResponse` can be completed directly without restarting:
+Note that `completePendingResponse` both completes the in-memory future (unblocking any waiting threads) and replaces the state map entry with the resolved value (so it survives serialization). The single-argument overload throws `IllegalStateException` if there is not exactly one deferred response. Similarly, `writeState` completes any `DeferredResponse` it replaces.
+
+The suspension mechanism naturally handles crash recovery. If the process crashes or restarts while waiting for human input, the scope can be recovered from the store:
 
 ```java
-// Complete the pending response in-flight (e.g., from a REST endpoint)
-AgenticScope scope = workflow.getAgenticScope("order-12345");
-scope.completePendingResponse("manager-approval", "APPROVED by manager");
-```
+// After restart: load the persisted scope and provide the human response
+AgenticScope recovered = workflow.getAgenticScope("order-12345");
+recovered.completePendingResponse("APPROVED by manager");
 
-This unblocks the waiting thread and the workflow continues to the shipping step without any restart.
+// Re-invoke — the planner resumes from the checkpoint
+String result = workflow.processOrder("order-12345", "1000 widgets");
+```
 
 ## Agents Registry
 

--- a/langchain4j-agentic/revapi.json
+++ b/langchain4j-agentic/revapi.json
@@ -133,6 +133,20 @@
           "code": "java.method.addedToInterface",
           "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::beforeCall(java.util.function.Consumer<dev.langchain4j.agentic.scope.AgenticScope>)",
           "justification": "SupervisorAgentService is a builder interface obtained via AgenticServices.supervisorBuilder() and is not meant to be implemented by users, so the added method breaks no real implementation. The method mirrors the pre-existing AgenticService#beforeCall and is required so beforeCall() can be called fluently on a SupervisorAgentService reference."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.kindChanged",
+          "old": "class dev.langchain4j.agentic.scope.ResultWithAgenticScope<T>",
+          "new": "class dev.langchain4j.agentic.scope.ResultWithAgenticScope<T>",
+          "justification": "ResultWithAgenticScope changed from a record to a regular final class to carry additional suspension state (the 'suspended' flag and a transient resume callback) that cannot be modeled as record components. The canonical constructor and the agenticScope()/result() accessors are preserved, so normal construction and access are unaffected. This module is still in beta (1.18.0-beta), and the only source-incompatible impact is record deconstruction patterns, which are not part of the intended usage of this type."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.noLongerInheritsFromClass",
+          "old": "class dev.langchain4j.agentic.scope.ResultWithAgenticScope<T>",
+          "new": "class dev.langchain4j.agentic.scope.ResultWithAgenticScope<T>",
+          "justification": "Consequence of converting ResultWithAgenticScope from a record (which implicitly extends java.lang.Record) to a regular final class in order to carry non-component suspension state. Public constructor and accessors are preserved."
         }
       ]
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.agentic.scope.DefaultAgenticScope.isSerializable;
 import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.agent.MissingArgumentException;
+import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
@@ -80,6 +81,11 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
 
             Object response = agentResponse(agenticScope, invokedAgent, planner, args, async);
             return completeAgentInvocation(response, agenticScope, invokedAgent, planner, args);
+        } catch (AgenticSystemSuspendedException e) {
+            if (planner != null) {
+                planner.onSubagentSuspended();
+            }
+            return null;
         } catch (AgentInvocationException e) {
             return handleAgentFailure(e, agenticScope, invokedAgent, planner, args, false);
         }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentInvoker.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentInvoker.java
@@ -7,6 +7,7 @@ import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
 import dev.langchain4j.agentic.UntypedAgent;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.invocation.LangChain4jManaged;
@@ -47,6 +48,10 @@ public interface AgentInvoker extends AgentInstance, InternalAgent {
         try {
             return method().invoke(agent, args.positionalArgs());
         } catch (Exception e) {
+            Throwable cause = e instanceof java.lang.reflect.InvocationTargetException ? e.getCause() : e;
+            if (cause instanceof AgenticSystemSuspendedException suspended) {
+                throw suspended;
+            }
             AgentInvocationException invocationException = new AgentInvocationException("Failed to invoke agent method: " + method(), e);
             agentError(listener, agenticScope, this, args.namedArgs(), invocationException);
             throw invocationException;

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/DeferredResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/DeferredResponse.java
@@ -1,0 +1,102 @@
+package dev.langchain4j.agentic.internal;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Abstract base for responses that are deferred to an external actor (e.g., a human,
+ * a REST endpoint, a message queue) and must be explicitly completed via {@link #complete(Object)}.
+ * <p>
+ * After serialization/deserialization, a new incomplete {@link CompletableFuture} is created,
+ * allowing an external system to reconnect and complete the response.
+ * <p>
+ * Concrete subclasses determine the runtime behavior when the response is not yet available:
+ * <ul>
+ *   <li>{@link PendingResponse} — blocks the calling thread until completed (future semantic)</li>
+ *   <li>{@link SuspendedResponse} — suspends the agentic system by throwing
+ *       {@link dev.langchain4j.agentic.scope.AgenticSystemSuspendedException} (exception semantic)</li>
+ * </ul>
+ *
+ * @param <T> the type of the response value
+ */
+public abstract class DeferredResponse<T> implements DelayedResponse<T> {
+
+    private final String responseId;
+
+    @JsonIgnore
+    private transient CompletableFuture<T> futureResponse;
+
+    protected DeferredResponse(@JsonProperty("responseId") String responseId) {
+        this.responseId = responseId;
+        this.futureResponse = new CompletableFuture<>();
+    }
+
+    /**
+     * Returns the unique identifier for this deferred response.
+     *
+     * @return the response identifier
+     */
+    public String responseId() {
+        return responseId;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isDone() {
+        return futureResponse.isDone();
+    }
+
+    @Override
+    @JsonIgnore
+    public T blockingGet() {
+        return DelayedResponse.join(futureResponse);
+    }
+
+    /**
+     * Waits for the response with a timeout.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit the time unit of the timeout argument
+     * @return the response value
+     * @throws TimeoutException if the wait timed out
+     */
+    public T blockingGet(long timeout, TimeUnit unit) throws TimeoutException {
+        try {
+            return futureResponse.get(timeout, unit);
+        } catch (TimeoutException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Completes this deferred response with the given value.
+     * Any threads blocked on {@link #blockingGet()} will be released.
+     *
+     * @param value the response value
+     * @return {@code true} if this invocation caused the response to transition to a completed state,
+     *         {@code false} if it was already completed
+     */
+    public boolean complete(T value) {
+        return futureResponse.complete(value);
+    }
+
+    /**
+     * Completes this deferred response exceptionally.
+     *
+     * @param exception the exception
+     * @return {@code true} if this invocation caused the response to transition to a completed state
+     */
+    public boolean completeExceptionally(Throwable exception) {
+        return futureResponse.completeExceptionally(exception);
+    }
+
+    @Override
+    public String toString() {
+        return isDone() ? String.valueOf(result()) : "<pending:" + responseId + ">";
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PendingResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PendingResponse.java
@@ -1,23 +1,15 @@
 package dev.langchain4j.agentic.internal;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
- * A {@link DelayedResponse} that can be completed externally, without spawning a background thread.
+ * A {@link DeferredResponse} that blocks the calling thread until completed.
  * <p>
- * Unlike {@link AsyncResponse}, which immediately starts executing a supplier on a thread pool,
- * {@code PendingResponse} creates an initially incomplete future that must be explicitly completed
- * via {@link #complete(Object)}. This makes it suitable for scenarios where the response comes from
- * an external source (e.g., a human via a REST API, a message queue, or an external event) and the
- * workflow must survive process restarts.
- * <p>
- * After serialization/deserialization, a new incomplete {@link CompletableFuture} is created,
- * allowing an external system to reconnect and complete the response.
+ * When the agentic system encounters this response via {@code readState()}, the calling thread
+ * blocks on the underlying {@link java.util.concurrent.CompletableFuture} until
+ * {@link #complete(Object)} is called externally. This is the default behavior for
+ * human-in-the-loop agents that do not require crash-resilient suspension.
  * <p>
  * Usage with {@link dev.langchain4j.agentic.workflow.HumanInTheLoop}:
  * <pre>{@code
@@ -25,94 +17,17 @@ import java.util.concurrent.TimeoutException;
  *     .responseProvider(scope -> new PendingResponse<>("user-approval"))
  *     .build();
  *
- * // Later, from an external system (e.g., REST endpoint):
+ * // From another thread:
  * scope.completePendingResponse("user-approval", "approved");
  * }</pre>
  *
  * @param <T> the type of the response value
+ * @see SuspendedResponse for crash-resilient suspension (exception-based)
  */
-public class PendingResponse<T> implements DelayedResponse<T> {
+public class PendingResponse<T> extends DeferredResponse<T> {
 
-    private final String responseId;
-
-    @JsonIgnore
-    private transient CompletableFuture<T> futureResponse;
-
-    /**
-     * Creates a new pending response with the given unique identifier.
-     *
-     * @param responseId a unique identifier for this pending response, used to locate and
-     *                   complete it from external systems
-     */
     @JsonCreator
     public PendingResponse(@JsonProperty("responseId") String responseId) {
-        this.responseId = responseId;
-        this.futureResponse = new CompletableFuture<>();
-    }
-
-    /**
-     * Returns the unique identifier for this pending response.
-     *
-     * @return the response identifier
-     */
-    public String responseId() {
-        return responseId;
-    }
-
-    @Override
-    @JsonIgnore
-    public boolean isDone() {
-        return futureResponse.isDone();
-    }
-
-    @Override
-    @JsonIgnore
-    public T blockingGet() {
-        return DelayedResponse.join(futureResponse);
-    }
-
-    /**
-     * Waits for the response with a timeout.
-     *
-     * @param timeout the maximum time to wait
-     * @param unit the time unit of the timeout argument
-     * @return the response value
-     * @throws TimeoutException if the wait timed out
-     */
-    public T blockingGet(long timeout, TimeUnit unit) throws TimeoutException {
-        try {
-            return futureResponse.get(timeout, unit);
-        } catch (TimeoutException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Completes this pending response with the given value.
-     * Any threads blocked on {@link #blockingGet()} will be released.
-     *
-     * @param value the response value
-     * @return {@code true} if this invocation caused the response to transition to a completed state,
-     *         {@code false} if it was already completed
-     */
-    public boolean complete(T value) {
-        return futureResponse.complete(value);
-    }
-
-    /**
-     * Completes this pending response exceptionally.
-     *
-     * @param exception the exception
-     * @return {@code true} if this invocation caused the response to transition to a completed state
-     */
-    public boolean completeExceptionally(Throwable exception) {
-        return futureResponse.completeExceptionally(exception);
-    }
-
-    @Override
-    public String toString() {
-        return isDone() ? String.valueOf(result()) : "<pending:" + responseId + ">";
+        super(responseId);
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -9,6 +9,7 @@ import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAg
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.agentError;
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgenticScopeCreated;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.onAgenticSystemSuspended;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -23,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -46,6 +48,7 @@ import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.agentic.workflow.impl.ParallelMapperServiceImpl;
@@ -218,6 +221,14 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
             throw e;
         }
 
+        if (result instanceof Action action && action.isSuspended()) {
+            onAgenticSystemSuspended(agentListener, currentScope);
+            if (isRootCall() && method.getReturnType().equals(ResultWithAgenticScope.class)) {
+                return new ResultWithAgenticScope<>(currentScope, null, true);
+            }
+            throw new AgenticSystemSuspendedException(currentScope);
+        }
+
         Object output = outputKey != null ? currentScope.readState(outputKey) : result;
 
         if (isRootCall()) {
@@ -357,11 +368,13 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
 
     private class PlannerLoop implements PlannerExecutor {
         static final String EXECUTION_STATE_PREFIX = "__planner_state_";
+        private static final String COMPLETED_AGENTS_KEY = "__completedAgents";
 
         private final Planner planner;
         private final DefaultAgenticScope agenticScope;
         private final AgenticScopeRegistry registry;
         private final ReentrantLock lock = new ReentrantLock();
+        private final Set<String> completedAgentIds = new java.util.HashSet<>();
 
         private volatile Action nextAction = null;
 
@@ -375,15 +388,23 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         public Object loop() {
             Map<String, Object> savedState = agenticScope.readState(executionStateId(), Map.of());
             if (!savedState.isEmpty()) {
+                restoreCompletedAgents(savedState);
                 planner.restoreExecutionState(savedState);
             }
 
             nextAction = planner.firstAction(new PlanningContext(agenticScope, null));
+            nextAction = filterCompletedAgents(nextAction);
             while (nextAction == null || !nextAction.isDone()) {
                 if (nextAction == null) {
                     Thread.yield();
                     continue;
                 }
+
+                if (hasSuspendedResponses(agenticScope)) {
+                    nextAction = planner.suspend();
+                    break;
+                }
+
                 List<AgentExecutor> agents = ((Action.AgentCallAction) nextAction).agentsToCall();
                 nextAction = null;
                 switch (agents.size()) {
@@ -393,10 +414,37 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
                 }
             }
 
+            if (nextAction != null && nextAction.isSuspended()) {
+                return nextAction;
+            }
+
+            if (hasSuspendedResponses(agenticScope)) {
+                return planner.suspend();
+            }
+
             // Clear execution state when planner is done
             agenticScope.writeState(executionStateId(), null);
 
             return result();
+        }
+
+        private Action filterCompletedAgents(Action action) {
+            if (completedAgentIds.isEmpty() || !(action instanceof Action.AgentCallAction aca) || aca.agentsToCall().size() <= 1) {
+                return action;
+            }
+            List<AgentExecutor> remaining = aca.agentsToCall().stream()
+                    .filter(a -> !completedAgentIds.contains(a.agentId()))
+                    .toList();
+            return remaining.isEmpty() ? planner.done() : new Action.AgentCallAction(remaining);
+        }
+
+        private void restoreCompletedAgents(Map<String, Object> savedState) {
+            Object completed = savedState.get(COMPLETED_AGENTS_KEY);
+            if (completed instanceof List<?> list) {
+                for (Object id : list) {
+                    completedAgentIds.add(id.toString());
+                }
+            }
         }
 
         private String executionStateId() {
@@ -417,6 +465,7 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
                 throw new RuntimeException(e);
             }
         }
+
         private Object result() {
             Object result = output != null ? output.apply(agenticScope) : nextAction.result();
 
@@ -431,18 +480,38 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
             return result;
         }
 
+        private void saveExecutionState() {
+            Map<String, Object> execState = planner.executionState();
+            if (!completedAgentIds.isEmpty()) {
+                execState = new HashMap<>(execState);
+                execState.put(COMPLETED_AGENTS_KEY, new ArrayList<>(completedAgentIds));
+            }
+            if (!execState.isEmpty()) {
+                agenticScope.writeState(executionStateId(), execState);
+            }
+        }
+
+        @Override
+        public void onSubagentSuspended() {
+            lock.lock();
+            try {
+                this.nextAction = planner.suspend();
+                saveExecutionState();
+                if (registry != null) {
+                    agenticScope.checkpoint(registry);
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
         @Override
         public void onSubagentInvoked(AgentInvocation agentInvocation) {
             lock.lock();
             try {
+                completedAgentIds.add(agentInvocation.agentId());
                 this.nextAction = composeActions(this.nextAction, planner.nextAction(new PlanningContext(agenticScope, agentInvocation)));
-
-                // Save planner execution state after each agent invocation
-                Map<String, Object> execState = planner.executionState();
-                if (!execState.isEmpty()) {
-                    agenticScope.writeState(executionStateId(), execState);
-                }
-
+                saveExecutionState();
                 if (registry != null) {
                     agenticScope.checkpoint(registry);
                 }
@@ -473,6 +542,11 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         private static boolean isEmptyCall(Action action) {
             return action instanceof Action.AgentCallAction aca && aca.agentsToCall().isEmpty();
         }
+    }
+
+    private static boolean hasSuspendedResponses(AgenticScope agenticScope) {
+        return agenticScope.state().values().stream()
+                .anyMatch(v -> v instanceof SuspendedResponse<?> sr && !sr.isDone());
     }
 
     private boolean isRootCall() {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -224,7 +224,8 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         if (result instanceof Action action && action.isSuspended()) {
             onAgenticSystemSuspended(agentListener, currentScope);
             if (isRootCall() && method.getReturnType().equals(ResultWithAgenticScope.class)) {
-                return new ResultWithAgenticScope<>(currentScope, null, true);
+                return new ResultWithAgenticScope<>(currentScope, null, true,
+                        () -> (ResultWithAgenticScope) executeAgentMethod(registry, method, args));
             }
             throw new AgenticSystemSuspendedException(currentScope);
         }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerExecutor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerExecutor.java
@@ -6,5 +6,7 @@ public interface PlannerExecutor {
 
     void onSubagentInvoked(AgentInvocation agentInvocation);
 
+    default void onSubagentSuspended() {}
+
     boolean propagateStreaming();
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/SuspendedResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/SuspendedResponse.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.agentic.internal;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A {@link DeferredResponse} that suspends the agentic system instead of blocking.
+ * <p>
+ * When the agentic system encounters this response, it checkpoints its state (if a
+ * {@link dev.langchain4j.agentic.scope.AgenticScopeStore} is configured) and throws
+ * {@link dev.langchain4j.agentic.scope.AgenticSystemSuspendedException}, releasing the
+ * calling thread. The system can be resumed later by completing the response via
+ * {@link dev.langchain4j.agentic.scope.AgenticScope#completePendingResponse(String, Object)}
+ * and re-invoking the agent method with the same memory ID.
+ * <p>
+ * Usage with {@link dev.langchain4j.agentic.workflow.HumanInTheLoop}:
+ * <pre>{@code
+ * HumanInTheLoop.builder()
+ *     .responseProvider(scope -> new SuspendedResponse<>("user-approval"))
+ *     .build();
+ *
+ * // After suspension, from an external system:
+ * scope.completePendingResponse("user-approval", "approved");
+ * // Then re-invoke the agent method with the same memory ID
+ * }</pre>
+ *
+ * @param <T> the type of the response value
+ * @see PendingResponse for thread-blocking behavior (future-based)
+ */
+public class SuspendedResponse<T> extends DeferredResponse<T> {
+
+    @JsonCreator
+    public SuspendedResponse(@JsonProperty("responseId") String responseId) {
+        super(responseId);
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AgentListener.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AgentListener.java
@@ -14,6 +14,8 @@ public interface AgentListener {
     default void afterAgenticScopeCreated(AgenticScope agenticScope) { }
     default void beforeAgenticScopeDestroyed(AgenticScope agenticScope) { }
 
+    default void onAgenticSystemSuspended(AgenticScope agenticScope) { }
+
     default void beforeAgentToolExecution(BeforeAgentToolExecution beforeAgentToolExecution) { }
     default void afterAgentToolExecution(AfterAgentToolExecution afterAgentToolExecution) { }
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/ComposedAgentListener.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/ComposedAgentListener.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+
 @Internal
 public class ComposedAgentListener implements AgentListener {
 
@@ -95,6 +96,13 @@ public class ComposedAgentListener implements AgentListener {
     public void beforeAgenticScopeDestroyed(final AgenticScope agenticScope) {
         for (AgentListener listener : listeners) {
             listener.beforeAgenticScopeDestroyed(agenticScope);
+        }
+    }
+
+    @Override
+    public void onAgenticSystemSuspended(final AgenticScope agenticScope) {
+        for (AgentListener listener : listeners) {
+            listener.onAgenticSystemSuspended(agenticScope);
         }
     }
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/ListenerNotifierUtil.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/ListenerNotifierUtil.java
@@ -70,4 +70,14 @@ public class ListenerNotifierUtil {
             }
         }
     }
+
+    public static void onAgenticSystemSuspended(AgentListener listener, AgenticScope agenticScope) {
+        if (listener != null) {
+            try {
+                listener.onAgenticSystemSuspended(agenticScope);
+            } catch (Exception e) {
+                LOG.error("onAgenticSystemSuspended listener failed: " + e.getMessage(), e);
+            }
+        }
+    }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/Action.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/Action.java
@@ -4,14 +4,43 @@ import dev.langchain4j.agentic.internal.AgentExecutor;
 import java.util.List;
 import java.util.stream.Stream;
 
+/**
+ * Represents the outcome of a {@link Planner} decision. Each action tells the execution loop
+ * what to do next: invoke one or more agents, signal completion, or suspend the agentic system.
+ */
 public interface Action {
 
+    /**
+     * Returns {@code true} if this action signals that the planner has finished
+     * (either completed or suspended) and the execution loop should exit.
+     *
+     * @return {@code true} if the planner is done or suspended
+     */
     boolean isDone();
 
+    /**
+     * Returns {@code true} if this action represents a suspension of the agentic system.
+     * A suspended action is also done ({@link #isDone()} returns {@code true}).
+     *
+     * @return {@code true} if the agentic system should suspend
+     */
+    default boolean isSuspended() {
+        return false;
+    }
+
+    /**
+     * Returns the result produced by the planner, if any.
+     *
+     * @return the result, or {@code null} if no result is available
+     */
     default Object result() {
         return null;
     }
 
+    /**
+     * Signals that the planner has completed successfully with no explicit result.
+     * The execution loop reads the final output from the scope state.
+     */
     class DoneAction implements Action {
 
         static final Action INSTANCE = new DoneAction();
@@ -27,6 +56,9 @@ public interface Action {
         }
     }
 
+    /**
+     * Signals that the planner has completed successfully with an explicit result value.
+     */
     class DoneWithResultAction implements Action {
 
         private final Object result;
@@ -51,6 +83,10 @@ public interface Action {
         }
     }
 
+    /**
+     * Requests that the execution loop invoke one or more agents. When multiple agents
+     * are listed they are dispatched in parallel.
+     */
     class AgentCallAction implements Action {
 
         private final List<AgentExecutor> agents;
@@ -78,7 +114,37 @@ public interface Action {
         }
     }
 
+    /**
+     * A no-op action that yields control back to the execution loop without invoking any agent.
+     * Used by planners that need to wait for an external event before deciding the next step.
+     */
     class NoOpAction extends AgentCallAction {
         static final Action INSTANCE = new NoOpAction();
+    }
+
+    /**
+     * Signals that the agentic system should suspend. The execution loop checkpoints the
+     * scope state and throws {@link dev.langchain4j.agentic.scope.AgenticSystemSuspendedException}
+     * (or returns a suspended {@link dev.langchain4j.agentic.scope.ResultWithAgenticScope})
+     * to release the calling thread.
+     */
+    class SuspendAction implements Action {
+
+        static final Action INSTANCE = new SuspendAction();
+
+        @Override
+        public String toString() {
+            return "SuspendAction";
+        }
+
+        @Override
+        public boolean isDone() {
+            return true;
+        }
+
+        @Override
+        public boolean isSuspended() {
+            return true;
+        }
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/Planner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/Planner.java
@@ -32,38 +32,100 @@ public interface Planner {
      */
     default void restoreExecutionState(Map<String, Object> state) { }
 
+    /**
+     * Returns the first action to execute when the planner starts (or resumes).
+     * Defaults to delegating to {@link #nextAction(PlanningContext)}.
+     *
+     * @param planningContext the current planning context
+     * @return the first action to execute
+     */
     default Action firstAction(PlanningContext planningContext) {
         return nextAction(planningContext);
     }
 
+    /**
+     * Returns the topology of the agentic system managed by this planner.
+     *
+     * @return the topology (defaults to {@link AgenticSystemTopology#SEQUENCE})
+     */
     default AgenticSystemTopology topology() {
         return AgenticSystemTopology.SEQUENCE;
     }
 
+    /**
+     * Determines the next action to execute based on the result of the previous agent invocation.
+     *
+     * @param planningContext the current planning context, including the previous agent's result
+     * @return the next action to execute
+     */
     Action nextAction(PlanningContext planningContext);
 
+    /**
+     * Returns {@code true} if the planner has reached a terminal state and will not
+     * produce further actions.
+     *
+     * @return {@code true} if the planner is terminated
+     */
     default boolean terminated() {
         return false;
     }
 
+    /**
+     * Returns a no-op action that yields control without invoking any agent.
+     *
+     * @return a no-op action
+     */
     default Action noOp() {
         return Action.NoOpAction.INSTANCE;
     }
 
+    /**
+     * Returns an action that invokes the given agents. Multiple agents are dispatched in parallel.
+     *
+     * @param agents the agents to invoke
+     * @return an agent call action
+     */
     default Action call(AgentInstance... agents) {
         return new Action.AgentCallAction(agents);
     }
 
+    /**
+     * Returns an action that invokes the given agents. Multiple agents are dispatched in parallel.
+     *
+     * @param agents the agents to invoke
+     * @return an agent call action
+     */
     default Action call(List<AgentInstance> agents) {
         return call(agents.toArray(new AgentInstance[0]));
     }
 
+    /**
+     * Returns an action signaling that the planner has completed with no explicit result.
+     *
+     * @return a done action
+     */
     default Action done() {
         return Action.DoneAction.INSTANCE;
     }
 
+    /**
+     * Returns an action signaling that the planner has completed with the given result.
+     *
+     * @param result the result value
+     * @return a done action carrying the result
+     */
     default Action done(Object result) {
         return new Action.DoneWithResultAction(result);
+    }
+
+    /**
+     * Returns an action signaling that the agentic system should suspend.
+     * The execution loop will checkpoint the scope state and release the calling thread.
+     *
+     * @return a suspend action
+     */
+    default Action suspend() {
+        return Action.SuspendAction.INSTANCE;
     }
 
     default <T extends AgentInstance> T as(Class<T> agentInstanceClass, AgentInstance agentInstance) {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScope.java
@@ -1,7 +1,7 @@
 package dev.langchain4j.agentic.scope;
 
 import dev.langchain4j.agentic.declarative.TypedKey;
-import dev.langchain4j.agentic.internal.PendingResponse;
+import dev.langchain4j.agentic.internal.DeferredResponse;
 import dev.langchain4j.invocation.LangChain4jManaged;
 import java.util.List;
 import java.util.Map;
@@ -179,7 +179,7 @@ public interface AgenticScope extends LangChain4jManaged {
     List<AgentInvocation> agentInvocations(Class<?> agentType);
 
     /**
-     * Completes a {@link PendingResponse} stored in this scope's state.
+     * Completes a {@link DeferredResponse} stored in this scope's state.
      * This is typically called by an external system (e.g., a REST endpoint) to provide
      * a human's response after a process restart or when using a polling/event-driven model.
      *
@@ -192,7 +192,25 @@ public interface AgenticScope extends LangChain4jManaged {
     }
 
     /**
-     * Returns the identifiers of all {@link PendingResponse} instances stored in this scope's state
+     * Completes the single {@link DeferredResponse} stored in this scope's state.
+     * This is a convenience overload of {@link #completePendingResponse(String, Object)} for the
+     * common case where exactly one pending response is expected.
+     *
+     * @param value the value to complete the response with
+     * @return {@code true} if the pending response was found and completed
+     * @throws IllegalStateException if there is not exactly one pending response
+     */
+    default boolean completePendingResponse(Object value) {
+        Set<String> ids = pendingResponseIds();
+        if (ids.size() != 1) {
+            throw new IllegalStateException(
+                    "Expected exactly 1 pending response, but found " + ids.size() + ": " + ids);
+        }
+        return completePendingResponse(ids.iterator().next(), value);
+    }
+
+    /**
+     * Returns the identifiers of all {@link DeferredResponse} instances stored in this scope's state
      * that have not yet been completed.
      *
      * @return a set of pending response identifiers

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticSystemSuspendedException.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticSystemSuspendedException.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.agentic.scope;
+
+/**
+ * Thrown when a persistent agentic system suspends because it contains unresolved
+ * {@link dev.langchain4j.agentic.internal.SuspendedResponse} entries (typically
+ * from a HumanInTheLoop agent). The system's state has been checkpointed
+ * and the calling thread is released.
+ * <p>
+ * To resume the agentic system:
+ * <ol>
+ *   <li>Provide the human response via {@link AgenticScope#completePendingResponse(String, Object)}
+ *       or {@link AgenticScope#writeState(String, Object)}</li>
+ *   <li>Re-invoke the agent method with the same memory ID</li>
+ * </ol>
+ */
+public class AgenticSystemSuspendedException extends RuntimeException {
+
+    private final AgenticScope scope;
+
+    public AgenticSystemSuspendedException(AgenticScope scope) {
+        super("Agentic system suspended: awaiting responses for " + scope.pendingResponseIds());
+        this.scope = scope;
+    }
+
+    public AgenticScope scope() {
+        return scope;
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticSystemSuspendedException.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticSystemSuspendedException.java
@@ -18,7 +18,8 @@ public class AgenticSystemSuspendedException extends RuntimeException {
     private final AgenticScope scope;
 
     public AgenticSystemSuspendedException(AgenticScope scope) {
-        super("Agentic system suspended: awaiting responses for " + scope.pendingResponseIds());
+        super("Agentic system suspended: awaiting responses for " + scope.pendingResponseIds(),
+                null, false, false);
         this.scope = scope;
     }
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
@@ -10,7 +10,7 @@ import dev.langchain4j.agentic.agent.ErrorContext;
 import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.internal.DelayedResponse;
-import dev.langchain4j.agentic.internal.PendingResponse;
+import dev.langchain4j.agentic.internal.DeferredResponse;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.data.message.AiMessage;
@@ -129,12 +129,17 @@ public class DefaultAgenticScope implements AgenticScope {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void writeState(String key, Object value) {
         withReadLock(() -> {
+            Object old;
             if (value == null) {
-                state.remove(key);
+                old = state.remove(key);
             } else {
-                state.put(key, value);
+                old = state.put(key, value);
+            }
+            if (old instanceof DeferredResponse<?> pending && !pending.isDone()) {
+                ((DeferredResponse<Object>) pending).complete(value);
             }
         });
     }
@@ -386,10 +391,14 @@ public class DefaultAgenticScope implements AgenticScope {
     @Override
     @SuppressWarnings("unchecked")
     public boolean completePendingResponse(String responseId, Object value) {
-        for (Object stateValue : state.values()) {
-            if (stateValue instanceof PendingResponse<?> pending
-                    && pending.responseId().equals(responseId)) {
-                return ((PendingResponse<Object>) pending).complete(value);
+        for (Map.Entry<String, Object> entry : state.entrySet()) {
+            if (entry.getValue() instanceof DeferredResponse<?> deferred
+                    && deferred.responseId().equals(responseId)) {
+                boolean completed = ((DeferredResponse<Object>) deferred).complete(value);
+                if (completed) {
+                    withReadLock(() -> state.put(entry.getKey(), value));
+                }
+                return completed;
             }
         }
         return false;
@@ -398,10 +407,10 @@ public class DefaultAgenticScope implements AgenticScope {
     @Override
     public Set<String> pendingResponseIds() {
         return state.values().stream()
-                .filter(PendingResponse.class::isInstance)
-                .map(PendingResponse.class::cast)
+                .filter(DeferredResponse.class::isInstance)
+                .map(DeferredResponse.class::cast)
                 .filter(p -> !p.isDone())
-                .map(PendingResponse::responseId)
+                .map(DeferredResponse::responseId)
                 .collect(Collectors.toSet());
     }
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/ResultWithAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/ResultWithAgenticScope.java
@@ -1,15 +1,116 @@
 package dev.langchain4j.agentic.scope;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 /**
  * Holds the result of an agent invocation along with its associated {@link AgenticScope}.
  * This is useful for returning results from agents while also providing access to the cognitive
  * scope through which that result has been generated.
+ * <p>
+ * When the invocation is suspended ({@link #suspended()} returns {@code true}), the caller
+ * can provide the human response and resume in a single call via
+ * {@link #completePendingResponse(Object)}.
  *
  * @param <T> The type of the result.
  */
-public record ResultWithAgenticScope<T>(AgenticScope agenticScope, T result, boolean suspended) {
+public final class ResultWithAgenticScope<T> {
+
+    private final AgenticScope agenticScope;
+    private final T result;
+    private final boolean suspended;
+    private final transient Supplier<ResultWithAgenticScope<T>> resumeCallback;
 
     public ResultWithAgenticScope(AgenticScope agenticScope, T result) {
-        this(agenticScope, result, false);
+        this(agenticScope, result, false, null);
+    }
+
+    public ResultWithAgenticScope(AgenticScope agenticScope, T result, boolean suspended) {
+        this(agenticScope, result, suspended, null);
+    }
+
+    public ResultWithAgenticScope(AgenticScope agenticScope, T result, boolean suspended,
+                                  Supplier<ResultWithAgenticScope<T>> resumeCallback) {
+        this.agenticScope = agenticScope;
+        this.result = result;
+        this.suspended = suspended;
+        this.resumeCallback = resumeCallback;
+    }
+
+    public AgenticScope agenticScope() {
+        return agenticScope;
+    }
+
+    public T result() {
+        return result;
+    }
+
+    public boolean suspended() {
+        return suspended;
+    }
+
+    /**
+     * Completes the single pending response and re-invokes the agentic system to resume execution.
+     * The returned result may itself be suspended if the workflow has further human-in-the-loop steps.
+     *
+     * @param value the human response value
+     * @return the result of the resumed invocation
+     * @throws IllegalStateException if this result is not suspended, if there is not exactly one
+     *         pending response, or if no resume callback is available (e.g. after a crash/restart)
+     */
+    public ResultWithAgenticScope<T> completePendingResponse(Object value) {
+        return completePendingResponse(singlePendingResponseId(), value);
+    }
+
+    /**
+     * Completes the pending response with the given ID and re-invokes the agentic system to resume execution.
+     * The returned result may itself be suspended if the workflow has further human-in-the-loop steps.
+     *
+     * @param responseId the identifier of the pending response to complete
+     * @param value the human response value
+     * @return the result of the resumed invocation
+     * @throws IllegalStateException if this result is not suspended or if no resume callback
+     *         is available (e.g. after a crash/restart)
+     */
+    public ResultWithAgenticScope<T> completePendingResponse(String responseId, Object value) {
+        if (!suspended) {
+            throw new IllegalStateException("Cannot complete a pending response on a non-suspended result");
+        }
+        if (resumeCallback == null) {
+            throw new IllegalStateException(
+                    "No resume callback available. After a crash/restart, use AgenticScope.completePendingResponse() and re-invoke the agent method directly.");
+        }
+        agenticScope.completePendingResponse(responseId, value);
+        return resumeCallback.get();
+    }
+
+    private String singlePendingResponseId() {
+        var ids = agenticScope.pendingResponseIds();
+        if (ids.size() != 1) {
+            throw new IllegalStateException(
+                    "Expected exactly 1 pending response, but found " + ids.size() + ": " + ids);
+        }
+        return ids.iterator().next();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ResultWithAgenticScope<?> that)) return false;
+        return suspended == that.suspended
+                && Objects.equals(agenticScope, that.agenticScope)
+                && Objects.equals(result, that.result);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(agenticScope, result, suspended);
+    }
+
+    @Override
+    public String toString() {
+        return "ResultWithAgenticScope[agenticScope=" + agenticScope
+                + ", result=" + result
+                + ", suspended=" + suspended + "]";
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/ResultWithAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/ResultWithAgenticScope.java
@@ -7,4 +7,9 @@ package dev.langchain4j.agentic.scope;
  *
  * @param <T> The type of the result.
  */
-public record ResultWithAgenticScope<T>(AgenticScope agenticScope, T result) { }
+public record ResultWithAgenticScope<T>(AgenticScope agenticScope, T result, boolean suspended) {
+
+    public ResultWithAgenticScope(AgenticScope agenticScope, T result) {
+        this(agenticScope, result, false);
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/NestedSuspensionIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/NestedSuspensionIT.java
@@ -1,0 +1,426 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
+import dev.langchain4j.agentic.internal.SuspendedResponse;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
+import dev.langchain4j.agentic.scope.AgenticScopeKey;
+import dev.langchain4j.agentic.scope.AgenticScopePersister;
+import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
+import dev.langchain4j.agentic.scope.AgenticScopeStore;
+import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.agentic.workflow.HumanInTheLoop;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.V;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class NestedSuspensionIT {
+
+    public interface NestedWorkflow extends AgenticScopeAccess {
+        @Agent
+        String process(@MemoryId String sessionId, @V("input") String input);
+    }
+
+    static class FileBasedAgenticScopeStore implements AgenticScopeStore {
+        private final Path directory;
+
+        FileBasedAgenticScopeStore(Path directory) {
+            this.directory = directory;
+        }
+
+        @Override
+        public boolean save(AgenticScopeKey key, DefaultAgenticScope agenticScope) {
+            try {
+                Files.writeString(fileFor(key), AgenticScopeSerializer.toJson(agenticScope));
+                return true;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Optional<DefaultAgenticScope> load(AgenticScopeKey key) {
+            Path file = fileFor(key);
+            if (!Files.exists(file)) return Optional.empty();
+            try {
+                return Optional.of(AgenticScopeSerializer.fromJson(Files.readString(file)));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean delete(AgenticScopeKey key) {
+            try {
+                return Files.deleteIfExists(fileFor(key));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Set<AgenticScopeKey> getAllKeys() {
+            try (Stream<Path> files = Files.list(directory)) {
+                return files.filter(f -> f.toString().endsWith(".json"))
+                        .map(f -> {
+                            String name = f.getFileName().toString().replace(".json", "");
+                            String[] parts = name.split("__", 2);
+                            return new AgenticScopeKey(parts[0], parts.length > 1 ? parts[1] : "");
+                        })
+                        .collect(Collectors.toSet());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private Path fileFor(AgenticScopeKey key) {
+            String filename = key.agentId().replaceAll("[^a-zA-Z0-9._-]", "_")
+                    + "__" + key.memoryId().toString().replaceAll("[^a-zA-Z0-9._-]", "_")
+                    + ".json";
+            return directory.resolve(filename);
+        }
+    }
+
+    @AfterEach
+    void cleanup() {
+        AgenticScopePersister.setStore(null);
+    }
+
+    // ================================================================
+    // Nested sequential: RootSequence(A, InnerSequence(B, HITL, C), D)
+    // ================================================================
+
+    @Test
+    void nestedSequentialSuspendAndResume(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        AgenticServices.AgenticScopeAction agentA = AgenticServices.agentAction(scope ->
+                scope.writeState("step_a", "A_DONE"));
+
+        AgenticServices.AgenticScopeAction agentB = AgenticServices.agentAction(scope ->
+                scope.writeState("step_b", "B_DONE"));
+
+        HumanInTheLoop hitl = AgenticServices.humanInTheLoopBuilder()
+                .description("Human review")
+                .outputKey("approval")
+                .responseProvider(scope -> new SuspendedResponse<>("human-review"))
+                .build();
+
+        AgenticServices.AgenticScopeAction agentC = AgenticServices.agentAction(scope ->
+                scope.writeState("step_c", "C_DONE:" + scope.readState("approval")));
+
+        UntypedAgent innerSequence = AgenticServices.sequenceBuilder()
+                .subAgents(agentB, hitl, agentC)
+                .outputKey("inner_result")
+                .build();
+
+        AgenticServices.AgenticScopeAction agentD = AgenticServices.agentAction(scope -> {
+            String c = (String) scope.readState("step_c");
+            scope.writeState("final_result", "D_DONE:" + c);
+        });
+
+        NestedWorkflow workflow = AgenticServices.sequenceBuilder(NestedWorkflow.class)
+                .subAgents(agentA, innerSequence, agentD)
+                .outputKey("final_result")
+                .build();
+
+        AgenticSystemSuspendedException suspended = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s1", "data"));
+
+        assertThat(suspended.scope().pendingResponseIds()).containsExactly("human-review");
+        assertThat(suspended.scope().readState("step_a", "")).isEqualTo("A_DONE");
+        assertThat(suspended.scope().readState("step_b", "")).isEqualTo("B_DONE");
+
+        suspended.scope().completePendingResponse("APPROVED");
+        String result = workflow.process("s1", "data");
+
+        assertThat(result).isEqualTo("D_DONE:C_DONE:APPROVED");
+    }
+
+    // ================================================================
+    // Nested parallel: RootSequence(Parallel([InnerSeq(A,HITL,B), AgentC]), D)
+    // ================================================================
+
+    @Test
+    void nestedParallelSuspendAndResume(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        AgenticServices.AgenticScopeAction agentA = AgenticServices.agentAction(scope ->
+                scope.writeState("branch1_step_a", "A_DONE"));
+
+        HumanInTheLoop hitl = AgenticServices.humanInTheLoopBuilder()
+                .description("Human review")
+                .outputKey("approval")
+                .responseProvider(scope -> new SuspendedResponse<>("human-review"))
+                .build();
+
+        AgenticServices.AgenticScopeAction agentB = AgenticServices.agentAction(scope ->
+                scope.writeState("branch1_result", "B_DONE:" + scope.readState("approval")));
+
+        UntypedAgent innerSequence = AgenticServices.sequenceBuilder()
+                .subAgents(agentA, hitl, agentB)
+                .outputKey("branch1_result")
+                .build();
+
+        AgenticServices.AgenticScopeAction agentC = AgenticServices.agentAction(scope ->
+                scope.writeState("branch2_result", "C_DONE"));
+
+        UntypedAgent parallelBlock = AgenticServices.parallelBuilder()
+                .subAgents(innerSequence, agentC)
+                .build();
+
+        AgenticServices.AgenticScopeAction agentD = AgenticServices.agentAction(scope -> {
+            String b1 = (String) scope.readState("branch1_result");
+            String b2 = (String) scope.readState("branch2_result");
+            scope.writeState("final_result", b1 + "|" + b2);
+        });
+
+        NestedWorkflow workflow = AgenticServices.sequenceBuilder(NestedWorkflow.class)
+                .subAgents(parallelBlock, agentD)
+                .outputKey("final_result")
+                .build();
+
+        AgenticSystemSuspendedException suspended = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s2", "data"));
+
+        assertThat(suspended.scope().pendingResponseIds()).containsExactly("human-review");
+        // AgentC completed even though the parallel block suspended
+        assertThat(suspended.scope().readState("branch2_result", "")).isEqualTo("C_DONE");
+
+        suspended.scope().completePendingResponse("APPROVED");
+        String result = workflow.process("s2", "data");
+
+        assertThat(result).isEqualTo("B_DONE:APPROVED|C_DONE");
+    }
+
+    // ================================================================
+    // Nested loop: RootSequence(Loop([A, HITL, B], max=2), D)
+    // ================================================================
+
+    @Test
+    void nestedLoopSuspendAndResume(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        AgenticServices.AgenticScopeAction agentA = AgenticServices.agentAction(scope -> {
+            int count = scope.readState("iteration_count", 0);
+            scope.writeState("iteration_count", count + 1);
+        });
+
+        HumanInTheLoop hitl = AgenticServices.humanInTheLoopBuilder()
+                .description("Human review")
+                .outputKey("approval")
+                .responseProvider(scope -> new SuspendedResponse<>("human-review"))
+                .build();
+
+        AgenticServices.AgenticScopeAction agentB = AgenticServices.agentAction(scope ->
+                scope.writeState("loop_result",
+                        "iter" + scope.readState("iteration_count") + ":" + scope.readState("approval")));
+
+        UntypedAgent loop = AgenticServices.loopBuilder()
+                .subAgents(agentA, hitl, agentB)
+                .maxIterations(2)
+                .build();
+
+        AgenticServices.AgenticScopeAction agentD = AgenticServices.agentAction(scope ->
+                scope.writeState("final_result", "DONE:" + scope.readState("loop_result")));
+
+        NestedWorkflow workflow = AgenticServices.sequenceBuilder(NestedWorkflow.class)
+                .subAgents(loop, agentD)
+                .outputKey("final_result")
+                .build();
+
+        // First suspension: iteration 1
+        AgenticSystemSuspendedException suspended1 = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s3", "data"));
+
+        assertThat(suspended1.scope().readState("iteration_count", 0)).isEqualTo(1);
+
+        // Provide response and resume — loop continues, may suspend again at iteration 2
+        suspended1.scope().completePendingResponse("OK1");
+
+        // The loop will re-enter iteration 2, hit HITL again
+        AgenticSystemSuspendedException suspended2 = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s3", "data"));
+
+        assertThat(suspended2.scope().readState("iteration_count", 0)).isEqualTo(2);
+
+        // Provide second response — exit condition met, loop completes
+        suspended2.scope().completePendingResponse("OK2");
+        String result = workflow.process("s3", "data");
+
+        assertThat(result).isEqualTo("DONE:iter2:OK2");
+    }
+
+    // ================================================================
+    // Deep nesting: Root → Sequence → Parallel → Sequence(HITL)
+    // ================================================================
+
+    @Test
+    void deeplyNestedSuspension(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        HumanInTheLoop hitl = AgenticServices.humanInTheLoopBuilder()
+                .description("Deep review")
+                .outputKey("deep_approval")
+                .responseProvider(scope -> new SuspendedResponse<>("deep-review"))
+                .build();
+
+        AgenticServices.AgenticScopeAction innerAgent = AgenticServices.agentAction(scope ->
+                scope.writeState("deep_result", "DEEP:" + scope.readState("deep_approval")));
+
+        UntypedAgent innerSequence = AgenticServices.sequenceBuilder()
+                .subAgents(hitl, innerAgent)
+                .outputKey("deep_result")
+                .build();
+
+        AgenticServices.AgenticScopeAction otherBranch = AgenticServices.agentAction(scope ->
+                scope.writeState("other_result", "OTHER_DONE"));
+
+        UntypedAgent parallelBlock = AgenticServices.parallelBuilder()
+                .subAgents(innerSequence, otherBranch)
+                .build();
+
+        AgenticServices.AgenticScopeAction outerAgent = AgenticServices.agentAction(scope ->
+                scope.writeState("outer_result",
+                        scope.readState("deep_result") + "|" + scope.readState("other_result")));
+
+        UntypedAgent outerSequence = AgenticServices.sequenceBuilder()
+                .subAgents(parallelBlock, outerAgent)
+                .outputKey("outer_result")
+                .build();
+
+        AgenticServices.AgenticScopeAction finalizer = AgenticServices.agentAction(scope ->
+                scope.writeState("final_result", "FINAL:" + scope.readState("outer_result")));
+
+        NestedWorkflow workflow = AgenticServices.sequenceBuilder(NestedWorkflow.class)
+                .subAgents(outerSequence, finalizer)
+                .outputKey("final_result")
+                .build();
+
+        AgenticSystemSuspendedException suspended = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s4", "data"));
+
+        assertThat(suspended.scope().pendingResponseIds()).containsExactly("deep-review");
+        assertThat(suspended.scope().readState("other_result", "")).isEqualTo("OTHER_DONE");
+
+        suspended.scope().completePendingResponse("DEEP_OK");
+        String result = workflow.process("s4", "data");
+
+        assertThat(result).isEqualTo("FINAL:DEEP:DEEP_OK|OTHER_DONE");
+    }
+
+    // ================================================================
+    // Nested crash recovery
+    // ================================================================
+
+    @Test
+    void nestedCrashRecovery(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        AgenticServices.AgenticScopeAction agentA = AgenticServices.agentAction(scope ->
+                scope.writeState("step_a", "A_DONE"));
+
+        AgenticServices.AgenticScopeAction agentB = AgenticServices.agentAction(scope ->
+                scope.writeState("step_b", "B_DONE"));
+
+        HumanInTheLoop hitl = AgenticServices.humanInTheLoopBuilder()
+                .description("Human review")
+                .outputKey("approval")
+                .responseProvider(scope -> new SuspendedResponse<>("human-review"))
+                .build();
+
+        AgenticServices.AgenticScopeAction agentC = AgenticServices.agentAction(scope ->
+                scope.writeState("step_c", "C_DONE:" + scope.readState("approval")));
+
+        UntypedAgent innerSequence = AgenticServices.sequenceBuilder()
+                .subAgents(agentB, hitl, agentC)
+                .outputKey("inner_result")
+                .build();
+
+        AgenticServices.AgenticScopeAction agentD = AgenticServices.agentAction(scope ->
+                scope.writeState("final_result", "D_DONE:" + scope.readState("step_c")));
+
+        NestedWorkflow workflow = AgenticServices.sequenceBuilder(NestedWorkflow.class)
+                .subAgents(agentA, innerSequence, agentD)
+                .outputKey("final_result")
+                .build();
+
+        assertThrows(AgenticSystemSuspendedException.class,
+                () -> workflow.process("s5", "data"));
+
+        // Simulate crash
+        AgenticScopeRegistry registry = ((AgenticScopeOwner) workflow).registry();
+        registry.clearInMemory();
+        assertThat(registry.getAllAgenticScopeKeysInMemory()).isEmpty();
+
+        // Recover: load from store, provide response, re-invoke
+        workflow.getAgenticScope("s5").writeState("approval", "CRASH_RECOVERED");
+        String result = workflow.process("s5", "data");
+
+        assertThat(result).isEqualTo("D_DONE:C_DONE:CRASH_RECOVERED");
+    }
+
+    // ================================================================
+    // Direct HITL in parallel — both branches complete, skipped on resume
+    // ================================================================
+
+    @Test
+    void parallelDirectHitlSkippedOnResume(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        HumanInTheLoop hitl = AgenticServices.humanInTheLoopBuilder()
+                .description("Parallel review")
+                .outputKey("parallel_approval")
+                .responseProvider(scope -> new SuspendedResponse<>("parallel-review"))
+                .build();
+
+        AgenticServices.AgenticScopeAction agentA = AgenticServices.agentAction(scope ->
+                scope.writeState("agent_a_result", "A_DONE"));
+
+        UntypedAgent parallelBlock = AgenticServices.parallelBuilder()
+                .subAgents(hitl, agentA)
+                .build();
+
+        AgenticServices.AgenticScopeAction finalizer = AgenticServices.agentAction(scope -> {
+            String approval = (String) scope.readState("parallel_approval");
+            String a = (String) scope.readState("agent_a_result");
+            scope.writeState("final_result", approval + "|" + a);
+        });
+
+        NestedWorkflow workflow = AgenticServices.sequenceBuilder(NestedWorkflow.class)
+                .subAgents(parallelBlock, finalizer)
+                .outputKey("final_result")
+                .build();
+
+        AgenticSystemSuspendedException suspended = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s6", "data"));
+
+        assertThat(suspended.scope().pendingResponseIds()).containsExactly("parallel-review");
+        assertThat(suspended.scope().readState("agent_a_result", "")).isEqualTo("A_DONE");
+
+        suspended.scope().completePendingResponse("PAR_APPROVED");
+        String result = workflow.process("s6", "data");
+
+        assertThat(result).isEqualTo("PAR_APPROVED|A_DONE");
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/RecoverabilityIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/RecoverabilityIT.java
@@ -1,9 +1,10 @@
 package dev.langchain4j.agentic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import dev.langchain4j.agentic.internal.AgenticScopeOwner;
-import dev.langchain4j.agentic.internal.PendingResponse;
+import dev.langchain4j.agentic.internal.SuspendedResponse;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.scope.AgenticScopeKey;
@@ -11,6 +12,7 @@ import dev.langchain4j.agentic.scope.AgenticScopePersister;
 import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
 import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
 import dev.langchain4j.agentic.scope.AgenticScopeStore;
+import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.agentic.workflow.HumanInTheLoop;
 import dev.langchain4j.service.MemoryId;
@@ -24,27 +26,25 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * End-to-end integration test demonstrating workflow persistence and recovery
+ * End-to-end integration test demonstrating workflow suspension and recovery
  * after a simulated crash, including HumanInTheLoop with PendingResponse.
  *
  * <p>Scenario: a sequential workflow runs three agents:
  * <ol>
  *   <li><b>DataProcessor</b> — processes input and writes intermediate state</li>
  *   <li><b>HumanReviewer</b> — a HumanInTheLoop that creates a {@link PendingResponse}
- *       to request human approval; the workflow blocks waiting for this response</li>
+ *       to request human approval; the workflow suspends here</li>
  *   <li><b>ResultFinalizer</b> — reads the human approval and produces the final output</li>
  * </ol>
  *
  * <p>The test:
  * <ol>
- *   <li>Starts the workflow — agents 1 and 2 execute; agent 3 blocks on the pending response</li>
+ *   <li>Starts the workflow — agents 1 and 2 execute; the workflow suspends
+ *       (throws {@link AgenticSystemSuspendedException}) instead of blocking</li>
  *   <li>Simulates a crash — clears all in-memory state</li>
  *   <li>Recovers from the file-persisted scope — provides the human response and re-invokes</li>
  *   <li>The planner resumes from the checkpoint: only agent 3 runs, using the provided response</li>
@@ -52,14 +52,10 @@ import java.util.stream.Stream;
  */
 class RecoverabilityIT {
 
-    // ---- Agent interface with @MemoryId for persistence ----
-
     public interface RecoverableWorkflow extends AgenticScopeAccess {
         @Agent
         String process(@MemoryId String sessionId, @V("input") String input);
     }
-
-    // ---- File-based AgenticScopeStore using JSON serialization to temp files ----
 
     static class FileBasedAgenticScopeStore implements AgenticScopeStore {
 
@@ -132,39 +128,27 @@ class RecoverabilityIT {
     }
 
     @Test
-    void workflow_recovers_from_crash_with_human_in_the_loop(@TempDir Path tempDir) throws Exception {
+    void workflow_suspends_and_recovers_from_crash_with_human_in_the_loop(@TempDir Path tempDir) {
 
         // ---- Setup persistence with file-based store ----
         FileBasedAgenticScopeStore store = new FileBasedAgenticScopeStore(tempDir);
         AgenticScopePersister.setStore(store);
 
-        // ---- Track the PendingResponse created by HumanInTheLoop so we can unblock Phase 1 during cleanup ----
-        AtomicReference<PendingResponse<String>> phase1PendingRef = new AtomicReference<>();
-
-        // ---- Build the workflow ----
-        RecoverableWorkflow workflow = buildWorkflow(phase1PendingRef);
+        RecoverableWorkflow workflow = buildWorkflow();
 
         // ================================================================
-        //  PHASE 1: Start workflow — it will block waiting for human input
+        //  PHASE 1: Start workflow — it will suspend (not block!)
         // ================================================================
-        CompletableFuture<String> phase1Future = CompletableFuture.supplyAsync(
+        AgenticSystemSuspendedException suspended = assertThrows(
+                AgenticSystemSuspendedException.class,
                 () -> workflow.process("session-1", "raw data to process"));
 
-        // Wait until the HumanInTheLoop agent has executed and persisted the PendingResponse
-        // The per-step checkpointing saves state after each agent invocation
-        awaitPendingResponse(workflow, "session-1");
+        assertThat(suspended.scope().pendingResponseIds()).containsExactly("human-review");
 
-        // At this point:
-        // - DataProcessor has run → state contains "processed_data"
-        // - HumanInTheLoop has run → state contains PendingResponse("human-review") under key "approval"
-        // - ResultFinalizer is blocked on readState("approval") → waiting for PendingResponse completion
-        // - Per-step checkpointing has saved the scope with cursor position = 2
-
-        AgenticScope scopeBeforeCrash = workflow.getAgenticScope("session-1");
+        AgenticScope scopeBeforeCrash = suspended.scope();
         assertThat(scopeBeforeCrash.readState("processed_data", "")).isEqualTo("PROCESSED: raw data to process");
-        assertThat(scopeBeforeCrash.pendingResponseIds()).containsExactly("human-review");
 
-        // Verify that the planner execution state was saved in scope state (by PlannerLoop)
+        // Verify that the planner execution state was saved in scope state
         assertThat(scopeBeforeCrash.state().entrySet().stream()
                 .anyMatch(e -> e.getKey().startsWith("__planner_state_"))).isTrue();
 
@@ -174,10 +158,6 @@ class RecoverabilityIT {
         // ================================================================
         //  PHASE 2: Simulate crash — clear all in-memory state
         // ================================================================
-        // Note: Phase 1 thread is still blocked on PendingResponse.blockingGet() in the Finalizer.
-        // We do NOT complete the Phase 1 PendingResponse here — that would cause rootCallEnded
-        // to replace the PendingResponse in state with the resolved value and flush to the store.
-        // Instead we simulate a hard crash by simply clearing in-memory state.
         AgenticScopeRegistry registry = ((AgenticScopeOwner) workflow).registry();
         registry.clearInMemory();
 
@@ -188,45 +168,28 @@ class RecoverabilityIT {
         //  PHASE 3: Recovery — provide human response and resume workflow
         // ================================================================
 
-        // Load the persisted scope (via the agent's AgenticScopeAccess interface)
-        // This loads the scope from the file store into the in-memory registry
+        // Load the persisted scope from the file store
         AgenticScope recoveredScope = workflow.getAgenticScope("session-1");
 
         // Verify state survived the crash
         assertThat(recoveredScope.readState("processed_data", "")).isEqualTo("PROCESSED: raw data to process");
-        // The PendingResponse was deserialized as a new incomplete future
-        assertThat(recoveredScope.pendingResponseIds()).containsExactly("human-review");
 
-        // Simulate the human providing their response (e.g., via a REST endpoint in a Quarkus extension)
-        // Replace the PendingResponse with the actual value so the finalizer can read it immediately
+        // Provide the human response by replacing the PendingResponse with the actual value
         recoveredScope.writeState("approval", "APPROVED by human reviewer");
 
         // Re-invoke the workflow with the same session ID
-        // The SequentialPlanner will restore cursor=2 from state and skip DataProcessor + HumanInTheLoop
-        // Only ResultFinalizer runs
+        // The SequentialPlanner restores cursor and skips DataProcessor + HumanReviewer
         String finalResult = workflow.process("session-1", "raw data to process");
 
         // ================================================================
         //  VERIFY: the workflow completed successfully using recovered state
         // ================================================================
         assertThat(finalResult).isEqualTo("Final result: PROCESSED: raw data to process | Approval: APPROVED by human reviewer");
-
-        // Cleanup: unblock the Phase 1 thread (it's blocked on the OLD PendingResponse object)
-        PendingResponse<String> phase1Pending = phase1PendingRef.get();
-        if (phase1Pending != null) {
-            phase1Pending.complete("cleanup");
-        }
-        try {
-            phase1Future.get(5, TimeUnit.SECONDS);
-        } catch (Exception ignored) {
-            // Phase 1 result is irrelevant
-        }
     }
 
     // ---- Workflow construction ----
 
-    @SuppressWarnings("unchecked")
-    private RecoverableWorkflow buildWorkflow(AtomicReference<PendingResponse<String>> pendingRef) {
+    private RecoverableWorkflow buildWorkflow() {
         // Agent 1: DataProcessor — transforms raw input and writes to state
         AgenticServices.AgenticScopeAction dataProcessor = AgenticServices.agentAction(
                 scope -> {
@@ -238,11 +201,7 @@ class RecoverabilityIT {
         HumanInTheLoop humanReviewer = AgenticServices.humanInTheLoopBuilder()
                 .description("Request human approval for the processed data")
                 .outputKey("approval")
-                .responseProvider(scope -> {
-                    PendingResponse<String> pending = new PendingResponse<>("human-review");
-                    pendingRef.set(pending);
-                    return pending;
-                })
+                .responseProvider(scope -> new SuspendedResponse<>("human-review"))
                 .build();
 
         // Agent 3: ResultFinalizer — combines processed data with human approval
@@ -258,27 +217,5 @@ class RecoverabilityIT {
                 .subAgents(dataProcessor, humanReviewer, resultFinalizer)
                 .outputKey("final_result")
                 .build();
-    }
-
-    // ---- Helpers ----
-
-    /**
-     * Polls until the HumanInTheLoop agent has executed and the PendingResponse
-     * is visible in the scope state.
-     */
-    private void awaitPendingResponse(RecoverableWorkflow workflow, String sessionId) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + 10_000;
-        while (System.currentTimeMillis() < deadline) {
-            try {
-                AgenticScope scope = workflow.getAgenticScope(sessionId);
-                if (scope != null && !scope.pendingResponseIds().isEmpty()) {
-                    return;
-                }
-            } catch (Exception ignored) {
-                // Scope may not exist yet
-            }
-            Thread.sleep(100);
-        }
-        throw new AssertionError("Timed out waiting for PendingResponse to appear in scope state");
     }
 }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SuspensionResumeIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SuspensionResumeIT.java
@@ -210,11 +210,34 @@ class SuspensionResumeIT {
         assertThat(result.result()).isNull();
         assertThat(result.agenticScope()).isNotNull();
 
-        // Provide response and resume
-        result.agenticScope().completePendingResponse("APPROVED");
-        ResultWithAgenticScope<String> resumed = workflow.process("s5", "data");
+        // Complete and resume in a single call
+        ResultWithAgenticScope<String> resumed = result.completePendingResponse("APPROVED");
         assertThat(resumed.suspended()).isFalse();
         assertThat(resumed.result()).isEqualTo("Final: PROCESSED: data | APPROVED");
+    }
+
+    // ================================================================
+    // Multi-step chaining via ResultWithAgenticScope.completePendingResponse
+    // ================================================================
+
+    @Test
+    void multiStepChainingViaCompletePendingResponse(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+        SuspendableWorkflowWithResult workflow = buildDoubleHitlWorkflowWithResult();
+
+        ResultWithAgenticScope<String> result = workflow.process("s5b", "request");
+        assertThat(result.suspended()).isTrue();
+        assertThat(result.agenticScope().pendingResponseIds()).containsExactly("manager-approval");
+
+        // First resume — suspends again at legal approval
+        result = result.completePendingResponse("Manager OK");
+        assertThat(result.suspended()).isTrue();
+        assertThat(result.agenticScope().pendingResponseIds()).containsExactly("legal-approval");
+
+        // Second resume — completes
+        result = result.completePendingResponse("Legal OK");
+        assertThat(result.suspended()).isFalse();
+        assertThat(result.result()).isEqualTo("Result: PROCESSED: request | Manager OK | Legal OK");
     }
 
     // ================================================================
@@ -431,6 +454,33 @@ class SuspensionResumeIT {
         });
 
         return AgenticServices.sequenceBuilder(SuspendableWorkflow.class)
+                .subAgents(dataProcessor(), managerApproval, legalApproval, finalizer)
+                .outputKey("final_result")
+                .build();
+    }
+
+    private SuspendableWorkflowWithResult buildDoubleHitlWorkflowWithResult() {
+        HumanInTheLoop managerApproval = AgenticServices.humanInTheLoopBuilder()
+                .description("Manager approval")
+                .outputKey("manager_approval")
+                .responseProvider(scope -> new SuspendedResponse<>("manager-approval"))
+                .build();
+
+        HumanInTheLoop legalApproval = AgenticServices.humanInTheLoopBuilder()
+                .description("Legal approval")
+                .outputKey("legal_approval")
+                .responseProvider(scope -> new SuspendedResponse<>("legal-approval"))
+                .build();
+
+        AgenticServices.AgenticScopeAction finalizer = AgenticServices.agentAction(scope -> {
+            String processed = (String) scope.readState("processed_data");
+            String manager = (String) scope.readState("manager_approval");
+            String legal = (String) scope.readState("legal_approval");
+            scope.writeState("final_result",
+                    "Result: " + processed + " | " + manager + " | " + legal);
+        });
+
+        return AgenticServices.sequenceBuilder(SuspendableWorkflowWithResult.class)
                 .subAgents(dataProcessor(), managerApproval, legalApproval, finalizer)
                 .outputKey("final_result")
                 .build();

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SuspensionResumeIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SuspensionResumeIT.java
@@ -1,0 +1,464 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
+import dev.langchain4j.agentic.internal.PendingResponse;
+import dev.langchain4j.agentic.internal.SuspendedResponse;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
+import dev.langchain4j.agentic.scope.AgenticScopeKey;
+import dev.langchain4j.agentic.scope.AgenticScopePersister;
+import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
+import dev.langchain4j.agentic.scope.AgenticScopeStore;
+import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import dev.langchain4j.agentic.workflow.HumanInTheLoop;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.V;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class SuspensionResumeIT {
+
+    // ---- Agent interfaces ----
+
+    public interface SuspendableWorkflow extends AgenticScopeAccess {
+        @Agent
+        String process(@MemoryId String sessionId, @V("input") String input);
+    }
+
+    public interface SuspendableWorkflowWithResult extends AgenticScopeAccess {
+        @Agent
+        ResultWithAgenticScope<String> process(@MemoryId String sessionId, @V("input") String input);
+    }
+
+    // ---- File-based store (reused across tests) ----
+
+    static class FileBasedAgenticScopeStore implements AgenticScopeStore {
+        private final Path directory;
+
+        FileBasedAgenticScopeStore(Path directory) {
+            this.directory = directory;
+        }
+
+        @Override
+        public boolean save(AgenticScopeKey key, DefaultAgenticScope agenticScope) {
+            try {
+                Files.writeString(fileFor(key), AgenticScopeSerializer.toJson(agenticScope));
+                return true;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Optional<DefaultAgenticScope> load(AgenticScopeKey key) {
+            Path file = fileFor(key);
+            if (!Files.exists(file)) return Optional.empty();
+            try {
+                return Optional.of(AgenticScopeSerializer.fromJson(Files.readString(file)));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean delete(AgenticScopeKey key) {
+            try {
+                return Files.deleteIfExists(fileFor(key));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Set<AgenticScopeKey> getAllKeys() {
+            try (Stream<Path> files = Files.list(directory)) {
+                return files.filter(f -> f.toString().endsWith(".json"))
+                        .map(f -> {
+                            String name = f.getFileName().toString().replace(".json", "");
+                            String[] parts = name.split("__", 2);
+                            return new AgenticScopeKey(parts[0], parts.length > 1 ? parts[1] : "");
+                        })
+                        .collect(Collectors.toSet());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private Path fileFor(AgenticScopeKey key) {
+            String filename = key.agentId().replaceAll("[^a-zA-Z0-9._-]", "_")
+                    + "__" + key.memoryId().toString().replaceAll("[^a-zA-Z0-9._-]", "_")
+                    + ".json";
+            return directory.resolve(filename);
+        }
+    }
+
+    @AfterEach
+    void cleanup() {
+        AgenticScopePersister.setStore(null);
+    }
+
+    // ================================================================
+    // Happy path — suspend and resume in-process without crash
+    // ================================================================
+
+    @Test
+    void suspendAndResumeInProcess(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+        SuspendableWorkflow workflow = buildSingleHitlWorkflow();
+
+        // Workflow suspends at the HITL step
+        AgenticSystemSuspendedException suspended = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s1", "data"));
+
+        assertThat(suspended.scope().pendingResponseIds()).containsExactly("human-review");
+        assertThat(suspended.scope().readState("processed_data", "")).isEqualTo("PROCESSED: data");
+
+        // Provide human response and resume
+        suspended.scope().completePendingResponse("APPROVED");
+        String result = workflow.process("s1", "data");
+        assertThat(result).isEqualTo("Final: PROCESSED: data | APPROVED");
+    }
+
+    // ================================================================
+    // Full crash recovery
+    // ================================================================
+
+    @Test
+    void suspendCrashAndRecover(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+        SuspendableWorkflow workflow = buildSingleHitlWorkflow();
+
+        assertThrows(AgenticSystemSuspendedException.class,
+                () -> workflow.process("s2", "important data"));
+
+        // Simulate crash
+        AgenticScopeRegistry registry = ((AgenticScopeOwner) workflow).registry();
+        registry.clearInMemory();
+        assertThat(registry.getAllAgenticScopeKeysInMemory()).isEmpty();
+
+        // Recover: load from store, provide response, re-invoke
+        AgenticScope recovered = workflow.getAgenticScope("s2");
+        assertThat(recovered.readState("processed_data", "")).isEqualTo("PROCESSED: important data");
+        recovered.completePendingResponse("APPROVED after crash");
+
+        String result = workflow.process("s2", "important data");
+        assertThat(result).isEqualTo("Final: PROCESSED: important data | APPROVED after crash");
+    }
+
+    // ================================================================
+    // Multiple sequential HITL agents — two suspension/resume cycles
+    // ================================================================
+
+    @Test
+    void multiplePendingResponses(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+        SuspendableWorkflow workflow = buildDoubleHitlWorkflow();
+
+        // First suspension: manager approval
+        AgenticSystemSuspendedException suspended1 = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s4", "request"));
+
+        assertThat(suspended1.scope().pendingResponseIds()).containsExactly("manager-approval");
+
+        // Provide first response and resume — suspends again at legal approval
+        suspended1.scope().writeState("manager_approval", "Manager OK");
+
+        AgenticSystemSuspendedException suspended2 = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s4", "request"));
+
+        assertThat(suspended2.scope().pendingResponseIds()).containsExactly("legal-approval");
+
+        // Provide second response and resume — completes
+        suspended2.scope().writeState("legal_approval", "Legal OK");
+        String result = workflow.process("s4", "request");
+        assertThat(result).isEqualTo("Result: PROCESSED: request | Manager OK | Legal OK");
+    }
+
+    // ================================================================
+    // ResultWithAgenticScope return type — no exception, suspended flag
+    // ================================================================
+
+    @Test
+    void resultWithAgenticScopeSuspension(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+        SuspendableWorkflowWithResult workflow = buildSingleHitlWorkflowWithResult();
+
+        ResultWithAgenticScope<String> result = workflow.process("s5", "data");
+        assertThat(result.suspended()).isTrue();
+        assertThat(result.result()).isNull();
+        assertThat(result.agenticScope()).isNotNull();
+
+        // Provide response and resume
+        result.agenticScope().completePendingResponse("APPROVED");
+        ResultWithAgenticScope<String> resumed = workflow.process("s5", "data");
+        assertThat(resumed.suspended()).isFalse();
+        assertThat(resumed.result()).isEqualTo("Final: PROCESSED: data | APPROVED");
+    }
+
+    // ================================================================
+    // Re-invoke without providing response — suspends again (idempotent)
+    // ================================================================
+
+    @Test
+    void reInvokeWithoutProvidingResponseSuspendsAgain(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+        SuspendableWorkflow workflow = buildSingleHitlWorkflow();
+
+        AgenticSystemSuspendedException first = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s6", "data"));
+
+        // Re-invoke WITHOUT providing response
+        AgenticSystemSuspendedException second = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("s6", "data"));
+
+        assertThat(second.scope().pendingResponseIds()).isEqualTo(first.scope().pendingResponseIds());
+
+        // Now provide response and resume
+        second.scope().writeState("approval", "APPROVED");
+        String result = workflow.process("s6", "data");
+        assertThat(result).isEqualTo("Final: PROCESSED: data | APPROVED");
+    }
+
+    // ================================================================
+    // Non-persistent scope still blocks (backward compatibility)
+    // ================================================================
+
+    @Test
+    void nonPersistentScopeStillBlocks() throws Exception {
+        // No store configured — scopes are REGISTERED, not PERSISTENT
+        SuspendableWorkflow workflow = buildSingleHitlWorkflow();
+
+        AtomicReference<PendingResponse<String>> pendingRef = new AtomicReference<>();
+        SuspendableWorkflow blockingWorkflow = buildSingleHitlWorkflowWithPendingRef(pendingRef);
+
+        // Run on a background thread — it should BLOCK, not throw
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(
+                () -> blockingWorkflow.process("s7", "data"));
+
+        // Wait a bit to confirm it's blocking
+        Thread.sleep(200);
+        assertThat(future.isDone()).isFalse();
+
+        // Complete the pending response — the blocked thread should unblock
+        PendingResponse<String> pending = pendingRef.get();
+        assertThat(pending).isNotNull();
+        pending.complete("APPROVED");
+
+        String result = future.get(5, TimeUnit.SECONDS);
+        assertThat(result).isEqualTo("Final: PROCESSED: data | APPROVED");
+    }
+
+    // ================================================================
+    // Listener receives suspension event
+    // ================================================================
+
+    @Test
+    void listenerReceivesSuspensionEvent(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        AtomicReference<AgenticScope> suspendedScope = new AtomicReference<>();
+
+        AgentListener listener = new AgentListener() {
+            @Override
+            public void onAgenticSystemSuspended(AgenticScope scope) {
+                suspendedScope.set(scope);
+            }
+        };
+
+        SuspendableWorkflow workflow = buildSingleHitlWorkflowWithListener(listener);
+
+        assertThrows(AgenticSystemSuspendedException.class,
+                () -> workflow.process("s8", "data"));
+
+        assertThat(suspendedScope.get()).isNotNull();
+        assertThat(suspendedScope.get().pendingResponseIds()).containsExactly("human-review");
+    }
+
+    // ================================================================
+    // Declarative API with @HumanInTheLoop annotation — suspend, crash, resume
+    // ================================================================
+
+    public static class DataProcessor {
+        @Agent(description = "Processes raw input", outputKey = "processed_data")
+        public static String process(@V("input") String input) {
+            return "PROCESSED: " + input;
+        }
+    }
+
+    public static class ApprovalGate {
+        @dev.langchain4j.agentic.declarative.HumanInTheLoop(
+                description = "Human approval gate",
+                outputKey = "approval")
+        public static Object review() {
+            return new SuspendedResponse<>("human-review");
+        }
+    }
+
+    public static class ResultFinalizer {
+        @Agent(description = "Assembles final result", outputKey = "final_result")
+        public static String finalize(@V("processed_data") String processed, @V("approval") String approval) {
+            return "Final: " + processed + " | " + approval;
+        }
+    }
+
+    public interface DeclarativeSuspendableWorkflow extends AgenticScopeAccess {
+        @dev.langchain4j.agentic.declarative.SequenceAgent(
+                outputKey = "final_result",
+                subAgents = {DataProcessor.class, ApprovalGate.class, ResultFinalizer.class})
+        String process(@MemoryId String sessionId, @V("input") String input);
+    }
+
+    @Test
+    void declarativeSuspendCrashAndResume(@TempDir Path tempDir) {
+        AgenticScopePersister.setStore(new FileBasedAgenticScopeStore(tempDir));
+
+        DeclarativeSuspendableWorkflow workflow =
+                AgenticServices.createAgenticSystem(DeclarativeSuspendableWorkflow.class);
+
+        AgenticSystemSuspendedException suspended = assertThrows(
+                AgenticSystemSuspendedException.class,
+                () -> workflow.process("d1", "important data"));
+
+        assertThat(suspended.scope().pendingResponseIds()).containsExactly("human-review");
+        assertThat(suspended.scope().readState("processed_data", "")).isEqualTo("PROCESSED: important data");
+
+        // Simulate crash
+        AgenticScopeRegistry registry = ((AgenticScopeOwner) workflow).registry();
+        registry.clearInMemory();
+        assertThat(registry.getAllAgenticScopeKeysInMemory()).isEmpty();
+
+        // Recover: load from store, provide response via single-arg overload, re-invoke
+        AgenticScope recovered = workflow.getAgenticScope("d1");
+        recovered.completePendingResponse("APPROVED after crash");
+
+        String result = workflow.process("d1", "important data");
+        assertThat(result).isEqualTo("Final: PROCESSED: important data | APPROVED after crash");
+    }
+
+    // ---- Workflow builders ----
+
+    private SuspendableWorkflow buildSingleHitlWorkflow() {
+        return AgenticServices.sequenceBuilder(SuspendableWorkflow.class)
+                .subAgents(
+                        dataProcessor(),
+                        singleHitlAgent(),
+                        resultFinalizer("approval"))
+                .outputKey("final_result")
+                .build();
+    }
+
+    private SuspendableWorkflow buildSingleHitlWorkflowWithPendingRef(AtomicReference<PendingResponse<String>> ref) {
+        HumanInTheLoop hitl = AgenticServices.humanInTheLoopBuilder()
+                .description("Human review")
+                .outputKey("approval")
+                .responseProvider(scope -> {
+                    PendingResponse<String> p = new PendingResponse<>("human-review");
+                    ref.set(p);
+                    return p;
+                })
+                .build();
+
+        return AgenticServices.sequenceBuilder(SuspendableWorkflow.class)
+                .subAgents(dataProcessor(), hitl, resultFinalizer("approval"))
+                .outputKey("final_result")
+                .build();
+    }
+
+    private SuspendableWorkflow buildSingleHitlWorkflowWithListener(AgentListener listener) {
+        return AgenticServices.sequenceBuilder(SuspendableWorkflow.class)
+                .subAgents(
+                        dataProcessor(),
+                        singleHitlAgent(),
+                        resultFinalizer("approval"))
+                .outputKey("final_result")
+                .listener(listener)
+                .build();
+    }
+
+    private SuspendableWorkflowWithResult buildSingleHitlWorkflowWithResult() {
+        return AgenticServices.sequenceBuilder(SuspendableWorkflowWithResult.class)
+                .subAgents(
+                        dataProcessor(),
+                        singleHitlAgent(),
+                        resultFinalizer("approval"))
+                .outputKey("final_result")
+                .build();
+    }
+
+    private SuspendableWorkflow buildDoubleHitlWorkflow() {
+        HumanInTheLoop managerApproval = AgenticServices.humanInTheLoopBuilder()
+                .description("Manager approval")
+                .outputKey("manager_approval")
+                .responseProvider(scope -> new SuspendedResponse<>("manager-approval"))
+                .build();
+
+        HumanInTheLoop legalApproval = AgenticServices.humanInTheLoopBuilder()
+                .description("Legal approval")
+                .outputKey("legal_approval")
+                .responseProvider(scope -> new SuspendedResponse<>("legal-approval"))
+                .build();
+
+        AgenticServices.AgenticScopeAction finalizer = AgenticServices.agentAction(scope -> {
+            String processed = (String) scope.readState("processed_data");
+            String manager = (String) scope.readState("manager_approval");
+            String legal = (String) scope.readState("legal_approval");
+            scope.writeState("final_result",
+                    "Result: " + processed + " | " + manager + " | " + legal);
+        });
+
+        return AgenticServices.sequenceBuilder(SuspendableWorkflow.class)
+                .subAgents(dataProcessor(), managerApproval, legalApproval, finalizer)
+                .outputKey("final_result")
+                .build();
+    }
+
+    // ---- Shared agent components ----
+
+    private AgenticServices.AgenticScopeAction dataProcessor() {
+        return AgenticServices.agentAction(scope -> {
+            String input = (String) scope.readState("input");
+            scope.writeState("processed_data", "PROCESSED: " + input);
+        });
+    }
+
+    private HumanInTheLoop singleHitlAgent() {
+        return AgenticServices.humanInTheLoopBuilder()
+                .description("Human review")
+                .outputKey("approval")
+                .responseProvider(scope -> new SuspendedResponse<>("human-review"))
+                .build();
+    }
+
+    private AgenticServices.AgenticScopeAction resultFinalizer(String approvalKey) {
+        return AgenticServices.agentAction(scope -> {
+            String processed = (String) scope.readState("processed_data");
+            String approval = (String) scope.readState(approvalKey);
+            scope.writeState("final_result",
+                    "Final: " + processed + " | " + approval);
+        });
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change

This work has been inspired by the discussion in this issue on the quarkus-langchain4j extension https://github.com/quarkiverse/quarkus-langchain4j/issues/2638 

However the task of improving the Human-in-the-Loop suspension is something that we already discussed and that in my opinion belong mostly to the langchain4j implementation.

This pull request:

- Adds the ability to suspend an agentic system when human input is required, checkpoint its state to a persistent store, and resume it later — even after a process restart or crash. Users choose the behavior by returning either a `SuspendedResponse` (suspend and release the thread) or a `PendingResponse` (block and wait in-process) from their human-in-the-loop handler.
- Supports nested and parallel suspension points within the same workflow, each independently resumable by response ID.
- Provides a `completePendingResponse(value)` convenience method on `AgenticScope` for the common single-response case.
- Works with both the programmatic API (`HumanInTheLoop.builder()`) and the declarative `@HumanInTheLoop` annotation.

You can find more details on how this works giving a look to the updated documentation.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
