### PR TITLE
fix: pass builder skipCreateVectorExtension to PgVectorEmbeddingStore

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
@@ -229,18 +229,20 @@ public class PgVectorEmbeddingStore implements EmbeddingStore<TextSegment> {
      * @param builder The builder containing all configuration
      */
     protected PgVectorEmbeddingStore(PgVectorEmbeddingStoreBuilder builder) {
-        this(
-                createDataSource(builder.host, builder.port, builder.user, builder.password, builder.database),
-                builder.table,
-                builder.dimension,
-                builder.useIndex,
-                builder.indexListSize,
-                builder.createTable,
-                builder.dropTableFirst,
-                builder.metadataStorageConfig,
-                builder.searchMode,
-                builder.textSearchConfig,
-                builder.rrfK);
+        this(new DatasourceBuilder()
+                .datasource(
+                        createDataSource(builder.host, builder.port, builder.user, builder.password, builder.database))
+                .table(builder.table)
+                .dimension(builder.dimension)
+                .useIndex(builder.useIndex)
+                .indexListSize(builder.indexListSize)
+                .createTable(builder.createTable)
+                .dropTableFirst(builder.dropTableFirst)
+                .skipCreateVectorExtension(builder.skipCreateVectorExtension)
+                .metadataStorageConfig(builder.metadataStorageConfig)
+                .searchMode(builder.searchMode)
+                .textSearchConfig(builder.textSearchConfig)
+                .rrfK(builder.rrfK));
     }
 
     /**
@@ -897,7 +899,8 @@ public class PgVectorEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         public String toString() {
             return "PgVectorEmbeddingStore.PgVectorEmbeddingStoreBuilder(host=" + this.host + ", port=" + this.port
-                    + ", user=" + this.user + ", password=" + (this.password == null ? null : "********") + ", database=" + this.database + ", table="
+                    + ", user=" + this.user + ", password=" + (this.password == null ? null : "********")
+                    + ", database=" + this.database + ", table="
                     + this.table + ", dimension=" + this.dimension + ", useIndex=" + this.useIndex + ", indexListSize="
                     + this.indexListSize + ", createTable=" + this.createTable + ", dropTableFirst="
                     + this.dropTableFirst + ", skipCreateVectorExtension=" + this.skipCreateVectorExtension

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreBuilderTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreBuilderTest.java
@@ -1,0 +1,50 @@
+package dev.langchain4j.store.embedding.pgvector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class PgVectorEmbeddingStoreBuilderTest {
+
+    @Test
+    void builder_passes_skipCreateVectorExtension_to_the_store() throws Exception {
+        PgVectorEmbeddingStore store = PgVectorEmbeddingStore.builder()
+                .host("localhost")
+                .port(5432)
+                .user("user")
+                .password("password")
+                .database("database")
+                .table("embeddings")
+                .dropTableFirst(false)
+                .createTable(false)
+                .useIndex(false)
+                .skipCreateVectorExtension(true)
+                .build();
+
+        assertThat(skipCreateVectorExtension(store)).isTrue();
+    }
+
+    @Test
+    void builder_defaults_skipCreateVectorExtension_to_false() throws Exception {
+        PgVectorEmbeddingStore store = PgVectorEmbeddingStore.builder()
+                .host("localhost")
+                .port(5432)
+                .user("user")
+                .password("password")
+                .database("database")
+                .table("embeddings")
+                .dropTableFirst(false)
+                .createTable(false)
+                .useIndex(false)
+                .build();
+
+        assertThat(skipCreateVectorExtension(store)).isFalse();
+    }
+
+    private static boolean skipCreateVectorExtension(PgVectorEmbeddingStore store) throws Exception {
+        Field field = PgVectorEmbeddingStore.class.getDeclaredField("skipCreateVectorExtension");
+        field.setAccessible(true);
+        return field.getBoolean(store);
+    }
+}


### PR DESCRIPTION
## Issue 
Closes #5784


## Change

`PgVectorEmbeddingStore.builder().skipCreateVectorExtension(true)` had no effect. The
`PgVectorEmbeddingStoreBuilder` constructor routed through an older constructor that passes
`skipCreateVectorExtension(null)`, so the value set on the builder never reached the store and defaulted to `false`.
The store kept running `CREATE EXTENSION IF NOT EXISTS vector` on every connection. The `datasourceBuilder()` path
was not affected.

Fix: build the store through `DatasourceBuilder` directly and pass `skipCreateVectorExtension` with the other
settings. No API change.

## Tests

Added `PgVectorEmbeddingStoreBuilderTest` (offline): `skipCreateVectorExtension(true)` on the builder now reaches
the store (fails on current `main`), and stays `false` when unset. Full module `verify` is green (unit +
Testcontainers integration tests).

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
