### PR TITLE
docs(agentic): remove invalid executor() from async sequence example

### DIFF
--- a/docs/docs/tutorials/agents.md
+++ b/docs/docs/tutorials/agents.md
@@ -561,7 +561,7 @@ By default, all agents invocations are performed in the same thread that invoked
 
 For this reason it is possible to flag an agent as asynchronous using the `async` method of the agent builder. When doing so, the invocation of that agent is performed in a separate thread, and the execution of the agentic system will proceed without waiting for the completion of that agent. The result of the asynchronous agent will be available in the `AgenticScope` as soon as it is completed, and the `AgenticScope` will be blocked waiting for that result only when it is required as an input for a subsequent invocation of a different agent.
 
-For instance, since they are independent of each other, flagging the `FoodExpert` and `MovieExpert` agents, discussed in the parallel workflow section, as asynchronous, will make them to be executed at the same time even when used in a sequential workflow.
+For instance, since they are independent of each other, flagging the `FoodExpert` and `MovieExpert` agents, discussed in the parallel workflow section, as asynchronous with `.async(true)` on each sub-agent, will make them to be executed at the same time even when used in a sequential workflow. Unlike `parallelBuilder()`, `sequenceBuilder()` has no `executor()` method; the optional `executor()` belongs on parallel workflows only.
 
 ```java
 FoodExpert foodExpert = AgenticServices
@@ -581,7 +581,6 @@ MovieExpert movieExpert = AgenticServices
 EveningPlannerAgent eveningPlannerAgent = AgenticServices
         .sequenceBuilder(EveningPlannerAgent.class)
         .subAgents(foodExpert, movieExpert)
-        .executor(Executors.newFixedThreadPool(2))
         .outputKey("plans")
         .output(agenticScope -> {
             List<String> movies = agenticScope.readState("movies", List.of());


### PR DESCRIPTION
## Issue
Fixes #5840

## Change
The "Asynchronous agents" tutorial example used `AgenticServices.sequenceBuilder(...).executor(...)`, but `SequentialAgentService` does not expose `executor()` (unlike `ParallelAgentService` used with `parallelBuilder()`).

- Removed the invalid `.executor(Executors.newFixedThreadPool(2))` line from the `sequenceBuilder` example in `docs/docs/tutorials/agents.md`.
- Clarified in the surrounding prose that async behavior is configured with `.async(true)` on sub-agents, and that `executor()` applies to parallel workflows only.

Parallel workflow examples that legitimately use `.executor(...)` on `parallelBuilder()` / `parallelMapperBuilder()` are unchanged.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change (docs-only fix)
- [ ] The tests cover both positive and negative cases (N/A)
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (N/A — documentation only)
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green (N/A — documentation only)
- [X] I have added/updated the documentation
- [ ] I have added an example in the examples repo (N/A)
- [ ] I have added/updated Spring Boot starter(s) (N/A)

## Test plan
- [X] Reviewed the diff in `docs/docs/tutorials/agents.md`
- [X] Confirmed the async `sequenceBuilder` example no longer references `executor()`
- [X] Confirmed parallel workflow examples still correctly document `.executor(...)` on `parallelBuilder()`


Made with [Cursor](https://cursor.com)