### PR TITLE
fix: preserve Ollama-specific parameters set via defaultRequestParameters

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaBaseChatModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaBaseChatModel.java
@@ -76,6 +76,13 @@ abstract class OllamaBaseChatModel {
                 .minP(getOrDefault(builder.minP, ollamaParameters.minP()))
                 .keepAlive(ollamaParameters.keepAlive())
                 .think(getOrDefault(builder.think, ollamaParameters.think()))
+                .numThread(ollamaParameters.numThread())
+                .numKeep(ollamaParameters.numKeep())
+                .typicalP(ollamaParameters.typicalP())
+                .numBatch(ollamaParameters.numBatch())
+                .numGPU(ollamaParameters.numGPU())
+                .mainGPU(ollamaParameters.mainGPU())
+                .useMmap(ollamaParameters.useMmap())
                 .build();
         this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.listeners = copy(builder.listeners);

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatModelTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatModelTest.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.model.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class OllamaChatModelTest {
+
+    @Test
+    void default_request_parameters_should_preserve_all_ollama_specific_parameters() {
+        OllamaChatModel model = OllamaChatModel.builder()
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .defaultRequestParameters(OllamaChatRequestParameters.builder()
+                        .mirostat(1)
+                        .mirostatEta(0.1)
+                        .mirostatTau(5.0)
+                        .numCtx(2048)
+                        .numThread(4)
+                        .numKeep(5)
+                        .typicalP(0.8)
+                        .numBatch(16)
+                        .numGPU(1)
+                        .mainGPU(0)
+                        .useMmap(true)
+                        .repeatLastN(64)
+                        .repeatPenalty(1.1)
+                        .seed(42)
+                        .minP(0.05)
+                        .keepAlive(300)
+                        .think(true)
+                        .build())
+                .build();
+
+        OllamaChatRequestParameters parameters = model.defaultRequestParameters();
+
+        // Already-copied parameters (guard against regressions)
+        assertThat(parameters.mirostat()).isEqualTo(1);
+        assertThat(parameters.mirostatEta()).isEqualTo(0.1);
+        assertThat(parameters.mirostatTau()).isEqualTo(5.0);
+        assertThat(parameters.numCtx()).isEqualTo(2048);
+        assertThat(parameters.repeatLastN()).isEqualTo(64);
+        assertThat(parameters.repeatPenalty()).isEqualTo(1.1);
+        assertThat(parameters.seed()).isEqualTo(42);
+        assertThat(parameters.minP()).isEqualTo(0.05);
+        assertThat(parameters.keepAlive()).isEqualTo(300);
+        assertThat(parameters.think()).isTrue();
+
+        // Parameters that were previously dropped by init()
+        assertThat(parameters.numThread()).isEqualTo(4);
+        assertThat(parameters.numKeep()).isEqualTo(5);
+        assertThat(parameters.typicalP()).isEqualTo(0.8);
+        assertThat(parameters.numBatch()).isEqualTo(16);
+        assertThat(parameters.numGPU()).isEqualTo(1);
+        assertThat(parameters.mainGPU()).isEqualTo(0);
+        assertThat(parameters.useMmap()).isTrue();
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5775

## Context

`OllamaBaseChatModel#init()` rebuilds the model's default `OllamaChatRequestParameters` by copying fields one by one, but it omitted seven Ollama-specific fields:

`numThread`, `numKeep`, `typicalP`, `numBatch`, `numGPU`, `mainGPU`, `useMmap`.

These fields have no shortcut setter on the model builder, so `defaultRequestParameters(...)` is the only way to configure them as model-level defaults. Because `init()` dropped them, the values were silently lost and never sent to Ollama — even though `OllamaChatRequestParameters#overrideWith(...)` and the wire mapping in `InternalOllamaHelper#toOllamaChatRequest(...)` already handle all seven. They therefore worked as per-request overrides but not as model defaults.

## Change

Copy the seven missing fields in `init()`, matching the field handling already present in `overrideWith(...)`. The change is purely additive and does not alter behavior when the fields are unset (they remain `null`, as today). Both `OllamaChatModel` and `OllamaStreamingChatModel` benefit (shared `init()`).

## Tests

Added `OllamaChatModelTest#default_request_parameters_should_preserve_all_ollama_specific_parameters`, a pure unit test (no running Ollama server) that builds a model with all Ollama-specific parameters set via `defaultRequestParameters(...)` and asserts they are preserved on `model.defaultRequestParameters()`. It fails on `main` (the seven fields are `null`) and passes with this fix. Existing `OllamaChatRequestParametersTest` and `InternalOllamaHelperTest` continue to pass.

- [x] Unit tests added, covering the previously-dropped fields (and guarding the already-copied ones against regression)
- [x] `./mvnw -Pspotless spotless:check` passes