### PR TITLE
Disable Apache HttpClient's automatic retries by default in ApacheHttpClient

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -51,6 +51,8 @@ public class ApacheHttpClient implements HttpClient {
     private final CloseableHttpAsyncClient asyncClient;
 
     public ApacheHttpClient(ApacheHttpClientBuilder builder) {
+        boolean syncBuilderProvidedByUser = builder.httpClientBuilder() != null;
+        boolean asyncBuilderProvidedByUser = builder.httpAsyncClientBuilder() != null;
         org.apache.hc.client5.http.impl.classic.HttpClientBuilder syncHttpClientBuilder =
                 getOrDefault(builder.httpClientBuilder(), HttpClients::custom);
         org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder asyncHttpClientBuilder =
@@ -69,6 +71,14 @@ public class ApacheHttpClient implements HttpClient {
         RequestConfig requestConfig = requestConfigBuilder.build();
         asyncHttpClientBuilder.setDefaultRequestConfig(requestConfig);
         syncHttpClientBuilder.setDefaultRequestConfig(requestConfig);
+
+        if (!syncBuilderProvidedByUser) {
+            syncHttpClientBuilder.disableAutomaticRetries();
+        }
+        if (!asyncBuilderProvidedByUser) {
+            asyncHttpClientBuilder.disableAutomaticRetries();
+        }
+
         this.syncClient = syncHttpClientBuilder.build();
         this.asyncClient = asyncHttpClientBuilder.build();
         this.asyncClient.start();

--- a/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientRetriesIT.java
+++ b/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientRetriesIT.java
@@ -1,0 +1,86 @@
+package dev.langchain4j.http.client.apache;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpRequest;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.util.TimeValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApacheHttpClientRetriesIT {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void beforeEach() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        WireMock.configureFor("localhost", wireMockServer.port());
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void should_not_retry_transport_level_by_default() {
+
+        // given a server that always responds with a retryable status (503)
+        String path = "/retryable";
+        wireMockServer.stubFor(get(path).willReturn(aResponse().withStatus(503).withBody("unavailable")));
+
+        // and a client that uses the default (LangChain4j-created) Apache builder
+        ApacheHttpClient client = ApacheHttpClient.builder().build();
+
+        // when-then: the failure surfaces immediately, without Apache's automatic retries
+        assertThatThrownBy(() -> client.execute(request(path)))
+                .isInstanceOf(HttpException.class)
+                .satisfies(e -> assertThat(((HttpException) e).statusCode()).isEqualTo(503));
+
+        // and only a single request reached the server (no transport-level retry)
+        wireMockServer.verify(1, getRequestedFor(urlEqualTo(path)));
+    }
+
+    @Test
+    void should_preserve_user_configured_retries() {
+
+        // given a server that always responds with a retryable status (503)
+        String path = "/retryable";
+        wireMockServer.stubFor(get(path).willReturn(aResponse().withStatus(503).withBody("unavailable")));
+
+        // and a user-supplied Apache builder that explicitly configures 2 retries
+        ApacheHttpClient client = ApacheHttpClient.builder()
+                .httpClientBuilder(HttpClients.custom()
+                        .setRetryStrategy(new DefaultHttpRequestRetryStrategy(2, TimeValue.ofMilliseconds(1))))
+                .build();
+
+        // when-then
+        assertThatThrownBy(() -> client.execute(request(path))).isInstanceOf(HttpException.class);
+
+        // then the user's retry configuration is honored: 1 initial attempt + 2 retries = 3 requests
+        wireMockServer.verify(3, getRequestedFor(urlEqualTo(path)));
+    }
+
+    private HttpRequest request(String path) {
+        return HttpRequest.builder()
+                .method(GET)
+                .url(String.format("http://localhost:%s%s", wireMockServer.port(), path))
+                .build();
+    }
+}


### PR DESCRIPTION
## Issue
  Related to #5789

  ## Change
  `ApacheHttpClient` builds the underlying Apache HttpClient 5 sync/async clients from `HttpClients.custom()` / `HttpAsyncClients.custom()`, which have `automaticRetriesDisabled = false` by default. As a result,
  Apache's `DefaultHttpRequestRetryStrategy` transparently retries requests (e.g. on connection failures and on HTTP `429`/`503`) **underneath** LangChain4j's own retry logic. This has two consequences:

  - `maxRetries=0` does not actually disable retries — Apache still retries at the transport level.
  - For any `maxRetries` value, retries are effectively stacked (LangChain4j retries × Apache retries).

  This PR makes LangChain4j the single source of truth for retry behavior: when `ApacheHttpClient` creates the client builders itself, it now calls `disableAutomaticRetries()` on both the sync and async
  builders.

  To avoid overriding an explicit user choice, this is only applied to the **default (LangChain4j-created) builders**. If a user supplies their own `httpClientBuilder`/`httpAsyncClientBuilder`, their retry
  configuration is left untouched — they remain free to configure retries as they wish (and can call `disableAutomaticRetries()` themselves if they want LangChain4j to be the only retry layer).

  **Note on behavior:** for users on the default builder who were (often unknowingly) relying on Apache's implicit retries, those transport-level retries are no longer performed; retries are now governed solely
  by LangChain4j's `maxRetries`. No public API changes (verified with `revapi:check`).

  This mirrors the Spring-side fix for `SpringRestClient` in langchain4j/langchain4j-spring#200.

  ### Tests
  Added `ApacheHttpClientRetriesIT` (WireMock, always returns `503`), covering both cases:
  - default builder → exactly **1** request is made (no transport-level retry);
  - user-supplied builder with an explicit `DefaultHttpRequestRetryStrategy(2, …)` → **3** requests are made (1 initial + 2 retries), i.e. the user's configuration is honored.

  No new dependencies were added (WireMock is already a test dependency across modules).

  ## General checklist
  - [ ] There are no breaking changes (API, behaviour)
  - [x] I have added unit and/or integration tests for my change
  - [x] The tests cover both positive and negative cases
  - [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langch 1 new message (ctrl+End) ↓ ig" features)