### PR TITLE
fix: treat an MCP $ref outside $defs as a plain schema, not a reference

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -84,11 +84,11 @@ class ToolSpecificationHelper {
             }
             return anyOf.build();
         }
-        // Handle $ref (JSON Schema reference)
         if (node.has("$ref")) {
-            return JsonReferenceSchema.builder()
-                    .reference(extractReferenceKey(node.get("$ref").asText()))
-                    .build();
+            String referenceKey = extractReferenceKey(node.get("$ref").asText());
+            if (referenceKey != null) {
+                return JsonReferenceSchema.builder().reference(referenceKey).build();
+            }
         }
         JsonNode typeNode = node.get("type");
         // If no type is specified, default to object schema
@@ -243,8 +243,10 @@ class ToolSpecificationHelper {
     }
 
     /**
-     * Extracts the reference key from a JSON Schema $ref value.
-     * For example, "#/$defs/Foo" returns "Foo", "#/definitions/Bar" returns "Bar".
+     * Extracts the definition key from a JSON Schema $ref that targets a definition.
+     * For example, "#/$defs/Foo" returns "Foo" and "#/definitions/Bar" returns "Bar".
+     * Returns {@code null} for any other $ref (for example a pointer into the schema body),
+     * which is not a definition key.
      */
     private static String extractReferenceKey(String ref) {
         if (ref.startsWith("#/$defs/")) {
@@ -253,7 +255,7 @@ class ToolSpecificationHelper {
         if (ref.startsWith("#/definitions/")) {
             return ref.substring("#/definitions/".length());
         }
-        return ref;
+        return null;
     }
 
     private static String[] toStringArray(ArrayNode jsonArray) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
@@ -851,5 +852,103 @@ class ToolSpecificationHelperTest {
         JsonObjectSchema textInputDef =
                 (JsonObjectSchema) parameters.definitions().get("TextInput");
         assertThat(textInputDef.properties()).containsOnlyKeys("text", "language");
+    }
+
+    @Test
+    void toolWithNonDefsRefIsNotTreatedAsReference() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "send-chat-message",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "chatId": { "type": "string" },
+                        "body": {
+                          "type": "object",
+                          "properties": {
+                            "from": {
+                              "type": "object",
+                              "properties": {
+                                "application": { "$ref": "#/properties/body/properties/from/properties/application" }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": ["chatId"]
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
+
+        JsonObjectSchema body = (JsonObjectSchema) parameters.properties().get("body");
+        JsonObjectSchema from = (JsonObjectSchema) body.properties().get("from");
+        JsonSchemaElement application = from.properties().get("application");
+
+        assertThat(application).isNotInstanceOf(JsonReferenceSchema.class);
+        assertThat(application).isInstanceOf(JsonObjectSchema.class);
+        assertThat(JsonSchemaElementUtils.toMap(parameters, false).toString()).doesNotContain("#/$defs/#");
+    }
+
+    @Test
+    void toolWithDefsRefAndBodyPointerRefAreHandledDifferently() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "mixed_refs",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "contact": { "$ref": "#/$defs/Contact" },
+                        "self": { "$ref": "#/properties/contact" }
+                      },
+                      "$defs": {
+                        "Contact": { "type": "object", "properties": { "name": { "type": "string" } } }
+                      }
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
+
+        JsonSchemaElement contact = parameters.properties().get("contact");
+        assertThat(contact).isInstanceOf(JsonReferenceSchema.class);
+        assertThat(((JsonReferenceSchema) contact).reference()).isEqualTo("Contact");
+
+        assertThat(parameters.properties().get("self")).isNotInstanceOf(JsonReferenceSchema.class);
+    }
+
+    @Test
+    void toolWithNonDefsRefKeepsSiblingKeywords() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "mixed_ref_keywords",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "note": {
+                          "$ref": "#/properties/other",
+                          "type": "string",
+                          "description": "a note"
+                        }
+                      }
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
+
+        JsonSchemaElement note = parameters.properties().get("note");
+        assertThat(note).isInstanceOf(JsonStringSchema.class);
+        assertThat(((JsonStringSchema) note).description()).isEqualTo("a note");
     }
 }


### PR DESCRIPTION
## Issue
Closes #5783

## Change

An MCP tool whose `inputSchema` has a `$ref` pointing outside `$defs` (for example `#/properties/...`, a pointer
into the schema body) produced a malformed reference. `extractReferenceKey` returned the pointer unchanged, it
became the `reference()` of a `JsonReferenceSchema`, and the serializer emitted `"#/$defs/" + reference` =
`#/$defs/#/properties/...`. That has two `#`, is not a valid uri-reference, so the provider rejects the whole
request and every other tool in it. This is a regression: #4793 added `$ref`/`$defs` support but handled only
`$defs`-style refs, so before it such a node became an empty object schema, and after it anything else became this
malformed reference.

`extractReferenceKey` now returns `null` for any `$ref` that is not `#/$defs/<name>` or `#/definitions/<name>`, and
the `$ref` branch falls through to normal schema handling instead of building a reference from it. No API change,
and the `$defs`/`definitions` handling is untouched.

Why drop the pointer rather than rewrite it: `JsonReferenceSchema.reference()` is a definition key by contract, so a
body pointer cannot be represented as one without producing the malformed `$ref` above. Rewriting it into a valid
`#/$defs/<name>` would mean synthesizing a definition, and in practice these pointers are often unresolvable.
Falling back to an unconstrained schema degrades safely for every input, keeps the call working, and restores the
pre-#4793 behaviour (an empty object schema).

## Tests

Added to `ToolSpecificationHelperTest` (offline), each failing on current `main`:
- a body-pointer `$ref` (the reported schema) is not turned into a reference, and the serialized schema contains no
  `#/$defs/#`;
- a `$defs` ref and a body-pointer ref in the same schema are handled differently;
- a `$ref` alongside sibling keywords keeps those keywords.


With the fix, all three pass and the full `langchain4j-mcp` unit suite is green (89), including the existing
`$ref`/`$defs` tests. The transport integration tests are unrelated to schema parsing and run in CI.

```
mvn -pl langchain4j-mcp test
```

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
