### PR TITLE
docs: update Valkey embedding store to 9.1 GA container

### DIFF
--- a/docs/docs/integrations/embedding-stores/valkey.md
+++ b/docs/docs/integrations/embedding-stores/valkey.md
@@ -56,15 +56,11 @@ Embeddings, text, and metadata are stored as structured JSON documents with HNSW
 
 ### Prerequisites
 
-Requires Valkey 9.1+ (currently available as `9.1.0-rc2`). The `valkey-bundle` image includes the JSON and Search modules needed for vector indexing.
+Requires Valkey 9.1+. The `valkey-bundle` image includes the JSON and Search modules needed for vector indexing.
 
 ```bash
-docker run -d --name valkey -p 6379:6379 valkey/valkey-bundle:9.1.0-rc2
+docker run -d --name valkey -p 6379:6379 valkey/valkey-bundle:latest
 ```
-
-:::note
-Once Valkey 9.1.0 GA is released, you can use `valkey/valkey-bundle:latest`.
-:::
 
 
 ## APIs


### PR DESCRIPTION
## Summary

Valkey 9.1 is now GA, so the Valkey embedding store docs no longer need to reference the release candidate.

- Change the \`docker run\` image tag from \`valkey/valkey-bundle:9.1.0-rc2\` to \`valkey/valkey-bundle:latest\`
- Drop "currently available as \`9.1.0-rc2\`" from the prerequisites line
- Remove the now-obsolete \`:::note\` about waiting for 9.1.0 GA

Verified against Docker Hub: \`valkey/valkey-bundle\` publishes GA tags (\`9\`, \`9.1\`, \`9.1.1\`, \`latest\`, all sharing one digest); there is no longer any rc tag needed.

This was generated by AI but verified, with love, by a human.