### PR TITLE
fix: make enum tool-argument coercion locale-independent

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -333,7 +334,7 @@ public class DefaultToolExecutor implements ToolExecutor {
                     // try to convert to uppercase as a last resort
                     return Enum.valueOf(
                             enumClass,
-                            Objects.requireNonNull(argument).toString().toUpperCase());
+                            Objects.requireNonNull(argument).toString().toUpperCase(Locale.ROOT));
                 }
             } catch (Exception | Error e) {
                 throw new IllegalArgumentException(

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorLocaleTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorLocaleTest.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.service.tool;
+
+import static dev.langchain4j.service.tool.DefaultToolExecutor.coerceArgument;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * and single-threaded to avoid races with the otherwise parallel test suite.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class DefaultToolExecutorLocaleTest {
+
+    public enum LocaleSensitiveEnum {
+        ACTIVE,
+        INACTIVE
+    }
+
+    @Test
+    void coerce_argument_to_enum_should_be_locale_independent() {
+        // In the Turkish locale, "active".toUpperCase() yields "ACTİVE" (dotted capital I),
+        // which must still resolve to the enum constant ACTIVE.
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(coerceArgument("active", "arg", LocaleSensitiveEnum.class, null))
+                    .isEqualTo(LocaleSensitiveEnum.ACTIVE);
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -17,6 +17,7 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -32,6 +33,11 @@ class DefaultToolExecutorTest implements WithAssertions {
         A,
         B,
         C
+    }
+
+    public enum LocaleSensitiveEnum {
+        ACTIVE,
+        INACTIVE
     }
 
     @SuppressWarnings("unused")
@@ -773,5 +779,19 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).isEqualTo("Test exception with details");
+    }
+
+    @Test
+    void coerce_argument_to_enum_should_be_locale_independent() {
+        // In the Turkish locale, "active".toUpperCase() yields "ACTİVE" (dotted capital I),
+        // which must still resolve to the enum constant ACTIVE.
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(coerceArgument("active", "arg", LocaleSensitiveEnum.class, null))
+                    .isEqualTo(LocaleSensitiveEnum.ACTIVE);
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -17,7 +17,6 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -33,11 +32,6 @@ class DefaultToolExecutorTest implements WithAssertions {
         A,
         B,
         C
-    }
-
-    public enum LocaleSensitiveEnum {
-        ACTIVE,
-        INACTIVE
     }
 
     @SuppressWarnings("unused")
@@ -779,19 +773,5 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).isEqualTo("Test exception with details");
-    }
-
-    @Test
-    void coerce_argument_to_enum_should_be_locale_independent() {
-        // In the Turkish locale, "active".toUpperCase() yields "ACTİVE" (dotted capital I),
-        // which must still resolve to the enum constant ACTIVE.
-        Locale previousDefault = Locale.getDefault();
-        try {
-            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
-            assertThat(coerceArgument("active", "arg", LocaleSensitiveEnum.class, null))
-                    .isEqualTo(LocaleSensitiveEnum.ACTIVE);
-        } finally {
-            Locale.setDefault(previousDefault);
-        }
     }
 }


### PR DESCRIPTION
## Issue

Closes #5777

## Context

When resolving an enum-typed `@Tool` argument, `DefaultToolExecutor#coerceArgument(...)` uppercases the argument as a last resort so an LLM value like `"active"` can match the enum constant `ACTIVE`. It used `String#toUpperCase()` without a `Locale`, making it depend on the JVM default locale.

Under a locale such as Turkish (`tr-TR`), `"active".toUpperCase()` yields `"ACTİVE"` (dotted capital I), so `Enum.valueOf` fails and a valid value is rejected with `IllegalArgumentException`.

## Change

Use `Locale.ROOT` for the fallback uppercasing. This matches `EnumOutputParser`, which already resolves enums in a locale-independent way. The change is a one-liner and does not affect ASCII inputs in any locale.

## Tests

Added `DefaultToolExecutorTest#coerce_argument_to_enum_should_be_locale_independent`, which sets the default locale to `tr-TR`, coerces `"active"` into an enum whose constant is `ACTIVE`, and asserts the result is `ACTIVE` (restoring the previous default locale afterwards). It fails on `main` (throws `IllegalArgumentException`) and passes with this fix.

- [x] Unit test added covering the locale-dependent path
- [x] `./mvnw -Pspotless spotless:check` passes