### PR TITLE
Fix NPE when LanguageModelQueryRouter receives an unknown retriever id from the LLM

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouter.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouter.java
@@ -1,17 +1,5 @@
 package dev.langchain4j.rag.query.router;
 
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.input.Prompt;
-import dev.langchain4j.model.input.PromptTemplate;
-import dev.langchain4j.rag.content.retriever.ContentRetriever;
-import dev.langchain4j.rag.query.Query;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
@@ -20,6 +8,17 @@ import static dev.langchain4j.rag.query.router.LanguageModelQueryRouter.Fallback
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.input.Prompt;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A {@link QueryRouter} that utilizes a {@link ChatModel} to make a routing decision.
@@ -41,15 +40,13 @@ import static java.util.stream.Collectors.toList;
  */
 public class LanguageModelQueryRouter implements QueryRouter {
 
-    public static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = PromptTemplate.from(
-            """
+    public static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = PromptTemplate.from("""
                     Based on the user query, determine the most suitable data source(s) \
                     to retrieve relevant information from the following options:
                     {{options}}
                     It is very important that your answer consists of either a single number \
                     or multiple numbers separated by commas and nothing else!
-                    User query: {{query}}"""
-    );
+                    User query: {{query}}""");
 
     protected final ChatModel chatModel;
     protected final PromptTemplate promptTemplate;
@@ -57,15 +54,15 @@ public class LanguageModelQueryRouter implements QueryRouter {
     protected final Map<Integer, ContentRetriever> idToRetriever;
     protected final FallbackStrategy fallbackStrategy;
 
-    public LanguageModelQueryRouter(ChatModel chatModel,
-                                    Map<ContentRetriever, String> retrieverToDescription) {
+    public LanguageModelQueryRouter(ChatModel chatModel, Map<ContentRetriever, String> retrieverToDescription) {
         this(chatModel, retrieverToDescription, DEFAULT_PROMPT_TEMPLATE, DO_NOT_ROUTE);
     }
 
-    public LanguageModelQueryRouter(ChatModel chatModel,
-                                    Map<ContentRetriever, String> retrieverToDescription,
-                                    PromptTemplate promptTemplate,
-                                    FallbackStrategy fallbackStrategy) {
+    public LanguageModelQueryRouter(
+            ChatModel chatModel,
+            Map<ContentRetriever, String> retrieverToDescription,
+            PromptTemplate promptTemplate,
+            FallbackStrategy fallbackStrategy) {
         this.chatModel = ensureNotNull(chatModel, "chatModel");
         ensureNotEmpty(retrieverToDescription, "retrieverToDescription");
         this.promptTemplate = getOrDefault(promptTemplate, DEFAULT_PROMPT_TEMPLATE);
@@ -128,8 +125,20 @@ public class LanguageModelQueryRouter implements QueryRouter {
         return stream(choices.split(","))
                 .map(String::trim)
                 .map(Integer::parseInt)
-                .map(idToRetriever::get)
+                .map(this::retrieverById)
                 .collect(toList());
+    }
+
+    private ContentRetriever retrieverById(int id) {
+        ContentRetriever retriever = idToRetriever.get(id);
+        if (retriever == null) {
+            // The LLM returned an id that does not correspond to any known retriever (e.g. a
+            // hallucinated number outside the available range). Throwing here lets route() apply
+            // the configured fallbackStrategy instead of propagating a null retriever downstream.
+            throw new IllegalArgumentException("LLM returned an unknown content retriever id: " + id
+                    + ". Available ids: " + idToRetriever.keySet());
+        }
+        return retriever;
     }
 
     /**
@@ -161,15 +170,15 @@ public class LanguageModelQueryRouter implements QueryRouter {
         private PromptTemplate promptTemplate;
         private FallbackStrategy fallbackStrategy;
 
-        LanguageModelQueryRouterBuilder() {
-        }
+        LanguageModelQueryRouterBuilder() {}
 
         public LanguageModelQueryRouterBuilder chatModel(ChatModel chatModel) {
             this.chatModel = chatModel;
             return this;
         }
 
-        public LanguageModelQueryRouterBuilder retrieverToDescription(Map<ContentRetriever, String> retrieverToDescription) {
+        public LanguageModelQueryRouterBuilder retrieverToDescription(
+                Map<ContentRetriever, String> retrieverToDescription) {
             this.retrieverToDescription = retrieverToDescription;
             return this;
         }
@@ -185,7 +194,8 @@ public class LanguageModelQueryRouter implements QueryRouter {
         }
 
         public LanguageModelQueryRouter build() {
-            return new LanguageModelQueryRouter(this.chatModel, this.retrieverToDescription, this.promptTemplate, this.fallbackStrategy);
+            return new LanguageModelQueryRouter(
+                    this.chatModel, this.retrieverToDescription, this.promptTemplate, this.fallbackStrategy);
         }
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouterTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouterTest.java
@@ -1,24 +1,23 @@
 package dev.langchain4j.rag.query.router;
 
+import static dev.langchain4j.rag.query.router.LanguageModelQueryRouter.FallbackStrategy.FAIL;
+import static dev.langchain4j.rag.query.router.LanguageModelQueryRouter.FallbackStrategy.ROUTE_TO_ALL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.rag.query.router.LanguageModelQueryRouter.FallbackStrategy;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static dev.langchain4j.rag.query.router.LanguageModelQueryRouter.FallbackStrategy.FAIL;
-import static dev.langchain4j.rag.query.router.LanguageModelQueryRouter.FallbackStrategy.ROUTE_TO_ALL;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class LanguageModelQueryRouterTest {
@@ -28,6 +27,9 @@ class LanguageModelQueryRouterTest {
 
     @Mock
     ContentRetriever dogArticlesRetriever;
+
+    @Mock
+    ContentRetriever birdArticlesRetriever;
 
     @Test
     void should_route_to_single_retriever() {
@@ -50,8 +52,7 @@ class LanguageModelQueryRouterTest {
         // then
         assertThat(retrievers).containsExactly(dogArticlesRetriever);
 
-        assertThat(model.userMessageText()).isEqualTo(
-                """
+        assertThat(model.userMessageText()).isEqualTo("""
                 Based on the user query, determine the most suitable data source(s) \
                 to retrieve relevant information from the following options:
                 1: articles about cats
@@ -85,8 +86,7 @@ class LanguageModelQueryRouterTest {
         // then
         assertThat(retrievers).containsExactly(dogArticlesRetriever);
 
-        assertThat(model.userMessageText()).isEqualTo(
-                """
+        assertThat(model.userMessageText()).isEqualTo("""
                 Based on the user query, determine the most suitable data source(s) \
                 to retrieve relevant information from the following options:
                 1: articles about cats
@@ -122,9 +122,7 @@ class LanguageModelQueryRouterTest {
 
         // given
         PromptTemplate promptTemplate = PromptTemplate.from(
-                "Which source should I use to get answer for '{{query}}'? " +
-                        "Options: {{options}}'"
-        );
+                "Which source should I use to get answer for '{{query}}'? " + "Options: {{options}}'");
 
         Query query = Query.from("Which animal is the fluffiest?");
 
@@ -160,9 +158,8 @@ class LanguageModelQueryRouterTest {
         ChatModelMock model = ChatModelMock.thatAlwaysResponds("Sorry, I don't know");
 
         final var retrieverToDescription = Map.of(
-            catArticlesRetriever, "articles about cats",
-            dogArticlesRetriever, "articles about dogs"
-        );
+                catArticlesRetriever, "articles about cats",
+                dogArticlesRetriever, "articles about dogs");
 
         QueryRouter router = new LanguageModelQueryRouter(model, retrieverToDescription);
 
@@ -231,7 +228,6 @@ class LanguageModelQueryRouterTest {
         retrieverToDescription.put(catArticlesRetriever, "articles about cats");
         retrieverToDescription.put(dogArticlesRetriever, "articles about dogs");
 
-
         QueryRouter router = LanguageModelQueryRouter.builder()
                 .chatModel(model)
                 .retrieverToDescription(retrieverToDescription)
@@ -264,8 +260,7 @@ class LanguageModelQueryRouterTest {
                 .build();
 
         // when-then
-        assertThatThrownBy(() -> router.route(query))
-                .hasRootCauseExactlyInstanceOf(NumberFormatException.class);
+        assertThatThrownBy(() -> router.route(query)).hasRootCauseExactlyInstanceOf(NumberFormatException.class);
     }
 
     @Test
@@ -290,5 +285,107 @@ class LanguageModelQueryRouterTest {
         assertThatThrownBy(() -> router.route(query))
                 .isExactlyInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Something went wrong");
+    }
+
+    @Test
+    void should_not_route_by_default_when_LLM_returns_unknown_retriever_id() {
+
+        // given
+        Query query = Query.from("Hey what's up?");
+
+        // LLM hallucinates an id that is out of range: only ids 1-3 are available
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds("4");
+
+        Map<ContentRetriever, String> retrieverToDescription = new LinkedHashMap<>();
+        retrieverToDescription.put(catArticlesRetriever, "articles about cats");
+        retrieverToDescription.put(dogArticlesRetriever, "articles about dogs");
+        retrieverToDescription.put(birdArticlesRetriever, "articles about birds");
+
+        QueryRouter router = new LanguageModelQueryRouter(model, retrieverToDescription);
+
+        // when
+        Collection<ContentRetriever> retrievers = router.route(query);
+
+        // then
+        assertThat(retrievers).isEmpty();
+    }
+
+    @Test
+    void should_route_to_all_retrievers_when_LLM_returns_unknown_retriever_id() {
+
+        // given
+        Query query = Query.from("Hey what's up?");
+
+        // LLM hallucinates an id that is out of range: only ids 1-3 are available
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds("4");
+
+        Map<ContentRetriever, String> retrieverToDescription = new LinkedHashMap<>();
+        retrieverToDescription.put(catArticlesRetriever, "articles about cats");
+        retrieverToDescription.put(dogArticlesRetriever, "articles about dogs");
+        retrieverToDescription.put(birdArticlesRetriever, "articles about birds");
+
+        QueryRouter router = LanguageModelQueryRouter.builder()
+                .chatModel(model)
+                .retrieverToDescription(retrieverToDescription)
+                .fallbackStrategy(ROUTE_TO_ALL)
+                .build();
+
+        // when
+        Collection<ContentRetriever> retrievers = router.route(query);
+
+        // then
+        assertThat(retrievers)
+                .containsExactlyInAnyOrder(catArticlesRetriever, dogArticlesRetriever, birdArticlesRetriever);
+    }
+
+    @Test
+    void should_fail_when_LLM_returns_unknown_retriever_id() {
+
+        // given
+        Query query = Query.from("Hey what's up?");
+
+        // LLM hallucinates an id that is out of range: only ids 1-3 are available
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds("4");
+
+        Map<ContentRetriever, String> retrieverToDescription = new LinkedHashMap<>();
+        retrieverToDescription.put(catArticlesRetriever, "articles about cats");
+        retrieverToDescription.put(dogArticlesRetriever, "articles about dogs");
+        retrieverToDescription.put(birdArticlesRetriever, "articles about birds");
+
+        QueryRouter router = LanguageModelQueryRouter.builder()
+                .chatModel(model)
+                .retrieverToDescription(retrieverToDescription)
+                .fallbackStrategy(FAIL)
+                .build();
+
+        // when-then
+        assertThatThrownBy(() -> router.route(query))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasRootCauseExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown content retriever id: 4");
+    }
+
+    @Test
+    void should_not_route_by_default_when_LLM_returns_partially_unknown_retriever_ids() {
+
+        // given
+        Query query = Query.from("Hey what's up?");
+
+        // "1" is a valid id, but "4" is out of range: the fallback strategy should be applied
+        // instead of routing to a partial list of retrievers
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds("1, 4");
+
+        Map<ContentRetriever, String> retrieverToDescription = new LinkedHashMap<>();
+        retrieverToDescription.put(catArticlesRetriever, "articles about cats");
+        retrieverToDescription.put(dogArticlesRetriever, "articles about dogs");
+        retrieverToDescription.put(birdArticlesRetriever, "articles about birds");
+
+        QueryRouter router = new LanguageModelQueryRouter(model, retrieverToDescription);
+
+        // when
+        Collection<ContentRetriever> retrievers = router.route(query);
+
+        // then
+        assertThat(retrievers).isEmpty();
     }
 }


### PR DESCRIPTION
## Issue
Closes #2338

## Change
When the LLM hallucinates a retriever id that is numeric but out of range (e.g. answers `4` when only ids 1–3 were offered), `LanguageModelQueryRouter.parse()` mapped it via `idToRetriever::get`, which silently produced a `null` element in the returned collection. `route()` only applies the `fallbackStrategy` on exceptions, so the `null` retriever propagated into `DefaultRetrievalAugmentor` and caused a `NullPointerException`, bypassing the configured `fallbackStrategy` entirely (stack trace in #2338). Non-numeric responses were already handled correctly, because `Integer.parseInt` throws `NumberFormatException` and the fallback kicks in.

This PR makes out-of-range ids behave exactly like other invalid LLM responses: `parse()` now resolves each id via a helper that throws `IllegalArgumentException` (naming the unknown id and the available ids) when the id is unknown. The exception is caught in `route()` and the configured `FallbackStrategy` is applied, matching its documented contract:
- `DO_NOT_ROUTE` (default) → empty collection, RAG flow skipped
- `ROUTE_TO_ALL` → all retrievers
- `FAIL` → exception is re-thrown

This is the same behavior already exercised by the existing fallback tests for non-numeric responses (`should_not_route_by_default_when_LLM_returns_invalid_response` etc.); the fix extends it to partially valid responses too (e.g. `"1, 4"` falls back instead of routing to a list containing `null`).

Added tests covering all three strategies with an unknown id and the partially-valid case. All four fail on `main` (collection contains `null`) and pass with the fix.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
