### PR TITLE
fix: return empty collection from parallel mapper agent on empty input

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/workflow/impl/ParallelMapperPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/workflow/impl/ParallelMapperPlanner.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.agentic.workflow.impl;
 
+import static java.util.Arrays.copyOf;
+
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.MapperAgentInvoker;
 import dev.langchain4j.agentic.planner.Action;
@@ -12,8 +14,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static java.util.Arrays.copyOf;
 
 public class ParallelMapperPlanner implements Planner {
 
@@ -49,7 +49,7 @@ public class ParallelMapperPlanner implements Planner {
         List<?> items = collectItems(collectionObj);
 
         if (items.isEmpty()) {
-            return done();
+            return doneWithResults(planningContext, new ArrayList<>());
         }
 
         this.itemCount = items.size();
@@ -89,13 +89,17 @@ public class ParallelMapperPlanner implements Planner {
                 results.add(planningContext.agenticScope().readState(resultKeyPrefix + "_" + i));
                 planningContext.agenticScope().writeState(resultKeyPrefix + "_" + i, null);
             }
-            Object result = isArrayResult ? copyOf(results.toArray(), results.size(), arrayclass) : results;
-            if (outputKey != null && !outputKey.isBlank()) {
-                planningContext.agenticScope().writeState(outputKey, result);
-            }
-            return done(result);
+            return doneWithResults(planningContext, results);
         }
         return done();
+    }
+
+    private Action doneWithResults(PlanningContext planningContext, List<Object> results) {
+        Object result = isArrayResult ? copyOf(results.toArray(), results.size(), arrayclass) : results;
+        if (outputKey != null && !outputKey.isBlank()) {
+            planningContext.agenticScope().writeState(outputKey, result);
+        }
+        return done(result);
     }
 
     @Override

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/workflow/impl/ParallelMapperPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/workflow/impl/ParallelMapperPlanner.java
@@ -49,7 +49,7 @@ public class ParallelMapperPlanner implements Planner {
         List<?> items = collectItems(collectionObj);
 
         if (items.isEmpty()) {
-            return doneWithResults(planningContext, new ArrayList<>());
+            return doneWithResults(planningContext, List.of());
         }
 
         this.itemCount = items.size();

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ParallelMapperEmptyInputTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ParallelMapperEmptyInputTest.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ParallelMapperEmptyInputTest {
+
+    static final ChatModel DUMMY_MODEL = new ChatModel() {
+        @Override
+        public ChatResponse chat(ChatRequest chatRequest) {
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("test-response"))
+                    .build();
+        }
+    };
+
+    public interface ItemAgent {
+
+        @UserMessage("Map: {{item}}")
+        @Agent(description = "Maps a single item", outputKey = "mapped")
+        String map(@V("item") String item);
+    }
+
+    public interface ListReturningMapperAgent {
+
+        @Agent(outputKey = "mappedItems")
+        List<String> mapAll(@V("items") List<String> items);
+    }
+
+    public interface ArrayReturningMapperAgent {
+
+        @Agent
+        String[] mapAll(@V("items") String... items);
+    }
+
+    @Test
+    void empty_list_is_mapped_to_empty_list() {
+        assertThat(listMapper().mapAll(List.of())).isNotNull().isEmpty();
+    }
+
+    @Test
+    void non_empty_list_is_mapped_item_by_item() {
+        assertThat(listMapper().mapAll(List.of("first", "second"))).containsExactly("test-response", "test-response");
+    }
+
+    @Test
+    void empty_array_is_mapped_to_empty_array() {
+        assertThat(arrayMapper().mapAll()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void non_empty_array_is_mapped_item_by_item() {
+        assertThat(arrayMapper().mapAll("first", "second")).containsExactly("test-response", "test-response");
+    }
+
+    private static ListReturningMapperAgent listMapper() {
+        return AgenticServices.parallelMapperBuilder(ListReturningMapperAgent.class)
+                .subAgents(itemAgent())
+                .build();
+    }
+
+    private static ArrayReturningMapperAgent arrayMapper() {
+        return AgenticServices.parallelMapperBuilder(ArrayReturningMapperAgent.class)
+                .subAgents(itemAgent())
+                .build();
+    }
+
+    private static ItemAgent itemAgent() {
+        return AgenticServices.agentBuilder(ItemAgent.class)
+                .chatModel(DUMMY_MODEL)
+                .outputKey("mapped")
+                .build();
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5846

## Change

`ParallelMapperPlanner.firstAction()` returned a bare `done()` when the input collection was empty, so the agent returned `null`. The normal path, `nextAction()`, builds a list (or array), writes it to `outputKey`, and returns `done(result)`.

The result assembly moved into a private helper shared by both exit paths, so an empty input now yields an empty `List` or zero-length array, written to `outputKey`.

```java
if (items.isEmpty()) {
    return doneWithResults(planningContext, new ArrayList<>());
}
```

- The `collectionObj == null` branch is untouched: a missing state key means "no input at all", a separate question from "empty input".
- Returning an empty collection instead of `null` is a behaviour change. For a typed mapper without an `@Output` method, `ParallelMapperServiceImpl.isArrayResult()` already rejects any return type that is not a `Collection` or an array, so `null` was never a valid result — this restores the contract.

## Build/test notes

`ParallelMapperEmptyInputTest` covers list and array return types (the array path goes through `Arrays.copyOf`), empty and non-empty. The two empty-input tests fail on `main` and pass here.

`./mvnw -pl langchain4j-agentic -am clean test`: 91 tests green. `*IT` classes need API keys and were not run.

`ParallelMapperPlanner.java` predates the Palantir format, so `spotless:apply` also moves its existing static import to the top. Included because `spotless:check` fails without it.

## General checklist
- [ ] There are no breaking changes (API, behaviour) — no API change; behaviour changes from `null` to an empty collection on empty input, which is the fix itself (see above)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green — unit tests green (91 tests in `langchain4j-agentic`); `*IT` not run locally, they need API keys
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green — unit tests only, via `./mvnw -pl langchain4j-agentic -am clean test`
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


