### PR TITLE
fix: Read SSE error response body as UTF-8 without reassembling line separators

### DIFF
--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -2,7 +2,6 @@ package dev.langchain4j.http.client.jdk;
 
 import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.TimeoutException;
@@ -12,10 +11,8 @@ import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -154,9 +151,8 @@ public class JdkHttpClient implements HttpClient {
     }
 
     private static String readBody(java.net.http.HttpResponse<InputStream> response) {
-        try (InputStream inputStream = response.body();
-                BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-            return reader.lines().collect(joining(System.lineSeparator()));
+        try (InputStream inputStream = response.body()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             return "Cannot read error response body: " + e.getMessage();
         }

--- a/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/JdkHttpClientErrorBodyTest.java
+++ b/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/JdkHttpClientErrorBodyTest.java
@@ -1,0 +1,120 @@
+package dev.langchain4j.http.client.jdk;
+
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.sse.DefaultServerSentEventParser;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JdkHttpClientErrorBodyTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void beforeEach() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void should_preserve_line_separators_of_error_response_body() throws Exception {
+
+        // given
+        String body = "line1\r\nline2\r\n";
+        stubError(body);
+
+        // when
+        Throwable error = executeStreamingAndWaitForError();
+
+        // then
+        assertThat(error).isInstanceOf(HttpException.class).hasMessage(body);
+        assertThat(((HttpException) error).statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void should_decode_error_response_body_as_utf8() throws Exception {
+
+        // given
+        String body = "모델 오류";
+        stubError(body);
+
+        // when
+        Throwable error = executeStreamingAndWaitForError();
+
+        // then
+        assertThat(error).isInstanceOf(HttpException.class).hasMessage(body);
+    }
+
+    @Test
+    void should_not_fail_on_successful_response() throws Exception {
+
+        // given
+        wireMockServer.stubFor(WireMock.get("/endpoint")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody("data: hello\n\n")));
+
+        CompletableFuture<ServerSentEvent> event = new CompletableFuture<>();
+        CompletableFuture<Throwable> error = new CompletableFuture<>();
+
+        // when
+        JdkHttpClient.builder()
+                .build()
+                .execute(request(), new DefaultServerSentEventParser(), new ServerSentEventListener() {
+
+                    @Override
+                    public void onEvent(ServerSentEvent sse) {
+                        event.complete(sse);
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        error.complete(throwable);
+                    }
+                });
+
+        // then
+        assertThat(event.get(10, SECONDS).data()).isEqualTo("hello");
+        assertThat(error).isNotCompleted();
+    }
+
+    private void stubError(String body) {
+        wireMockServer.stubFor(WireMock.get("/endpoint")
+                .willReturn(WireMock.aResponse().withStatus(400).withBody(body.getBytes(UTF_8))));
+    }
+
+    private Throwable executeStreamingAndWaitForError() throws Exception {
+        CompletableFuture<Throwable> error = new CompletableFuture<>();
+
+        JdkHttpClient.builder().build().execute(request(), new DefaultServerSentEventParser(), error::complete);
+
+        return error.get(10, SECONDS);
+    }
+
+    private HttpRequest request() {
+        return HttpRequest.builder()
+                .method(GET)
+                .url("http://localhost:" + wireMockServer.port() + "/endpoint")
+                .build();
+    }
+}


### PR DESCRIPTION

## Issue

Closes #5808

## Change

`JdkHttpClient.readBody(HttpResponse<InputStream>)` builds the `HttpException` message that streaming (SSE) callers receive through `listener.onError()`. It read the stream with `reader.lines().collect(joining(System.lineSeparator()))`, which drops the original line separators and the trailing one, and its `InputStreamReader` had no charset, so decoding fell back to the JVM default.

The synchronous path in the same class (`execute(HttpRequest)`) already does `new String(body, UTF_8)`. This change makes the streaming path match:

```java
try (InputStream inputStream = response.body()) {
    return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
}
```

Three now-unused imports (`BufferedReader`, `InputStreamReader`, `Collectors.joining`) are removed. Nothing else in the file changes.

New unit test `JdkHttpClientErrorBodyTest` (WireMock, no API key) stubs a `400` with body `line1\r\nline2\r\n` and asserts the exception message matches exactly. It fails before this change (`line1\nline2`) regardless of the JVM default charset.

`ApacheHttpClient.readBody` has the same pattern. It is left alone so this one can be reviewed first.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green

  Unit tests in the module are green (9 tests). `JdkHttpClientIT` and `JdkHttpClientTimeoutIT` were not run locally because they need external services.

- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Will be added after approval, per the contribution guide -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A - internal bug fix, no example needed -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A - unrelated to Spring Boot starters -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

