### PR TITLE
fix: parse "reasoning" as an alias for "reasoning_content" in OpenAI chat responses

### DIFF
--- a/langchain4j-open-ai/revapi.json
+++ b/langchain4j-open-ai/revapi.json
@@ -98,6 +98,16 @@
           "code": "java.class.externalClassExposedInAPI",
           "new": "missing-class dev.langchain4j.model.audio.TextToSpeechResponse",
           "justification": "TextToSpeechResponse is intentionally exposed by OpenAiTextToSpeechModel because it implements the core TextToSpeechModel API"
+        },
+        {
+          "code": "java.annotation.added",
+          "new": "method dev.langchain4j.model.openai.internal.chat.AssistantMessage.Builder dev.langchain4j.model.openai.internal.chat.AssistantMessage.Builder::reasoningContent(java.lang.String)",
+          "justification": "@JsonAlias only widens deserialization to also accept the \"reasoning\" field name returned by current vLLM, OpenRouter and Groq; serialization and the Java API are unchanged"
+        },
+        {
+          "code": "java.annotation.added",
+          "new": "method dev.langchain4j.model.openai.internal.chat.Delta.Builder dev.langchain4j.model.openai.internal.chat.Delta.Builder::reasoningContent(java.lang.String)",
+          "justification": "@JsonAlias only widens deserialization to also accept the \"reasoning\" field name returned by current vLLM, OpenRouter and Groq; serialization and the Java API are unchanged"
         }
       ]
     }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/AssistantMessage.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/AssistantMessage.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.openai.internal.chat;
 
+import static dev.langchain4j.model.openai.internal.chat.Role.ASSISTANT;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -11,15 +16,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import static dev.langchain4j.model.openai.internal.chat.Role.ASSISTANT;
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
 
 @JsonDeserialize(builder = AssistantMessage.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -28,19 +28,26 @@ public final class AssistantMessage implements Message {
 
     @JsonProperty
     private final Role role = ASSISTANT;
+
     @JsonProperty
     private final String content;
+
     @JsonProperty
     private final String reasoningContent;
+
     @JsonProperty
     private final String name;
+
     @JsonProperty
     private final List<ToolCall> toolCalls;
+
     @JsonProperty
     private final String refusal;
+
     @JsonProperty
     @Deprecated
     private final FunctionCall functionCall;
+
     @JsonIgnore
     private final Map<String, Object> customParameters;
 
@@ -93,8 +100,7 @@ public final class AssistantMessage implements Message {
     @JacocoIgnoreCoverageGenerated
     public boolean equals(Object another) {
         if (this == another) return true;
-        return another instanceof AssistantMessage
-                && equalTo((AssistantMessage) another);
+        return another instanceof AssistantMessage && equalTo((AssistantMessage) another);
     }
 
     @JacocoIgnoreCoverageGenerated
@@ -140,9 +146,7 @@ public final class AssistantMessage implements Message {
     }
 
     public static AssistantMessage from(String content) {
-        return AssistantMessage.builder()
-                .content(content)
-                .build();
+        return AssistantMessage.builder().content(content).build();
     }
 
     public static Builder builder() {
@@ -159,8 +163,10 @@ public final class AssistantMessage implements Message {
         private String name;
         private List<ToolCall> toolCalls;
         private String refusal;
+
         @Deprecated
         private FunctionCall functionCall;
+
         private Map<String, Object> customParameters;
 
         public Builder content(String content) {
@@ -168,6 +174,7 @@ public final class AssistantMessage implements Message {
             return this;
         }
 
+        @JsonAlias("reasoning")
         public Builder reasoningContent(String reasoningContent) {
             this.reasoningContent = reasoningContent;
             return this;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.model.openai.internal.chat;
 
+import static java.util.Collections.unmodifiableList;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,11 +11,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
 import java.util.List;
 import java.util.Objects;
-
-import static java.util.Collections.unmodifiableList;
 
 @JsonDeserialize(builder = Delta.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -21,12 +21,16 @@ public final class Delta {
 
     @JsonProperty
     private final String role;
+
     @JsonProperty
     private final String content;
+
     @JsonProperty
     private final String reasoningContent;
+
     @JsonProperty
     private final List<ToolCall> toolCalls;
+
     @JsonProperty
     @Deprecated
     private final FunctionCall functionCall;
@@ -64,8 +68,7 @@ public final class Delta {
     @JacocoIgnoreCoverageGenerated
     public boolean equals(Object another) {
         if (this == another) return true;
-        return another instanceof Delta
-                && equalTo((Delta) another);
+        return another instanceof Delta && equalTo((Delta) another);
     }
 
     @JacocoIgnoreCoverageGenerated
@@ -114,6 +117,7 @@ public final class Delta {
         private String content;
         private String reasoningContent;
         private List<ToolCall> toolCalls;
+
         @Deprecated
         private FunctionCall functionCall;
 
@@ -127,6 +131,7 @@ public final class Delta {
             return this;
         }
 
+        @JsonAlias("reasoning")
         public Builder reasoningContent(String reasoningContent) {
             this.reasoningContent = reasoningContent;
             return this;

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/ChatCompletionResponseDeserializeTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/ChatCompletionResponseDeserializeTest.java
@@ -2,8 +2,10 @@ package dev.langchain4j.model.openai.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.model.openai.internal.chat.AssistantMessage;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
+import dev.langchain4j.model.openai.internal.chat.Delta;
 import dev.langchain4j.model.openai.internal.chat.ToolCall;
 import org.junit.jupiter.api.Test;
 
@@ -55,5 +57,137 @@ class ChatCompletionResponseDeserializeTest {
         ChatCompletionChoice chatCompletionChoice = response.choices().get(0);
         ToolCall toolCall = chatCompletionChoice.delta().toolCalls().get(0);
         assertThat(toolCall.function().arguments()).isEqualTo("{\"");
+    }
+
+    @Test
+    void should_deserialize_message_with_reasoning_content_field() {
+
+        // given
+        String json = """
+                {
+                    "id": "chatcmpl-123",
+                    "object": "chat.completion",
+                    "created": 1742268380,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "4",
+                                "reasoning_content": "2 + 2 = 4"
+                            },
+                            "finish_reason": "stop"
+                        }
+                    ]
+                }
+                """;
+
+        // when
+        ChatCompletionResponse response = Json.fromJson(json, ChatCompletionResponse.class);
+
+        // then
+        AssistantMessage message = response.choices().get(0).message();
+        assertThat(message.content()).isEqualTo("4");
+        assertThat(message.reasoningContent()).isEqualTo("2 + 2 = 4");
+    }
+
+    @Test
+    void should_deserialize_message_with_reasoning_field() {
+
+        // given
+        // vLLM >= 0.10 and OpenRouter return the reasoning text in a "reasoning" field
+        // instead of "reasoning_content": https://github.com/langchain4j/langchain4j/issues/4796
+        String json = """
+                {
+                    "id": "chatcmpl-123",
+                    "object": "chat.completion",
+                    "created": 1742268380,
+                    "model": "qwen3",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "4",
+                                "reasoning": "2 + 2 = 4"
+                            },
+                            "finish_reason": "stop"
+                        }
+                    ]
+                }
+                """;
+
+        // when
+        ChatCompletionResponse response = Json.fromJson(json, ChatCompletionResponse.class);
+
+        // then
+        AssistantMessage message = response.choices().get(0).message();
+        assertThat(message.content()).isEqualTo("4");
+        assertThat(message.reasoningContent()).isEqualTo("2 + 2 = 4");
+    }
+
+    @Test
+    void should_deserialize_delta_with_reasoning_field() {
+
+        // given
+        String json = """
+                {
+                    "id": "chatcmpl-123",
+                    "object": "chat.completion.chunk",
+                    "created": 1742268380,
+                    "model": "qwen3",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "content": null,
+                                "reasoning": "2 + 2"
+                            },
+                            "finish_reason": null
+                        }
+                    ]
+                }
+                """;
+
+        // when
+        ChatCompletionResponse response = Json.fromJson(json, ChatCompletionResponse.class);
+
+        // then
+        Delta delta = response.choices().get(0).delta();
+        assertThat(delta.content()).isNull();
+        assertThat(delta.reasoningContent()).isEqualTo("2 + 2");
+    }
+
+    @Test
+    void should_deserialize_message_without_reasoning_fields() {
+
+        // given
+        String json = """
+                {
+                    "id": "chatcmpl-123",
+                    "object": "chat.completion",
+                    "created": 1742268380,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "4"
+                            },
+                            "finish_reason": "stop"
+                        }
+                    ]
+                }
+                """;
+
+        // when
+        ChatCompletionResponse response = Json.fromJson(json, ChatCompletionResponse.class);
+
+        // then
+        AssistantMessage message = response.choices().get(0).message();
+        assertThat(message.content()).isEqualTo("4");
+        assertThat(message.reasoningContent()).isNull();
     }
 }


### PR DESCRIPTION
## Issue
Closes #4796

## Change

Current vLLM returns the reasoning text of its OpenAI-compatible chat responses in a `reasoning` field rather than `reasoning_content`, and it's not just vLLM. OpenAI's own guidance for serving gpt-oss recommends `reasoning` on chat completions responses, which is what prompted the vLLM rename (vllm-project/vllm#27755). OpenRouter and Groq already use `reasoning`, and SGLang is planning the same migration (sgl-project/sglang#18219). `reasoning_content` came from DeepSeek and is still what their API, llama.cpp and others return, so clients realistically need to read both names for the foreseeable future.

Right now the module only parses `reasoning_content`, so `returnThinking(true)` quietly returns null thinking against any of the `reasoning` backends. Setting `thinkingFieldName` doesn't help because it only affects how thinking is serialized back into request messages, not response parsing.

This adds `@JsonAlias("reasoning")` on the `reasoningContent` builder setters of `AssistantMessage` and `Delta`, so both field names deserialize into `reasoningContent`. Serialization is untouched, requests on the wire don't change, and `reasoning_content` keeps working as before. Same approach that was suggested in the review of #5018 before that PR was closed.

Besides the unit tests I verified both models manually against a live vLLM v0.25.1 server running a Qwen3.5 reasoning model: before the change `thinking()` is null for `OpenAiChatModel` and `onPartialThinking` never fires for the streaming model, after the change both come through.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
