### PR TITLE
Fix error propagation and tracing in MonitoredExecution

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.agentic.internal.AgentUtil.rawType;
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.listenerOfType;
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgentInvocation;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.agentError;
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgenticScopeCreated;
 
@@ -205,7 +206,18 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
 
         Planner planner = plannerSupplier.get();
         planner.init(new InitPlanningContext(currentScope, this, subagents));
-        Object result = new PlannerLoop(planner, currentScope, registry).loop();
+
+        Object result;
+        try {
+            result = new PlannerLoop(planner, currentScope, registry).loop();
+        } catch (Exception e) {
+            if (isRootCall()) {
+                agentError(agentListener, currentScope, this, namedArgs, e);
+                currentScope.rootCallEnded(registry, agentListener);
+            }
+            throw e;
+        }
+
         Object output = outputKey != null ? currentScope.readState(outputKey) : result;
 
         if (isRootCall()) {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/MonitoredExecution.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/MonitoredExecution.java
@@ -55,7 +55,12 @@ public class MonitoredExecution {
     }
 
     void onAgentInvocationError(AgentInvocationError agentInvocationError) {
-        this.agentInvocationError = agentInvocationError;
+        // Preserve the first (root-cause) error: when an error propagates up a sequential
+        // chain, onAgentInvocationError is called once per agent in the chain, but only the
+        // first call carries the original failing agent.
+        if (this.agentInvocationError == null) {
+            this.agentInvocationError = agentInvocationError;
+        }
         ongoingInvocations.remove(agentInvocationError.agentId());
     }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WorkflowAgentsIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WorkflowAgentsIT.java
@@ -760,6 +760,45 @@ public class WorkflowAgentsIT {
     }
 
     @Test
+    void loop_agents_with_error_should_evict_ephemeral_scope() {
+        CreativeWriter creativeWriter = AgenticServices.agentBuilder(CreativeWriter.class)
+                .chatModel(baseModel())
+                .outputKey("story")
+                .build();
+
+        StyleEditor styleEditor = AgenticServices.agentBuilder(StyleEditor.class)
+                .chatModel(baseModel())
+                .outputKey("story")
+                .build();
+
+        StyleScorer styleScorer = AgenticServices.agentBuilder(StyleScorer.class)
+                .chatModel(throwingModel())
+                .outputKey("score")
+                .build();
+
+        UntypedAgent styleReviewLoop = AgenticServices.loopBuilder()
+                .name("reviewLoop")
+                .subAgents(styleScorer, styleEditor)
+                .maxIterations(5)
+                .exitCondition(agenticScope -> agenticScope.readState("score", 0.0) >= 0.8)
+                .build();
+
+        UntypedAgent styledWriter = AgenticServices.sequenceBuilder()
+                .subAgents(creativeWriter, styleReviewLoop)
+                .outputKey("story")
+                .build();
+
+        Map<String, Object> input = Map.of(
+                "topic", "dragons and wizards",
+                "style", "comedy");
+
+        assertThrows(AgentInvocationException.class, () -> styledWriter.invokeWithAgenticScope(input));
+
+        AgenticScopeRegistry registry = ((AgenticScopeOwner) styledWriter).registry();
+        assertThat(registry.getAllAgenticScopeKeysInMemory()).isEmpty();
+    }
+
+    @Test
     void typed_loop_agents_tests() {
         check_typed_loop_agents(false);
     }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change

PR #5759 changed `AgentMonitor.onAgentInvocationError` to defer moving the `MonitoredExecution` from `ongoingExecutions` to `failedExecutions` until all agents in `ongoingInvocations` have completed. This correctly fixes the parallel sub-agent race condition described in the PR, but it breaks the sequential (sequence/loop) error case.

Investigating this issue I also found a secondary bug: `rootCallEnded` was never called on error, leaking ephemeral `AgenticScope` instances in the registry. I added one more test case for this.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
