### PR TITLE
fix: Complete A2A response future when the stream ends without a result

### DIFF
--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
@@ -232,14 +232,7 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
                         new IllegalArgumentException("The event expected should be of type " + event.getClass()));
             }
         });
-        Consumer<Throwable> streamingErrorHandler = error -> {
-            if (messageResponse.isDone()) {
-                LOG.debug("SSE stream closed after response received: {}", error.getMessage());
-            } else {
-                LOG.error("Streaming error occurred: {}", error.getMessage(), error);
-                messageResponse.completeExceptionally(error);
-            }
-        };
+        Consumer<Throwable> streamingErrorHandler = error -> handleStreamEnd(error, messageResponse);
         a2aClient.sendMessage(message, consumers, streamingErrorHandler, null);
 
         String finalContextIdKey = contextIdKey;
@@ -263,6 +256,24 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
     private static void captureTaskIds(Task task, AtomicReference<String> contextId, AtomicReference<String> taskId) {
         contextId.set(task.contextId());
         taskId.set(task.id());
+    }
+
+    static void handleStreamEnd(Throwable error, CompletableFuture<String> messageResponse) {
+        if (error == null) {
+            // The A2A SDK reports a normal end of the stream by passing a null error.
+            LOG.debug("SSE stream closed normally");
+            if (!messageResponse.isDone()) {
+                messageResponse.completeExceptionally(
+                        new RuntimeException("A2A stream closed before a result was received"));
+            }
+            return;
+        }
+        if (messageResponse.isDone()) {
+            LOG.debug("SSE stream closed after response received: {}", error.getMessage());
+        } else {
+            LOG.error("Streaming error occurred: {}", error.getMessage(), error);
+            messageResponse.completeExceptionally(error);
+        }
     }
 
     static void completeFromTask(Task task, CompletableFuture<String> messageResponse) {

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
@@ -91,4 +91,47 @@ class DefaultA2AClientBuilderTest {
         assertThat(future).isCompleted();
         assertThat(future.get()).isEmpty();
     }
+
+    @Test
+    void handleStreamEnd_streamEndsWithoutResult_completesExceptionally() {
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        DefaultA2AClientBuilder.handleStreamEnd(null, future);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get)
+                .hasCauseInstanceOf(RuntimeException.class)
+                .hasMessageContaining("A2A stream closed before a result was received");
+    }
+
+    @Test
+    void handleStreamEnd_streamEndsAfterResult_keepsResult() throws Exception {
+        CompletableFuture<String> future = CompletableFuture.completedFuture("the answer");
+
+        DefaultA2AClientBuilder.handleStreamEnd(null, future);
+
+        assertThat(future).isCompleted();
+        assertThat(future.get()).isEqualTo("the answer");
+    }
+
+    @Test
+    void handleStreamEnd_errorBeforeResult_completesExceptionallyWithThatError() {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        RuntimeException error = new RuntimeException("connection reset");
+
+        DefaultA2AClientBuilder.handleStreamEnd(error, future);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get).hasCause(error);
+    }
+
+    @Test
+    void handleStreamEnd_errorAfterResult_keepsResult() throws Exception {
+        CompletableFuture<String> future = CompletableFuture.completedFuture("the answer");
+
+        DefaultA2AClientBuilder.handleStreamEnd(new RuntimeException("connection reset"), future);
+
+        assertThat(future).isCompleted();
+        assertThat(future.get()).isEqualTo("the answer");
+    }
 }


### PR DESCRIPTION
## Issue
Closes #5849

## Change

On the streaming path, the A2A SDK calls the `DefaultA2AClientBuilder` error handler with `null` to report a normal end of the stream (`SSEEventListener.onComplete()`: *"null error means successful completion"*), but the handler dereferenced its argument unconditionally. If the stream ended before any event completed the response future, the resulting `NullPointerException` skipped `completeExceptionally(error)`, and `messageResponse.get()`, which has no timeout, blocked forever.

The lambda moved into a package-private static `handleStreamEnd(...)` — the seam `completeFromTask` already uses — where a `null` error now completes a still-pending future with a `RuntimeException`. Non-null errors are handled as before, and the non-streaming path never invokes this handler.

```java
static void handleStreamEnd(Throwable error, CompletableFuture<String> messageResponse) {
    if (error == null) { // the SDK signals a normal end of the stream
        LOG.debug("SSE stream closed normally");
        if (!messageResponse.isDone()) {
            messageResponse.completeExceptionally(
                    new RuntimeException("A2A stream closed before a result was received"));
        }
        return;
    }
    // unchanged: log, and complete exceptionally if still pending
}
```

Four tests cover the new method: a `null` and a non-null error against a pending and a completed future.

Follow-up: interrupted task states (`input-required`, `auth-required`) go in a separate PR that delays completion further, so this one should land first.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green

Testing: `langchain4j-agentic-a2a` (12 tests), `langchain4j-core` (1198) and `langchain4j` (1270) are green. Integration tests were not run — `A2AAgentIT` needs a running A2A server.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A — bug fix with no user-facing API change; docs are added after review if requested. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — not a feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no Spring Boot starter covers this module. -->

<!-- The conditional "new maven module" and "embedding store integration" sections are omitted — neither applies to this PR. -->

