### PR TITLE
fix: preserve progressToken when applying a user-supplied MCP _meta

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -44,6 +44,7 @@ import dev.langchain4j.mcp.protocol.McpUnsubscribeResourceRequest;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -810,13 +811,28 @@ public class DefaultMcpClient implements McpClient {
             if (request.getParams() == null) {
                 request.setParams(new McpClientParams());
             }
-            request.getParams().setMeta(meta);
+            request.getParams().setMeta(mergeMeta(request.getParams().getMeta(), meta));
         } else if (message instanceof McpClientNotification notification) {
             if (notification.getParams() == null) {
                 notification.setParams(new McpClientParams());
             }
-            notification.getParams().setMeta(meta);
+            notification.getParams().setMeta(mergeMeta(notification.getParams().getMeta(), meta));
         }
+    }
+
+    /**
+     * Merges the user-supplied {@code _meta} entries into the {@code _meta} already present on the
+     * message. Entries already set by the client (such as the framework-managed
+     * {@code progressToken}) take precedence, so that protocol metadata is never overwritten by the
+     * user-supplied values.
+     */
+    private static Map<String, Object> mergeMeta(Map<String, Object> existing, Map<String, Object> supplied) {
+        if (existing == null || existing.isEmpty()) {
+            return supplied;
+        }
+        Map<String, Object> merged = new LinkedHashMap<>(supplied);
+        merged.putAll(existing);
+        return merged;
     }
 
     private void notifyListeners(Consumer<McpClientListener> action) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -21,6 +21,7 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpClientRequest;
 import dev.langchain4j.mcp.protocol.McpListToolsParams;
 import dev.langchain4j.mcp.protocol.McpListToolsRequest;
 import dev.langchain4j.service.tool.ToolExecutionResult;
@@ -528,6 +529,39 @@ public class DefaultMcpClientTest {
                 (McpListToolsRequest) callCaptor.getAllValues().get(1).message();
         assertThat(secondRequest.getParams()).isInstanceOf(McpListToolsParams.class);
         assertThat(((McpListToolsParams) secondRequest.getParams()).getCursor()).isEqualTo("cursor-page2");
+    }
+
+    @Test
+    public void meta_supplier_should_not_drop_progress_token() throws Exception {
+        final McpTransport transport = getMinimalMcpTransportMock();
+
+        ObjectNode toolResult = JsonNodeFactory.instance.objectNode();
+        toolResult
+                .putObject("result")
+                .putArray("content")
+                .addObject()
+                .put("type", "text")
+                .put("text", "ok");
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(toolResult));
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .progressHandler(notification -> {})
+                .metaSupplier(context -> Map.of("tenant", "acme"))
+                .build();
+
+        client.executeTool(
+                ToolExecutionRequest.builder().name("test").arguments("{}").build());
+
+        ArgumentCaptor<McpCallContext> captor = ArgumentCaptor.forClass(McpCallContext.class);
+        verify(transport).executeOperationWithResponse(captor.capture());
+        McpClientRequest request = (McpClientRequest) captor.getValue().message();
+        Map<String, Object> meta = request.getParams().getMeta();
+
+        // The user-supplied _meta must not overwrite the framework-managed progressToken.
+        assertThat(meta).containsKey("tenant");
+        assertThat(meta).containsKey("progressToken");
     }
 
     private static McpTransport getMinimalMcpTransportMock() {


### PR DESCRIPTION
## Issue

Closes #5791

## Context

When an MCP client is configured with **both** a `progressHandler` and a `metaSupplier`, `DefaultMcpClient#applyMeta` replaced the request/notification `_meta` wholesale via `McpClientParams#setMeta`. The `progressToken` that the client injects into `_meta` (so the server can emit `notifications/progress`) was therefore overwritten by the supplier's `_meta` and lost — so the `progressHandler` silently never fired. Each feature works in isolation; the bug only surfaces when they are combined.

## Change

`applyMeta` now **merges** the user-supplied `_meta` into the `_meta` already present on the message instead of replacing it. Client-managed entries such as `progressToken` take precedence, so protocol metadata is never clobbered by user-supplied values. When the message has no existing `_meta`, behavior is unchanged.

## Tests

Added `DefaultMcpClientTest#meta_supplier_should_not_drop_progress_token`: builds a client with both a `progressHandler` and a `metaSupplier`, executes a tool against a mocked transport, captures the outgoing request, and asserts its `_meta` contains **both** `progressToken` and the supplier-provided key. The test fails on `main` (only the supplier key is present) and passes with this change.

- [x] Unit test added covering the feature interaction
- [x] `./mvnw -pl langchain4j-mcp -Pspotless spotless:check` passes
- [x] `./mvnw -pl langchain4j-mcp test` passes locally
