### PR TITLE
Map provider errors to LangChain4j exceptions in Google GenAI, Vertex AI Gemini, Vertex AI Anthropic, Workers AI and Cohere

### DIFF
--- a/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereEmbeddingModel.java
+++ b/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereEmbeddingModel.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.cohere;
 
+import static dev.langchain4j.internal.ExceptionMapper.mappingException;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
@@ -170,7 +171,7 @@ public class CohereEmbeddingModel extends DimensionAwareEmbeddingModel {
         for (int i = 0; i < inputs.size(); i += maxSegmentsPerBatch) {
             List<EmbeddingInput> batch = inputs.subList(i, Math.min(i + maxSegmentsPerBatch, inputs.size()));
 
-            EmbedV2Response response = v2Client.embedV2(buildV2Request(batch, effectiveInputType));
+            EmbedV2Response response = mappingException(() -> v2Client.embedV2(buildV2Request(batch, effectiveInputType)));
 
             if (response.getEmbeddings() != null && response.getEmbeddings().getFloatEmbeddings() != null) {
                 embeddings.addAll(response.getEmbeddings().getFloatEmbeddings().stream()
@@ -259,7 +260,7 @@ public class CohereEmbeddingModel extends DimensionAwareEmbeddingModel {
                     .model(modelName)
                     .build();
 
-            EmbedResponse response = this.client.embed(request);
+            EmbedResponse response = mappingException(() -> this.client.embed(request));
 
             embeddings.addAll(getEmbeddings(response));
             totalTokenUsage += getTokenUsage(response);

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
@@ -149,7 +149,8 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
         CreateBatchJobConfig config =
                 CreateBatchJobConfig.builder().displayName(displayName).build();
 
-        BatchJob batchJob = withRetryMappingExceptions(() -> client.batches.create(modelName, src, config), maxRetries);
+        BatchJob batchJob = withRetryMappingExceptions(
+                () -> client.batches.create(modelName, src, config), maxRetries, GoogleGenAiExceptionMapper.INSTANCE);
         return processResponse(batchJob);
     }
 
@@ -170,7 +171,8 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
         CreateBatchJobConfig config =
                 CreateBatchJobConfig.builder().displayName(displayName).build();
 
-        BatchJob batchJob = withRetryMappingExceptions(() -> client.batches.create(modelName, src, config), maxRetries);
+        BatchJob batchJob = withRetryMappingExceptions(
+                () -> client.batches.create(modelName, src, config), maxRetries, GoogleGenAiExceptionMapper.INSTANCE);
         return processResponse(batchJob);
     }
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchEmbeddingModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchEmbeddingModel.java
@@ -140,7 +140,10 @@ public final class GoogleGenAiBatchEmbeddingModel implements BatchEmbeddingModel
                 .build();
 
         BatchJob batchJob =
-                withRetryMappingExceptions(() -> client.batches.createEmbeddings(modelName, src, config), maxRetries);
+                withRetryMappingExceptions(
+                        () -> client.batches.createEmbeddings(modelName, src, config),
+                        maxRetries,
+                        GoogleGenAiExceptionMapper.INSTANCE);
         return processResponse(batchJob);
     }
 
@@ -161,7 +164,10 @@ public final class GoogleGenAiBatchEmbeddingModel implements BatchEmbeddingModel
                 .build();
 
         BatchJob batchJob =
-                withRetryMappingExceptions(() -> client.batches.createEmbeddings(modelName, src, config), maxRetries);
+                withRetryMappingExceptions(
+                        () -> client.batches.createEmbeddings(modelName, src, config),
+                        maxRetries,
+                        GoogleGenAiExceptionMapper.INSTANCE);
         return processResponse(batchJob);
     }
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchImageModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchImageModel.java
@@ -129,7 +129,8 @@ public final class GoogleGenAiBatchImageModel implements BatchImageModel {
         CreateBatchJobConfig config =
                 CreateBatchJobConfig.builder().displayName(displayName).build();
 
-        BatchJob batchJob = withRetryMappingExceptions(() -> client.batches.create(modelName, src, config), maxRetries);
+        BatchJob batchJob = withRetryMappingExceptions(
+                () -> client.batches.create(modelName, src, config), maxRetries, GoogleGenAiExceptionMapper.INSTANCE);
         return processResponse(batchJob);
     }
 
@@ -148,7 +149,8 @@ public final class GoogleGenAiBatchImageModel implements BatchImageModel {
         CreateBatchJobConfig config =
                 CreateBatchJobConfig.builder().displayName(displayName).build();
 
-        BatchJob batchJob = withRetryMappingExceptions(() -> client.batches.create(modelName, src, config), maxRetries);
+        BatchJob batchJob = withRetryMappingExceptions(
+                () -> client.batches.create(modelName, src, config), maxRetries, GoogleGenAiExceptionMapper.INSTANCE);
         return processResponse(batchJob);
     }
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
@@ -133,7 +133,9 @@ public class GoogleGenAiChatModel implements ChatModel {
         }
 
         var result = withRetryMappingExceptions(
-                () -> client.models.generateContent(chatRequest.modelName(), contents, config), maxRetries);
+                () -> client.models.generateContent(chatRequest.modelName(), contents, config),
+                maxRetries,
+                GoogleGenAiExceptionMapper.INSTANCE);
 
         ChatResponse response = GoogleGenAiContentMapper.toChatResponse(result, chatRequest.modelName());
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiEmbeddingModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiEmbeddingModel.java
@@ -151,7 +151,9 @@ public class GoogleGenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
             for (EmbeddingInput input : request.inputs()) {
                 Content content = toContent(input, inputType);
                 responses.add(withRetryMappingExceptions(
-                        () -> client.models.embedContent(modelName, content, config), maxRetries));
+                        () -> client.models.embedContent(modelName, content, config),
+                        maxRetries,
+                        GoogleGenAiExceptionMapper.INSTANCE));
             }
         } else {
             List<String> texts = request.inputs().stream()
@@ -160,7 +162,9 @@ public class GoogleGenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
             for (int i = 0; i < texts.size(); i += maxSegmentsPerBatch) {
                 List<String> batch = texts.subList(i, Math.min(i + maxSegmentsPerBatch, texts.size()));
                 responses.add(withRetryMappingExceptions(
-                        () -> client.models.embedContent(modelName, batch, config), maxRetries));
+                        () -> client.models.embedContent(modelName, batch, config),
+                        maxRetries,
+                        GoogleGenAiExceptionMapper.INSTANCE));
             }
         }
 
@@ -316,7 +320,9 @@ public class GoogleGenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
                 }
 
                 EmbedContentResponse response = withRetryMappingExceptions(
-                        () -> client.models.embedContent(modelName, texts, configBuilder.build()), maxRetries);
+                        () -> client.models.embedContent(modelName, texts, configBuilder.build()),
+                        maxRetries,
+                        GoogleGenAiExceptionMapper.INSTANCE);
 
                 if (response.embeddings().isPresent()) {
                     var embeddings = response.embeddings().get();

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiExceptionMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiExceptionMapper.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.model.google.genai;
+
+import com.google.genai.errors.ApiException;
+import dev.langchain4j.Internal;
+import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.internal.ExceptionMapper;
+
+@Internal
+class GoogleGenAiExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
+
+    static final GoogleGenAiExceptionMapper INSTANCE = new GoogleGenAiExceptionMapper();
+
+    private GoogleGenAiExceptionMapper() {}
+
+    @Override
+    public RuntimeException mapException(Throwable t) {
+        if (t instanceof ApiException apiException) {
+            return mapHttpStatusCode(apiException, apiException.code());
+        } else if (t.getCause() instanceof ApiException apiException) {
+            return mapHttpStatusCode(apiException, apiException.code());
+        }
+
+        return t instanceof RuntimeException re ? re : new LangChain4jException(t);
+    }
+}

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiFiles.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiFiles.java
@@ -60,7 +60,8 @@ public final class GoogleGenAiFiles {
                                     : filePath.getFileName().toString())
                     .mimeType(detectMimeType(filePath))
                     .build();
-            return client.files.upload(filePath.toFile(), config);
+            return GoogleGenAiExceptionMapper.INSTANCE.withExceptionMapper(
+                    () -> client.files.upload(filePath.toFile(), config));
         } catch (IOException e) {
             throw new RuntimeException("Failed to upload file", e);
         }
@@ -83,7 +84,7 @@ public final class GoogleGenAiFiles {
 
         UploadFileConfig config =
                 UploadFileConfig.builder().displayName(name).mimeType(mimeType).build();
-        return client.files.upload(fileBytes, config);
+        return GoogleGenAiExceptionMapper.INSTANCE.withExceptionMapper(() -> client.files.upload(fileBytes, config));
     }
 
     /**
@@ -93,7 +94,8 @@ public final class GoogleGenAiFiles {
      */
     public File getMetadata(String name) {
         ensureNotBlank(name, "name");
-        return client.files.get(name, GetFileConfig.builder().build());
+        return GoogleGenAiExceptionMapper.INSTANCE.withExceptionMapper(
+                () -> client.files.get(name, GetFileConfig.builder().build()));
     }
 
     /**
@@ -103,9 +105,11 @@ public final class GoogleGenAiFiles {
      * maximum size of 2 GB. Files are stored for 48 hours.
      */
     public List<File> listFiles() {
-        List<File> allFiles = new ArrayList<>();
-        client.files.list(ListFilesConfig.builder().build()).forEach(allFiles::add);
-        return allFiles;
+        return GoogleGenAiExceptionMapper.INSTANCE.withExceptionMapper(() -> {
+            List<File> allFiles = new ArrayList<>();
+            client.files.list(ListFilesConfig.builder().build()).forEach(allFiles::add);
+            return allFiles;
+        });
     }
 
     /**
@@ -115,7 +119,10 @@ public final class GoogleGenAiFiles {
      */
     public void deleteFile(String name) {
         ensureNotBlank(name, "name");
-        client.files.delete(name, DeleteFileConfig.builder().build());
+        GoogleGenAiExceptionMapper.INSTANCE.withExceptionMapper(() -> {
+            client.files.delete(name, DeleteFileConfig.builder().build());
+            return null;
+        });
     }
 
     /**

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiImageModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiImageModel.java
@@ -129,7 +129,9 @@ public class GoogleGenAiImageModel implements ImageModel {
         }
 
         GenerateContentResponse response = withRetryMappingExceptions(
-                () -> client.models.generateContent(modelName, contents, config), maxRetries);
+                () -> client.models.generateContent(modelName, contents, config),
+                maxRetries,
+                GoogleGenAiExceptionMapper.INSTANCE);
 
         Response<Image> imageResponse = toResponse(response);
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
@@ -246,7 +246,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
 
                 trackingHandler.onCompleteResponse(finalChatResponse);
             } catch (Exception e) {
-                trackingHandler.onError(e);
+                trackingHandler.onError(GoogleGenAiExceptionMapper.INSTANCE.mapException(e));
             }
         });
     }

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiTokenCountEstimator.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiTokenCountEstimator.java
@@ -107,7 +107,10 @@ public class GoogleGenAiTokenCountEstimator implements TokenCountEstimator {
 
     private int estimateTokenCount(List<Content> contents, CountTokensConfig config) {
         CountTokensResponse response =
-                withRetryMappingExceptions(() -> client.models.countTokens(modelName, contents, config), maxRetries);
+                withRetryMappingExceptions(
+                        () -> client.models.countTokens(modelName, contents, config),
+                        maxRetries,
+                        GoogleGenAiExceptionMapper.INSTANCE);
         return response.totalTokens().orElse(0);
     }
 

--- a/langchain4j-vertex-ai-anthropic/revapi.json
+++ b/langchain4j-vertex-ai-anthropic/revapi.json
@@ -1,0 +1,15 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.chat.request.ChatRequestParameters",
+          "justification": "Core langchain4j type intentionally exposed by defaultRequestParameters() and the defaultRequestParameters(ChatRequestParameters) builder method, consistent with the other chat model implementations"
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/VertexAiAnthropicChatModel.java
+++ b/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/VertexAiAnthropicChatModel.java
@@ -13,7 +13,6 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.vertexai.anthropic.internal.ValidationUtils;
 import dev.langchain4j.model.vertexai.anthropic.internal.api.AnthropicRequest;
@@ -60,7 +59,12 @@ public class VertexAiAnthropicChatModel implements ChatModel, Closeable {
     private static final Logger logger = LoggerFactory.getLogger(VertexAiAnthropicChatModel.class);
 
     private final VertexAiAnthropicClient client;
-    private final ChatRequestParameters defaultRequestParameters;
+    private final String modelName;
+    private final Integer maxTokens;
+    private final Double temperature;
+    private final Double topP;
+    private final Integer topK;
+    private final List<String> stopSequences;
     private final Boolean logRequests;
     private final Boolean logResponses;
     private final Boolean enablePromptCaching;
@@ -68,40 +72,22 @@ public class VertexAiAnthropicChatModel implements ChatModel, Closeable {
     private final String location;
 
     public VertexAiAnthropicChatModel(VertexAiAnthropicChatModelBuilder builder) {
-        ChatRequestParameters commonParameters = builder.defaultRequestParameters != null
-                ? builder.defaultRequestParameters
-                : DefaultChatRequestParameters.EMPTY;
-
-        String modelName = ensureNotBlank(getOrDefault(builder.modelName, commonParameters.modelName()), "modelName");
-
         this.client = new VertexAiAnthropicClient(
                 ensureNotBlank(builder.project, "project"),
                 ensureNotBlank(builder.location, "location"),
-                modelName,
+                ensureNotBlank(builder.modelName, "modelName"),
                 builder.credentials);
-        this.defaultRequestParameters = DefaultChatRequestParameters.builder()
-                .modelName(modelName)
-                .maxOutputTokens(
-                        ValidationUtils.validateMaxTokens(getOrDefault(builder.maxTokens, commonParameters.maxOutputTokens())))
-                .temperature(
-                        ValidationUtils.validateTemperature(getOrDefault(builder.temperature, commonParameters.temperature())))
-                .topP(ValidationUtils.validateTopP(getOrDefault(builder.topP, commonParameters.topP())))
-                .topK(ValidationUtils.validateTopK(getOrDefault(builder.topK, commonParameters.topK())))
-                .stopSequences(getOrDefault(builder.stopSequences, commonParameters.stopSequences()))
-                .toolSpecifications(commonParameters.toolSpecifications())
-                .toolChoice(commonParameters.toolChoice())
-                .responseFormat(commonParameters.responseFormat())
-                .build();
+        this.modelName = builder.modelName;
+        this.maxTokens = ValidationUtils.validateMaxTokens(builder.maxTokens);
+        this.temperature = ValidationUtils.validateTemperature(builder.temperature);
+        this.topP = ValidationUtils.validateTopP(builder.topP);
+        this.topK = ValidationUtils.validateTopK(builder.topK);
+        this.stopSequences = builder.stopSequences;
         this.logRequests = getOrDefault(builder.logRequests, false);
         this.logResponses = getOrDefault(builder.logResponses, false);
         this.enablePromptCaching = getOrDefault(builder.enablePromptCaching, false);
         this.listeners = builder.listeners != null ? List.copyOf(builder.listeners) : List.of();
         this.location = ensureNotBlank(builder.location, "location");
-    }
-
-    @Override
-    public ChatRequestParameters defaultRequestParameters() {
-        return defaultRequestParameters;
     }
 
     @Override
@@ -117,11 +103,15 @@ public class VertexAiAnthropicChatModel implements ChatModel, Closeable {
         }
 
         try {
-            String requestModelName = parameters.modelName();
+            String requestModelName = getOrDefault(parameters.modelName(), modelName);
 
             if (logRequests) {
                 logger.debug("Base URL: {}-aiplatform.googleapis.com:443", location);
-                logger.debug("Using model name: {}", requestModelName);
+                logger.debug(
+                        "Using model name: {} (from parameters: {}, default: {})",
+                        requestModelName,
+                        parameters.modelName(),
+                        modelName);
             }
 
             AnthropicRequest anthropicRequest = AnthropicRequestMapper.toRequest(
@@ -129,11 +119,14 @@ public class VertexAiAnthropicChatModel implements ChatModel, Closeable {
                     messages,
                     toolSpecifications,
                     parameters.toolChoice(),
-                    parameters.maxOutputTokens(),
-                    parameters.temperature(),
-                    parameters.topP(),
-                    parameters.topK(),
-                    parameters.stopSequences(),
+                    parameters.maxOutputTokens() != null ? parameters.maxOutputTokens() : maxTokens,
+                    temperature,
+                    topP,
+                    topK,
+                    parameters.stopSequences() != null
+                                    && !parameters.stopSequences().isEmpty()
+                            ? parameters.stopSequences()
+                            : stopSequences,
                     enablePromptCaching);
 
             if (logRequests) {
@@ -148,7 +141,7 @@ public class VertexAiAnthropicChatModel implements ChatModel, Closeable {
 
             return AnthropicResponseMapper.toChatResponse(anthropicResponse);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to generate response", e);
+            throw VertexAiAnthropicExceptionMapper.INSTANCE.mapException(e);
         }
     }
 

--- a/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/VertexAiAnthropicExceptionMapper.java
+++ b/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/VertexAiAnthropicExceptionMapper.java
@@ -1,0 +1,34 @@
+package dev.langchain4j.model.vertexai.anthropic;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import dev.langchain4j.Internal;
+import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.exception.TimeoutException;
+import dev.langchain4j.internal.ExceptionMapper;
+
+@Internal
+class VertexAiAnthropicExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
+
+    static final VertexAiAnthropicExceptionMapper INSTANCE = new VertexAiAnthropicExceptionMapper();
+
+    private VertexAiAnthropicExceptionMapper() {}
+
+    @Override
+    public RuntimeException mapException(Throwable t) {
+        // The client wraps gax exceptions into IOException, so the whole cause chain has to be searched
+        Throwable cause = t;
+        while (cause != null) {
+            if (cause instanceof ApiException apiException) {
+                if (apiException.getStatusCode().getCode() == StatusCode.Code.DEADLINE_EXCEEDED) {
+                    return new TimeoutException(apiException);
+                }
+                return mapHttpStatusCode(
+                        apiException, apiException.getStatusCode().getCode().getHttpStatusCode());
+            }
+            cause = cause.getCause() == cause ? null : cause.getCause();
+        }
+
+        return t instanceof RuntimeException re ? re : new LangChain4jException(t);
+    }
+}

--- a/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/VertexAiAnthropicStreamingChatModel.java
+++ b/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/VertexAiAnthropicStreamingChatModel.java
@@ -106,15 +106,9 @@ public class VertexAiAnthropicStreamingChatModel implements StreamingChatModel, 
             client.generateContentStreaming(anthropicRequest, requestModelName,
                     createStreamingResponseHandler(handler));
 
-        } catch (IOException e) {
-            try {
-                handler.onError(new RuntimeException("Failed to generate response", e));
-            } catch (Exception userException) {
-                logger.warn("User's onError handler threw an exception, ignoring", userException);
-            }
         } catch (Exception e) {
             try {
-                handler.onError(e);
+                handler.onError(VertexAiAnthropicExceptionMapper.INSTANCE.mapException(e));
             } catch (Exception userException) {
                 logger.warn("User's onError handler threw an exception, ignoring", userException);
             }
@@ -197,7 +191,7 @@ public class VertexAiAnthropicStreamingChatModel implements StreamingChatModel, 
             @Override
             public void onError(Throwable error) {
                 try {
-                    handler.onError(error);
+                    handler.onError(VertexAiAnthropicExceptionMapper.INSTANCE.mapException(error));
                 } catch (Exception userException) {
                     logger.warn("User's onError handler threw an exception, ignoring", userException);
                 }

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -492,8 +492,9 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
                                 .generateContentCallable()
                                 .call(request);
                     },
-                    maxRetries);
-        } catch (Exception e) {
+                    maxRetries,
+                    VertexAiGeminiExceptionMapper.INSTANCE);
+        } catch (RuntimeException e) {
             listeners.forEach(listener -> {
                 try {
                     ChatModelErrorContext chatModelErrorContext =
@@ -504,7 +505,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
                 }
             });
 
-            throw new RuntimeException(e);
+            throw e; // already mapped by VertexAiGeminiExceptionMapper, do not wrap it again
         }
 
         if (this.logResponses && logger.isDebugEnabled()) {

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiExceptionMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiExceptionMapper.java
@@ -1,0 +1,33 @@
+package dev.langchain4j.model.vertexai.gemini;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import dev.langchain4j.Internal;
+import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.exception.TimeoutException;
+import dev.langchain4j.internal.ExceptionMapper;
+
+@Internal
+class VertexAiGeminiExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
+
+    static final VertexAiGeminiExceptionMapper INSTANCE = new VertexAiGeminiExceptionMapper();
+
+    private VertexAiGeminiExceptionMapper() {}
+
+    @Override
+    public RuntimeException mapException(Throwable t) {
+        Throwable cause = t;
+        while (cause != null) {
+            if (cause instanceof ApiException apiException) {
+                if (apiException.getStatusCode().getCode() == StatusCode.Code.DEADLINE_EXCEEDED) {
+                    return new TimeoutException(apiException);
+                }
+                return mapHttpStatusCode(
+                        apiException, apiException.getStatusCode().getCode().getHttpStatusCode());
+            }
+            cause = cause.getCause() == cause ? null : cause.getCause();
+        }
+
+        return t instanceof RuntimeException re ? re : new LangChain4jException(t);
+    }
+}

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
@@ -530,17 +530,18 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
                     logger.debug("GEMINI ({}) response: {}", modelName, fullResponse);
                 }
             } catch (Exception exception) {
+                RuntimeException mappedException = VertexAiGeminiExceptionMapper.INSTANCE.mapException(exception);
                 listeners.forEach((listener) -> {
                     try {
-                        ChatModelErrorContext chatModelErrorContext =
-                                new ChatModelErrorContext(exception, listenerRequest, provider(), listenerAttributes);
+                        ChatModelErrorContext chatModelErrorContext = new ChatModelErrorContext(
+                                mappedException, listenerRequest, provider(), listenerAttributes);
                         listener.onError(chatModelErrorContext);
                     } catch (Exception t) {
                         logger.warn("Exception while calling model listener (onError)", t);
                     }
                 });
 
-                handler.onError(exception);
+                handler.onError(mappedException);
             }
         });
     }

--- a/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/client/WorkersAiClient.java
+++ b/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/client/WorkersAiClient.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.workersai.client;
 
 import static dev.langchain4j.http.client.HttpMethod.POST;
+import static dev.langchain4j.internal.ExceptionMapper.mappingException;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.workersai.client.WorkersAiJsonUtils.fromJson;
 import static dev.langchain4j.model.workersai.client.WorkersAiJsonUtils.toJson;
@@ -93,7 +94,8 @@ public class WorkersAiClient {
 
     /**
      * Surfaces Cloudflare API errors returned in a 2xx envelope with {@code success=false}.
-     * Non-2xx responses are already turned into an {@link dev.langchain4j.exception.HttpException} by the HTTP client.
+     * Non-2xx responses are already mapped to specific {@link dev.langchain4j.exception.LangChain4jException}
+     * subtypes (e.g. {@link dev.langchain4j.exception.RateLimitException}) in {@link #execute}.
      */
     private static <T extends ApiResponse<?>> T checkSuccess(T response) {
         if (response == null || !response.isSuccess()) {
@@ -117,7 +119,7 @@ public class WorkersAiClient {
                 .addHeader("Authorization", authorizationHeader)
                 .body(toJson(apiRequest))
                 .build();
-        return httpClient.execute(httpRequest);
+        return mappingException(() -> httpClient.execute(httpRequest));
     }
 
     /**


### PR DESCRIPTION
## Change

  Several providers did not map their native errors to the specific `dev.langchain4j.exception.*` types (`RateLimitException`, `AuthenticationException`, `ModelNotFoundException`, `InvalidRequestException`,
  `TimeoutException`, `InternalServerException`), so retry/error-handling logic keyed on these exception types (as already works for OpenAI, Anthropic, Ollama, Mistral, Bedrock, watsonx.ai, etc.) silently did
  not work for them. This PR closes that gap:

  - **`langchain4j-google-genai`**: added `GoogleGenAiExceptionMapper` (maps `com.google.genai.errors.ApiException` by its HTTP status code, same pattern as `BedrockExceptionMapper`/`WatsonxExceptionMapper`).
  The module already used `withRetryMappingExceptions(...)`, but with the default mapper, which only understands lc4j's `HttpException` — the GenAI SDK exceptions fell through unmapped. The mapper is now passed
  to all call sites (chat, streaming, embedding, image, batch models, token count estimator), the streaming `onError` path, and the `GoogleGenAiFiles` API calls (which previously threw raw SDK exceptions).
  - **`langchain4j-vertex-ai-gemini`**: added `VertexAiGeminiExceptionMapper` (maps gax `ApiException` via its HTTP status code equivalent; `DEADLINE_EXCEEDED` maps to `TimeoutException`). Same "default mapper
  cannot map SDK exceptions" issue as above. Also fixed a double-wrap: the sync path re-wrapped the already-mapped exception in `new RuntimeException(e)`, destroying the mapped type. The streaming path now maps
  the error before invoking `handler.onError(...)` and the listener error context.
  - **`langchain4j-vertex-ai-anthropic`**: added `VertexAiAnthropicExceptionMapper` (gax-based, like the Gemini one, but walks the whole cause chain because the internal client wraps gax exceptions into
  `IOException`). Replaces `new RuntimeException("Failed to generate response", e)` in the sync path and maps both streaming error paths.
  - **`langchain4j-workers-ai`**: `HttpException` from the HTTP client passed through unmapped; all requests go through the single `WorkersAiClient.execute(...)`, which now wraps the call in
  `ExceptionMapper.mappingException(...)`.
  - **`langchain4j-cohere`**: `CohereEmbeddingModel` called `client.embed(...)` / `v2Client.embedV2(...)` without mapping (unlike `CohereScoringModel`, which already uses `withRetryMappingExceptions`). Both call
  sites are now wrapped in `ExceptionMapper.mappingException(...)` (mapping only, no retry added, to preserve existing behavior).

  Behavior note: exceptions thrown by these modules on provider errors change from raw `RuntimeException`/SDK exceptions to the specific `dev.langchain4j.exception.*` types. All of them extend `RuntimeException`
  and carry the original exception as the cause, so existing code catching `RuntimeException` keeps working; this aligns these providers with the behavior of the already-migrated ones.

  ## General checklist
  - [X] There are no breaking changes (API, behaviour): thrown exception types become more specific (see behavior note above), matching the established behavior of the other providers
  - [ ] I have added unit and/or integration tests for my change
  - [ ] The tests cover both positive and negative cases
  - [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (unit tests: green; integration tests requiring provider credentials were not run)
  - [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)