### PR TITLE
Add `BedrockBatchChatModel` for AWS Bedrock batch inference

### DIFF
--- a/docs/docs/integrations/language-models/amazon-bedrock.md
+++ b/docs/docs/integrations/language-models/amazon-bedrock.md
@@ -103,6 +103,60 @@ StreamingChatModel model = BedrockStreamingChatModel.builder()
 - [BedrockStreamingChatModelExample](https://github.com/langchain4j/langchain4j-examples/blob/main/bedrock-examples/src/main/java/converse/BedrockStreamingChatModelExample.java)
 
 
+## BedrockBatchChatModel
+
+`BedrockBatchChatModel` implements the core `BatchChatModel` interface on top of the Bedrock
+[batch inference API](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html), which processes
+many chat requests asynchronously at a 50% lower price than on-demand for supported models.
+
+Requests are written as a JSONL file to an S3 input location, a model invocation job is submitted, and the results are
+read back from the S3 output location once the job completes. It requires an S3 bucket in the same region as the job and
+a [service role](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-iam-sr.html) that Bedrock assumes to read
+the input and write the output.
+
+:::note
+Bedrock batch inference does not support tool calling or structured output. A request that specifies tools or a
+response format is rejected with an `UnsupportedFeatureException`. Only a subset of models supports batch inference, see
+[supported models](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference-supported.html).
+:::
+
+### Configuration
+```java
+BedrockBatchChatModel model = BedrockBatchChatModel.builder()
+        .region(...)
+        .modelId("anthropic.claude-3-haiku-20240307-v1:0")
+        .roleArn("arn:aws:iam::123456789012:role/my-bedrock-batch-role")
+        .outputS3Uri("s3://my-bucket/batch-output")
+        .inputS3Uri(...)             // optional, defaults to outputS3Uri
+        .defaultRequestParameters(...)
+        .timeoutDurationInHours(...)
+        .maxRetries(...)
+        .logRequests(...)
+        .logResponses(...)
+        .build();
+```
+
+### Usage
+```java
+// Submit a batch of chat requests
+BatchResponse<ChatResponse> submitted = model.submit(new BatchRequest<>(List.of(
+        ChatRequest.builder().messages(UserMessage.from("Summarize: ...")).build(),
+        ChatRequest.builder().messages(UserMessage.from("Classify: ...")).build())));
+
+String batchId = submitted.batchId();
+
+// Poll until the job reaches a terminal state, then read the results
+BatchResponse<ChatResponse> result = model.retrieve(batchId);
+if (result.state() == BatchState.SUCCEEDED) {
+    for (BatchItemResult<ChatResponse> item : result.results()) {
+        if (item.isSuccess()) {
+            System.out.println(item.response().aiMessage().text());
+        }
+    }
+}
+```
+
+
 ## Additional Model Request Fields
 
 The field `additionalModelRequestFields` in the `BedrockChatRequestParameters` is a `Map<String, Object>`.

--- a/langchain4j-bedrock/pom.xml
+++ b/langchain4j-bedrock/pom.xml
@@ -41,6 +41,16 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>bedrock</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
@@ -84,12 +94,6 @@
             <version>1.19.0-SNAPSHOT</version>
             <classifier>tests</classifier>
             <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>bedrock</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-bedrock/revapi.json
+++ b/langchain4j-bedrock/revapi.json
@@ -33,6 +33,36 @@
           "code": "java.method.removed",
           "old": "method dev.langchain4j.model.output.Response<java.util.List<dev.langchain4j.data.embedding.Embedding>> dev.langchain4j.model.bedrock.AbstractBedrockEmbeddingModel<T extends dev.langchain4j.model.bedrock.BedrockEmbeddingResponse>::embedAll(java.util.List<dev.langchain4j.data.segment.TextSegment>) @ dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel",
           "justification": "embedAll now inherits its default implementation from EmbeddingModel (routing through embed(EmbeddingRequest)/doEmbed); the raw batch logic moved to the protected doEmbedAll. The method is still present and callable via inheritance — non-breaking"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchRequest",
+          "justification": "Core langchain4j type intentionally exposed by the BatchChatModel API implemented by BedrockBatchChatModel (submit/retrieve/cancel/list)"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchResponse",
+          "justification": "Core langchain4j type intentionally exposed by the BatchChatModel API implemented by BedrockBatchChatModel (submit/retrieve/cancel/list)"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchPage",
+          "justification": "Core langchain4j type intentionally exposed by the BatchChatModel API implemented by BedrockBatchChatModel (submit/retrieve/cancel/list)"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchPagination",
+          "justification": "Core langchain4j type intentionally exposed by the BatchChatModel API implemented by BedrockBatchChatModel (submit/retrieve/cancel/list)"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class software.amazon.awssdk.services.bedrock.BedrockClient",
+          "justification": "AWS SDK control-plane client intentionally exposed by BedrockBatchChatModel.Builder for injecting a pre-configured client, matching BedrockChatModel.Builder.client(BedrockRuntimeClient)"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class software.amazon.awssdk.services.s3.S3Client",
+          "justification": "AWS SDK client intentionally exposed by BedrockBatchChatModel.Builder for injecting a pre-configured S3 client used for batch input/output"
         }
       ]
     }

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockBatchChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockBatchChatModel.java
@@ -1,0 +1,526 @@
+package dev.langchain4j.model.bedrock;
+
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static java.util.Objects.isNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.batch.BatchError;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.BatchChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrock.BedrockClient;
+import software.amazon.awssdk.services.bedrock.model.CreateModelInvocationJobResponse;
+import software.amazon.awssdk.services.bedrock.model.GetModelInvocationJobResponse;
+import software.amazon.awssdk.services.bedrock.model.ModelInvocationJobStatus;
+import software.amazon.awssdk.services.bedrock.model.ModelInvocationJobSummary;
+import software.amazon.awssdk.services.bedrock.model.S3InputFormat;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/**
+ * A {@link BatchChatModel} for the Amazon Bedrock
+ * <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html">batch inference API</a>,
+ * which processes multiple chat requests asynchronously at a 50% lower price than on-demand for supported models.
+ *
+ * <p>Jobs are created with the {@code Converse} invocation type. Each {@link ChatRequest} is written as a JSONL
+ * record to an Amazon S3 input location, a model invocation job is submitted, and the results are read back from the
+ * S3 output location once the job completes. All requests in a batch run against the single model configured on this
+ * batch model (via {@link Builder#modelId(String)}), matching the Bedrock one-model-per-job constraint.</p>
+ *
+ * <p>Bedrock batch inference does not support tool calling or structured output. A {@link ChatRequest} that specifies
+ * tools or a JSON response format is rejected with an {@link UnsupportedFeatureException}.</p>
+ *
+ * @see BatchChatModel
+ * @see BatchResponse
+ */
+@Experimental
+public final class BedrockBatchChatModel implements BatchChatModel {
+
+    // Bedrock requires an alphanumeric recordId; the submission index is encoded in it so results, whose order
+    // Bedrock does not guarantee, can be restored to request order.
+    private static final String RECORD_ID_PREFIX = "r";
+    private static final String INPUT_FILE_NAME = "input.jsonl";
+    private static final String RESULT_FILE_SUFFIX = ".jsonl.out";
+    private static final String MANIFEST_FILE = "manifest.json.out";
+
+    private static final ObjectMapper JSONL_MAPPER =
+            new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    private final BedrockClient bedrockClient;
+    private final S3Client s3Client;
+    private final String modelId;
+    private final String roleArn;
+    private final S3Location outputLocation;
+    private final S3Location inputLocation;
+    private final ChatRequestParameters defaultRequestParameters;
+    private final Integer timeoutDurationInHours;
+    private final int maxRetries;
+
+    private BedrockBatchChatModel(Builder builder) {
+        this.modelId = ensureNotNull(builder.modelId, "modelId");
+        this.roleArn = ensureNotNull(builder.roleArn, "roleArn");
+        this.outputLocation = S3Location.parse(ensureNotNull(builder.outputS3Uri, "outputS3Uri"));
+        this.inputLocation = builder.inputS3Uri != null ? S3Location.parse(builder.inputS3Uri) : outputLocation;
+        this.defaultRequestParameters =
+                getOrDefault(builder.defaultRequestParameters, DefaultChatRequestParameters.EMPTY);
+        this.timeoutDurationInHours = builder.timeoutDurationInHours;
+        this.maxRetries = getOrDefault(builder.maxRetries, 2);
+
+        Region region = getOrDefault(builder.region, Region.US_EAST_1);
+        AwsCredentialsProvider credentials =
+                getOrDefault(builder.credentialsProvider, DefaultCredentialsProvider.create());
+        boolean logRequests = getOrDefault(builder.logRequests, false);
+        boolean logResponses = getOrDefault(builder.logResponses, false);
+        Consumer<ClientOverrideConfiguration.Builder> overrideConfiguration = config -> {
+            if (logRequests || logResponses) {
+                config.addExecutionInterceptor(new AwsLoggingInterceptor(logRequests, logResponses, builder.logger));
+            }
+        };
+        this.bedrockClient = isNull(builder.bedrockClient)
+                ? BedrockClient.builder()
+                        .region(region)
+                        .credentialsProvider(credentials)
+                        .overrideConfiguration(overrideConfiguration)
+                        .build()
+                : builder.bedrockClient;
+        this.s3Client = isNull(builder.s3Client)
+                ? S3Client.builder()
+                        .region(region)
+                        .credentialsProvider(credentials)
+                        .overrideConfiguration(overrideConfiguration)
+                        .build()
+                : builder.s3Client;
+    }
+
+    @Override
+    public BatchResponse<ChatResponse> submit(BatchRequest<ChatRequest> request) {
+        List<ChatRequest> requests = request.requests();
+        StringBuilder jsonl = new StringBuilder();
+        for (int i = 0; i < requests.size(); i++) {
+            ChatRequest effective = effectiveRequest(requests.get(i));
+            validateSupported(effective);
+            Map<String, Object> record = new LinkedHashMap<>();
+            record.put("recordId", recordId(i));
+            record.put("modelInput", BedrockBatchConverseMapper.toModelInput(effective));
+            jsonl.append(writeLine(record)).append('\n');
+        }
+
+        String jobName = "lc4j-batch-" + UUID.randomUUID();
+        String inputKey = joinKey(inputLocation.key(), jobName, INPUT_FILE_NAME);
+        s3Client.putObject(
+                b -> b.bucket(inputLocation.bucket()).key(inputKey), RequestBody.fromString(jsonl.toString()));
+
+        String inputUri = "s3://" + inputLocation.bucket() + "/" + inputKey;
+        CreateModelInvocationJobResponse response = withRetryMappingExceptions(
+                () -> bedrockClient.createModelInvocationJob(b -> b.jobName(jobName)
+                        .roleArn(roleArn)
+                        .modelId(modelId)
+                        .timeoutDurationInHours(timeoutDurationInHours)
+                        .inputDataConfig(in ->
+                                in.s3InputDataConfig(s3 -> s3.s3Uri(inputUri).s3InputFormat(S3InputFormat.JSONL)))
+                        .outputDataConfig(out -> out.s3OutputDataConfig(s3 -> s3.s3Uri(outputLocation.uri())))),
+                maxRetries,
+                BedrockExceptionMapper.INSTANCE);
+
+        return BatchResponse.<ChatResponse>builder()
+                .batchId(response.jobArn())
+                .state(BatchState.PENDING)
+                .results(List.of())
+                .build();
+    }
+
+    @Override
+    public BatchResponse<ChatResponse> retrieve(String batchId) {
+        GetModelInvocationJobResponse job = withRetryMappingExceptions(
+                () -> bedrockClient.getModelInvocationJob(b -> b.jobIdentifier(batchId)),
+                maxRetries,
+                BedrockExceptionMapper.INSTANCE);
+
+        BatchState state = toBatchState(job.status());
+        List<BatchItemResult<ChatResponse>> results = List.of();
+        if (job.status() == ModelInvocationJobStatus.COMPLETED
+                || job.status() == ModelInvocationJobStatus.PARTIALLY_COMPLETED) {
+            results = readResults(batchId);
+        }
+
+        return BatchResponse.<ChatResponse>builder()
+                .batchId(job.jobArn())
+                .state(state)
+                .results(results)
+                .build();
+    }
+
+    @Override
+    public void cancel(String batchId) {
+        withRetryMappingExceptions(
+                () -> bedrockClient.stopModelInvocationJob(b -> b.jobIdentifier(batchId)),
+                maxRetries,
+                BedrockExceptionMapper.INSTANCE);
+    }
+
+    @Override
+    public BatchPage<ChatResponse> list(@Nullable BatchPagination pagination) {
+        Integer pageSize = pagination != null ? pagination.pageSize() : null;
+        String pageToken = pagination != null ? pagination.pageToken() : null;
+        var response = withRetryMappingExceptions(
+                () -> bedrockClient.listModelInvocationJobs(
+                        b -> b.maxResults(pageSize).nextToken(pageToken)),
+                maxRetries,
+                BedrockExceptionMapper.INSTANCE);
+
+        List<BatchResponse<ChatResponse>> batches = new ArrayList<>();
+        for (ModelInvocationJobSummary summary : response.invocationJobSummaries()) {
+            batches.add(BatchResponse.<ChatResponse>builder()
+                    .batchId(summary.jobArn())
+                    .state(toBatchState(summary.status()))
+                    .results(List.of())
+                    .build());
+        }
+        return new BatchPage<>(batches, response.nextToken());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private ChatRequest effectiveRequest(ChatRequest chatRequest) {
+        return ChatRequest.builder()
+                .messages(chatRequest.messages())
+                .parameters(defaultRequestParameters.overrideWith(chatRequest.parameters()))
+                .build();
+    }
+
+    private static void validateSupported(ChatRequest request) {
+        if (!isNullOrEmpty(request.toolSpecifications())) {
+            throw new UnsupportedFeatureException("Tool calling is not supported by Bedrock batch inference");
+        }
+        if (request.responseFormat() != null) {
+            throw new UnsupportedFeatureException("Structured output is not supported by Bedrock batch inference");
+        }
+    }
+
+    private List<BatchItemResult<ChatResponse>> readResults(String jobArn) {
+        String jobId = jobArn.substring(jobArn.lastIndexOf('/') + 1);
+        String prefix = joinKey(outputLocation.key(), jobId) + "/";
+        List<String> resultKeys =
+                s3Client.listObjectsV2(b -> b.bucket(outputLocation.bucket()).prefix(prefix)).contents().stream()
+                        .map(S3Object::key)
+                        // Skip the manifest.json.out summary; Bedrock writes one *.jsonl.out per input file.
+                        .filter(key -> key.endsWith(RESULT_FILE_SUFFIX) && !key.endsWith(MANIFEST_FILE))
+                        .toList();
+
+        List<IndexedResult> indexed = new ArrayList<>();
+        for (String resultKey : resultKeys) {
+            String content = s3Client.getObjectAsBytes(
+                            b -> b.bucket(outputLocation.bucket()).key(resultKey))
+                    .asUtf8String();
+            for (String line : content.split("\n")) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                JsonNode node = readTree(line);
+                String recordId = node.path("recordId").asText("");
+                indexed.add(new IndexedResult(recordIdIndex(recordId), toItemResult(node)));
+            }
+        }
+        // Bedrock does not guarantee output order, so restore it from the index encoded in each recordId.
+        indexed.sort(Comparator.comparingInt(IndexedResult::index));
+        return indexed.stream().map(IndexedResult::result).toList();
+    }
+
+    private BatchItemResult<ChatResponse> toItemResult(JsonNode record) {
+        JsonNode modelOutput = record.get("modelOutput");
+        if (modelOutput == null || modelOutput.isNull()) {
+            String message = record.hasNonNull("error")
+                    ? record.get("error").toString()
+                    : "Record failed without a model output";
+            return BatchItemResult.failure(new BatchError(0, message, null));
+        }
+        return BatchItemResult.success(BedrockBatchConverseMapper.toChatResponse(modelOutput, modelId));
+    }
+
+    private static String recordId(int index) {
+        return RECORD_ID_PREFIX + String.format("%010d", index);
+    }
+
+    private static int recordIdIndex(String recordId) {
+        if (recordId.startsWith(RECORD_ID_PREFIX)) {
+            try {
+                return Integer.parseInt(recordId.substring(RECORD_ID_PREFIX.length()));
+            } catch (NumberFormatException ignored) {
+                // recordId not produced by this model; keep it last rather than failing
+            }
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    static BatchState toBatchState(@Nullable ModelInvocationJobStatus status) {
+        if (status == null) {
+            return BatchState.UNSPECIFIED;
+        }
+        return switch (status) {
+            case SUBMITTED, VALIDATING, SCHEDULED -> BatchState.PENDING;
+            case IN_PROGRESS, STOPPING -> BatchState.RUNNING;
+            case COMPLETED, PARTIALLY_COMPLETED -> BatchState.SUCCEEDED;
+            case FAILED -> BatchState.FAILED;
+            case STOPPED -> BatchState.CANCELLED;
+            case EXPIRED -> BatchState.EXPIRED;
+            case UNKNOWN_TO_SDK_VERSION -> BatchState.UNSPECIFIED;
+        };
+    }
+
+    private static String writeLine(Object value) {
+        try {
+            return JSONL_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize batch record", e);
+        }
+    }
+
+    private static JsonNode readTree(String json) {
+        try {
+            return JSONL_MAPPER.readTree(json);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to parse batch result line", e);
+        }
+    }
+
+    private static String joinKey(String... parts) {
+        StringBuilder key = new StringBuilder();
+        for (String part : parts) {
+            String trimmed = part.replaceAll("^/+", "").replaceAll("/+$", "");
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (key.length() > 0) {
+                key.append('/');
+            }
+            key.append(trimmed);
+        }
+        return key.toString();
+    }
+
+    private static <T> T ensureNotNull(T value, String name) {
+        if (value == null) {
+            throw new IllegalArgumentException(name + " must be set");
+        }
+        return value;
+    }
+
+    private record IndexedResult(int index, BatchItemResult<ChatResponse> result) {}
+
+    private record S3Location(String bucket, String key) {
+        static S3Location parse(String uri) {
+            if (!uri.startsWith("s3://")) {
+                throw new IllegalArgumentException("Not an S3 URI (expected s3://bucket/key): " + uri);
+            }
+            String withoutScheme = uri.substring("s3://".length());
+            int slash = withoutScheme.indexOf('/');
+            if (slash < 0) {
+                return new S3Location(withoutScheme, "");
+            }
+            return new S3Location(withoutScheme.substring(0, slash), withoutScheme.substring(slash + 1));
+        }
+
+        String uri() {
+            return key.isEmpty() ? "s3://" + bucket : "s3://" + bucket + "/" + key;
+        }
+    }
+
+    public static final class Builder {
+
+        private BedrockClient bedrockClient;
+        private S3Client s3Client;
+        private Region region;
+        private AwsCredentialsProvider credentialsProvider;
+        private String modelId;
+        private String roleArn;
+        private String outputS3Uri;
+        private String inputS3Uri;
+        private ChatRequestParameters defaultRequestParameters;
+        private Integer timeoutDurationInHours;
+        private Integer maxRetries;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Logger logger;
+
+        private Builder() {}
+
+        /**
+         * Sets the {@link BedrockClient} used for job control-plane calls. If not set, one is created from
+         * {@link #region(Region)} and {@link #credentialsProvider(AwsCredentialsProvider)}.
+         *
+         * @return {@code this}
+         */
+        public Builder bedrockClient(BedrockClient bedrockClient) {
+            this.bedrockClient = bedrockClient;
+            return this;
+        }
+
+        /**
+         * Sets the {@link S3Client} used to write inputs and read outputs. If not set, one is created from
+         * {@link #region(Region)} and {@link #credentialsProvider(AwsCredentialsProvider)}. The bucket must be in
+         * the same region as the job.
+         *
+         * @return {@code this}
+         */
+        public Builder s3Client(S3Client s3Client) {
+            this.s3Client = s3Client;
+            return this;
+        }
+
+        /**
+         * Sets the AWS region for the clients created when none are supplied. Defaults to {@code us-east-1}.
+         *
+         * @return {@code this}
+         */
+        public Builder region(Region region) {
+            this.region = region;
+            return this;
+        }
+
+        /**
+         * Sets the credentials provider for the clients created when none are supplied.
+         * Defaults to {@link DefaultCredentialsProvider}.
+         *
+         * @return {@code this}
+         */
+        public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+            return this;
+        }
+
+        /**
+         * Sets the model that every request in the batch runs against (one model per job).
+         *
+         * @return {@code this}
+         */
+        public Builder modelId(String modelId) {
+            this.modelId = modelId;
+            return this;
+        }
+
+        /**
+         * Sets the ARN of the service role Bedrock assumes to read the input and write the output in S3.
+         *
+         * @return {@code this}
+         */
+        public Builder roleArn(String roleArn) {
+            this.roleArn = roleArn;
+            return this;
+        }
+
+        /**
+         * Sets the S3 URI (for example {@code s3://my-bucket/batch-output}) where Bedrock writes the results.
+         *
+         * @return {@code this}
+         */
+        public Builder outputS3Uri(String outputS3Uri) {
+            this.outputS3Uri = outputS3Uri;
+            return this;
+        }
+
+        /**
+         * Sets the S3 URI under which the generated input file is uploaded. Defaults to {@link #outputS3Uri(String)}.
+         *
+         * @return {@code this}
+         */
+        public Builder inputS3Uri(String inputS3Uri) {
+            this.inputS3Uri = inputS3Uri;
+            return this;
+        }
+
+        /**
+         * Sets common default {@link ChatRequestParameters}; per-request parameters take precedence over these.
+         *
+         * @return {@code this}
+         */
+        public Builder defaultRequestParameters(ChatRequestParameters defaultRequestParameters) {
+            this.defaultRequestParameters = defaultRequestParameters;
+            return this;
+        }
+
+        /**
+         * Sets the job timeout in hours, after which unprocessed records expire.
+         *
+         * @return {@code this}
+         */
+        public Builder timeoutDurationInHours(Integer timeoutDurationInHours) {
+            this.timeoutDurationInHours = timeoutDurationInHours;
+            return this;
+        }
+
+        /**
+         * Sets the number of times to retry a control-plane call on transient errors. Defaults to {@code 2}.
+         *
+         * @return {@code this}
+         */
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * Enables logging of the control-plane and S3 requests. Defaults to {@code false}.
+         *
+         * @return {@code this}
+         */
+        public Builder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        /**
+         * Enables logging of the control-plane and S3 responses. Defaults to {@code false}.
+         *
+         * @return {@code this}
+         */
+        public Builder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Logger} used when {@link #logRequests(Boolean)} or {@link #logResponses(Boolean)} is enabled.
+         *
+         * @return {@code this}
+         */
+        public Builder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        public BedrockBatchChatModel build() {
+            return new BedrockBatchChatModel(this);
+        }
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockBatchConverseMapper.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockBatchConverseMapper.java
@@ -1,0 +1,180 @@
+package dev.langchain4j.model.bedrock;
+
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.Utils.readBytes;
+import static dev.langchain4j.model.bedrock.Utils.extractAndValidateFormat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.Internal;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps between LangChain4j chat types and the Bedrock batch JSONL payloads.
+ *
+ * <p>Batch jobs use the {@code Converse} invocation type, so {@code modelInput} is a Converse request body
+ * (without {@code modelId}, which is set at the job level) and {@code modelOutput} is a Converse response body.
+ * The payloads are built as plain maps and parsed with Jackson, mirroring how the embedding models build their
+ * request bodies, rather than sending a request through the runtime client.</p>
+ */
+@Internal
+final class BedrockBatchConverseMapper {
+
+    private BedrockBatchConverseMapper() {}
+
+    /**
+     * Builds the {@code modelInput} (a Converse request body) for one chat request. Tool calling and structured
+     * output are not supported by Bedrock batch inference and are rejected before this point.
+     */
+    static Map<String, Object> toModelInput(ChatRequest chatRequest) {
+        Map<String, Object> modelInput = new LinkedHashMap<>();
+
+        List<Map<String, Object>> messages = new ArrayList<>();
+        List<Map<String, Object>> system = new ArrayList<>();
+        for (ChatMessage message : chatRequest.messages()) {
+            if (message instanceof SystemMessage systemMessage) {
+                system.add(Map.of("text", systemMessage.text()));
+            } else if (message instanceof UserMessage userMessage) {
+                messages.add(message("user", contentBlocks(userMessage.contents())));
+            } else if (message instanceof AiMessage aiMessage) {
+                messages.add(message("assistant", List.of(Map.of("text", aiMessage.text()))));
+            } else {
+                throw new UnsupportedFeatureException(
+                        message.type() + " messages are not supported by Bedrock batch inference");
+            }
+        }
+
+        modelInput.put("messages", messages);
+        if (!system.isEmpty()) {
+            modelInput.put("system", system);
+        }
+        Map<String, Object> inferenceConfig = inferenceConfig(chatRequest.parameters());
+        if (!inferenceConfig.isEmpty()) {
+            modelInput.put("inferenceConfig", inferenceConfig);
+        }
+
+        return modelInput;
+    }
+
+    private static Map<String, Object> message(String role, List<Map<String, Object>> content) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", role);
+        message.put("content", content);
+        return message;
+    }
+
+    private static List<Map<String, Object>> contentBlocks(List<Content> contents) {
+        List<Map<String, Object>> blocks = new ArrayList<>();
+        for (Content content : contents) {
+            if (content instanceof TextContent text) {
+                blocks.add(Map.of("text", text.text()));
+            } else if (content instanceof ImageContent image) {
+                String format = extractAndValidateFormat(image.image());
+                String bytes = base64(image.image().base64Data(), image.image().url());
+                blocks.add(Map.of("image", Map.of("format", format, "source", Map.of("bytes", bytes))));
+            } else if (content instanceof PdfFileContent pdf) {
+                String bytes = base64(pdf.pdfFile().base64Data(), pdf.pdfFile().url());
+                blocks.add(Map.of(
+                        "document", Map.of("format", "pdf", "name", "document", "source", Map.of("bytes", bytes))));
+            } else {
+                throw new UnsupportedFeatureException(
+                        content.type() + " content is not supported by Bedrock batch inference");
+            }
+        }
+        return blocks;
+    }
+
+    private static Map<String, Object> inferenceConfig(ChatRequestParameters parameters) {
+        Map<String, Object> config = new LinkedHashMap<>();
+        putIfNotNull(config, "maxTokens", parameters.maxOutputTokens());
+        putIfNotNull(config, "temperature", parameters.temperature());
+        putIfNotNull(config, "topP", parameters.topP());
+        if (!isNullOrEmpty(parameters.stopSequences())) {
+            config.put("stopSequences", parameters.stopSequences());
+        }
+        return config;
+    }
+
+    /**
+     * Parses one {@code modelOutput} JSON (a Converse response body) into a {@link ChatResponse}. Only text content
+     * blocks are surfaced: tool-use blocks are rejected before submission, and any {@code reasoningContent}
+     * (thinking) blocks a model may emit are intentionally ignored, since batch inference does not surface thinking.
+     */
+    static ChatResponse toChatResponse(JsonNode modelOutput, String modelName) {
+        List<String> texts = new ArrayList<>();
+        JsonNode content = modelOutput.path("output").path("message").path("content");
+        for (JsonNode block : content) {
+            if (block.hasNonNull("text")) {
+                String value = block.get("text").asText();
+                if (!value.isEmpty()) {
+                    texts.add(value);
+                }
+            }
+        }
+        // Join like BedrockChatModel so batch and non-batch parse the same response identically.
+        String text = String.join("\n\n", texts);
+
+        JsonNode usage = modelOutput.path("usage");
+        BedrockTokenUsage tokenUsage = BedrockTokenUsage.builder()
+                .inputTokenCount(intOrNull(usage, "inputTokens"))
+                .outputTokenCount(intOrNull(usage, "outputTokens"))
+                .build();
+
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(text))
+                .metadata(BedrockChatResponseMetadata.builder()
+                        .finishReason(
+                                finishReason(modelOutput.path("stopReason").asText(null)))
+                        .tokenUsage(tokenUsage)
+                        .modelName(modelName)
+                        .build())
+                .build();
+    }
+
+    private static FinishReason finishReason(String stopReason) {
+        if (stopReason == null) {
+            return null;
+        }
+        return switch (stopReason) {
+            case "end_turn", "stop_sequence" -> FinishReason.STOP;
+            case "max_tokens" -> FinishReason.LENGTH;
+            case "content_filtered", "guardrail_intervened" -> FinishReason.CONTENT_FILTER;
+            case "tool_use" -> FinishReason.TOOL_EXECUTION;
+            default -> FinishReason.OTHER;
+        };
+    }
+
+    private static String base64(String base64Data, java.net.URI url) {
+        if (base64Data != null) {
+            return base64Data;
+        }
+        return Base64.getEncoder().encodeToString(readBytes(String.valueOf(url)));
+    }
+
+    private static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
+    private static Integer intOrNull(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value == null || value.isNull() ? null : value.asInt();
+    }
+}

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockBatchChatModelIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockBatchChatModelIT.java
@@ -1,0 +1,113 @@
+package dev.langchain4j.model.bedrock;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/**
+ * Live integration test for {@link BedrockBatchChatModel}. Requires an AWS account with Bedrock model access, an S3
+ * bucket, and a service role, so it is skipped in CI (gated on {@code BEDROCK_BATCH_ROLE_ARN}). Batch jobs run
+ * asynchronously and can take several minutes, so this is a slow, manual test. It is self-contained: it writes under a
+ * unique S3 prefix and deletes everything it created afterwards.
+ *
+ * <p>Environment: {@code BEDROCK_BATCH_ROLE_ARN}, {@code BEDROCK_BATCH_BUCKET}, optional {@code BEDROCK_BATCH_MODEL}
+ * (default {@code anthropic.claude-3-haiku-20240307-v1:0}) and {@code AWS_REGION} (default {@code us-east-1}).
+ * The model must be one that supports batch inference. Credentials come from the default AWS chain.</p>
+ */
+@EnabledIfEnvironmentVariable(named = "BEDROCK_BATCH_ROLE_ARN", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "BEDROCK_BATCH_BUCKET", matches = ".+")
+class BedrockBatchChatModelIT {
+
+    private static final int RECORD_COUNT = 100;
+
+    private final Region region = Region.of(System.getenv().getOrDefault("AWS_REGION", "us-east-1"));
+    private final String bucket = System.getenv("BEDROCK_BATCH_BUCKET");
+    private final String roleArn = System.getenv("BEDROCK_BATCH_ROLE_ARN");
+    private final String model =
+            System.getenv().getOrDefault("BEDROCK_BATCH_MODEL", "anthropic.claude-3-haiku-20240307-v1:0");
+    private final String prefix = "langchain4j-batch-it/" + UUID.randomUUID();
+
+    private final S3Client s3 = S3Client.builder().region(region).build();
+
+    private BedrockBatchChatModel model() {
+        return BedrockBatchChatModel.builder()
+                .region(region)
+                .modelId(model)
+                .roleArn(roleArn)
+                .outputS3Uri("s3://" + bucket + "/" + prefix)
+                .defaultRequestParameters(DefaultChatRequestParameters.builder()
+                        .maxOutputTokens(16)
+                        .build())
+                .build();
+    }
+
+    @Test
+    void submits_polls_and_reads_results() throws Exception {
+        List<ChatRequest> requests = new ArrayList<>();
+        for (int i = 0; i < RECORD_COUNT; i++) {
+            requests.add(ChatRequest.builder()
+                    .messages(UserMessage.from("Reply with the single word: ok"))
+                    .build());
+        }
+
+        BedrockBatchChatModel model = model();
+        BatchResponse<ChatResponse> submitted = model.submit(new dev.langchain4j.model.batch.BatchRequest<>(requests));
+        assertThat(submitted.batchId()).isNotBlank();
+        assertThat(submitted.state()).isEqualTo(BatchState.PENDING);
+
+        BatchResponse<ChatResponse> result = pollUntilTerminal(model, submitted.batchId());
+        assertThat(result.state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(result.results()).hasSize(RECORD_COUNT);
+        assertThat(result.results().get(0).isSuccess()).isTrue();
+        assertThat(result.results().get(0).response().aiMessage().text()).isNotBlank();
+    }
+
+    @Test
+    void lists_jobs() {
+        assertThat(model().list(null).batches()).isNotNull();
+    }
+
+    private BatchResponse<ChatResponse> pollUntilTerminal(BedrockBatchChatModel model, String batchId)
+            throws InterruptedException {
+        long deadline = System.currentTimeMillis() + MINUTES.toMillis(60);
+        while (System.currentTimeMillis() < deadline) {
+            BatchResponse<ChatResponse> response = model.retrieve(batchId);
+            BatchState state = response.state();
+            if (state == BatchState.SUCCEEDED
+                    || state == BatchState.FAILED
+                    || state == BatchState.CANCELLED
+                    || state == BatchState.EXPIRED) {
+                return response;
+            }
+            MINUTES.sleep(1);
+        }
+        throw new AssertionError("Batch job did not complete within the timeout");
+    }
+
+    @AfterEach
+    void cleanup() {
+        List<ObjectIdentifier> objects = s3.listObjectsV2(b -> b.bucket(bucket).prefix(prefix)).contents().stream()
+                .map(S3Object::key)
+                .map(key -> ObjectIdentifier.builder().key(key).build())
+                .toList();
+        if (!objects.isEmpty()) {
+            s3.deleteObjects(b -> b.bucket(bucket).delete(d -> d.objects(objects)));
+        }
+    }
+}

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockBatchChatModelTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockBatchChatModelTest.java
@@ -1,0 +1,254 @@
+package dev.langchain4j.model.bedrock;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.bedrock.BedrockClient;
+import software.amazon.awssdk.services.bedrock.model.CreateModelInvocationJobRequest;
+import software.amazon.awssdk.services.bedrock.model.CreateModelInvocationJobResponse;
+import software.amazon.awssdk.services.bedrock.model.GetModelInvocationJobResponse;
+import software.amazon.awssdk.services.bedrock.model.ListModelInvocationJobsResponse;
+import software.amazon.awssdk.services.bedrock.model.ModelInvocationJobStatus;
+import software.amazon.awssdk.services.bedrock.model.ModelInvocationJobSummary;
+import software.amazon.awssdk.services.bedrock.model.S3InputFormat;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+class BedrockBatchChatModelTest {
+
+    private static final String JOB_ARN = "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/job-123";
+
+    private final BedrockClient bedrock = org.mockito.Mockito.mock(BedrockClient.class);
+    private final S3Client s3 = org.mockito.Mockito.mock(S3Client.class);
+
+    private BedrockBatchChatModel model() {
+        return BedrockBatchChatModel.builder()
+                .bedrockClient(bedrock)
+                .s3Client(s3)
+                .modelId("model-x")
+                .roleArn("arn:role")
+                .outputS3Uri("s3://out-bucket/out")
+                .inputS3Uri("s3://in-bucket/in")
+                .build();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void submit_uploads_jsonl_and_creates_job() throws Exception {
+        when(s3.putObject(any(Consumer.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+        when(bedrock.createModelInvocationJob(any(Consumer.class)))
+                .thenReturn(CreateModelInvocationJobResponse.builder()
+                        .jobArn(JOB_ARN)
+                        .build());
+
+        BatchResponse<ChatResponse> response = model().submit(new BatchRequest<>(List.of(
+                ChatRequest.builder().messages(UserMessage.from("A")).build(),
+                ChatRequest.builder().messages(UserMessage.from("B")).build())));
+
+        assertThat(response.batchId()).isEqualTo(JOB_ARN);
+        assertThat(response.state()).isEqualTo(BatchState.PENDING);
+
+        ArgumentCaptor<RequestBody> body = ArgumentCaptor.forClass(RequestBody.class);
+        verify(s3).putObject(any(Consumer.class), body.capture());
+        String jsonl =
+                new String(body.getValue().contentStreamProvider().newStream().readAllBytes(), UTF_8);
+        assertThat(jsonl.strip().split("\n")).hasSize(2);
+        assertThat(jsonl).contains("\"recordId\":\"r0000000000\"").contains("\"recordId\":\"r0000000001\"");
+        assertThat(jsonl).doesNotContain("request-");
+
+        ArgumentCaptor<Consumer<CreateModelInvocationJobRequest.Builder>> job = ArgumentCaptor.forClass(Consumer.class);
+        verify(bedrock).createModelInvocationJob(job.capture());
+        CreateModelInvocationJobRequest.Builder builder = CreateModelInvocationJobRequest.builder();
+        job.getValue().accept(builder);
+        CreateModelInvocationJobRequest built = builder.build();
+        assertThat(built.jobName()).startsWith("lc4j-batch-");
+        assertThat(built.roleArn()).isEqualTo("arn:role");
+        assertThat(built.modelId()).isEqualTo("model-x");
+        assertThat(built.inputDataConfig().s3InputDataConfig().s3Uri()).startsWith("s3://in-bucket/in/lc4j-batch-");
+        assertThat(built.inputDataConfig().s3InputDataConfig().s3InputFormat()).isEqualTo(S3InputFormat.JSONL);
+        assertThat(built.outputDataConfig().s3OutputDataConfig().s3Uri()).isEqualTo("s3://out-bucket/out");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void retrieve_completed_excludes_manifest_and_orders_by_record_id() {
+        when(bedrock.getModelInvocationJob(any(Consumer.class)))
+                .thenReturn(GetModelInvocationJobResponse.builder()
+                        .jobArn(JOB_ARN)
+                        .status(ModelInvocationJobStatus.PARTIALLY_COMPLETED)
+                        .build());
+        when(s3.listObjectsV2(any(Consumer.class)))
+                .thenReturn(ListObjectsV2Response.builder()
+                        .contents(
+                                S3Object.builder()
+                                        .key("out/job-123/manifest.json.out")
+                                        .build(),
+                                S3Object.builder()
+                                        .key("out/job-123/input.jsonl.out")
+                                        .build())
+                        .build());
+        String output = "{\"recordId\":\"r0000000001\",\"error\":{\"message\":\"boom\"}}\n"
+                + "{\"recordId\":\"r0000000000\",\"modelOutput\":{\"output\":{\"message\":{\"content\":"
+                + "[{\"text\":\"first\"}]}},\"stopReason\":\"end_turn\"}}\n";
+        when(s3.getObjectAsBytes(any(Consumer.class)))
+                .thenReturn(
+                        ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), output.getBytes(UTF_8)));
+
+        BatchResponse<ChatResponse> response = model().retrieve(JOB_ARN);
+
+        assertThat(response.state()).isEqualTo(BatchState.SUCCEEDED);
+        List<BatchItemResult<ChatResponse>> results = response.results();
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).isSuccess()).isTrue();
+        assertThat(results.get(0).response().aiMessage().text()).isEqualTo("first");
+        assertThat(results.get(1).isSuccess()).isFalse();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void retrieve_reads_and_merges_all_result_files_in_record_order() {
+        when(bedrock.getModelInvocationJob(any(Consumer.class)))
+                .thenReturn(GetModelInvocationJobResponse.builder()
+                        .jobArn(JOB_ARN)
+                        .status(ModelInvocationJobStatus.COMPLETED)
+                        .build());
+        when(s3.listObjectsV2(any(Consumer.class)))
+                .thenReturn(ListObjectsV2Response.builder()
+                        .contents(
+                                S3Object.builder()
+                                        .key("out/job-123/manifest.json.out")
+                                        .build(),
+                                S3Object.builder()
+                                        .key("out/job-123/part1.jsonl.out")
+                                        .build(),
+                                S3Object.builder()
+                                        .key("out/job-123/part2.jsonl.out")
+                                        .build())
+                        .build());
+        String part1 = "{\"recordId\":\"r0000000002\",\"modelOutput\":{\"output\":{\"message\":{\"content\":"
+                + "[{\"text\":\"third\"}]}},\"stopReason\":\"end_turn\"}}\n";
+        String part2 = "{\"recordId\":\"r0000000000\",\"modelOutput\":{\"output\":{\"message\":{\"content\":"
+                + "[{\"text\":\"first\"}]}},\"stopReason\":\"end_turn\"}}\n"
+                + "{\"recordId\":\"r0000000001\",\"modelOutput\":{\"output\":{\"message\":{\"content\":"
+                + "[{\"text\":\"second\"}]}},\"stopReason\":\"end_turn\"}}\n";
+        when(s3.getObjectAsBytes(any(Consumer.class)))
+                .thenReturn(
+                        ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), part1.getBytes(UTF_8)))
+                .thenReturn(
+                        ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), part2.getBytes(UTF_8)));
+
+        BatchResponse<ChatResponse> response = model().retrieve(JOB_ARN);
+
+        List<BatchItemResult<ChatResponse>> results = response.results();
+        assertThat(results).hasSize(3);
+        assertThat(results.get(0).response().aiMessage().text()).isEqualTo("first");
+        assertThat(results.get(1).response().aiMessage().text()).isEqualTo("second");
+        assertThat(results.get(2).response().aiMessage().text()).isEqualTo("third");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void retrieve_running_returns_no_results() {
+        when(bedrock.getModelInvocationJob(any(Consumer.class)))
+                .thenReturn(GetModelInvocationJobResponse.builder()
+                        .jobArn(JOB_ARN)
+                        .status(ModelInvocationJobStatus.IN_PROGRESS)
+                        .build());
+
+        BatchResponse<ChatResponse> response = model().retrieve(JOB_ARN);
+
+        assertThat(response.state()).isEqualTo(BatchState.RUNNING);
+        assertThat(response.results()).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void cancel_stops_the_job() {
+        model().cancel(JOB_ARN);
+        verify(bedrock).stopModelInvocationJob(any(Consumer.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void list_maps_summaries_and_next_token() {
+        when(bedrock.listModelInvocationJobs(any(Consumer.class)))
+                .thenReturn(ListModelInvocationJobsResponse.builder()
+                        .invocationJobSummaries(ModelInvocationJobSummary.builder()
+                                .jobArn(JOB_ARN)
+                                .status(ModelInvocationJobStatus.COMPLETED)
+                                .build())
+                        .nextToken("next")
+                        .build());
+
+        BatchPage<ChatResponse> page = model().list(new BatchPagination(10, null));
+
+        assertThat(page.batches()).hasSize(1);
+        assertThat(page.batches().get(0).batchId()).isEqualTo(JOB_ARN);
+        assertThat(page.batches().get(0).state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(page.nextPageToken()).isEqualTo("next");
+    }
+
+    @Test
+    void submit_rejects_tool_specifications() {
+        BatchRequest<ChatRequest> request = new BatchRequest<>(List.of(ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .toolSpecifications(ToolSpecification.builder().name("t").build())
+                .build()));
+
+        assertThatExceptionOfType(UnsupportedFeatureException.class)
+                .isThrownBy(() -> model().submit(request))
+                .withMessageContaining("Tool calling is not supported");
+    }
+
+    @Test
+    void maps_all_job_statuses_to_batch_states() {
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.SUBMITTED))
+                .isEqualTo(BatchState.PENDING);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.VALIDATING))
+                .isEqualTo(BatchState.PENDING);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.SCHEDULED))
+                .isEqualTo(BatchState.PENDING);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.IN_PROGRESS))
+                .isEqualTo(BatchState.RUNNING);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.STOPPING))
+                .isEqualTo(BatchState.RUNNING);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.COMPLETED))
+                .isEqualTo(BatchState.SUCCEEDED);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.PARTIALLY_COMPLETED))
+                .isEqualTo(BatchState.SUCCEEDED);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.FAILED))
+                .isEqualTo(BatchState.FAILED);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.STOPPED))
+                .isEqualTo(BatchState.CANCELLED);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.EXPIRED))
+                .isEqualTo(BatchState.EXPIRED);
+        assertThat(BedrockBatchChatModel.toBatchState(ModelInvocationJobStatus.UNKNOWN_TO_SDK_VERSION))
+                .isEqualTo(BatchState.UNSPECIFIED);
+        assertThat(BedrockBatchChatModel.toBatchState(null)).isEqualTo(BatchState.UNSPECIFIED);
+    }
+}

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockBatchConverseMapperTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockBatchConverseMapperTest.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class BedrockBatchConverseMapperTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void builds_converse_model_input_for_text_and_inference_config() throws Exception {
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Say hello in one word."))
+                .parameters(DefaultChatRequestParameters.builder()
+                        .maxOutputTokens(16)
+                        .temperature(0.2)
+                        .build())
+                .build();
+
+        String json = MAPPER.writeValueAsString(BedrockBatchConverseMapper.toModelInput(request));
+
+        assertThat(json)
+                .isEqualTo("{\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"Say hello in one word.\"}]}],"
+                        + "\"inferenceConfig\":{\"maxTokens\":16,\"temperature\":0.2}}");
+    }
+
+    @Test
+    void system_messages_go_into_the_system_field() {
+        ChatRequest request = ChatRequest.builder()
+                .messages(SystemMessage.from("You are terse."), UserMessage.from("Hi"))
+                .build();
+
+        Map<String, Object> modelInput = BedrockBatchConverseMapper.toModelInput(request);
+
+        assertThat(modelInput).containsKey("system");
+        assertThat(modelInput.get("system")).isEqualTo(java.util.List.of(Map.of("text", "You are terse.")));
+        assertThat(modelInput).doesNotContainKey("inferenceConfig");
+    }
+
+    @Test
+    void parses_converse_model_output_into_chat_response() throws Exception {
+        String modelOutput = "{\"output\":{\"message\":{\"role\":\"assistant\",\"content\":[{\"text\":\"Hello!\"}]}},"
+                + "\"stopReason\":\"end_turn\",\"usage\":{\"inputTokens\":5,\"outputTokens\":2,\"totalTokens\":7}}";
+
+        ChatResponse response = BedrockBatchConverseMapper.toChatResponse(MAPPER.readTree(modelOutput), "some-model");
+
+        assertThat(response.aiMessage().text()).isEqualTo("Hello!");
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.STOP);
+        assertThat(response.metadata().tokenUsage().inputTokenCount()).isEqualTo(5);
+        assertThat(response.metadata().tokenUsage().outputTokenCount()).isEqualTo(2);
+        assertThat(response.metadata().modelName()).isEqualTo("some-model");
+    }
+
+    @Test
+    void joins_multiple_text_blocks_with_blank_line_like_bedrock_chat_model() throws Exception {
+        String modelOutput = "{\"output\":{\"message\":{\"content\":"
+                + "[{\"text\":\"first\"},{\"reasoningContent\":{\"reasoningText\":{\"text\":\"ignored\"}}},"
+                + "{\"text\":\"second\"}]}},\"stopReason\":\"end_turn\"}";
+
+        ChatResponse response = BedrockBatchConverseMapper.toChatResponse(MAPPER.readTree(modelOutput), "m");
+
+        assertThat(response.aiMessage().text()).isEqualTo("first\n\nsecond");
+    }
+
+    @Test
+    void maps_max_tokens_stop_reason_to_length() throws Exception {
+        String modelOutput =
+                "{\"output\":{\"message\":{\"content\":[{\"text\":\"x\"}]}},\"stopReason\":\"max_tokens\"}";
+
+        ChatResponse response = BedrockBatchConverseMapper.toChatResponse(MAPPER.readTree(modelOutput), "m");
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+}


### PR DESCRIPTION


Relates to #3916
## Issue

Closes #5765

## Change

Adds `BedrockBatchChatModel`, a `BatchChatModel` on the Bedrock [batch inference API](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html) using the
`Converse` invocation type. `submit` writes the requests as one JSONL file to S3 and calls
`CreateModelInvocationJob`; `retrieve`, `cancel` and `list` call `GetModelInvocationJob`, `StopModelInvocationJob`
and `ListModelInvocationJobs`.

```java
BedrockBatchChatModel model = BedrockBatchChatModel.builder()
        .modelId("anthropic.claude-3-haiku-20240307-v1:0")
        .roleArn("arn:aws:iam::123456789012:role/my-bedrock-batch-role")
        .outputS3Uri("s3://my-bucket/batch-output")
        .build();

BatchResponse<ChatResponse> submitted = model.submit(new BatchRequest<>(requests));
BatchResponse<ChatResponse> result = model.retrieve(submitted.batchId());
```

Results follow the same contract as `OpenAiOfficialBatchChatModel`. They are read for every ended job that
produced output, including the partial results of a stopped or expired job, since Bedrock charges for the records
it processed. They are correlated by `recordId` into submission order, a request without a result becomes a
failure, and when the record ids were not generated by this model correlation is abandoned with a warning rather
than results being discarded. `BatchError.code()` carries Bedrock's `errorCode`.

Tool calling and JSON structured output are rejected with `UnsupportedFeatureException`, because Bedrock batch
inference "does not support tool calling (function calling) or structured output" per the page linked above, and so
are prompt cache points, since
[prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) "is not supported with the
batch inference API". `serviceTier` is rejected too: service tiers are documented for runtime calls, not batch jobs. A
request naming a model other than the job's is rejected as well, since a job runs one model. As in
`BedrockChatModel`, the builder's `modelId` is folded into the default parameters, so a model name already set on
them cannot conflict with it, and `topK`, `frequencyPenalty` and `presencePenalty` are rejected through the same
`validate` it uses, rather than being dropped from the record.

`BedrockChatRequestParameters` reaches each record the way `BedrockChatModel` sends it:
`additionalModelRequestFields` merged key by key over the defaults, plus `guardrailConfig` and `requestMetadata`,
a PDF is named after its file, and the text of a `BedrockSystemMessage` goes into `system`.
`returnThinking`, `sendThinking`, `timeout` and `customHeaders` mirror the `BedrockChatModel` builder, and
`jobTimeout` takes a `Duration`, rounded up to the whole hours Bedrock accepts.

JSON goes through the core `ProviderJson` codec rather than Jackson directly, so the batch tests also pass under the
module's `jackson3` profile. It uses its own compact spec, because the module's `Json` helper pretty-prints and a
multi-line record is not valid JSONL. `THINKING_SIGNATURE_KEY` in `AbstractBedrockChatModel` becomes
package-private so batch responses carry the thinking signature under the same attribute key.

Adds `software.amazon.awssdk:s3` and promotes `software.amazon.awssdk:bedrock` from test to compile scope, both
managed by the BOM.

### Tests

- `BedrockBatchChatModelTest` (new): request building and merging, rejections, job creation, correlation, missing
  and unreadable results, partial results of stopped and expired jobs, failed jobs, thinking, cancel, list, and every
  job status.
- `BedrockBatchConverseMapperTest` (new): the Converse request body, content and message mapping, thinking in both
  directions, single-line JSONL, and response parsing including cache token usage and every stop reason.
- `BedrockBatchChatModelIT` (new): submits 100 records, polls to completion and reads the results; it stops an
  unfinished job and deletes its S3 objects afterwards.

Reverting single behaviours, each fails its own tests: dropping the missing-result failure fails 2, reading results
only for completed jobs fails 3, writing pretty-printed JSON fails 7, discarding results with unrecognized record ids
fails 4, ignoring Bedrock's `errorCode` fails 1, not folding `modelId` into the defaults fails 2, swallowing an S3
error while reading the manifest fails 1, skipping `validate` fails 2, naming every PDF `document` fails 1, not
rejecting cache points fails 3, not rejecting `serviceTier` fails 1, and not mapping `BedrockSystemMessage` fails 2.

```
mvn -pl langchain4j-bedrock clean test
  Tests run: 374, Failures: 0, Errors: 0, Skipped: 8

mvn -pl langchain4j-bedrock -Pjackson3 -Dtest='BedrockBatch*Test' test
  Tests run: 78, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-bedrock verify -DskipTests
  revapi: API checks completed without failures.

mvn -pl langchain4j-core test
  Tests run: 1391, Failures: 0, Errors: 0, Skipped: 5

mvn -pl langchain4j test
  Tests run: 1724, Failures: 0, Errors: 0, Skipped: 19
```

`BedrockBatchChatModelIT` has not run: `CreateModelInvocationJob` returns "Your account is not authorized to perform
this action" on the AWS account I have, which AWS Support says is an eligibility level new accounts reach over time.
So the end-to-end path is unverified against a real job, in particular where Bedrock writes the output: `retrieve`
reads the `.jsonl.out` files and `manifest.json.out` described in
[View the results](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference-results.html) under
`{outputS3Uri}/{jobId}/`, and the unit tests stub that layout. I will run the IT and report back as soon as the
account is enabled.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

The two test boxes are unchecked because the integration tests did not run: `BedrockBatchChatModelIT` for the
reason above, and the core and main integration tests because they need provider keys. The examples and Spring Boot boxes are unchecked because this adds a model to an existing module and no starter property.
