### PR TITLE
docs: add DaoXE to OpenAI-compatible language models

### DIFF
--- a/docs/docs/integrations/language-models/openai-compatible.md
+++ b/docs/docs/integrations/language-models/openai-compatible.md
@@ -50,6 +50,7 @@ Below we provide specific examples for popular OpenAI-compatible APIs, including
 ### Contents:
 - [Prerequisites for Using OpenAI-Compatible Language Models](#prerequisites-for-using-openai-compatible-language-models)
 - [Tuning Engines](#tuning-engines)
+- [DaoXE](#daoxe)
 - [Groq](#groq)
 - [Docker Model Runner](#docker-model-runner)
 - [GPT4All](#gpt4all)
@@ -93,6 +94,32 @@ ChatModel model = OpenAiChatModel.builder()
         .modelName("gpt-4o-mini")
         .build();
 ```
+
+
+## DaoXE
+
+**Deployment:** SaaS (API key required)
+
+**Description:** [DaoXE](https://daoxe.com) is a multi-model API gateway with an OpenAI-compatible Chat Completions endpoint at `https://daoxe.com/v1`.
+
+**Setup:**
+Create an API key in the DaoXE dashboard. Model IDs are **account-scoped** — use exact IDs from authenticated `GET /v1/models` or the dashboard (do not hardcode a static public catalog). DaoXE is not available in mainland China.
+
+Configure LangChain4j's `OpenAiChatModel`:
+
+```java
+ChatModel model = OpenAiChatModel.builder()
+        .baseUrl("https://daoxe.com/v1")
+        .apiKey(System.getenv("DAOXE_API_KEY"))
+        .modelName("your-account-model-id")
+        .build();
+```
+
+Notes:
+
+- Chat Completions path only for this integration.
+- DaoXE also supports other protocols (for example Anthropic Messages) for other clients.
+- Contributor disclosure: this example was contributed by a DaoXE affiliate.
 
 ## Groq
 

--- a/docs/docs/integrations/language-models/openai-compatible.md
+++ b/docs/docs/integrations/language-models/openai-compatible.md
@@ -50,12 +50,12 @@ Below we provide specific examples for popular OpenAI-compatible APIs, including
 ### Contents:
 - [Prerequisites for Using OpenAI-Compatible Language Models](#prerequisites-for-using-openai-compatible-language-models)
 - [Tuning Engines](#tuning-engines)
-- [DaoXE](#daoxe)
 - [Groq](#groq)
 - [Docker Model Runner](#docker-model-runner)
 - [GPT4All](#gpt4all)
 - [Ollama](#ollama)
 - [LM Studio](#lm-studio)
+- [DaoXE](#daoxe)
 
 ## Prerequisites for Using OpenAI-Compatible Language Models
 
@@ -94,32 +94,6 @@ ChatModel model = OpenAiChatModel.builder()
         .modelName("gpt-4o-mini")
         .build();
 ```
-
-
-## DaoXE
-
-**Deployment:** SaaS (API key required)
-
-**Description:** [DaoXE](https://daoxe.com) is a multi-model API gateway with an OpenAI-compatible Chat Completions endpoint at `https://daoxe.com/v1`.
-
-**Setup:**
-Create an API key in the DaoXE dashboard. Model IDs are **account-scoped** — use exact IDs from authenticated `GET /v1/models` or the dashboard (do not hardcode a static public catalog). DaoXE is not available in mainland China.
-
-Configure LangChain4j's `OpenAiChatModel`:
-
-```java
-ChatModel model = OpenAiChatModel.builder()
-        .baseUrl("https://daoxe.com/v1")
-        .apiKey(System.getenv("DAOXE_API_KEY"))
-        .modelName("your-account-model-id")
-        .build();
-```
-
-Notes:
-
-- Chat Completions path only for this integration.
-- DaoXE also supports other protocols (for example Anthropic Messages) for other clients.
-- Contributor disclosure: this example was contributed by a DaoXE affiliate.
 
 ## Groq
 
@@ -247,3 +221,28 @@ ChatModel model = OpenAiChatModel.builder()
         .httpClientBuilder(jdkHttpClientBuilder)
         .build();
 ```
+
+## DaoXE
+
+**Deployment:** SaaS (API key required)
+
+**Description:** [DaoXE](https://daoxe.com) is a multi-model API gateway with an OpenAI-compatible Chat Completions endpoint at `https://daoxe.com/v1`.
+
+**Setup:**
+Create an API key in the DaoXE dashboard. Model IDs are **account-scoped** — use exact IDs from authenticated `GET /v1/models` or the dashboard (do not hardcode a static public catalog). DaoXE is not available in mainland China.
+
+Configure LangChain4j's `OpenAiChatModel`:
+
+```java
+ChatModel model = OpenAiChatModel.builder()
+        .baseUrl("https://daoxe.com/v1")
+        .apiKey(System.getenv("DAOXE_API_KEY"))
+        .modelName("your-account-model-id")
+        .build();
+```
+
+Notes:
+
+- Chat Completions path only for this integration.
+- DaoXE also supports other protocols (for example Anthropic Messages) for other clients.
+- Contributor disclosure: this example was contributed by a DaoXE affiliate.


### PR DESCRIPTION
## Summary

Adds a **DaoXE** section to the OpenAI-compatible language models docs, using existing `OpenAiChatModel.builder().baseUrl(...)`.

- File: `docs/docs/integrations/language-models/openai-compatible.md`
- Base URL: `https://daoxe.com/v1`
- Account-scoped model IDs (no static catalog)

Same pattern as Tuning Engines / Groq sections.

### Notes

- Chat Completions path only
- DaoXE not available in mainland China
- Contributor is affiliated with DaoXE

## Test plan

- [ ] Docs page TOC + section render
- [ ] Optional: compile snippet against langchain4j-open-ai