### PR TITLE
feat(google-genai): add Gemini Live API support (text and audio)

### DIFF
--- a/docs/docs/integrations/language-models/google-genai.md
+++ b/docs/docs/integrations/language-models/google-genai.md
@@ -31,6 +31,7 @@ https://github.com/googleapis/java-genai
 - [Cached Content Support](#cached-content-support)
 - [Thinking Models (Gemini 3.0+)](#thinking-models-gemini-30)
 - [Multimodality (Audio, Video, PDF)](#multimodality-audio-video-pdf)
+- [Live API (Experimental)](#live-api-experimental)
 - [Token Count Estimator](#token-count-estimator)
 - [Model Catalog](#model-catalog)
 
@@ -616,6 +617,117 @@ ChatResponse response = gemini.chat(ChatRequest.builder()
     ))
     .build());
 ```
+
+## Live API (Experimental)
+
+The [Gemini Live API](https://ai.google.dev/gemini-api/docs/live) is a stateful, bidirectional, real-time interface: you stream text and audio to the model over a persistent connection, and it streams text or audio back with low latency. It is designed for natural, interruptible voice conversations.
+
+Because a live session is not a request/response call, it does not fit the `ChatModel` contract. It is exposed as its own `GoogleGenAiLiveModel`, which opens a `GoogleGenAiLiveSession`.
+
+> [!NOTE]
+> The Live API is in preview and marked `@Experimental`; its surface may change in future releases.
+
+### How it works
+
+- **Open a session.** Configure a `GoogleGenAiLiveModel` with the builder, then call `connect(handler)` to open a `GoogleGenAiLiveSession`. The session is `AutoCloseable` — use it in a try-with-resources block so it always closes.
+- **Send input.** Push input through the session: `sendText(...)`, `sendAudio(...)`, or `sendClientContent(...)` to seed conversation history.
+- **Receive events.** Output is delivered to your `GoogleGenAiLiveResponseHandler`. Every method has a no-op default, so you override only the events you care about. The handler runs on the SDK's callback thread — don't block it; hand long-running work to your own executor.
+- **One response modality per session** — either `TEXT` or `AUDIO`, set with `responseModalities(...)`. To get a text version of an audio response, enable `outputAudioTranscription`.
+- **Audio format.** Input audio (`sendAudio`) must be raw 16 kHz, 16-bit little-endian PCM, sent in short chunks (about 20–40 ms). Output audio (`onAudio`) is 24 kHz, 16-bit little-endian PCM.
+
+> [!NOTE]
+> The current Gemini Developer API Live models are native-audio and require `responseModalities("AUDIO")`. Text-only output (`responseModalities("TEXT")`) is available with half-cascade Live models. The examples below use the native-audio path.
+
+### Quickstart: talk to the model and get audio back
+
+Send a text prompt and receive spoken audio plus its transcript. `onAudio` receives the raw PCM to play or buffer; `onOutputTranscription` receives the same response as text; `onTurnComplete` signals the model is done.
+
+```java
+GoogleGenAiLiveModel model = GoogleGenAiLiveModel.builder()
+    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
+    .modelName("gemini-2.5-flash-native-audio-latest")
+    .responseModalities("AUDIO")
+    .voiceName("Puck")                 // pick a prebuilt voice
+    .outputAudioTranscription(true)    // also receive the spoken response as text
+    .build();
+
+CountDownLatch turnComplete = new CountDownLatch(1);
+
+try (GoogleGenAiLiveSession session = model.connect(new GoogleGenAiLiveResponseHandler() {
+    @Override
+    public void onAudio(byte[] pcm) {
+        // play or buffer the 24 kHz PCM audio
+    }
+
+    @Override
+    public void onOutputTranscription(String text) {
+        System.out.print(text);
+    }
+
+    @Override
+    public void onTurnComplete() {
+        turnComplete.countDown();
+    }
+})) {
+    session.sendText("Say hello in one short sentence.");
+    turnComplete.await(30, TimeUnit.SECONDS);
+}
+```
+
+### Streaming audio input
+
+To hold a voice conversation, stream microphone audio to the model with `sendAudio`. Send small chunks (about 20–40 ms) as they are captured. When automatic voice activity detection is enabled (the default), call `sendAudioStreamEnd()` when the input pauses (for example, the user muted the microphone) to flush any buffered audio; you can resume by sending audio again.
+
+```java
+try (GoogleGenAiLiveSession session = model.connect(handler)) {
+    for (byte[] chunk : microphoneChunks) {       // ~20–40 ms of 16 kHz PCM each
+        session.sendAudio(chunk, "audio/pcm;rate=16000");
+    }
+    session.sendAudioStreamEnd();                  // input paused — flush buffered audio
+}
+```
+
+Enable `inputAudioTranscription(true)` on the builder to also receive a transcript of the user's audio via `onInputTranscription`.
+
+### Response events
+
+Implement only the callbacks you need on `GoogleGenAiLiveResponseHandler`:
+
+| Callback | Fires when |
+| --- | --- |
+| `onPartialText(String)` | A chunk of streamed text arrives (`TEXT` modality). |
+| `onCompleteText(String)` | A turn's full text, concatenated from its chunks. |
+| `onAudio(byte[])` | A chunk of output audio arrives (24 kHz PCM). |
+| `onInputTranscription(String)` | A transcript of the user's input audio (when enabled). |
+| `onOutputTranscription(String)` | A transcript of the model's output audio (when enabled). |
+| `onGenerationComplete()` | The model finished generating the response (fires before `onTurnComplete`). |
+| `onTurnComplete()` | The model finished its turn. |
+| `onInterrupted()` | The user interrupted the model (barge-in) — stop and discard queued audio. |
+| `onUsageMetadata(TokenUsage)` | Cumulative token usage for the session. |
+| `onGoAway(Duration)` | The server will soon close the connection. |
+| `onSessionResumptionUpdate(String)` | A handle you can use to resume the session later. |
+| `onError(Throwable)` | An error occurred while sending or receiving. |
+| `onClose()` | The session was closed. |
+
+### Advanced: passthrough configuration
+
+The builder surfaces the common Live options as first-class methods. Any other `LiveConnectConfig` option — for example `sessionResumption`, `contextWindowCompression`, `mediaResolution`, `safetySettings` or `translationConfig` — can be supplied through the `liveConnectConfig(...)` escape hatch. The passed config is used as the base, and any first-class builder option takes precedence over the same field in it.
+
+```java
+LiveConnectConfig baseConfig = LiveConnectConfig.builder()
+    .mediaResolution("MEDIA_RESOLUTION_LOW")
+    .build();
+
+GoogleGenAiLiveModel model = GoogleGenAiLiveModel.builder()
+    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
+    .modelName("gemini-2.5-flash-native-audio-latest")
+    .responseModalities("AUDIO")
+    .liveConnectConfig(baseConfig)     // advanced options not surfaced as builder methods
+    .build();
+```
+
+> [!NOTE]
+> Session length is limited by the model (audio-only sessions to about 15 minutes, audio + video to about 2 minutes). For longer conversations, enable context window compression via the passthrough config. See the [Live API guide](https://ai.google.dev/gemini-api/docs/live) for details.
 
 ## Token Count Estimator
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveEventDispatcher.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveEventDispatcher.java
@@ -1,0 +1,84 @@
+package dev.langchain4j.model.google.genai;
+
+import com.google.genai.types.Blob;
+import com.google.genai.types.LiveServerContent;
+import com.google.genai.types.LiveServerMessage;
+import com.google.genai.types.Part;
+import com.google.genai.types.Transcription;
+import com.google.genai.types.UsageMetadata;
+import dev.langchain4j.model.output.TokenUsage;
+
+/**
+ * Routes a {@link LiveServerMessage} to the matching {@link GoogleGenAiLiveResponseHandler} callbacks.
+ *
+ * <p>{@link #dispatch(LiveServerMessage)} is {@code synchronized}, since the SDK does not guarantee that
+ * callbacks run on a single thread; this also gives the accumulated turn text a consistent memory view. A
+ * single message can carry several independent fields, so every field is checked; they are not mutually
+ * exclusive.
+ */
+class GoogleGenAiLiveEventDispatcher {
+
+    private final GoogleGenAiLiveResponseHandler handler;
+    private final StringBuilder currentTurnText = new StringBuilder();
+
+    GoogleGenAiLiveEventDispatcher(GoogleGenAiLiveResponseHandler handler) {
+        this.handler = handler;
+    }
+
+    synchronized void dispatch(LiveServerMessage message) {
+        try {
+            message.serverContent().ifPresent(this::dispatchServerContent);
+            message.usageMetadata().ifPresent(usage -> handler.onUsageMetadata(toTokenUsage(usage)));
+            message.goAway()
+                    .ifPresent(goAway -> handler.onGoAway(goAway.timeLeft().orElse(null)));
+            message.sessionResumptionUpdate()
+                    .flatMap(update -> update.newHandle())
+                    .ifPresent(handler::onSessionResumptionUpdate);
+        } catch (RuntimeException e) {
+            handler.onError(e);
+        }
+    }
+
+    private void dispatchServerContent(LiveServerContent serverContent) {
+        if (serverContent.interrupted().orElse(false)) {
+            currentTurnText.setLength(0);
+            handler.onInterrupted();
+        }
+
+        serverContent
+                .modelTurn()
+                .flatMap(content -> content.parts())
+                .ifPresent(parts -> parts.forEach(this::dispatchPart));
+
+        serverContent.inputTranscription().flatMap(Transcription::text).ifPresent(handler::onInputTranscription);
+        serverContent.outputTranscription().flatMap(Transcription::text).ifPresent(handler::onOutputTranscription);
+
+        if (serverContent.generationComplete().orElse(false)) {
+            handler.onGenerationComplete();
+        }
+
+        if (serverContent.turnComplete().orElse(false)) {
+            if (currentTurnText.length() > 0) {
+                String completeText = currentTurnText.toString();
+                currentTurnText.setLength(0);
+                handler.onCompleteText(completeText);
+            }
+            handler.onTurnComplete();
+        }
+    }
+
+    private void dispatchPart(Part part) {
+        part.text().ifPresent(text -> {
+            currentTurnText.append(text);
+            handler.onPartialText(text);
+        });
+        part.inlineData().flatMap(Blob::data).ifPresent(handler::onAudio);
+    }
+
+    private static TokenUsage toTokenUsage(UsageMetadata usage) {
+        return new TokenUsage(
+                usage.promptTokenCount().orElse(null),
+                usage.responseTokenCount().orElse(null),
+                usage.totalTokenCount().orElse(null));
+    }
+}

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveModel.java
@@ -1,0 +1,359 @@
+package dev.langchain4j.model.google.genai;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.genai.AsyncSession;
+import com.google.genai.Client;
+import com.google.genai.types.AudioTranscriptionConfig;
+import com.google.genai.types.Content;
+import com.google.genai.types.LiveConnectConfig;
+import com.google.genai.types.Part;
+import com.google.genai.types.PrebuiltVoiceConfig;
+import com.google.genai.types.SpeechConfig;
+import com.google.genai.types.ThinkingConfig;
+import com.google.genai.types.VoiceConfig;
+import dev.langchain4j.Experimental;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Entry point for the Google Gemini <a href="https://ai.google.dev/gemini-api/docs/live">Live API</a>,
+ * built on the official {@code com.google.genai} SDK.
+ *
+ * <p>The Live API is a stateful, bidirectional, real-time interface: text and audio are streamed to the
+ * model over a persistent connection and text or audio is streamed back. It does not fit the
+ * request/response {@code ChatModel} contract, so it is exposed as its own session type.
+ *
+ * <p>Configure a model with the {@link Builder}, then open a session with
+ * {@link #connect(GoogleGenAiLiveResponseHandler)}:
+ *
+ * <pre>{@code
+ * GoogleGenAiLiveModel model = GoogleGenAiLiveModel.builder()
+ *         .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
+ *         .modelName("gemini-2.5-flash-native-audio-latest")
+ *         .responseModalities("AUDIO")
+ *         .outputAudioTranscription(true)
+ *         .build();
+ *
+ * try (GoogleGenAiLiveSession session = model.connect(new GoogleGenAiLiveResponseHandler() {
+ *     public void onAudio(byte[] pcm) { } // play the 24 kHz PCM audio
+ *     public void onOutputTranscription(String text) { System.out.print(text); }
+ * })) {
+ *     session.sendText("Say hello in one short sentence.");
+ *     // ... handle events until onTurnComplete
+ * }
+ * }</pre>
+ *
+ * <p>A session supports exactly one response modality ({@code TEXT} or {@code AUDIO}); native-audio models
+ * require {@code AUDIO}. For a text view of an audio response, enable output audio transcription.
+ */
+@Experimental
+public final class GoogleGenAiLiveModel {
+
+    private final Client client;
+    private final String modelName;
+    private final List<String> responseModalities;
+    private final String systemInstruction;
+    private final Double temperature;
+    private final Double topP;
+    private final Double topK;
+    private final Integer maxOutputTokens;
+    private final Integer seed;
+    private final String voiceName;
+    private final boolean inputAudioTranscription;
+    private final boolean outputAudioTranscription;
+    private final Integer thinkingBudget;
+    private final String thinkingLevel;
+    private final LiveConnectConfig liveConnectConfig;
+
+    private GoogleGenAiLiveModel(Builder builder) {
+        this.modelName = ensureNotBlank(builder.modelName, "modelName");
+        this.responseModalities = builder.responseModalities == null || builder.responseModalities.isEmpty()
+                ? List.of("TEXT")
+                : List.copyOf(builder.responseModalities);
+        if (this.responseModalities.size() != 1) {
+            throw new IllegalArgumentException(
+                    "The Live API supports exactly one response modality per session (\"TEXT\" or \"AUDIO\"), but got: "
+                            + this.responseModalities);
+        }
+        if (builder.thinkingBudget != null && builder.thinkingLevel != null) {
+            throw new IllegalArgumentException("Cannot use both thinkingBudget and thinkingLevel at the same time");
+        }
+        this.systemInstruction = builder.systemInstruction;
+        this.temperature = builder.temperature;
+        this.topP = builder.topP;
+        this.topK = builder.topK;
+        this.maxOutputTokens = builder.maxOutputTokens;
+        this.seed = builder.seed;
+        this.voiceName = builder.voiceName;
+        this.inputAudioTranscription = builder.inputAudioTranscription;
+        this.outputAudioTranscription = builder.outputAudioTranscription;
+        this.thinkingBudget = builder.thinkingBudget;
+        this.thinkingLevel = builder.thinkingLevel;
+        this.liveConnectConfig = builder.liveConnectConfig;
+        this.client = builder.client != null
+                ? builder.client
+                : GoogleGenAiClientFactory.createClient(
+                        builder.apiKey,
+                        builder.googleCredentials,
+                        builder.projectId,
+                        builder.location,
+                        builder.timeout,
+                        builder.customHeaders,
+                        builder.apiEndpoint);
+    }
+
+    /**
+     * Opens a live session and registers the handler that receives its events.
+     *
+     * @param handler the handler invoked for every server event on the session
+     * @return an open {@link GoogleGenAiLiveSession}
+     */
+    public GoogleGenAiLiveSession connect(GoogleGenAiLiveResponseHandler handler) {
+        ensureNotNull(handler, "handler");
+        try {
+            AsyncSession session =
+                    client.async.live.connect(modelName, buildConfig()).get();
+            try {
+                return new GoogleGenAiLiveSessionImpl(session, handler);
+            } catch (RuntimeException e) {
+                session.close();
+                throw e;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw GoogleGenAiExceptionMapper.INSTANCE.mapException(e);
+        } catch (ExecutionException e) {
+            throw GoogleGenAiExceptionMapper.INSTANCE.mapException(e.getCause() != null ? e.getCause() : e);
+        }
+    }
+
+    LiveConnectConfig buildConfig() {
+        LiveConnectConfig.Builder config =
+                liveConnectConfig != null ? liveConnectConfig.toBuilder() : LiveConnectConfig.builder();
+        config.responseModalities(responseModalities.toArray(new String[0]));
+        if (systemInstruction != null) {
+            config.systemInstruction(Content.fromParts(Part.fromText(systemInstruction)));
+        }
+        if (temperature != null) {
+            config.temperature(temperature.floatValue());
+        }
+        if (topP != null) {
+            config.topP(topP.floatValue());
+        }
+        if (topK != null) {
+            config.topK(topK.floatValue());
+        }
+        if (maxOutputTokens != null) {
+            config.maxOutputTokens(maxOutputTokens);
+        }
+        if (seed != null) {
+            config.seed(seed);
+        }
+        if (voiceName != null) {
+            config.speechConfig(SpeechConfig.builder()
+                    .voiceConfig(VoiceConfig.builder()
+                            .prebuiltVoiceConfig(PrebuiltVoiceConfig.builder()
+                                    .voiceName(voiceName)
+                                    .build())
+                            .build())
+                    .build());
+        }
+        if (inputAudioTranscription) {
+            config.inputAudioTranscription(AudioTranscriptionConfig.builder().build());
+        }
+        if (outputAudioTranscription) {
+            config.outputAudioTranscription(AudioTranscriptionConfig.builder().build());
+        }
+        if (thinkingBudget != null || thinkingLevel != null) {
+            ThinkingConfig.Builder thinking = ThinkingConfig.builder();
+            if (thinkingBudget != null) {
+                thinking.thinkingBudget(thinkingBudget);
+            }
+            if (thinkingLevel != null) {
+                thinking.thinkingLevel(thinkingLevel);
+            }
+            config.thinkingConfig(thinking.build());
+        }
+        return config.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Client client;
+        private String apiKey;
+        private GoogleCredentials googleCredentials;
+        private String projectId;
+        private String location;
+        private Duration timeout;
+        private Map<String, String> customHeaders;
+        private String apiEndpoint;
+        private String modelName;
+        private List<String> responseModalities;
+        private String systemInstruction;
+        private Double temperature;
+        private Double topP;
+        private Double topK;
+        private Integer maxOutputTokens;
+        private Integer seed;
+        private String voiceName;
+        private boolean inputAudioTranscription;
+        private boolean outputAudioTranscription;
+        private Integer thinkingBudget;
+        private String thinkingLevel;
+        private LiveConnectConfig liveConnectConfig;
+
+        /** A pre-built {@code com.google.genai.Client}. If set, the auth options below are ignored. */
+        public Builder client(Client client) {
+            this.client = client;
+            return this;
+        }
+
+        /** The Gemini Developer API key. */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /** Google credentials for the Vertex AI backend. */
+        public Builder googleCredentials(GoogleCredentials googleCredentials) {
+            this.googleCredentials = googleCredentials;
+            return this;
+        }
+
+        /** The Google Cloud project id for the Vertex AI backend. */
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            return this;
+        }
+
+        /** The Google Cloud location for the Vertex AI backend. */
+        public Builder location(String location) {
+            this.location = location;
+            return this;
+        }
+
+        /** The connection timeout. */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /** Custom HTTP headers to send with requests. */
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        /** A custom API endpoint (base URL). */
+        public Builder apiEndpoint(String apiEndpoint) {
+            this.apiEndpoint = apiEndpoint;
+            return this;
+        }
+
+        /** The Live-capable model name, e.g. {@code "gemini-2.0-flash-live-001"}. Required. */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * The single response modality for the session: {@code "TEXT"} or {@code "AUDIO"}. Defaults to
+         * {@code "TEXT"}. Exactly one modality is allowed per session.
+         */
+        public Builder responseModalities(String... responseModalities) {
+            this.responseModalities = List.of(responseModalities);
+            return this;
+        }
+
+        /** The system instruction that guides the model's behavior. */
+        public Builder systemInstruction(String systemInstruction) {
+            this.systemInstruction = systemInstruction;
+            return this;
+        }
+
+        /** The sampling temperature. */
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        /** The nucleus sampling probability. */
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        /** The top-k sampling value. */
+        public Builder topK(Double topK) {
+            this.topK = topK;
+            return this;
+        }
+
+        /** The maximum number of output tokens. */
+        public Builder maxOutputTokens(Integer maxOutputTokens) {
+            this.maxOutputTokens = maxOutputTokens;
+            return this;
+        }
+
+        /** The random seed for reproducible sampling. */
+        public Builder seed(Integer seed) {
+            this.seed = seed;
+            return this;
+        }
+
+        /** The prebuilt voice name for audio output, e.g. {@code "Puck"} or {@code "Kore"}. */
+        public Builder voiceName(String voiceName) {
+            this.voiceName = voiceName;
+            return this;
+        }
+
+        /** Enables transcription of the user's input audio, delivered via {@code onInputTranscription}. */
+        public Builder inputAudioTranscription(boolean inputAudioTranscription) {
+            this.inputAudioTranscription = inputAudioTranscription;
+            return this;
+        }
+
+        /** Enables transcription of the model's output audio, delivered via {@code onOutputTranscription}. */
+        public Builder outputAudioTranscription(boolean outputAudioTranscription) {
+            this.outputAudioTranscription = outputAudioTranscription;
+            return this;
+        }
+
+        /** The thinking token budget (Gemini 2.5 models); {@code 0} disables thinking. */
+        public Builder thinkingBudget(Integer thinkingBudget) {
+            this.thinkingBudget = thinkingBudget;
+            return this;
+        }
+
+        /** The thinking level (Gemini 3.x models), e.g. {@code "minimal"}, {@code "low"}, {@code "high"}. */
+        public Builder thinkingLevel(String thinkingLevel) {
+            this.thinkingLevel = thinkingLevel;
+            return this;
+        }
+
+        /**
+         * An advanced escape hatch: a base {@link LiveConnectConfig} used as the starting point for the
+         * session config, so options not surfaced as first-class builder methods (for example
+         * {@code sessionResumption}, {@code contextWindowCompression}, {@code mediaResolution},
+         * {@code safetySettings} or {@code translationConfig}) remain reachable. Any first-class option set on
+         * this builder takes precedence over the same field in the passed config.
+         */
+        public Builder liveConnectConfig(LiveConnectConfig liveConnectConfig) {
+            this.liveConnectConfig = liveConnectConfig;
+            return this;
+        }
+
+        public GoogleGenAiLiveModel build() {
+            return new GoogleGenAiLiveModel(this);
+        }
+    }
+}

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveResponseHandler.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveResponseHandler.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.model.google.genai;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.model.output.TokenUsage;
+import java.time.Duration;
+
+/**
+ * Receives events streamed back from a {@link GoogleGenAiLiveSession} over the
+ * <a href="https://ai.google.dev/gemini-api/docs/live">Gemini Live API</a>.
+ *
+ * <p>Every method has a no-op default, so an implementation overrides only the events it cares about.
+ * The methods are invoked from the SDK's callback threads and may run concurrently (for example, an error
+ * from a failed send can arrive while a response is still streaming), so a handler that keeps mutable state
+ * must guard it. Message events for a turn are delivered sequentially under an internal lock, so an
+ * implementation must not block or acquire locks of its own that other threads may hold; hand long-running
+ * work to your own executor.
+ *
+ * <p>A single server message can carry several of these events at once (for example audio plus a
+ * transcript), so more than one method may be called for one message.
+ */
+@Experimental
+public interface GoogleGenAiLiveResponseHandler {
+
+    /** A chunk of streamed text for the current turn (response modality {@code TEXT}). */
+    default void onPartialText(String text) {}
+
+    /** The full text of a turn, concatenated from its {@link #onPartialText(String)} chunks. */
+    default void onCompleteText(String text) {}
+
+    /** A chunk of streamed output audio (24 kHz, 16-bit little-endian PCM; response modality {@code AUDIO}). */
+    default void onAudio(byte[] audio) {}
+
+    /** A transcript of the user's input audio (when input audio transcription is enabled). */
+    default void onInputTranscription(String text) {}
+
+    /** A transcript of the model's output audio (when output audio transcription is enabled). */
+    default void onOutputTranscription(String text) {}
+
+    /**
+     * The model finished generating its response for the current turn. This fires before
+     * {@link #onTurnComplete()} and is a useful cue to update the UI (for example, to stop a "speaking"
+     * indicator) once no more output will arrive for the turn.
+     */
+    default void onGenerationComplete() {}
+
+    /** The model finished its turn. */
+    default void onTurnComplete() {}
+
+    /**
+     * The model's generation was interrupted (barge-in). Any queued output audio should be stopped and
+     * discarded.
+     */
+    default void onInterrupted() {}
+
+    /** Cumulative token usage for the session; sent periodically by the server. */
+    default void onUsageMetadata(TokenUsage tokenUsage) {}
+
+    /** The server will soon close the connection; {@code timeLeft} is how long remains, if provided. */
+    default void onGoAway(Duration timeLeft) {}
+
+    /** A session resumption handle that can be used to resume this session later. */
+    default void onSessionResumptionUpdate(String handle) {}
+
+    /** An error occurred while sending to or receiving from the session. */
+    default void onError(Throwable error) {}
+
+    /** The session was closed via {@link GoogleGenAiLiveSession#close()}. */
+    default void onClose() {}
+}

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveSession.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveSession.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.model.google.genai;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.data.message.ChatMessage;
+import java.util.List;
+
+/**
+ * A live, bidirectional session with the <a href="https://ai.google.dev/gemini-api/docs/live">Gemini
+ * Live API</a>, obtained from {@link GoogleGenAiLiveModel#connect(GoogleGenAiLiveResponseHandler)}.
+ *
+ * <p>Input is sent through this interface; output is delivered to the {@link GoogleGenAiLiveResponseHandler}
+ * supplied when the session was opened. The session is single, long-lived and stateful; close it when done
+ * (it is {@link AutoCloseable}). The {@code send*} methods throw {@link IllegalStateException} once the
+ * session is closed.
+ */
+@Experimental
+public interface GoogleGenAiLiveSession extends AutoCloseable {
+
+    /**
+     * Sends a text message as realtime input. This is the low-latency path and works across model
+     * versions; the model responds based on voice activity detection.
+     */
+    void sendText(String text);
+
+    /**
+     * Sends ordered conversation content. Used to seed context or send turn-by-turn messages.
+     *
+     * @param messages     the messages that make up the turn(s)
+     * @param turnComplete whether this completes the current turn (prompting the model to respond)
+     */
+    void sendClientContent(List<ChatMessage> messages, boolean turnComplete);
+
+    /**
+     * Sends a chunk of realtime input audio. Audio must be raw 16-bit little-endian PCM; send it in short
+     * chunks (about 20-40 ms) for responsive voice activity detection.
+     *
+     * @param audioData raw PCM audio bytes
+     * @param mimeType  the audio MIME type, e.g. {@code "audio/pcm;rate=16000"}
+     */
+    void sendAudio(byte[] audioData, String mimeType);
+
+    /**
+     * Signals the end of the realtime audio stream so the server flushes any buffered audio. Call this when
+     * the audio input pauses (using automatic voice activity detection).
+     */
+    void sendAudioStreamEnd();
+
+    /** Returns {@code true} while the session is open. */
+    boolean isOpen();
+
+    /** Returns the server-assigned session id, or {@code null} if the server did not assign one. */
+    String sessionId();
+
+    @Override
+    void close();
+}

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveSessionImpl.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveSessionImpl.java
@@ -1,0 +1,108 @@
+package dev.langchain4j.model.google.genai;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.google.genai.AsyncSession;
+import com.google.genai.types.Blob;
+import com.google.genai.types.Content;
+import com.google.genai.types.LiveSendClientContentParameters;
+import com.google.genai.types.LiveSendRealtimeInputParameters;
+import dev.langchain4j.data.message.ChatMessage;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class GoogleGenAiLiveSessionImpl implements GoogleGenAiLiveSession {
+
+    private final AsyncSession session;
+    private final GoogleGenAiLiveResponseHandler handler;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    GoogleGenAiLiveSessionImpl(AsyncSession session, GoogleGenAiLiveResponseHandler handler) {
+        this.session = session;
+        this.handler = handler;
+        session.receive(new GoogleGenAiLiveEventDispatcher(handler)::dispatch);
+    }
+
+    @Override
+    public void sendText(String text) {
+        ensureOpen();
+        ensureNotNull(text, "text");
+        session.sendRealtimeInput(realtimeText(text)).exceptionally(this::reportError);
+    }
+
+    @Override
+    public void sendClientContent(List<ChatMessage> messages, boolean turnComplete) {
+        ensureOpen();
+        ensureNotNull(messages, "messages");
+        session.sendClientContent(clientContent(messages, turnComplete)).exceptionally(this::reportError);
+    }
+
+    @Override
+    public void sendAudio(byte[] audioData, String mimeType) {
+        ensureOpen();
+        ensureNotNull(audioData, "audioData");
+        ensureNotBlank(mimeType, "mimeType");
+        session.sendRealtimeInput(realtimeAudio(audioData, mimeType)).exceptionally(this::reportError);
+    }
+
+    @Override
+    public void sendAudioStreamEnd() {
+        ensureOpen();
+        session.sendRealtimeInput(realtimeAudioStreamEnd()).exceptionally(this::reportError);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed.get();
+    }
+
+    @Override
+    public String sessionId() {
+        return session.sessionId();
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                session.close().exceptionally(this::reportError);
+            } finally {
+                handler.onClose();
+            }
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed.get()) {
+            throw new IllegalStateException("The live session is closed");
+        }
+    }
+
+    private Void reportError(Throwable t) {
+        handler.onError(GoogleGenAiExceptionMapper.INSTANCE.mapException(t));
+        return null;
+    }
+
+    static LiveSendRealtimeInputParameters realtimeText(String text) {
+        return LiveSendRealtimeInputParameters.builder().text(text).build();
+    }
+
+    static LiveSendRealtimeInputParameters realtimeAudio(byte[] audioData, String mimeType) {
+        return LiveSendRealtimeInputParameters.builder()
+                .audio(Blob.builder().data(audioData).mimeType(mimeType).build())
+                .build();
+    }
+
+    static LiveSendRealtimeInputParameters realtimeAudioStreamEnd() {
+        return LiveSendRealtimeInputParameters.builder().audioStreamEnd(true).build();
+    }
+
+    static LiveSendClientContentParameters clientContent(List<ChatMessage> messages, boolean turnComplete) {
+        List<Content> turns = GoogleGenAiContentMapper.toContents(messages);
+        return LiveSendClientContentParameters.builder()
+                .turns(turns)
+                .turnComplete(turnComplete)
+                .build();
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveEventDispatcherTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveEventDispatcherTest.java
@@ -1,0 +1,263 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.genai.types.Content;
+import com.google.genai.types.LiveServerContent;
+import com.google.genai.types.LiveServerGoAway;
+import com.google.genai.types.LiveServerMessage;
+import com.google.genai.types.LiveServerSessionResumptionUpdate;
+import com.google.genai.types.Part;
+import com.google.genai.types.Transcription;
+import com.google.genai.types.UsageMetadata;
+import dev.langchain4j.model.output.TokenUsage;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GoogleGenAiLiveEventDispatcherTest {
+
+    private final RecordingHandler handler = new RecordingHandler();
+    private final GoogleGenAiLiveEventDispatcher dispatcher = new GoogleGenAiLiveEventDispatcher(handler);
+
+    @Test
+    void streams_text_parts_then_completes_turn_accumulating_across_messages() {
+        dispatcher.dispatch(textMessage("Hel"));
+        dispatcher.dispatch(textMessage("lo"));
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder().turnComplete(true).build())
+                .build());
+
+        assertThat(handler.partialTexts).containsExactly("Hel", "lo");
+        assertThat(handler.completeTexts).containsExactly("Hello");
+        assertThat(handler.turnComplete).isEqualTo(1);
+    }
+
+    @Test
+    void routes_output_audio() {
+        byte[] audio = {1, 2, 3, 4};
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder()
+                        .modelTurn(Content.fromParts(Part.fromBytes(audio, "audio/pcm;rate=24000")))
+                        .build())
+                .build());
+
+        assertThat(handler.audioChunks).hasSize(1);
+        assertThat(handler.audioChunks.get(0)).isEqualTo(audio);
+        assertThat(handler.completeTexts).isEmpty();
+    }
+
+    @Test
+    void processes_audio_and_transcript_in_a_single_message() {
+        byte[] audio = {9, 8, 7};
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder()
+                        .modelTurn(Content.fromParts(Part.fromBytes(audio, "audio/pcm;rate=24000")))
+                        .outputTranscription(
+                                Transcription.builder().text("hello there").build())
+                        .build())
+                .build());
+
+        assertThat(handler.audioChunks).hasSize(1);
+        assertThat(handler.outputTranscripts).containsExactly("hello there");
+    }
+
+    @Test
+    void routes_input_and_output_transcription() {
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder()
+                        .inputTranscription(
+                                Transcription.builder().text("user said").build())
+                        .outputTranscription(
+                                Transcription.builder().text("model said").build())
+                        .build())
+                .build());
+
+        assertThat(handler.inputTranscripts).containsExactly("user said");
+        assertThat(handler.outputTranscripts).containsExactly("model said");
+    }
+
+    @Test
+    void interruption_fires_event_and_discards_pending_text() {
+        dispatcher.dispatch(textMessage("partial answer"));
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder().interrupted(true).build())
+                .build());
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder().turnComplete(true).build())
+                .build());
+
+        assertThat(handler.interrupted).isEqualTo(1);
+        assertThat(handler.completeTexts).isEmpty();
+    }
+
+    @Test
+    void turn_text_is_cleared_even_if_a_completion_callback_throws() {
+        List<String> completeTexts = new ArrayList<>();
+        GoogleGenAiLiveEventDispatcher throwingDispatcher =
+                new GoogleGenAiLiveEventDispatcher(new GoogleGenAiLiveResponseHandler() {
+                    @Override
+                    public void onCompleteText(String text) {
+                        completeTexts.add(text);
+                        throw new RuntimeException("handler failure");
+                    }
+                });
+
+        throwingDispatcher.dispatch(textMessage("first"));
+        throwingDispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder().turnComplete(true).build())
+                .build());
+        throwingDispatcher.dispatch(textMessage("second"));
+        throwingDispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder().turnComplete(true).build())
+                .build());
+
+        assertThat(completeTexts).containsExactly("first", "second");
+    }
+
+    @Test
+    void interrupted_is_handled_before_content_parts_in_the_same_message() {
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder()
+                        .interrupted(true)
+                        .modelTurn(Content.fromParts(Part.fromText("late chunk")))
+                        .build())
+                .build());
+
+        assertThat(handler.lifecycle).containsExactly("interrupted", "partial");
+    }
+
+    @Test
+    void generation_complete_fires_without_completing_the_turn() {
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(
+                        LiveServerContent.builder().generationComplete(true).build())
+                .build());
+
+        assertThat(handler.generationComplete).isEqualTo(1);
+        assertThat(handler.turnComplete).isZero();
+    }
+
+    @Test
+    void generation_complete_precedes_turn_complete_within_one_message() {
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder()
+                        .generationComplete(true)
+                        .turnComplete(true)
+                        .build())
+                .build());
+
+        assertThat(handler.lifecycle).containsExactly("generation", "turn");
+    }
+
+    @Test
+    void routes_usage_metadata_to_token_usage() {
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .usageMetadata(UsageMetadata.builder()
+                        .promptTokenCount(3)
+                        .responseTokenCount(5)
+                        .totalTokenCount(8)
+                        .build())
+                .build());
+
+        assertThat(handler.usages).containsExactly(new TokenUsage(3, 5, 8));
+    }
+
+    @Test
+    void routes_go_away_and_session_resumption_update() {
+        dispatcher.dispatch(LiveServerMessage.builder()
+                .goAway(LiveServerGoAway.builder()
+                        .timeLeft(Duration.ofSeconds(10))
+                        .build())
+                .sessionResumptionUpdate(LiveServerSessionResumptionUpdate.builder()
+                        .newHandle("handle-123")
+                        .build())
+                .build());
+
+        assertThat(handler.goAways).containsExactly(Duration.ofSeconds(10));
+        assertThat(handler.resumptionHandles).containsExactly("handle-123");
+    }
+
+    private static LiveServerMessage textMessage(String text) {
+        return LiveServerMessage.builder()
+                .serverContent(LiveServerContent.builder()
+                        .modelTurn(Content.fromParts(Part.fromText(text)))
+                        .build())
+                .build();
+    }
+
+    private static final class RecordingHandler implements GoogleGenAiLiveResponseHandler {
+        int turnComplete;
+        int generationComplete;
+        int interrupted;
+        final List<String> lifecycle = new ArrayList<>();
+        final List<String> partialTexts = new ArrayList<>();
+        final List<String> completeTexts = new ArrayList<>();
+        final List<byte[]> audioChunks = new ArrayList<>();
+        final List<String> inputTranscripts = new ArrayList<>();
+        final List<String> outputTranscripts = new ArrayList<>();
+        final List<TokenUsage> usages = new ArrayList<>();
+        final List<Duration> goAways = new ArrayList<>();
+        final List<String> resumptionHandles = new ArrayList<>();
+
+        @Override
+        public void onPartialText(String text) {
+            partialTexts.add(text);
+            lifecycle.add("partial");
+        }
+
+        @Override
+        public void onCompleteText(String text) {
+            completeTexts.add(text);
+        }
+
+        @Override
+        public void onAudio(byte[] audio) {
+            audioChunks.add(audio);
+        }
+
+        @Override
+        public void onInputTranscription(String text) {
+            inputTranscripts.add(text);
+        }
+
+        @Override
+        public void onOutputTranscription(String text) {
+            outputTranscripts.add(text);
+        }
+
+        @Override
+        public void onGenerationComplete() {
+            generationComplete++;
+            lifecycle.add("generation");
+        }
+
+        @Override
+        public void onTurnComplete() {
+            turnComplete++;
+            lifecycle.add("turn");
+        }
+
+        @Override
+        public void onInterrupted() {
+            interrupted++;
+            lifecycle.add("interrupted");
+        }
+
+        @Override
+        public void onUsageMetadata(TokenUsage tokenUsage) {
+            usages.add(tokenUsage);
+        }
+
+        @Override
+        public void onGoAway(Duration timeLeft) {
+            goAways.add(timeLeft);
+        }
+
+        @Override
+        public void onSessionResumptionUpdate(String handle) {
+            resumptionHandles.add(handle);
+        }
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveModelIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveModelIT.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
+class GoogleGenAiLiveModelIT {
+
+    private static final String GOOGLE_AI_GEMINI_API_KEY = System.getenv("GOOGLE_AI_GEMINI_API_KEY");
+
+    @Test
+    void streams_audio_and_a_transcript_for_a_text_turn() throws Exception {
+        GoogleGenAiLiveModel model = GoogleGenAiLiveModel.builder()
+                .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                .modelName("gemini-2.5-flash-native-audio-latest")
+                .responseModalities("AUDIO")
+                .voiceName("Puck")
+                .outputAudioTranscription(true)
+                .build();
+
+        AtomicInteger audioChunks = new AtomicInteger();
+        StringBuilder transcript = new StringBuilder();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch turnComplete = new CountDownLatch(1);
+
+        try (GoogleGenAiLiveSession session = model.connect(new GoogleGenAiLiveResponseHandler() {
+            @Override
+            public void onAudio(byte[] audio) {
+                if (audio.length > 0) {
+                    audioChunks.incrementAndGet();
+                }
+            }
+
+            @Override
+            public void onOutputTranscription(String text) {
+                transcript.append(text);
+            }
+
+            @Override
+            public void onTurnComplete() {
+                turnComplete.countDown();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.set(t);
+                turnComplete.countDown();
+            }
+        })) {
+            assertThat(session.isOpen()).isTrue();
+
+            session.sendText("Reply with a short spoken greeting.");
+
+            assertThat(turnComplete.await(60, TimeUnit.SECONDS))
+                    .as("expected a completed turn within 60s")
+                    .isTrue();
+        }
+
+        assertThat(error.get()).isNull();
+        assertThat(audioChunks.get()).as("expected at least one audio chunk").isPositive();
+        assertThat(transcript.toString()).isNotBlank();
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveModelTest.java
@@ -1,0 +1,142 @@
+package dev.langchain4j.model.google.genai;
+
+import static dev.langchain4j.model.google.genai.GoogleGenAiLiveSessionImpl.clientContent;
+import static dev.langchain4j.model.google.genai.GoogleGenAiLiveSessionImpl.realtimeAudio;
+import static dev.langchain4j.model.google.genai.GoogleGenAiLiveSessionImpl.realtimeAudioStreamEnd;
+import static dev.langchain4j.model.google.genai.GoogleGenAiLiveSessionImpl.realtimeText;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.genai.types.LiveConnectConfig;
+import com.google.genai.types.LiveSendClientContentParameters;
+import com.google.genai.types.LiveSendRealtimeInputParameters;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GoogleGenAiLiveModelTest {
+
+    private static GoogleGenAiLiveModel.Builder modelBuilder() {
+        return GoogleGenAiLiveModel.builder().apiKey("test-key").modelName("gemini-2.0-flash-live-001");
+    }
+
+    @Test
+    void build_requires_model_name() {
+        assertThatThrownBy(
+                        () -> GoogleGenAiLiveModel.builder().apiKey("test-key").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("modelName");
+    }
+
+    @Test
+    void rejects_more_than_one_response_modality() {
+        assertThatThrownBy(
+                        () -> modelBuilder().responseModalities("TEXT", "AUDIO").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one response modality");
+    }
+
+    @Test
+    void rejects_both_thinking_budget_and_thinking_level() {
+        assertThatThrownBy(() ->
+                        modelBuilder().thinkingBudget(100).thinkingLevel("low").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot use both thinkingBudget and thinkingLevel");
+    }
+
+    @Test
+    void defaults_to_a_single_response_modality() {
+        LiveConnectConfig config = modelBuilder().build().buildConfig();
+
+        assertThat(config.responseModalities()).isPresent();
+        assertThat(config.responseModalities().get()).hasSize(1);
+    }
+
+    @Test
+    void builds_config_from_builder_options() {
+        LiveConnectConfig config = modelBuilder()
+                .responseModalities("AUDIO")
+                .systemInstruction("be brief")
+                .temperature(0.7)
+                .maxOutputTokens(256)
+                .voiceName("Puck")
+                .outputAudioTranscription(true)
+                .thinkingBudget(0)
+                .build()
+                .buildConfig();
+
+        assertThat(config.systemInstruction()).isPresent();
+        assertThat(config.temperature()).contains(0.7f);
+        assertThat(config.maxOutputTokens()).contains(256);
+        assertThat(config.speechConfig()).isPresent();
+        assertThat(config.outputAudioTranscription()).isPresent();
+        assertThat(config.inputAudioTranscription()).isEmpty();
+        assertThat(config.thinkingConfig()).isPresent();
+    }
+
+    @Test
+    void transcription_is_off_unless_enabled() {
+        LiveConnectConfig config = modelBuilder().build().buildConfig();
+
+        assertThat(config.inputAudioTranscription()).isEmpty();
+        assertThat(config.outputAudioTranscription()).isEmpty();
+    }
+
+    @Test
+    void passthrough_config_reaches_options_not_surfaced_as_builder_methods() {
+        LiveConnectConfig passthrough = LiveConnectConfig.builder()
+                .mediaResolution("MEDIA_RESOLUTION_LOW")
+                .build();
+
+        LiveConnectConfig config =
+                modelBuilder().liveConnectConfig(passthrough).build().buildConfig();
+
+        assertThat(config.mediaResolution()).isPresent();
+    }
+
+    @Test
+    void first_class_options_take_precedence_over_passthrough_config() {
+        LiveConnectConfig passthrough =
+                LiveConnectConfig.builder().temperature(0.1f).build();
+
+        LiveConnectConfig config = modelBuilder()
+                .liveConnectConfig(passthrough)
+                .temperature(0.9)
+                .build()
+                .buildConfig();
+
+        assertThat(config.temperature()).contains(0.9f);
+    }
+
+    @Test
+    void realtime_text_carries_the_text() {
+        LiveSendRealtimeInputParameters params = realtimeText("hello");
+
+        assertThat(params.text()).contains("hello");
+    }
+
+    @Test
+    void realtime_audio_carries_bytes_and_mime_type() {
+        byte[] pcm = {1, 2, 3};
+        LiveSendRealtimeInputParameters params = realtimeAudio(pcm, "audio/pcm;rate=16000");
+
+        assertThat(params.audio()).isPresent();
+        assertThat(params.audio().get().data()).isPresent();
+        assertThat(params.audio().get().data().get()).isEqualTo(pcm);
+        assertThat(params.audio().get().mimeType()).contains("audio/pcm;rate=16000");
+    }
+
+    @Test
+    void realtime_audio_stream_end_sets_the_flag() {
+        assertThat(realtimeAudioStreamEnd().audioStreamEnd()).contains(true);
+    }
+
+    @Test
+    void client_content_maps_messages_and_turn_complete() {
+        LiveSendClientContentParameters params = clientContent(List.of(UserMessage.from("hi")), true);
+
+        assertThat(params.turnComplete()).contains(true);
+        assertThat(params.turns()).isPresent();
+        assertThat(params.turns().get()).hasSize(1);
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveSessionImplTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiLiveSessionImplTest.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.genai.AsyncSession;
+import com.google.genai.types.LiveSendRealtimeInputParameters;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class GoogleGenAiLiveSessionImplTest {
+
+    private final AsyncSession session = mock(AsyncSession.class);
+    private final GoogleGenAiLiveResponseHandler handler = mock(GoogleGenAiLiveResponseHandler.class);
+    private GoogleGenAiLiveSessionImpl liveSession;
+
+    @BeforeEach
+    void setUp() {
+        when(session.receive(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(session.sendRealtimeInput(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(session.close()).thenReturn(CompletableFuture.completedFuture(null));
+        liveSession = new GoogleGenAiLiveSessionImpl(session, handler);
+    }
+
+    @Test
+    void send_text_forwards_realtime_input_to_the_session() {
+        liveSession.sendText("hello");
+
+        ArgumentCaptor<LiveSendRealtimeInputParameters> captor =
+                ArgumentCaptor.forClass(LiveSendRealtimeInputParameters.class);
+        verify(session).sendRealtimeInput(captor.capture());
+        assertThat(captor.getValue().text()).contains("hello");
+    }
+
+    @Test
+    void close_is_idempotent_and_notifies_the_handler_once() {
+        liveSession.close();
+        liveSession.close();
+
+        assertThat(liveSession.isOpen()).isFalse();
+        verify(session, times(1)).close();
+        verify(handler, times(1)).onClose();
+    }
+
+    @Test
+    void sending_after_close_throws() {
+        liveSession.close();
+
+        assertThatThrownBy(() -> liveSession.sendText("hi")).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> liveSession.sendAudio(new byte[] {1}, "audio/pcm;rate=16000"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void send_rejects_invalid_arguments() {
+        assertThatThrownBy(() -> liveSession.sendText(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> liveSession.sendAudio(null, "audio/pcm;rate=16000"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> liveSession.sendAudio(new byte[] {1}, " "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## What

Adds [Gemini Live API](https://ai.google.dev/gemini-api/docs/live) support to `langchain4j-google-genai`. The Live API is a stateful, bidirectional session: text and audio stream to the model over a persistent connection, and text or audio stream back. It wraps the official `com.google.genai` SDK's `AsyncLive`/`AsyncSession` rather than hand-rolling a WebSocket client.

It is the foundation PR of a short series: it establishes the session API (`GoogleGenAiLiveModel` / `GoogleGenAiLiveSession` / `GoogleGenAiLiveResponseHandler`) that the follow-ups extend without changing, so reviewing the API here reviews the base for all of them. See [Roadmap](#roadmap).

## Why a new type, not a `ChatModel`

A live, event-driven session is not a request/response call, so it does not fit `ChatModel`/`StreamingChatModel`. It is a module-local session type, matching the module's existing non-chat capabilities (`GoogleGenAiCaches`, `GoogleGenAiFiles`); it adds no new langchain4j-core interface.

## API

- `GoogleGenAiLiveModel` — builder entry point; `connect(handler)` opens a session. Reuses `GoogleGenAiClientFactory`, so the Developer API (`apiKey`) and Vertex AI both work. Options: `responseModalities` (exactly one), `systemInstruction`, generation params, `voiceName`, input/output audio transcription, `thinkingBudget`/`thinkingLevel`, plus a `liveConnectConfig(...)` passthrough for any advanced SDK option not surfaced as a first-class builder method (first-class options take precedence).
- `GoogleGenAiLiveSession` (`AutoCloseable`) — `sendText`, `sendClientContent`, `sendAudio`, `sendAudioStreamEnd`, `isOpen`, `sessionId`, `close`.
- `GoogleGenAiLiveResponseHandler` — no-op-default events: `onPartialText`/`onCompleteText`, `onAudio`, `onInputTranscription`/`onOutputTranscription`, `onGenerationComplete`, `onTurnComplete`, `onInterrupted`, `onUsageMetadata`, `onGoAway`, `onSessionResumptionUpdate`, `onError`, `onClose`.

A session uses one response modality. The current Developer API Live models are native-audio and require `AUDIO` (enable output audio transcription to also get text); text-only output needs a half-cascade model. Input audio is 16 kHz, output audio 24 kHz, raw 16-bit little-endian PCM.

The three public types are marked `@Experimental` so the shape can still be refined from review feedback. The change adds no new dependencies — the module already uses the `com.google.genai` SDK.

## Example

```java
GoogleGenAiLiveModel model = GoogleGenAiLiveModel.builder()
    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
    .modelName("gemini-2.5-flash-native-audio-latest")
    .responseModalities("AUDIO")
    .voiceName("Puck")
    .outputAudioTranscription(true)
    .build();

try (GoogleGenAiLiveSession session = model.connect(new GoogleGenAiLiveResponseHandler() {
    public void onAudio(byte[] pcm) { /* play the 24 kHz PCM */ }
    public void onOutputTranscription(String text) { System.out.print(text); }
})) {
    session.sendText("Say hello in one short sentence.");
    // ... handle events until onTurnComplete
}
```

## Tests

- Offline unit — 24 tests (`mvn -pl langchain4j-google-genai test`): dispatch routing (text, audio, transcription, interruption, usage, go-away, resumption, generation/turn completion ordering, and multiple fields per message), config building + the exactly-one-modality validation + `liveConnectConfig` passthrough precedence, and session send/close/validation.
- Key-gated IT `GoogleGenAiLiveModelIT` (skipped in CI): a live session against `gemini-2.5-flash-native-audio-latest` — sends a text turn, asserts audio chunks, an output transcript and turn completion. Run and verified end to end against the live API.
- `mvn -pl langchain4j-google-genai verify` green (Spotless + revapi). The change is additive; the module's existing `revapi.json` already covers the exposed SDK types.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) — planned as a follow-up
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) — not applicable

## Roadmap

Delivered as a short series, foundation first — this PR is the base the rest extend. The follow-ups are in progress and will be opened as drafts shortly.
1. This PR — session API + text and audio conversation.
2. Function/tool calling, video input, and manual voice-activity detection — *in progress*.
3. Session management (resumption), Live Translation, and other advanced options — *in progress*.

Part of #4310