### PR TITLE
Add FileSystemChatMemoryStore for persistent chat memory storage

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/memory/chat/FileSystemChatMemoryStore.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/memory/chat/FileSystemChatMemoryStore.java
@@ -1,0 +1,263 @@
+package dev.langchain4j.store.memory.chat;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Implementation of {@link ChatMemoryStore} that stores state of {@link dev.langchain4j.memory.ChatMemory}
+ * (chat messages) on the local file system.
+ * <p>
+ * Each chat memory is persisted as a separate JSON file within the specified directory.
+ * Messages are serialized using {@link ChatMessageSerializer} and deserialized using {@link ChatMessageDeserializer}.
+ * <p>
+ * <b>Storage Layout:</b>
+ * <pre>
+ * chat-memory/
+ *     conversation-1.json
+ *     conversation-2.json
+ *     customer-42.json
+ * </pre>
+ * <p>
+ * <b>Persistence Behavior:</b>
+ * <ul>
+ *     <li>All files are encoded in UTF-8</li>
+ *     <li>Updates overwrite the previous state (not append)</li>
+ *     <li>Atomic file replacement is used to minimize corruption risk</li>
+ *     <li>Memory IDs are sanitized to produce valid filenames</li>
+ * </ul>
+ * <p>
+ * <b>Thread Safety:</b>
+ * This implementation is thread-safe. Concurrent operations on different memory IDs do not block each other.
+ * Concurrent operations on the same memory ID are serialized to prevent file corruption.
+ */
+public class FileSystemChatMemoryStore implements ChatMemoryStore {
+
+    private static final String FILE_EXTENSION = ".json";
+    private static final String TEMP_FILE_PREFIX = ".tmp-";
+    private static final char[] ILLEGAL_FILENAME_CHARS = {'/', '\\', ':', '*', '?', '"', '<', '>', '|'};
+
+    private final Path directory;
+    private final Map<Path, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    /**
+     * Constructs a new {@link FileSystemChatMemoryStore} that persists chat memories to the specified directory.
+     * <p>
+     * If the directory does not exist, it will be created automatically (including parent directories).
+     *
+     * @param directory The root directory where chat memories will be stored. Must not be null.
+     * @throws UncheckedIOException if the directory cannot be created.
+     * @throws IllegalArgumentException if directory is null.
+     */
+    public FileSystemChatMemoryStore(Path directory) {
+        if (directory == null) {
+            throw new IllegalArgumentException("Directory must not be null");
+        }
+        this.directory = directory.toAbsolutePath().normalize();
+        createDirectoryIfNotExists(this.directory);
+    }
+
+    /**
+     * Retrieves messages for a specified chat memory.
+     * <p>
+     * If the memory does not exist, an empty list is returned.
+     *
+     * @param memoryId The ID of the chat memory.
+     * @return List of messages for the specified chat memory. Never null.
+     * @throws UncheckedIOException if an I/O error occurs while reading the memory.
+     */
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        Path file = file(memoryId);
+
+        ReentrantLock lock = lock(file);
+        lock.lock();
+        try {
+            if (!Files.exists(file)) {
+                return Collections.emptyList();
+            }
+            String json = read(file);
+            return ChatMessageDeserializer.messagesFromJson(json);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Updates messages for a specified chat memory.
+     * <p>
+     * The provided messages represent the complete current state and will overwrite any existing messages.
+     * The update is performed atomically to minimize the risk of file corruption.
+     *
+     * @param memoryId The ID of the chat memory.
+     * @param messages List of messages for the specified chat memory.
+     * @throws UncheckedIOException if an I/O error occurs while writing the memory.
+     */
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        Path file = file(memoryId);
+        String json = ChatMessageSerializer.messagesToJson(messages);
+
+        ReentrantLock lock = lock(file);
+        lock.lock();
+        try {
+            writeAtomically(file, json);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Deletes all messages for a specified chat memory.
+     * <p>
+     * If the memory does not exist, this method completes without error.
+     *
+     * @param memoryId The ID of the chat memory.
+     * @throws UncheckedIOException if an I/O error occurs while deleting the memory.
+     */
+    @Override
+    public void deleteMessages(Object memoryId) {
+        Path file = file(memoryId);
+
+        ReentrantLock lock = lock(file);
+        lock.lock();
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    String.format("Failed to delete memory '%s' from file '%s'", memoryId, file), e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Resolves the file path for a given memory ID.
+     *
+     * @param memoryId The memory ID.
+     * @return The file path.
+     */
+    private Path file(Object memoryId) {
+        String sanitizedId = sanitize(memoryId);
+        return directory.resolve(sanitizedId + FILE_EXTENSION);
+    }
+
+    /**
+     * Sanitizes a memory ID to produce a valid filename.
+     * <p>
+     * Illegal filename characters are replaced with underscore.
+     *
+     * @param memoryId The memory ID.
+     * @return A sanitized filename-safe string.
+     */
+    private String sanitize(Object memoryId) {
+        String filename = String.valueOf(memoryId);
+        for (char illegalChar : ILLEGAL_FILENAME_CHARS) {
+            filename = filename.replace(illegalChar, '_');
+        }
+        return filename;
+    }
+
+    /**
+     * Writes content to a file atomically.
+     * <p>
+     * The content is first written to a temporary file, then atomically moved to the target location.
+     * If atomic move is not supported, falls back to regular replacement.
+     *
+     * @param target The target file path.
+     * @param json The JSON content to write.
+     * @throws UncheckedIOException if an I/O error occurs.
+     */
+    private void writeAtomically(Path target, String json) {
+        Path temp = null;
+        try {
+            // Create temporary file in the same directory to ensure atomic move is possible
+            temp = Files.createTempFile(directory, TEMP_FILE_PREFIX, FILE_EXTENSION);
+            Files.writeString(temp, json, UTF_8);
+
+            // Attempt atomic move
+            try {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                // Fallback to regular replacement if atomic move is not supported
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+            temp = null; // Successfully moved, no cleanup needed
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    String.format("Failed to write memory to file '%s'", target), e);
+        } finally {
+            // Clean up temporary file if it still exists (move failed)
+            if (temp != null) {
+                try {
+                    Files.deleteIfExists(temp);
+                } catch (IOException e) {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+    }
+
+    /**
+     * Reads the content of a file.
+     *
+     * @param file The file to read.
+     * @return The file content, or empty string if the file no longer exists.
+     * @throws UncheckedIOException if an I/O error occurs.
+     */
+    private String read(Path file) {
+        try {
+            return Files.readString(file, UTF_8);
+        } catch (java.nio.file.NoSuchFileException e) {
+            // File was deleted between existence check and read - treat as empty
+            return "[]";
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    String.format("Failed to read memory from file '%s'", file), e);
+        }
+    }
+
+    /**
+     * Obtains a lock for the specified file.
+     * <p>
+     * Ensures thread-safe access to individual memory files.
+     *
+     * @param file The file path.
+     * @return A reentrant lock for the file.
+     */
+    private ReentrantLock lock(Path file) {
+        return locks.computeIfAbsent(file, ignored -> new ReentrantLock());
+    }
+
+    /**
+     * Creates a directory if it does not exist.
+     *
+     * @param directory The directory path.
+     * @throws UncheckedIOException if the directory cannot be created.
+     */
+    private void createDirectoryIfNotExists(Path directory) {
+        if (Files.exists(directory)) {
+            return;
+        }
+        try {
+            Files.createDirectories(directory);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    String.format("Failed to create directory '%s'", directory), e);
+        }
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/memory/chat/FileSystemChatMemoryStoreTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/memory/chat/FileSystemChatMemoryStoreTest.java
@@ -1,0 +1,337 @@
+package dev.langchain4j.store.memory.chat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.data.message.UserMessage;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+class FileSystemChatMemoryStoreTest implements WithAssertions {
+
+    @ParameterizedTest
+    @MethodSource("provideDirectoryPaths")
+    void should_create_directory_structure(String pathDescription, Path subdirectory, @TempDir Path tempDir) {
+        Path targetDir = subdirectory != null ? tempDir.resolve(subdirectory) : tempDir;
+        
+        if (!targetDir.equals(tempDir)) {
+            assertThat(targetDir).doesNotExist();
+        }
+
+        new FileSystemChatMemoryStore(targetDir);
+
+        assertThat(targetDir).exists().isDirectory();
+    }
+
+    static Stream<Arguments> provideDirectoryPaths() {
+        return Stream.of(
+                Arguments.of("new directory", Path.of("chat-memory")),
+                Arguments.of("existing directory", null),
+                Arguments.of("nested directory", Path.of("level1").resolve("level2").resolve("chat-memory"))
+        );
+    }
+
+    @Test
+    void should_throw_when_directory_is_null() {
+        assertThatThrownBy(() -> new FileSystemChatMemoryStore(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be null");
+    }
+
+    @Test
+    void should_return_empty_list_for_non_existing_memory(@TempDir Path tempDir) {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+
+        List<ChatMessage> messages = store.getMessages("non-existing");
+
+        assertThat(messages).isNotNull().isEmpty();
+    }
+
+    @Test
+    void should_store_retrieve_and_overwrite_messages(@TempDir Path tempDir) {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+        List<ChatMessage> firstMessages = Arrays.asList(
+                new UserMessage("Hello"),
+                new AiMessage("Hi there!")
+        );
+        List<ChatMessage> secondMessages = Arrays.asList(
+                new UserMessage("Second message"),
+                new AiMessage("Second response")
+        );
+
+        // Store and retrieve
+        store.updateMessages("conversation-1", firstMessages);
+        assertThat(store.getMessages("conversation-1")).isEqualTo(firstMessages);
+
+        // Overwrite and verify
+        store.updateMessages("conversation-1", secondMessages);
+        assertThat(store.getMessages("conversation-1")).isEqualTo(secondMessages);
+
+        // Multiple successive updates
+        for (int i = 0; i < 10; i++) {
+            store.updateMessages("conversation-1", Arrays.asList(new UserMessage("Message " + i)));
+        }
+        assertThat(store.getMessages("conversation-1")).containsExactly(new UserMessage("Message 9"));
+    }
+
+    @Test
+    void should_delete_messages(@TempDir Path tempDir) {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+        List<ChatMessage> messages = Arrays.asList(new UserMessage("Hello"));
+
+        // Delete existing memory
+        store.updateMessages("conversation-1", messages);
+        assertThat(store.getMessages("conversation-1")).isNotEmpty();
+        store.deleteMessages("conversation-1");
+        assertThat(store.getMessages("conversation-1")).isEmpty();
+
+        // Delete non-existing memory should not throw
+        assertThatCode(() -> store.deleteMessages("non-existing"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_persist_across_store_instances(@TempDir Path tempDir) {
+        List<ChatMessage> messages = Arrays.asList(
+                new UserMessage("Persisted message"),
+                new AiMessage("Persisted response")
+        );
+
+        // First store instance
+        FileSystemChatMemoryStore store1 = new FileSystemChatMemoryStore(tempDir);
+        store1.updateMessages("conversation-1", messages);
+
+        // Second store instance (simulating application restart)
+        FileSystemChatMemoryStore store2 = new FileSystemChatMemoryStore(tempDir);
+        List<ChatMessage> retrieved = store2.getMessages("conversation-1");
+
+        assertThat(retrieved).isEqualTo(messages);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMemoryIds")
+    void should_handle_various_memory_ids(Object memoryId, String expectedFilename, @TempDir Path tempDir) {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+        List<ChatMessage> messages = Arrays.asList(new UserMessage("Test message"));
+
+        store.updateMessages(memoryId, messages);
+        List<ChatMessage> retrieved = store.getMessages(memoryId);
+
+        assertThat(retrieved).isEqualTo(messages);
+        if (expectedFilename != null) {
+            assertThat(tempDir.resolve(expectedFilename)).exists();
+        }
+    }
+
+    static Stream<Arguments> provideMemoryIds() {
+        return Stream.of(
+                Arguments.of("customer/123:456*789?abc\"def<ghi>jkl|mno\\pqr", 
+                           "customer_123_456_789_abc_def_ghi_jkl_mno_pqr.json"),
+                Arguments.of(12345, "12345.json"),
+                Arguments.of("conversation-1", "conversation-1.json"),
+                Arguments.of("conversation-2", "conversation-2.json"),
+                Arguments.of("conversation-3", "conversation-3.json")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMessageLists")
+    void should_handle_various_message_contents(String description, List<ChatMessage> messages, @TempDir Path tempDir) {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+
+        store.updateMessages("test-" + description, messages);
+        List<ChatMessage> retrieved = store.getMessages("test-" + description);
+
+        assertThat(retrieved).isEqualTo(messages);
+    }
+
+    static Stream<Arguments> provideMessageLists() {
+        List<ChatMessage> largeList = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            largeList.add(new UserMessage("User message " + i));
+            largeList.add(new AiMessage("AI response " + i));
+        }
+
+        return Stream.of(
+                Arguments.of("utf8", Arrays.asList(
+                        new UserMessage("Hello 你好 مرحبا שלום"),
+                        new AiMessage("Response with emoji 😀🎉")
+                )),
+                Arguments.of("empty", new ArrayList<ChatMessage>()),
+                Arguments.of("large", largeList)
+        );
+    }
+
+    @Test
+    void should_create_valid_json_files(@TempDir Path tempDir) throws IOException {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+        List<ChatMessage> messages = Arrays.asList(
+                new UserMessage("Test"),
+                new AiMessage("Response")
+        );
+
+        store.updateMessages("test", messages);
+
+        Path file = tempDir.resolve("test.json");
+        assertThat(file).exists();
+
+        String content = Files.readString(file);
+        assertThat(content).isNotEmpty();
+
+        // Verify the content is valid by deserializing it
+        String expectedJson = ChatMessageSerializer.messagesToJson(messages);
+        assertThat(content).isEqualTo(expectedJson);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideConcurrentScenarios")
+    void should_handle_concurrent_operations(String scenario, 
+                                             int threadCount, int operationsPerThread,
+                                             boolean useSameMemoryId, @TempDir Path tempDir) throws InterruptedException {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+        
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        List<Exception> exceptions = new CopyOnWriteArrayList<>();
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            int threadId = i;
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        String memoryId = useSameMemoryId ? "shared-memory" : "thread-" + threadId + "-memory-" + j;
+                        List<ChatMessage> messages = Arrays.asList(
+                                new UserMessage("Thread-" + threadId + "-Op-" + j)
+                        );
+                        store.updateMessages(memoryId, messages);
+                        store.getMessages(memoryId);
+                        successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+
+        assertThat(exceptions).isEmpty();
+        assertThat(successCount.get()).isEqualTo(threadCount * operationsPerThread);
+    }
+
+    static Stream<Arguments> provideConcurrentScenarios() {
+        return Stream.of(
+                Arguments.of("same memory", 10, 20, true),
+                Arguments.of("different memories", 10, 50, false)
+        );
+    }
+
+    @Test
+    void should_handle_mixed_concurrent_operations(@TempDir Path tempDir) throws InterruptedException {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+        int threadCount = 8;
+        String sharedMemoryId = "shared-memory";
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        List<Exception> exceptions = new CopyOnWriteArrayList<>();
+
+        // Pre-populate the shared memory
+        store.updateMessages(sharedMemoryId, Arrays.asList(new UserMessage("Initial")));
+
+        for (int i = 0; i < threadCount; i++) {
+            int threadId = i;
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < 20; j++) {
+                        switch (j % 3) {
+                            case 0: // Write
+                                store.updateMessages(sharedMemoryId, Arrays.asList(
+                                        new UserMessage("Update from thread " + threadId)
+                                ));
+                                break;
+                            case 1: // Read
+                                List<ChatMessage> messages = store.getMessages(sharedMemoryId);
+                                assertThat(messages).isNotNull();
+                                break;
+                            case 2: // Delete and recreate
+                                store.deleteMessages(sharedMemoryId);
+                                store.updateMessages(sharedMemoryId, Arrays.asList(
+                                        new UserMessage("Recreated by thread " + threadId)
+                                ));
+                                break;
+                        }
+                    }
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+
+        // Verify no exceptions occurred
+        assertThat(exceptions).isEmpty();
+
+        // Verify the file is not corrupted
+        List<ChatMessage> finalMessages = store.getMessages(sharedMemoryId);
+        assertThat(finalMessages).isNotNull();
+    }
+
+    @Test
+    void should_not_leave_temporary_files_on_successful_write(@TempDir Path tempDir) throws InterruptedException {
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(tempDir);
+        List<ChatMessage> messages = Arrays.asList(new UserMessage("Test"));
+
+        store.updateMessages("test", messages);
+
+        // Give filesystem time to complete any pending operations
+        Thread.sleep(100);
+
+        // Check for temporary files
+        assertThat(tempDir.toFile().listFiles())
+                .filteredOn(file -> file.getName().startsWith(".tmp-"))
+                .isEmpty();
+    }
+
+    @Test
+    void should_normalize_directory_path(@TempDir Path tempDir) {
+        Path unnormalizedPath = tempDir.resolve("./foo/../bar");
+        FileSystemChatMemoryStore store = new FileSystemChatMemoryStore(unnormalizedPath);
+
+        List<ChatMessage> messages = Arrays.asList(new UserMessage("Test"));
+        store.updateMessages("test", messages);
+
+        // Verify the file was created in the normalized path
+        Path normalizedPath = tempDir.resolve("bar");
+        Path expectedFile = normalizedPath.resolve("test.json");
+        assertThat(expectedFile).exists();
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `ChatMemoryStore` implementation, `FileSystemChatMemoryStore`, which persists chat memory to the local file system.

Unlike `InMemoryChatMemoryStore`, which stores messages only in memory and loses them when the application terminates, this implementation stores each chat memory as a separate JSON file, allowing conversations to survive application restarts.

The implementation is dependency-free, uses only the Java Standard Library, and leverages the existing `ChatMessageSerializer` and `ChatMessageDeserializer` utilities.

## Motivation

`ChatMemoryStore` was designed to support pluggable persistence mechanisms. While LangChain4j currently provides an in-memory implementation, there isn't a lightweight persistence option suitable for:

- Local development
- Learning and experimentation
- Console applications
- Desktop applications
- Small single-node deployments
- Demos and tutorials

`FileSystemChatMemoryStore` fills this gap by providing a simple persistent storage implementation without requiring an external database.

## Features

- Persists each chat memory as an individual JSON file
- Automatically creates the storage directory if it does not exist
- Uses UTF-8 encoding for all files
- One file per `memoryId`
- Uses existing `ChatMessageSerializer` and `ChatMessageDeserializer`
- Atomic file replacement (with graceful fallback when atomic moves are unsupported)
- Thread-safe concurrent access
- Safe filename sanitization for cross-platform compatibility
- No external dependencies

## Storage Layout

Example directory structure:

```text
chat-memory/
├── conversation-1.json
├── conversation-2.json
└── customer-42.json
```

## Implementation Details

- Implements the existing `ChatMemoryStore` interface
- Stores the complete chat memory state on every update
- Returns an empty message list when no persisted memory exists
- Uses per-file locking to avoid concurrent write corruption while allowing operations on different memories to proceed independently
- Wraps I/O failures using `UncheckedIOException`
- Automatically creates missing storage directories


## Backward Compatibility

This change is fully backward compatible.

No existing APIs or behavior have been modified.

`FileSystemChatMemoryStore` is an additional optional implementation that can be used anywhere a `ChatMemoryStore` is accepted.

## Example

```java
ChatMemoryStore store =
        new FileSystemChatMemoryStore(Path.of("chat-memory"));

ChatMemory memory =
        MessageWindowChatMemory.builder()
                .id("conversation-1")
                .chatMemoryStore(store)
                .maxMessages(20)
                .build();
```