### PR TITLE
fix: Map connectTimeout to connection establishment in Apache HTTP client

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,8 +59,7 @@ public class ApacheHttpClient implements HttpClient {
         RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
 
         if (builder.connectTimeout() != null) {
-            requestConfigBuilder.setConnectionRequestTimeout(
-                    Timeout.ofMilliseconds(builder.connectTimeout().toMillis()));
+            setConnectTimeout(requestConfigBuilder, builder.connectTimeout());
         }
         if (builder.readTimeout() != null) {
             requestConfigBuilder.setResponseTimeout(
@@ -72,6 +72,18 @@ public class ApacheHttpClient implements HttpClient {
         this.syncClient = syncHttpClientBuilder.build();
         this.asyncClient = asyncHttpClientBuilder.build();
         this.asyncClient.start();
+    }
+
+    /**
+     * {@code RequestConfig.Builder.setConnectTimeout} is deprecated in favour of
+     * {@code ConnectionConfig.Builder.setConnectTimeout}, but the latter can only be applied through a
+     * connection manager, which would override the one a user may have configured on the supplied client builders.
+     * The connect timeout from {@code RequestConfig} takes precedence over {@code ConnectionConfig} when set,
+     * and is read by both the sync and the async execution runtimes.
+     */
+    @SuppressWarnings("deprecation")
+    private static void setConnectTimeout(RequestConfig.Builder requestConfigBuilder, Duration connectTimeout) {
+        requestConfigBuilder.setConnectTimeout(Timeout.ofMilliseconds(connectTimeout.toMillis()));
     }
 
     public static ApacheHttpClientBuilder builder() {

--- a/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientConnectTimeoutTest.java
+++ b/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientConnectTimeoutTest.java
@@ -1,0 +1,128 @@
+package dev.langchain4j.http.client.apache;
+
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpRequest;
+import java.io.IOException;
+import java.time.Duration;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.io.ConnectionEndpoint;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.io.LeaseRequest;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the connect timeout configured on the builder reaches the connection manager,
+ * which is what Apache HttpClient uses to limit connection establishment.
+ * The timeout expiring on a slow connection cannot be tested here: WireMock cannot simulate connection timeouts.
+ */
+class ApacheHttpClientConnectTimeoutTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void beforeEach() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        wireMockServer.stubFor(WireMock.get("/endpoint").willReturn(WireMock.ok()));
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void should_apply_connect_timeout_when_establishing_connection() {
+
+        ConnectTimeoutCapturingConnectionManager connectionManager = new ConnectTimeoutCapturingConnectionManager();
+
+        HttpClient client = ApacheHttpClient.builder()
+                .httpClientBuilder(HttpClients.custom().setConnectionManager(connectionManager))
+                .connectTimeout(Duration.ofSeconds(7))
+                .build();
+
+        client.execute(request());
+
+        assertThat(connectionManager.connectTimeout).isNotNull();
+        assertThat(connectionManager.connectTimeout.toMilliseconds()).isEqualTo(7000);
+    }
+
+    @Test
+    void should_not_apply_connect_timeout_when_not_configured() {
+
+        ConnectTimeoutCapturingConnectionManager connectionManager = new ConnectTimeoutCapturingConnectionManager();
+
+        HttpClient client = ApacheHttpClient.builder()
+                .httpClientBuilder(HttpClients.custom().setConnectionManager(connectionManager))
+                .build();
+
+        client.execute(request());
+
+        assertThat(connectionManager.connectTimeout).isNull();
+    }
+
+    private HttpRequest request() {
+        return HttpRequest.builder()
+                .method(GET)
+                .url(String.format("http://localhost:%s/endpoint", wireMockServer.port()))
+                .build();
+    }
+
+    /**
+     * Delegates to a real connection manager and records the connect timeout it is called with.
+     */
+    private static class ConnectTimeoutCapturingConnectionManager implements HttpClientConnectionManager {
+
+        private final PoolingHttpClientConnectionManager delegate = new PoolingHttpClientConnectionManager();
+
+        private TimeValue connectTimeout;
+
+        @Override
+        public LeaseRequest lease(String id, HttpRoute route, Timeout requestTimeout, Object state) {
+            return delegate.lease(id, route, requestTimeout, state);
+        }
+
+        @Override
+        public void release(ConnectionEndpoint endpoint, Object newState, TimeValue validDuration) {
+            delegate.release(endpoint, newState, validDuration);
+        }
+
+        @Override
+        public void connect(ConnectionEndpoint endpoint, TimeValue connectTimeout, HttpContext context)
+                throws IOException {
+            this.connectTimeout = connectTimeout;
+            delegate.connect(endpoint, connectTimeout, context);
+        }
+
+        @Override
+        public void upgrade(ConnectionEndpoint endpoint, HttpContext context) throws IOException {
+            delegate.upgrade(endpoint, context);
+        }
+
+        @Override
+        public void close(CloseMode closeMode) {
+            delegate.close(closeMode);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5805

## Change

`ApacheHttpClient` passed the SPI `connectTimeout` to `RequestConfig.Builder.setConnectionRequestTimeout`, which limits waiting for a pooled connection, not connection establishment. Establishment reads `RequestConfig.getConnectTimeout()`, never set here, so the connection manager fell back to the `ConnectionConfig` default of 3 minutes. `JdkHttpClient` and `OkHttpClient` map the same value to the real connection timeout.

The mapping is replaced; the pool lease timeout returns to the Apache default.

```java
if (builder.connectTimeout() != null) {
    setConnectTimeout(requestConfigBuilder, builder.connectTimeout());
}
```

The `RequestConfig` is shared by the sync and async client builders, so both paths are covered.

`RequestConfig.Builder.setConnectTimeout` is deprecated, hence `@SuppressWarnings("deprecation")` on a small private helper. Its `ConnectionConfig` replacement can only be applied through a connection manager, which would override the one a user passes via `httpClientBuilder(...)`. httpclient5 gives `RequestConfig.getConnectTimeout()` precedence over `ConnectionConfig` when it is set.

Testing: a delegating `HttpClientConnectionManager` spy asserts the `Timeout` passed to `connect(...)` on a real request to WireMock localhost — null when unset, the configured value when set. Whether the timeout fires on a slow connection is not covered: WireMock cannot simulate connection timeouts.

No text conflict with the open draft #5527, which touches the same file but not this block; I will rebase if it merges first.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Unit tests green (8/8, JDK 17). The module integration tests were not run locally: they need network/external services. -->
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Unit tests only, via `-pl langchain4j-core,langchain4j clean test`. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A — docs are added after review per the template -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — bug fix, not a feature -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no public API change -->
