### PR TITLE
Decode gzip/deflate responses in Utils.readBytes

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -378,9 +378,6 @@ public class Utils {
         if (contentEncoding == null) {
             return inputStream;
         }
-        // The request advertises "Accept-Encoding: gzip, deflate", so a server may compress the
-        // response body. The raw stream must be decoded according to the Content-Encoding header,
-        // otherwise the caller receives compressed bytes (e.g. a corrupted image or PDF).
         return switch (contentEncoding.trim().toLowerCase(Locale.ROOT)) {
             case "gzip", "x-gzip" -> new GZIPInputStream(inputStream);
             case "deflate" -> new InflaterInputStream(inputStream);

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -10,6 +10,7 @@ import static java.util.Collections.unmodifiableSet;
 
 import dev.langchain4j.Internal;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -25,10 +26,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -36,6 +38,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -345,7 +349,8 @@ public class Utils {
                 int responseCode = connection.getResponseCode();
 
                 if (responseCode == HTTP_OK) {
-                    try (InputStream inputStream = connection.getInputStream();
+                    try (InputStream inputStream =
+                                    decompress(connection.getInputStream(), connection.getContentEncoding());
                             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
                         byte[] buffer = new byte[1024];
                         int bytesRead;
@@ -367,6 +372,20 @@ public class Utils {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static InputStream decompress(InputStream inputStream, String contentEncoding) throws IOException {
+        if (contentEncoding == null) {
+            return inputStream;
+        }
+        // The request advertises "Accept-Encoding: gzip, deflate", so a server may compress the
+        // response body. The raw stream must be decoded according to the Content-Encoding header,
+        // otherwise the caller receives compressed bytes (e.g. a corrupted image or PDF).
+        return switch (contentEncoding.trim().toLowerCase(Locale.ROOT)) {
+            case "gzip", "x-gzip" -> new GZIPInputStream(inputStream);
+            case "deflate" -> new InflaterInputStream(inputStream);
+            default -> inputStream;
+        };
     }
 
     /**
@@ -600,9 +619,12 @@ public class Utils {
         }
     }
 
-    private static void collectInterfaceMethods(Class<?> clazz, Set<MethodSignature> seen,
-                                                List<Method> result, Set<Class<?>> visited,
-                                                boolean concreteOnly) {
+    private static void collectInterfaceMethods(
+            Class<?> clazz,
+            Set<MethodSignature> seen,
+            List<Method> result,
+            Set<Class<?>> visited,
+            boolean concreteOnly) {
         if (clazz == null) {
             return;
         }
@@ -611,8 +633,9 @@ public class Utils {
                 continue;
             }
             for (Method method : iface.getDeclaredMethods()) {
-                if (method.isBridge() || method.isSynthetic() ||
-                        (concreteOnly && Modifier.isAbstract(method.getModifiers()))) {
+                if (method.isBridge()
+                        || method.isSynthetic()
+                        || (concreteOnly && Modifier.isAbstract(method.getModifiers()))) {
                     continue;
                 }
                 MethodSignature sig = new MethodSignature(method.getName(), List.of(method.getParameterTypes()));

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -36,6 +37,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -281,9 +284,37 @@ class UtilsTest {
                 exchange.getResponseBody().write(response);
                 exchange.close();
             });
+            httpServer.createContext("/gzip_endpoint", exchange -> {
+                ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+                try (GZIPOutputStream gzip = new GZIPOutputStream(compressed)) {
+                    gzip.write("hello".getBytes());
+                }
+                byte[] response = compressed.toByteArray();
+                exchange.getResponseHeaders().set("Content-Encoding", "gzip");
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            });
+            httpServer.createContext("/deflate_endpoint", exchange -> {
+                ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+                try (DeflaterOutputStream deflate = new DeflaterOutputStream(compressed)) {
+                    deflate.write("hello".getBytes());
+                }
+                byte[] response = compressed.toByteArray();
+                exchange.getResponseHeaders().set("Content-Encoding", "deflate");
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            });
             httpServer.start();
 
             assertThat(Utils.readBytes("http://localhost:" + port + "/ok_endpoint"))
+                    .isEqualTo("hello".getBytes());
+
+            // A compressed response must be transparently decoded, not returned as raw bytes.
+            assertThat(Utils.readBytes("http://localhost:" + port + "/gzip_endpoint"))
+                    .isEqualTo("hello".getBytes());
+            assertThat(Utils.readBytes("http://localhost:" + port + "/deflate_endpoint"))
                     .isEqualTo("hello".getBytes());
 
             assertThatExceptionOfType(RuntimeException.class)


### PR DESCRIPTION
## Issue
Closes #5800

## Change
`Utils.readBytes(String url)` sends `Accept-Encoding: gzip, deflate` but reads the
response body as a **raw** `InputStream`. `HttpURLConnection` only decompresses gzip
transparently when it adds the `Accept-Encoding` header itself; because the header is set
explicitly here, the JDK disables transparent decoding and returns the body exactly as
sent. So when a server responds with `Content-Encoding: gzip` (nginx, CDNs, S3, most image
hosts), `readBytes` returns the still-compressed bytes.

`readBytes(url)` is used to inline remote images/PDFs as base64 for several model
integrations (Ollama, Bedrock, Vertex/Gemini image mappers, `Image`/`PdfFile` helpers), so
a gzip-serving host silently produced a corrupted payload.

This PR decodes the response stream according to the `Content-Encoding` header via a small
private helper:
- `gzip` / `x-gzip` → `GZIPInputStream`
- `deflate` → `InflaterInputStream` (zlib, per RFC 9110)
- anything else / no header → the raw stream, unchanged

No new dependencies. The uncompressed happy path is byte-for-byte unchanged (same stream,
same copy loop). The wrapper is created inside the existing try-with-resources, so closing
it closes the underlying HTTP stream.

Added `/gzip_endpoint` and `/deflate_endpoint` cases to `UtilsTest.read_bytes` that serve a
compressed body with the matching `Content-Encoding` header and assert the decoded bytes;
both fail against the previous behaviour.

## General checklist
- [X] There are no breaking changes (API, behaviour) — uncompressed responses are unchanged
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases — decoded gzip/deflate plus the existing raw/uncompressed and HTTP-error paths
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green — `langchain4j-core` `UtilsTest` (46/46) and `spotless:check` pass
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation — n/a, internal utility, no public API or behaviour visible in docs
- [ ] I have added an example in the examples repo (only for "big" features) — n/a
- [ ] I have added/updated Spring Boot starter(s) (if applicable) — n/a
