### PR TITLE
fix(openai): expose refusal text in streaming chat response metadata

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -9,6 +9,7 @@ import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.ModelProvider.OPEN_AI;
@@ -22,6 +23,7 @@ import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.internal.ExceptionMapper;
 import dev.langchain4j.internal.MappingTrackingStreamingChatResponseHandler;
@@ -181,6 +183,12 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
                 .onComplete(() -> {
                     if (toolCallBuilder.hasRequests()) {
                         onCompleteToolCall(trackingHandler, toolCallBuilder.buildAndReset());
+                    }
+
+                    String refusal = openAiResponseBuilder.refusal();
+                    if (isNotNullOrBlank(refusal)) {
+                        withLoggingExceptions(() -> handler.onError(new ContentFilteredException(refusal)));
+                        return;
                     }
 
                     ChatResponse completeResponse = openAiResponseBuilder.build();

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class OpenAiStreamingResponseBuilder {
 
     private final StringBuffer contentBuilder = new StringBuffer();
+    private final StringBuffer refusalBuilder = new StringBuffer();
     private final StringBuffer reasoningContentBuilder;
 
     private final StringBuffer toolNameBuilder = new StringBuffer(); // legacy
@@ -155,6 +156,11 @@ public class OpenAiStreamingResponseBuilder {
             this.contentBuilder.append(content);
         }
 
+        String refusal = delta.refusal();
+        if (!isNullOrEmpty(refusal)) {
+            this.refusalBuilder.append(refusal);
+        }
+
         String reasoningContent = delta.reasoningContent();
         if (returnThinking && !isNullOrEmpty(reasoningContent)) {
             this.reasoningContentBuilder.append(reasoningContent);
@@ -251,6 +257,10 @@ public class OpenAiStreamingResponseBuilder {
                 .aiMessage(buildAiMessage())
                 .metadata(buildMetadata())
                 .build();
+    }
+
+    public String refusal() {
+        return refusalBuilder.isEmpty() ? null : refusalBuilder.toString();
     }
 
     private AiMessage buildAiMessage() {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
@@ -26,6 +26,8 @@ public final class Delta {
     @JsonProperty
     private final String reasoningContent;
     @JsonProperty
+    private final String refusal;
+    @JsonProperty
     private final List<ToolCall> toolCalls;
     @JsonProperty
     @Deprecated
@@ -35,6 +37,7 @@ public final class Delta {
         this.role = builder.role;
         this.content = builder.content;
         this.reasoningContent = builder.reasoningContent;
+        this.refusal = builder.refusal;
         this.toolCalls = builder.toolCalls;
         this.functionCall = builder.functionCall;
     }
@@ -49,6 +52,10 @@ public final class Delta {
 
     public String reasoningContent() {
         return reasoningContent;
+    }
+
+    public String refusal() {
+        return refusal;
     }
 
     public List<ToolCall> toolCalls() {
@@ -73,6 +80,7 @@ public final class Delta {
         return Objects.equals(role, another.role)
                 && Objects.equals(content, another.content)
                 && Objects.equals(reasoningContent, another.reasoningContent)
+                && Objects.equals(refusal, another.refusal)
                 && Objects.equals(toolCalls, another.toolCalls)
                 && Objects.equals(functionCall, another.functionCall);
     }
@@ -84,6 +92,7 @@ public final class Delta {
         h += (h << 5) + Objects.hashCode(role);
         h += (h << 5) + Objects.hashCode(content);
         h += (h << 5) + Objects.hashCode(reasoningContent);
+        h += (h << 5) + Objects.hashCode(refusal);
         h += (h << 5) + Objects.hashCode(toolCalls);
         h += (h << 5) + Objects.hashCode(functionCall);
         return h;
@@ -96,6 +105,7 @@ public final class Delta {
                 + "role=" + role
                 + ", content=" + content
                 + ", reasoningContent=" + reasoningContent
+                + ", refusal=" + refusal
                 + ", toolCalls=" + toolCalls
                 + ", functionCall=" + functionCall
                 + "}";
@@ -113,6 +123,7 @@ public final class Delta {
         private String role;
         private String content;
         private String reasoningContent;
+        private String refusal;
         private List<ToolCall> toolCalls;
         @Deprecated
         private FunctionCall functionCall;
@@ -129,6 +140,11 @@ public final class Delta {
 
         public Builder reasoningContent(String reasoningContent) {
             this.reasoningContent = reasoningContent;
+            return this;
+        }
+
+        public Builder refusal(String refusal) {
+            this.refusal = refusal;
             return this;
         }
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -335,4 +335,37 @@ class OpenAiStreamingResponseBuilderTest {
                         .build()))
                 .build();
     }
+
+    @Test
+    void should_accumulate_refusal() {
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        builder.append(ChatCompletionResponse.builder()
+                .id("resp_1")
+                .model("gpt-4o")
+                .choices(List.of(ChatCompletionChoice.builder()
+                        .index(0)
+                        .delta(Delta.builder()
+                                .refusal("I cannot help with that")
+                                .build())
+                        .build()))
+                .build());
+
+        assertThat(builder.refusal()).isEqualTo("I cannot help with that");
+    }
+
+    @Test
+    void should_keep_refusal_null_when_no_refusal() {
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+        builder.append(ChatCompletionResponse.builder()
+                .id("resp_1")
+                .model("gpt-4o")
+                .choices(List.of(ChatCompletionChoice.builder()
+                        .index(0)
+                        .delta(Delta.builder().content("Hello").build())
+                        .build()))
+                .build());
+
+        assertThat(builder.refusal()).isNull();
+    }
 }


### PR DESCRIPTION
Closes #5813

## Change

`OpenAiStreamingChatModel` discards the `refusal` text in streaming responses
because `Delta` POJO has no `refusal` field, and Jackson silently drops it
(`@JsonIgnoreProperties(ignoreUnknown = true)` on Delta.Builder).

Non-streaming chat (`OpenAiUtils.java:383-385`) already checks refusal and throws
`ContentFilteredException` — this PR fills the streaming gap.

- Add `refusal` field to `Delta` POJO (mirrors `reasoningContent` pattern)
- Accumulate refusal in `OpenAiStreamingResponseBuilder`
- Expose via `OpenAiChatResponseMetadata.refusal()` — returns `null` when absent

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)