### PR TITLE
fix: make tool search matching locale-independent

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategy.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategy.java
@@ -1,5 +1,11 @@
 package dev.langchain4j.service.tool.search.simple;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.Utils.toBase64;
+import static java.util.Arrays.stream;
+import static java.util.Comparator.comparingInt;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -12,17 +18,10 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.service.tool.search.ToolSearchRequest;
 import dev.langchain4j.service.tool.search.ToolSearchResult;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.internal.Utils.toBase64;
-import static java.util.Arrays.stream;
-import static java.util.Comparator.comparingInt;
 
 /**
  * A {@link ToolSearchStrategy} that allows an LLM to search for available tools
@@ -41,9 +40,11 @@ import static java.util.Comparator.comparingInt;
 public class SimpleToolSearchStrategy implements ToolSearchStrategy {
 
     private static final String DEFAULT_TOOL_NAME = "tool_search_tool";
-    private static final String DEFAULT_TOOL_DESCRIPTION = "Finds available tools whose name or description contains given search terms";
+    private static final String DEFAULT_TOOL_DESCRIPTION =
+            "Finds available tools whose name or description contains given search terms";
     private static final String DEFAULT_TOOL_ARGUMENT_NAME = "terms";
-    private static final String DEFAULT_TOOL_ARGUMENT_DESCRIPTION = "A list of individual search terms (single words) used to find relevant tools";
+    private static final String DEFAULT_TOOL_ARGUMENT_DESCRIPTION =
+            "A list of individual search terms (single words) used to find relevant tools";
     private static final int DEFAULT_MAX_RESULTS = 5;
     private static final int DEFAULT_MIN_SCORE = 1;
     private static final Function<List<String>, String> DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER = foundToolNames -> {
@@ -72,10 +73,13 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
                 .name(getOrDefault(builder.toolName, DEFAULT_TOOL_NAME))
                 .description(getOrDefault(builder.toolDescription, DEFAULT_TOOL_DESCRIPTION))
                 .parameters(JsonObjectSchema.builder()
-                        .addProperty(toolArgumentName, JsonArraySchema.builder()
-                                .description(getOrDefault(builder.toolArgumentDescription, DEFAULT_TOOL_ARGUMENT_DESCRIPTION))
-                                .items(new JsonStringSchema())
-                                .build())
+                        .addProperty(
+                                toolArgumentName,
+                                JsonArraySchema.builder()
+                                        .description(getOrDefault(
+                                                builder.toolArgumentDescription, DEFAULT_TOOL_ARGUMENT_DESCRIPTION))
+                                        .items(new JsonStringSchema())
+                                        .build())
                         .required(toolArgumentName)
                         .build())
                 .build();
@@ -83,7 +87,8 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
         this.maxResults = getOrDefault(builder.maxResults, DEFAULT_MAX_RESULTS);
         this.minScore = getOrDefault(builder.minScore, DEFAULT_MIN_SCORE);
         this.throwToolArgumentsExceptions = getOrDefault(builder.throwToolArgumentsExceptions, false);
-        this.toolResultMessageTextProvider = getOrDefault(builder.toolResultMessageTextProvider, DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER);
+        this.toolResultMessageTextProvider =
+                getOrDefault(builder.toolResultMessageTextProvider, DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER);
     }
 
     @Override
@@ -101,9 +106,7 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
                 .limit(maxResults)
                 .toList();
 
-        List<String> toolNames = scoredTools.stream()
-                .map(st -> st.tool.name())
-                .toList();
+        List<String> toolNames = scoredTools.stream().map(st -> st.tool.name()).toList();
 
         String toolResultMessageText = toolResultMessageTextProvider.apply(toolNames);
 
@@ -151,10 +154,7 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
 
         Object value = map.get(toolArgumentName);
         if (value instanceof List<?> list) {
-            return list.stream()
-                    .filter(Objects::nonNull)
-                    .map(Object::toString)
-                    .toList();
+            return list.stream().filter(Objects::nonNull).map(Object::toString).toList();
         } else {
             String message = "Tool argument '%s' must be an array of strings".formatted(toolArgumentName);
             throwArgumentException(message, null);
@@ -166,7 +166,8 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
         try {
             return Json.fromJson(json, Map.class);
         } catch (Exception e) {
-            String message = "Failed to parse tool search arguments: '%s' (base64: '%s')".formatted(json, toBase64(json));
+            String message =
+                    "Failed to parse tool search arguments: '%s' (base64: '%s')".formatted(json, toBase64(json));
             throwArgumentException(message, e);
             return null; // unreachable
         }
@@ -186,8 +187,7 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
         return value == null ? null : value.toLowerCase();
     }
 
-    private record ScoredTool(ToolSpecification tool, int score) {
-    }
+    private record ScoredTool(ToolSpecification tool, int score) {}
 
     public static Builder builder() {
         return new Builder();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategy.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategy.java
@@ -1,11 +1,5 @@
 package dev.langchain4j.service.tool.search.simple;
 
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.internal.Utils.toBase64;
-import static java.util.Arrays.stream;
-import static java.util.Comparator.comparingInt;
-
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -18,11 +12,18 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.service.tool.search.ToolSearchRequest;
 import dev.langchain4j.service.tool.search.ToolSearchResult;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.Utils.toBase64;
+import static java.util.Arrays.stream;
+import static java.util.Comparator.comparingInt;
 
 /**
  * A {@link ToolSearchStrategy} that allows an LLM to search for available tools
@@ -41,11 +42,9 @@ import java.util.function.Function;
 public class SimpleToolSearchStrategy implements ToolSearchStrategy {
 
     private static final String DEFAULT_TOOL_NAME = "tool_search_tool";
-    private static final String DEFAULT_TOOL_DESCRIPTION =
-            "Finds available tools whose name or description contains given search terms";
+    private static final String DEFAULT_TOOL_DESCRIPTION = "Finds available tools whose name or description contains given search terms";
     private static final String DEFAULT_TOOL_ARGUMENT_NAME = "terms";
-    private static final String DEFAULT_TOOL_ARGUMENT_DESCRIPTION =
-            "A list of individual search terms (single words) used to find relevant tools";
+    private static final String DEFAULT_TOOL_ARGUMENT_DESCRIPTION = "A list of individual search terms (single words) used to find relevant tools";
     private static final int DEFAULT_MAX_RESULTS = 5;
     private static final int DEFAULT_MIN_SCORE = 1;
     private static final Function<List<String>, String> DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER = foundToolNames -> {
@@ -74,13 +73,10 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
                 .name(getOrDefault(builder.toolName, DEFAULT_TOOL_NAME))
                 .description(getOrDefault(builder.toolDescription, DEFAULT_TOOL_DESCRIPTION))
                 .parameters(JsonObjectSchema.builder()
-                        .addProperty(
-                                toolArgumentName,
-                                JsonArraySchema.builder()
-                                        .description(getOrDefault(
-                                                builder.toolArgumentDescription, DEFAULT_TOOL_ARGUMENT_DESCRIPTION))
-                                        .items(new JsonStringSchema())
-                                        .build())
+                        .addProperty(toolArgumentName, JsonArraySchema.builder()
+                                .description(getOrDefault(builder.toolArgumentDescription, DEFAULT_TOOL_ARGUMENT_DESCRIPTION))
+                                .items(new JsonStringSchema())
+                                .build())
                         .required(toolArgumentName)
                         .build())
                 .build();
@@ -88,8 +84,7 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
         this.maxResults = getOrDefault(builder.maxResults, DEFAULT_MAX_RESULTS);
         this.minScore = getOrDefault(builder.minScore, DEFAULT_MIN_SCORE);
         this.throwToolArgumentsExceptions = getOrDefault(builder.throwToolArgumentsExceptions, false);
-        this.toolResultMessageTextProvider =
-                getOrDefault(builder.toolResultMessageTextProvider, DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER);
+        this.toolResultMessageTextProvider = getOrDefault(builder.toolResultMessageTextProvider, DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER);
     }
 
     @Override
@@ -107,7 +102,9 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
                 .limit(maxResults)
                 .toList();
 
-        List<String> toolNames = scoredTools.stream().map(st -> st.tool.name()).toList();
+        List<String> toolNames = scoredTools.stream()
+                .map(st -> st.tool.name())
+                .toList();
 
         String toolResultMessageText = toolResultMessageTextProvider.apply(toolNames);
 
@@ -155,7 +152,10 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
 
         Object value = map.get(toolArgumentName);
         if (value instanceof List<?> list) {
-            return list.stream().filter(Objects::nonNull).map(Object::toString).toList();
+            return list.stream()
+                    .filter(Objects::nonNull)
+                    .map(Object::toString)
+                    .toList();
         } else {
             String message = "Tool argument '%s' must be an array of strings".formatted(toolArgumentName);
             throwArgumentException(message, null);
@@ -167,8 +167,7 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
         try {
             return Json.fromJson(json, Map.class);
         } catch (Exception e) {
-            String message =
-                    "Failed to parse tool search arguments: '%s' (base64: '%s')".formatted(json, toBase64(json));
+            String message = "Failed to parse tool search arguments: '%s' (base64: '%s')".formatted(json, toBase64(json));
             throwArgumentException(message, e);
             return null; // unreachable
         }
@@ -188,7 +187,8 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
         return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 
-    private record ScoredTool(ToolSpecification tool, int score) {}
+    private record ScoredTool(ToolSpecification tool, int score) {
+    }
 
     public static Builder builder() {
         return new Builder();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategy.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategy.java
@@ -19,6 +19,7 @@ import dev.langchain4j.service.tool.search.ToolSearchRequest;
 import dev.langchain4j.service.tool.search.ToolSearchResult;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -139,7 +140,7 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
                 .flatMap(term -> stream(term.split("\\s+")))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
-                .map(String::toLowerCase)
+                .map(SimpleToolSearchStrategy::lower)
                 .distinct()
                 .toList();
     }
@@ -184,7 +185,7 @@ public class SimpleToolSearchStrategy implements ToolSearchStrategy {
     }
 
     private static String lower(String value) {
-        return value == null ? null : value.toLowerCase();
+        return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 
     private record ScoredTool(ToolSpecification tool, int score) {}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategyLocaleTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategyLocaleTest.java
@@ -5,32 +5,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import java.util.List;
 import java.util.Locale;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
  * and single-threaded to avoid races with the otherwise parallel test suite.
+ * <p>
+ * {@code tr} and {@code az} lowercase {@code 'I'} to the dotless {@code 'ı'} (U+0131),
+ * {@code lt} applies its own dot rules, and {@code en-US} is the baseline.
  */
 @Isolated
 @Execution(ExecutionMode.SAME_THREAD)
 class SimpleToolSearchStrategyLocaleTest {
-
-    private final SimpleToolSearchStrategy strategy =
-            SimpleToolSearchStrategy.builder().build();
 
     private static final ToolSpecification LIST_INVOICES = ToolSpecification.builder()
             .name("listInvoices")
             .description("Returns all Invoices for a customer")
             .build();
 
-    @Test
-    void score_should_be_locale_independent() {
-        // In the Turkish locale, "listInvoices".toLowerCase() yields "listınvoices" (dotless i),
-        // which no longer contains the term "invoices".
-        withDefaultLocale(Locale.forLanguageTag("tr-TR"), () -> {
+    private final SimpleToolSearchStrategy strategy =
+            SimpleToolSearchStrategy.builder().build();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ", "lt-LT", "en-US"})
+    void score_should_be_locale_independent(String languageTag) {
+        // Without Locale.ROOT, "listInvoices".toLowerCase() yields "listınvoices" under tr/az,
+        // which no longer contains the term "invoices", so the tool scores 0 and is dropped.
+        withDefaultLocale(languageTag, () -> {
             int score = strategy.score(LIST_INVOICES, List.of("invoices"));
 
             // name (+2) + description (+1)
@@ -38,19 +43,22 @@ class SimpleToolSearchStrategyLocaleTest {
         });
     }
 
-    @Test
-    void score_should_be_zero_for_non_matching_term_in_turkish_locale() {
-        withDefaultLocale(Locale.forLanguageTag("tr-TR"), () -> {
-            int score = strategy.score(LIST_INVOICES, List.of("weather"));
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ", "lt-LT", "en-US"})
+    void dotless_term_should_not_match_locale_independently(String languageTag) {
+        // The mirror image: without Locale.ROOT this term matches under tr/az (score 3),
+        // because the tool name and the term are both folded to the dotless form.
+        withDefaultLocale(languageTag, () -> {
+            int score = strategy.score(LIST_INVOICES, List.of("ınvoices"));
 
             assertThat(score).isZero();
         });
     }
 
-    private static void withDefaultLocale(Locale locale, Runnable action) {
+    private static void withDefaultLocale(String languageTag, Runnable action) {
         Locale previousDefault = Locale.getDefault();
         try {
-            Locale.setDefault(locale);
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
             action.run();
         } finally {
             Locale.setDefault(previousDefault);

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategyLocaleTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/search/simple/SimpleToolSearchStrategyLocaleTest.java
@@ -1,0 +1,59 @@
+package dev.langchain4j.service.tool.search.simple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * and single-threaded to avoid races with the otherwise parallel test suite.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class SimpleToolSearchStrategyLocaleTest {
+
+    private final SimpleToolSearchStrategy strategy =
+            SimpleToolSearchStrategy.builder().build();
+
+    private static final ToolSpecification LIST_INVOICES = ToolSpecification.builder()
+            .name("listInvoices")
+            .description("Returns all Invoices for a customer")
+            .build();
+
+    @Test
+    void score_should_be_locale_independent() {
+        // In the Turkish locale, "listInvoices".toLowerCase() yields "listınvoices" (dotless i),
+        // which no longer contains the term "invoices".
+        withDefaultLocale(Locale.forLanguageTag("tr-TR"), () -> {
+            int score = strategy.score(LIST_INVOICES, List.of("invoices"));
+
+            // name (+2) + description (+1)
+            assertThat(score).isEqualTo(3);
+        });
+    }
+
+    @Test
+    void score_should_be_zero_for_non_matching_term_in_turkish_locale() {
+        withDefaultLocale(Locale.forLanguageTag("tr-TR"), () -> {
+            int score = strategy.score(LIST_INVOICES, List.of("weather"));
+
+            assertThat(score).isZero();
+        });
+    }
+
+    private static void withDefaultLocale(Locale locale, Runnable action) {
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(locale);
+            action.run();
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}


### PR DESCRIPTION

## Issue

Closes #5860

## Change

`SimpleToolSearchStrategy` lowercases tool names, descriptions and LLM search terms with `String#toLowerCase()` without a `Locale`, so matching depends on the JVM default locale.

Under the Turkish locale (`tr-TR`), `"listInvoices".toLowerCase()` yields `"listınvoices"` (dotless i), which no longer contains the term `"invoices"`. The tool is dropped from the results and the LLM gets `"No matching tools found"`, contradicting the class Javadoc's "simple case-insensitive `contains` matching".

Both lowercasing sites now go through the existing `lower()` helper with `Locale.ROOT`, matching `DefaultToolExecutor` (#5778) and `EnumOutputParser`. ASCII input is unaffected in every locale.

```java
private static String lower(String value) {
    return value == null ? null : value.toLowerCase(Locale.ROOT);
}
```

This file predates Spotless formatting, so the `ratchetFrom origin/main` reformats the whole file once it is touched. That reformat is isolated in the first commit (`chore: apply spotless formatting to SimpleToolSearchStrategy`); the second commit contains only the fix and the test.

Tests: new `SimpleToolSearchStrategyLocaleTest` sets and restores the default locale, mirroring `DefaultToolExecutorLocaleTest` (`@Isolated` + `@Execution(SAME_THREAD)`, needed because this module runs tests in parallel). It fails on `main` (score 0 instead of 3) and passes with this fix.

## General checklist

- [ ] There are no breaking changes (API, behaviour) <!-- No signature change, but search results do change under tr/az/lt locales — that change is the fix. -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- `./mvnw -pl langchain4j-core,langchain4j clean test` → 1272 tests green. *IT not run — requires API keys. -->
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- core 1198 (5 skipped) + main 1272, BUILD SUCCESS (JDK 17). -->
- [ ] I have added/updated the documentation <!-- N/A — behaviour fix, no doc change needed. -->
- [ ] I have added an example in the examples repo (only for "big" features) <!-- N/A — one-line bug fix. -->
- [ ] I have added/updated Spring Boot starter(s) (if applicable) <!-- N/A — no starter impact. -->

