### PR TITLE
fix: make Utils.merge null-safe and never return null

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -687,17 +687,11 @@ public class Utils {
             throw new IllegalArgumentException("lists must have at least 2 elements");
         }
 
-        if (lists.length == 2) {
-            if (lists[0] == null || lists[0].isEmpty()) {
-                return lists[1];
-            } else if (lists[1] == null || lists[1].isEmpty()) {
-                return lists[0];
-            }
-        }
-
         List<T> result = new ArrayList<>();
         for (List<T> list : lists) {
-            result.addAll(list);
+            if (list != null) {
+                result.addAll(list);
+            }
         }
         return result;
     }
@@ -707,16 +701,11 @@ public class Utils {
             throw new IllegalArgumentException("maps must have at least 2 elements");
         }
 
-        if (maps.length == 2) {
-            if (maps[0] == null || maps[0].isEmpty()) {
-                return maps[1];
-            } else if (maps[1] == null || maps[1].isEmpty()) {
-                return maps[0];
-            }
-        }
-
         Map<K, V> result = new HashMap<>();
         for (Map<K, V> map : maps) {
+            if (map == null) {
+                continue;
+            }
             for (Map.Entry<K, V> e : map.entrySet()) {
                 if (result.putIfAbsent(e.getKey(), e.getValue()) != null) {
                     throw new IllegalArgumentException("Duplicate key: " + e.getKey());

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -519,9 +519,24 @@ class UtilsTest {
         assertThat(merge(List.of(), List.of(2))).isEqualTo(List.of(2));
         assertThat(merge(List.of(), List.of())).isEqualTo(List.of());
 
+        // more than two lists
+        assertThat(merge(List.of(1), List.of(2), List.of(3))).isEqualTo(List.of(1, 2, 3));
+
         assertThatThrownBy(() -> merge(List.of()))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("at least 2 elements");
+    }
+
+    @Test
+    void test_merge_lists_is_null_safe() {
+        // null lists are treated as empty, for any number of arguments
+        assertThat(merge(null, List.of(2))).isEqualTo(List.of(2));
+        assertThat(merge(List.of(1), null)).isEqualTo(List.of(1));
+        assertThat(merge(List.of(1), null, List.of(3))).isEqualTo(List.of(1, 3));
+
+        // never returns null, even when every list is null or empty
+        assertThat(merge((List<Integer>) null, null)).isNotNull().isEmpty();
+        assertThat(merge(List.of(), (List<Integer>) null)).isNotNull().isEmpty();
     }
 
     @Test
@@ -531,11 +546,27 @@ class UtilsTest {
         assertThat(merge(Map.of(), Map.of("two", 2))).isEqualTo(Map.of("two", 2));
         assertThat(merge(Map.of(), Map.of())).isEqualTo(Map.of());
 
+        // more than two maps
+        assertThat(merge(Map.of("one", 1), Map.of("two", 2), Map.of("three", 3)))
+                .isEqualTo(Map.of("one", 1, "two", 2, "three", 3));
+
         assertThatThrownBy(() -> merge(Map.of()))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("at least 2 elements");
         assertThatThrownBy(() -> merge(Map.of("one", 1), Map.of("one", 1)))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Duplicate key: one");
+    }
+
+    @Test
+    void test_merge_maps_is_null_safe() {
+        // null maps are treated as empty, for any number of arguments
+        assertThat(merge(null, Map.of("two", 2))).isEqualTo(Map.of("two", 2));
+        assertThat(merge(Map.of("one", 1), null)).isEqualTo(Map.of("one", 1));
+        assertThat(merge(Map.of("one", 1), null, Map.of("three", 3))).isEqualTo(Map.of("one", 1, "three", 3));
+
+        // never returns null, even when every map is null or empty
+        assertThat(merge((Map<String, Integer>) null, null)).isNotNull().isEmpty();
+        assertThat(merge(Map.of(), (Map<String, Integer>) null)).isNotNull().isEmpty();
     }
 }


### PR DESCRIPTION
## Issue
Closes #5816

## Problem
`Utils.merge(List...)` and `Utils.merge(Map...)` in `langchain4j-core` handled `null` inputs inconsistently:

- **3+ arguments with a `null` element threw `NullPointerException`**, even though the 2-argument fast path explicitly tolerated `null`.
- **`merge` could return `null`** — e.g. `merge(List.of(), null)` returned the `null` argument, which is a latent NPE for callers and inconsistent with the empty collections returned in every other case.

The existing tests only covered non-null inputs, so this behavior was unspecified.

## Fix
Both overloads now treat `null` inputs as empty **uniformly, for any number of arguments**, and always return a non-null merged collection. This also removes the special-case fast path, so the behavior no longer depends on argument count.

Existing behavior is preserved:
- results contain the merged elements in order,
- the `< 2 arguments` guard still throws `IllegalArgumentException`,
- the `Map` overload still rejects duplicate keys.

## Tests
Added positive and negative cases to `UtilsTest`:
- 3+ argument merges,
- `null` arguments in any position,
- never returns `null` when all inputs are null/empty.

Verified fail-without-fix / pass-with-fix, and the full `langchain4j-core` suite passes (`mvn -pl langchain4j-core clean test` → 1194 tests, 0 failures). Ran `./mvnw spotless:apply` + `spotless:check` on the changed files.