### PR TITLE
Introduce `MistralAiChatRequestParameters` for per-request overrides

### DIFF
--- a/docs/docs/integrations/language-models/mistral-ai.md
+++ b/docs/docs/integrations/language-models/mistral-ai.md
@@ -414,6 +414,33 @@ Toggling the safe prompt will prepend your messages with the following `@SystemM
 Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity.
 ```
 
+### Per-Request Parameters
+
+The Mistral-specific options (`safePrompt`, `randomSeed`, `sendThinking` and `returnThinking`) can also be
+set per request via `MistralAiChatRequestParameters`, overriding the values configured on the model builder.
+This lets a single shared model instance vary these options from one call to the next — for example, enabling
+`safePrompt` for one request but not another, or setting a `randomSeed` for a reproducible completion, without
+building a second model:
+
+```java
+ChatModel model = MistralAiChatModel.builder()
+        .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+        .modelName("mistral-small-latest")
+        .build();
+
+MistralAiChatRequestParameters parameters = MistralAiChatRequestParameters.builder()
+        .safePrompt(true)
+        .randomSeed(42)
+        .build();
+
+ChatRequest chatRequest = ChatRequest.builder()
+        .messages(UserMessage.from("What is the best French cheese?"))
+        .parameters(parameters)
+        .build();
+
+ChatResponse chatResponse = model.chat(chatRequest);
+```
+
 ## Thinking / Reasoning
 
 Both `MistralAiChatModel` and `MistralAiStreamingChatModel` support

--- a/langchain4j-mistral-ai/revapi.json
+++ b/langchain4j-mistral-ai/revapi.json
@@ -28,6 +28,18 @@
           "code": "java.class.externalClassExposedInAPI",
           "new": "missing-class dev.langchain4j.model.batch.BatchResponse",
           "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by MistralAiBatchChatModel"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.chat.request.ChatRequestParameters dev.langchain4j.model.mistralai.MistralAiChatModel::defaultRequestParameters()",
+          "new": "method dev.langchain4j.model.mistralai.MistralAiChatRequestParameters dev.langchain4j.model.mistralai.MistralAiChatModel::defaultRequestParameters()",
+          "justification": "Narrowing the return type to the Mistral-specific MistralAiChatRequestParameters subtype is source- and binary-compatible"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.chat.request.ChatRequestParameters dev.langchain4j.model.mistralai.MistralAiStreamingChatModel::defaultRequestParameters()",
+          "new": "method dev.langchain4j.model.mistralai.MistralAiChatRequestParameters dev.langchain4j.model.mistralai.MistralAiStreamingChatModel::defaultRequestParameters()",
+          "justification": "Narrowing the return type to the Mistral-specific MistralAiChatRequestParameters subtype is source- and binary-compatible"
         }
       ]
     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
@@ -43,15 +43,11 @@ import org.slf4j.Logger;
 public class MistralAiChatModel implements ChatModel {
 
     private final MistralAiClient client;
-    private final Boolean safePrompt;
-    private final Integer randomSeed;
-    private final boolean returnThinking;
-    private final boolean sendThinking;
     private final Integer maxRetries;
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
     private final boolean strictJsonSchema;
-    private final ChatRequestParameters defaultRequestParameters;
+    private final MistralAiChatRequestParameters defaultRequestParameters;
 
     public MistralAiChatModel(MistralAiChatModelBuilder builder) {
         this.client = MistralAiClient.builder()
@@ -65,10 +61,6 @@ public class MistralAiChatModel implements ChatModel {
                 .customHeaders(builder.customHeadersSupplier)
                 .build();
 
-        this.safePrompt = builder.safePrompt;
-        this.randomSeed = builder.randomSeed;
-        this.returnThinking = getOrDefault(builder.returnThinking, false);
-        this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
@@ -76,7 +68,7 @@ public class MistralAiChatModel implements ChatModel {
         this.defaultRequestParameters = initDefaultRequestParameters(builder);
     }
 
-    private ChatRequestParameters initDefaultRequestParameters(MistralAiChatModelBuilder builder) {
+    private MistralAiChatRequestParameters initDefaultRequestParameters(MistralAiChatModelBuilder builder) {
         ChatRequestParameters commonParameters;
         if (builder.defaultRequestParameters != null) {
             validate(builder.defaultRequestParameters);
@@ -85,7 +77,10 @@ public class MistralAiChatModel implements ChatModel {
             commonParameters = DefaultChatRequestParameters.EMPTY;
         }
 
-        return DefaultChatRequestParameters.builder()
+        MistralAiChatRequestParameters mistralParameters =
+                commonParameters instanceof MistralAiChatRequestParameters m ? m : MistralAiChatRequestParameters.EMPTY;
+
+        return MistralAiChatRequestParameters.builder()
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -96,15 +91,25 @@ public class MistralAiChatModel implements ChatModel {
                 .toolSpecifications(commonParameters.toolSpecifications())
                 .toolChoice(commonParameters.toolChoice())
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+                .safePrompt(getOrDefault(builder.safePrompt, mistralParameters.safePrompt()))
+                .randomSeed(getOrDefault(builder.randomSeed, mistralParameters.randomSeed()))
+                .sendThinking(getOrDefault(builder.sendThinking, mistralParameters.sendThinking()))
+                .returnThinking(getOrDefault(builder.returnThinking, mistralParameters.returnThinking()))
                 .build();
     }
 
     @Override
     public ChatResponse doChat(ChatRequest chatRequest) {
-        validate(chatRequest.parameters());
+        MistralAiChatRequestParameters parameters = (MistralAiChatRequestParameters) chatRequest.parameters();
+        validate(parameters);
 
-        MistralAiChatCompletionRequest request =
-                createMistralAiRequest(chatRequest, safePrompt, randomSeed, false, sendThinking, strictJsonSchema);
+        MistralAiChatCompletionRequest request = createMistralAiRequest(
+                chatRequest,
+                parameters.safePrompt(),
+                parameters.randomSeed(),
+                false,
+                getOrDefault(parameters.sendThinking(), false),
+                strictJsonSchema);
 
         ParsedAndRawResponse<MistralAiChatCompletionResponse> response =
                 withRetryMappingExceptions(() -> client.chatCompletionWithRawResponse(request), maxRetries);
@@ -112,7 +117,7 @@ public class MistralAiChatModel implements ChatModel {
         MistralAiChatCompletionResponse mistralAiResponse = response.parsedResponse();
 
         return ChatResponse.builder()
-                .aiMessage(aiMessageFrom(mistralAiResponse, returnThinking))
+                .aiMessage(aiMessageFrom(mistralAiResponse, getOrDefault(parameters.returnThinking(), false)))
                 .metadata(MistralAiChatResponseMetadata.builder()
                         .id(mistralAiResponse.getId())
                         .modelName(mistralAiResponse.getModel())
@@ -125,7 +130,7 @@ public class MistralAiChatModel implements ChatModel {
     }
 
     @Override
-    public ChatRequestParameters defaultRequestParameters() {
+    public MistralAiChatRequestParameters defaultRequestParameters() {
         return defaultRequestParameters;
     }
 

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatRequestParameters.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatRequestParameters.java
@@ -1,0 +1,192 @@
+package dev.langchain4j.model.mistralai;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import java.util.Objects;
+
+/**
+ * Mistral AI specific {@link ChatRequestParameters}.
+ * <p>
+ * In addition to the common {@link ChatRequestParameters}, this class exposes the Mistral AI specific
+ * options ({@code safePrompt}, {@code randomSeed}, {@code sendThinking}, {@code returnThinking}) so that
+ * they can be overridden per {@link dev.langchain4j.model.chat.request.ChatRequest}, not only at model
+ * build time.
+ *
+ * @see MistralAiChatModel
+ * @see MistralAiStreamingChatModel
+ */
+public class MistralAiChatRequestParameters extends DefaultChatRequestParameters {
+
+    public static final MistralAiChatRequestParameters EMPTY =
+            MistralAiChatRequestParameters.builder().build();
+
+    private final Boolean safePrompt;
+    private final Integer randomSeed;
+    private final Boolean sendThinking;
+    private final Boolean returnThinking;
+
+    private MistralAiChatRequestParameters(Builder builder) {
+        super(builder);
+        this.safePrompt = builder.safePrompt;
+        this.randomSeed = builder.randomSeed;
+        this.sendThinking = builder.sendThinking;
+        this.returnThinking = builder.returnThinking;
+    }
+
+    /**
+     * @return whether to inject a safety prompt before all conversations (Mistral {@code safe_prompt}).
+     */
+    public Boolean safePrompt() {
+        return safePrompt;
+    }
+
+    /**
+     * @return the seed to use for random sampling (Mistral {@code random_seed}).
+     */
+    public Integer randomSeed() {
+        return randomSeed;
+    }
+
+    /**
+     * @return whether to send thinking/reasoning text to the LLM in follow-up requests.
+     */
+    public Boolean sendThinking() {
+        return sendThinking;
+    }
+
+    /**
+     * @return whether to parse and return the thinking/reasoning text from the API response
+     * inside {@link dev.langchain4j.data.message.AiMessage#thinking()}.
+     */
+    public Boolean returnThinking() {
+        return returnThinking;
+    }
+
+    @Override
+    public MistralAiChatRequestParameters overrideWith(ChatRequestParameters that) {
+        return MistralAiChatRequestParameters.builder()
+                .overrideWith(this)
+                .overrideWith(that)
+                .build();
+    }
+
+    @Override
+    public MistralAiChatRequestParameters defaultedBy(ChatRequestParameters that) {
+        return MistralAiChatRequestParameters.builder()
+                .overrideWith(that)
+                .overrideWith(this)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        MistralAiChatRequestParameters that = (MistralAiChatRequestParameters) o;
+        return Objects.equals(safePrompt, that.safePrompt)
+                && Objects.equals(randomSeed, that.randomSeed)
+                && Objects.equals(sendThinking, that.sendThinking)
+                && Objects.equals(returnThinking, that.returnThinking);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), safePrompt, randomSeed, sendThinking, returnThinking);
+    }
+
+    @Override
+    public String toString() {
+        return "MistralAiChatRequestParameters{" + "modelName="
+                + modelName() + ", temperature="
+                + temperature() + ", topP="
+                + topP() + ", topK="
+                + topK() + ", frequencyPenalty="
+                + frequencyPenalty() + ", presencePenalty="
+                + presencePenalty() + ", maxOutputTokens="
+                + maxOutputTokens() + ", stopSequences="
+                + stopSequences() + ", toolSpecifications="
+                + toolSpecifications() + ", toolChoice="
+                + toolChoice() + ", responseFormat="
+                + responseFormat() + ", safePrompt="
+                + safePrompt + ", randomSeed="
+                + randomSeed + ", sendThinking="
+                + sendThinking + ", returnThinking="
+                + returnThinking + '}';
+    }
+
+    public Builder toBuilder() {
+        return builder().overrideWith(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {
+
+        private Boolean safePrompt;
+        private Integer randomSeed;
+        private Boolean sendThinking;
+        private Boolean returnThinking;
+
+        @Override
+        public Builder overrideWith(ChatRequestParameters parameters) {
+            super.overrideWith(parameters);
+            if (parameters instanceof MistralAiChatRequestParameters mistralParameters) {
+                safePrompt(getOrDefault(mistralParameters.safePrompt(), safePrompt));
+                randomSeed(getOrDefault(mistralParameters.randomSeed(), randomSeed));
+                sendThinking(getOrDefault(mistralParameters.sendThinking(), sendThinking));
+                returnThinking(getOrDefault(mistralParameters.returnThinking(), returnThinking));
+            }
+            return this;
+        }
+
+        public Builder modelName(MistralAiChatModelName modelName) {
+            return super.modelName(modelName == null ? null : modelName.toString());
+        }
+
+        /**
+         * @param safePrompt whether to inject a safety prompt before all conversations (Mistral {@code safe_prompt}).
+         * @return {@code this}.
+         */
+        public Builder safePrompt(Boolean safePrompt) {
+            this.safePrompt = safePrompt;
+            return this;
+        }
+
+        /**
+         * @param randomSeed the seed to use for random sampling (Mistral {@code random_seed}).
+         * @return {@code this}.
+         */
+        public Builder randomSeed(Integer randomSeed) {
+            this.randomSeed = randomSeed;
+            return this;
+        }
+
+        /**
+         * @param sendThinking whether to send thinking/reasoning text to the LLM in follow-up requests.
+         * @return {@code this}.
+         */
+        public Builder sendThinking(Boolean sendThinking) {
+            this.sendThinking = sendThinking;
+            return this;
+        }
+
+        /**
+         * @param returnThinking whether to parse and return the thinking/reasoning text from the API response.
+         * @return {@code this}.
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        @Override
+        public MistralAiChatRequestParameters build() {
+            return new MistralAiChatRequestParameters(this);
+        }
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
@@ -40,14 +40,10 @@ import org.slf4j.Logger;
 public class MistralAiStreamingChatModel implements StreamingChatModel {
 
     private final MistralAiClient client;
-    private final Boolean safePrompt;
-    private final Integer randomSeed;
-    private final boolean returnThinking;
-    private final boolean sendThinking;
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
     private final boolean strictJsonSchema;
-    private final ChatRequestParameters defaultRequestParameters;
+    private final MistralAiChatRequestParameters defaultRequestParameters;
 
     @SuppressWarnings({"unchecked"})
     public MistralAiStreamingChatModel(MistralAiStreamingChatModelBuilder builder) {
@@ -61,17 +57,13 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
                 .logger(builder.logger)
                 .customHeaders(builder.customHeadersSupplier)
                 .build();
-        this.safePrompt = builder.safePrompt;
-        this.randomSeed = builder.randomSeed;
-        this.returnThinking = getOrDefault(builder.returnThinking, false);
-        this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
         this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
         this.defaultRequestParameters = initDefaultRequestParameters(builder);
     }
 
-    private ChatRequestParameters initDefaultRequestParameters(MistralAiStreamingChatModelBuilder builder) {
+    private MistralAiChatRequestParameters initDefaultRequestParameters(MistralAiStreamingChatModelBuilder builder) {
         ChatRequestParameters commonParameters;
         if (builder.defaultRequestParameters != null) {
             validate(builder.defaultRequestParameters);
@@ -80,7 +72,10 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
             commonParameters = DefaultChatRequestParameters.EMPTY;
         }
 
-        return DefaultChatRequestParameters.builder()
+        MistralAiChatRequestParameters mistralParameters =
+                commonParameters instanceof MistralAiChatRequestParameters m ? m : MistralAiChatRequestParameters.EMPTY;
+
+        return MistralAiChatRequestParameters.builder()
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -91,21 +86,31 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
                 .toolSpecifications(commonParameters.toolSpecifications())
                 .toolChoice(commonParameters.toolChoice())
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+                .safePrompt(getOrDefault(builder.safePrompt, mistralParameters.safePrompt()))
+                .randomSeed(getOrDefault(builder.randomSeed, mistralParameters.randomSeed()))
+                .sendThinking(getOrDefault(builder.sendThinking, mistralParameters.sendThinking()))
+                .returnThinking(getOrDefault(builder.returnThinking, mistralParameters.returnThinking()))
                 .build();
     }
 
     @Override
     public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
         ensureNotNull(handler, "handler");
-        validate(chatRequest.parameters());
+        MistralAiChatRequestParameters parameters = (MistralAiChatRequestParameters) chatRequest.parameters();
+        validate(parameters);
 
-        MistralAiChatCompletionRequest request =
-                createMistralAiRequest(chatRequest, safePrompt, randomSeed, true, sendThinking, strictJsonSchema);
-        client.streamingChatCompletion(request, handler, returnThinking);
+        MistralAiChatCompletionRequest request = createMistralAiRequest(
+                chatRequest,
+                parameters.safePrompt(),
+                parameters.randomSeed(),
+                true,
+                getOrDefault(parameters.sendThinking(), false),
+                strictJsonSchema);
+        client.streamingChatCompletion(request, handler, getOrDefault(parameters.returnThinking(), false));
     }
 
     @Override
-    public ChatRequestParameters defaultRequestParameters() {
+    public MistralAiChatRequestParameters defaultRequestParameters() {
         return defaultRequestParameters;
     }
 

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelParametersTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelParametersTest.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import org.junit.jupiter.api.Test;
+
+class MistralAiChatModelParametersTest {
+
+    @Test
+    void default_request_parameters_expose_mistral_specific_type() {
+        MistralAiChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(new MockHttpClient()))
+                .apiKey("dummy")
+                .modelName("mistral-small-latest")
+                .safePrompt(true)
+                .randomSeed(42)
+                .build();
+
+        assertThat(model.defaultRequestParameters()).isInstanceOf(MistralAiChatRequestParameters.class);
+        assertThat(model.defaultRequestParameters().safePrompt()).isTrue();
+        assertThat(model.defaultRequestParameters().randomSeed()).isEqualTo(42);
+    }
+
+    @Test
+    void mistral_specific_default_request_parameters_are_honored() {
+        MistralAiChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(new MockHttpClient()))
+                .apiKey("dummy")
+                .modelName("mistral-small-latest")
+                .defaultRequestParameters(MistralAiChatRequestParameters.builder()
+                        .safePrompt(true)
+                        .randomSeed(7)
+                        .build())
+                .build();
+
+        assertThat(model.defaultRequestParameters().safePrompt()).isTrue();
+        assertThat(model.defaultRequestParameters().randomSeed()).isEqualTo(7);
+    }
+
+    @Test
+    void per_call_parameters_override_model_defaults_in_the_request_body() {
+        MockHttpClient mockHttpClient = new MockHttpClient();
+        MistralAiChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("dummy")
+                .modelName("mistral-small-latest")
+                .safePrompt(false)
+                .maxRetries(0)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(MistralAiChatRequestParameters.builder()
+                        .safePrompt(true)
+                        .randomSeed(123)
+                        .build())
+                .build();
+
+        try {
+            model.chat(request);
+        } catch (Exception ignored) {
+        }
+
+        assertThat(mockHttpClient.request().body().replaceAll("\\s", ""))
+                .contains("\"safe_prompt\":true")
+                .contains("\"random_seed\":123");
+    }
+
+    @Test
+    void model_default_parameters_are_used_when_not_overridden_per_call() {
+        MockHttpClient mockHttpClient = new MockHttpClient();
+        MistralAiChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("dummy")
+                .modelName("mistral-small-latest")
+                .safePrompt(true)
+                .maxRetries(0)
+                .build();
+
+        try {
+            model.chat("hi");
+        } catch (Exception ignored) {
+        }
+
+        assertThat(mockHttpClient.request().body().replaceAll("\\s", "")).contains("\"safe_prompt\":true");
+    }
+}

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatRequestParametersTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatRequestParametersTest.java
@@ -1,0 +1,129 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import org.junit.jupiter.api.Test;
+
+class MistralAiChatRequestParametersTest {
+
+    @Test
+    void should_build_with_mistral_specific_parameters() {
+        MistralAiChatRequestParameters parameters = MistralAiChatRequestParameters.builder()
+                .temperature(0.7)
+                .safePrompt(true)
+                .randomSeed(42)
+                .sendThinking(true)
+                .returnThinking(true)
+                .build();
+
+        assertThat(parameters.temperature()).isEqualTo(0.7);
+        assertThat(parameters.safePrompt()).isTrue();
+        assertThat(parameters.randomSeed()).isEqualTo(42);
+        assertThat(parameters.sendThinking()).isTrue();
+        assertThat(parameters.returnThinking()).isTrue();
+    }
+
+    @Test
+    void should_default_mistral_specific_parameters_to_null() {
+        assertThat(MistralAiChatRequestParameters.EMPTY.safePrompt()).isNull();
+        assertThat(MistralAiChatRequestParameters.EMPTY.randomSeed()).isNull();
+        assertThat(MistralAiChatRequestParameters.EMPTY.sendThinking()).isNull();
+        assertThat(MistralAiChatRequestParameters.EMPTY.returnThinking()).isNull();
+    }
+
+    @Test
+    void overrideWith_should_let_the_argument_win_for_provided_values() {
+        MistralAiChatRequestParameters base = MistralAiChatRequestParameters.builder()
+                .temperature(0.2)
+                .safePrompt(false)
+                .randomSeed(1)
+                .sendThinking(false)
+                .build();
+
+        MistralAiChatRequestParameters override = MistralAiChatRequestParameters.builder()
+                .safePrompt(true)
+                .randomSeed(99)
+                .build();
+
+        MistralAiChatRequestParameters result = base.overrideWith(override);
+
+        assertThat(result.safePrompt()).isTrue();
+        assertThat(result.randomSeed()).isEqualTo(99);
+        assertThat(result.sendThinking()).isFalse();
+        assertThat(result.temperature()).isEqualTo(0.2);
+    }
+
+    @Test
+    void overrideWith_should_keep_provider_fields_when_argument_is_not_mistral_specific() {
+        MistralAiChatRequestParameters base = MistralAiChatRequestParameters.builder()
+                .safePrompt(true)
+                .randomSeed(7)
+                .build();
+
+        MistralAiChatRequestParameters result = base.overrideWith(
+                DefaultChatRequestParameters.builder().temperature(0.9).build());
+
+        assertThat(result.temperature()).isEqualTo(0.9);
+        assertThat(result.safePrompt()).isTrue();
+        assertThat(result.randomSeed()).isEqualTo(7);
+    }
+
+    @Test
+    void defaultedBy_should_let_this_win() {
+        MistralAiChatRequestParameters primary =
+                MistralAiChatRequestParameters.builder().safePrompt(true).build();
+
+        MistralAiChatRequestParameters fallback = MistralAiChatRequestParameters.builder()
+                .safePrompt(false)
+                .randomSeed(5)
+                .build();
+
+        MistralAiChatRequestParameters result = primary.defaultedBy(fallback);
+
+        assertThat(result.safePrompt()).isTrue();
+        assertThat(result.randomSeed()).isEqualTo(5);
+    }
+
+    @Test
+    void toBuilder_should_round_trip() {
+        MistralAiChatRequestParameters parameters = MistralAiChatRequestParameters.builder()
+                .modelName("mistral-large-latest")
+                .safePrompt(true)
+                .randomSeed(42)
+                .build();
+
+        assertThat(parameters.toBuilder().build()).isEqualTo(parameters);
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        MistralAiChatRequestParameters a = MistralAiChatRequestParameters.builder()
+                .safePrompt(true)
+                .randomSeed(42)
+                .build();
+        MistralAiChatRequestParameters b = MistralAiChatRequestParameters.builder()
+                .safePrompt(true)
+                .randomSeed(42)
+                .build();
+        MistralAiChatRequestParameters different = MistralAiChatRequestParameters.builder()
+                .safePrompt(true)
+                .randomSeed(43)
+                .build();
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(different);
+    }
+
+    @Test
+    void should_not_equal_a_plain_default_parameters_with_same_common_fields() {
+        MistralAiChatRequestParameters mistral =
+                MistralAiChatRequestParameters.builder().temperature(0.5).build();
+        ChatRequestParameters plain =
+                DefaultChatRequestParameters.builder().temperature(0.5).build();
+
+        assertThat(mistral).isNotEqualTo(plain);
+        assertThat(plain).isNotEqualTo(mistral);
+    }
+}

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModelParametersTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModelParametersTest.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import org.junit.jupiter.api.Test;
+
+class MistralAiStreamingChatModelParametersTest {
+
+    @Test
+    void default_request_parameters_expose_mistral_specific_type() {
+        MistralAiStreamingChatModel model = MistralAiStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(new MockHttpClient()))
+                .apiKey("dummy")
+                .modelName("mistral-small-latest")
+                .safePrompt(true)
+                .randomSeed(42)
+                .build();
+
+        assertThat(model.defaultRequestParameters()).isInstanceOf(MistralAiChatRequestParameters.class);
+        assertThat(model.defaultRequestParameters().safePrompt()).isTrue();
+        assertThat(model.defaultRequestParameters().randomSeed()).isEqualTo(42);
+    }
+
+    @Test
+    void per_call_parameters_override_model_defaults_in_the_request_body() {
+        MockHttpClient mockHttpClient = new MockHttpClient();
+        MistralAiStreamingChatModel model = MistralAiStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("dummy")
+                .modelName("mistral-small-latest")
+                .safePrompt(false)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(MistralAiChatRequestParameters.builder()
+                        .safePrompt(true)
+                        .randomSeed(123)
+                        .build())
+                .build();
+
+        try {
+            model.chat(request, new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(ChatResponse completeResponse) {}
+
+                @Override
+                public void onError(Throwable error) {}
+            });
+        } catch (Exception ignored) {
+        }
+
+        assertThat(mockHttpClient.request().body().replaceAll("\\s", ""))
+                .contains("\"safe_prompt\":true")
+                .contains("\"random_seed\":123");
+    }
+}


### PR DESCRIPTION

## Issue

Closes #5851

## Change
Mistral's provider-specific options (`safePrompt`, `randomSeed`, `sendThinking`, `returnThinking`) were settable only at build time and could not be varied per request. This adds `MistralAiChatRequestParameters extends DefaultChatRequestParameters` so they can be overridden per `ChatRequest`, on both `MistralAiChatModel` and `MistralAiStreamingChatModel`.

```java
model.chat(ChatRequest.builder()
        .messages(UserMessage.from("What is the best French cheese?"))
        .parameters(MistralAiChatRequestParameters.builder()
                .safePrompt(true)
                .randomSeed(42)
                .build())
        .build());
```

- Backward compatible: the model builder options keep working and now populate the default parameters.
- `strictJsonSchema` remains a model-level setting.
- `defaultRequestParameters()` return type is narrowed to `MistralAiChatRequestParameters` (source- and binary-compatible; two `revapi.json` entries added).

Tests: `MistralAiChatRequestParametersTest` (build, `EMPTY`, `overrideWith`/`defaultedBy`, `toBuilder`, `equals`/`hashCode` incl. cross-type) and `MistralAiChatModelParametersTest` / `MistralAiStreamingChatModelParametersTest` (per-request options reach the request body and override the model defaults, for both models). Docs updated in `docs/docs/integrations/language-models/mistral-ai.md`.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

