### PR TITLE
Handle non-complex metadata field when reading Azure AI Search results

### DIFF
--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
@@ -364,11 +364,7 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
                 }
             }
         }
-        try {
-            return Metadata.from(attributesMap);
-        } catch (IllegalArgumentException e) {
-            return Metadata.from(Collections.emptyMap());
-        }
+        return Metadata.from(attributesMap);
     }
 
     private void addInternal(String id, Embedding embedding, TextSegment embedded) {

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
@@ -332,21 +332,7 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             String embeddedContent = (String) searchDocument.get(DEFAULT_FIELD_CONTENT);
             EmbeddingMatch<TextSegment> embeddingMatch;
             if (isNotNullOrBlank(embeddedContent)) {
-                LinkedHashMap metadata = (LinkedHashMap) searchDocument.get(DEFAULT_FIELD_METADATA);
-                Metadata langChainMetadata;
-                if (metadata == null) {
-                    langChainMetadata = Metadata.from(Collections.emptyMap());
-                } else {
-                    List attributes = (List) metadata.get(DEFAULT_FIELD_METADATA_ATTRS);
-                    Map<String, String> attributesMap = new HashMap<>();
-                    for (Object attribute : attributes) {
-                        LinkedHashMap innerAttribute = (LinkedHashMap) attribute;
-                        String key = (String) innerAttribute.get("key");
-                        String value = (String) innerAttribute.get("value");
-                        attributesMap.put(key, value);
-                    }
-                    langChainMetadata = Metadata.from(attributesMap);
-                }
+                Metadata langChainMetadata = metadataFrom(searchDocument.get(DEFAULT_FIELD_METADATA));
                 TextSegment embedded = TextSegment.textSegment(embeddedContent, langChainMetadata);
                 embeddingMatch = new EmbeddingMatch<>(score, embeddingId, embedding, embedded);
             } else {
@@ -355,6 +341,26 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             result.add(embeddingMatch);
         }
         return result;
+    }
+
+    static Metadata metadataFrom(Object rawMetadata) {
+        if (!(rawMetadata instanceof Map<?, ?> metadata)) {
+            return Metadata.from(Collections.emptyMap());
+        }
+        if (!(metadata.get(DEFAULT_FIELD_METADATA_ATTRS) instanceof List<?> attributes)) {
+            return Metadata.from(Collections.emptyMap());
+        }
+        Map<String, String> attributesMap = new HashMap<>();
+        for (Object attribute : attributes) {
+            if (attribute instanceof Map<?, ?> keyValue) {
+                Object key = keyValue.get("key");
+                Object value = keyValue.get("value");
+                if (key != null && value != null) {
+                    attributesMap.put(key.toString(), value.toString());
+                }
+            }
+        }
+        return Metadata.from(attributesMap);
     }
 
     private void addInternal(String id, Embedding embedding, TextSegment embedded) {

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
@@ -356,11 +356,19 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
                 Object key = keyValue.get("key");
                 Object value = keyValue.get("value");
                 if (key != null && value != null) {
-                    attributesMap.put(key.toString(), value.toString());
+                    String keyString = key.toString();
+                    if (isNullOrBlank(keyString)) {
+                        continue;
+                    }
+                    attributesMap.put(keyString, value.toString());
                 }
             }
         }
-        return Metadata.from(attributesMap);
+        try {
+            return Metadata.from(attributesMap);
+        } catch (IllegalArgumentException e) {
+            return Metadata.from(Collections.emptyMap());
+        }
     }
 
     private void addInternal(String id, Embedding embedding, TextSegment embedded) {

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
@@ -106,6 +106,16 @@ class AzureAiSearchEmbeddingStoreTest {
     }
 
     @Test
+    void metadata_attribute_with_blank_key_should_be_skipped() {
+        Object rawMetadata =
+                Map.of("attributes", List.of(Map.of("key", " ", "value", "orphan"), Map.of("key", "page", "value", "3")));
+
+        Metadata metadata = metadataFrom(rawMetadata);
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("page", "3"));
+    }
+
+    @Test
     void metadata_attribute_with_non_string_value_should_be_coerced() {
         Object rawMetadata = Map.of("attributes", List.of(Map.of("key", "page", "value", 3)));
 

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
@@ -108,10 +108,7 @@ class AzureAiSearchEmbeddingStoreTest {
     @Test
     void metadata_attribute_with_blank_key_should_be_skipped() {
         Object rawMetadata = Map.of(
-                "attributes",
-                List.of(
-                        Map.of("key", " ", "value", "orphan"),
-                        Map.of("key", "page", "value", "3")));
+                "attributes", List.of(Map.of("key", " ", "value", "orphan"), Map.of("key", "page", "value", "3")));
 
         Metadata metadata = metadataFrom(rawMetadata);
 

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
@@ -1,10 +1,15 @@
 package dev.langchain4j.store.embedding.azure.search;
 
+import static dev.langchain4j.store.embedding.azure.search.AbstractAzureAiSearchEmbeddingStore.metadataFrom;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.azure.core.credential.AzureKeyCredential;
 import com.azure.search.documents.indexes.models.SearchIndex;
+import dev.langchain4j.data.document.Metadata;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class AzureAiSearchEmbeddingStoreTest {
@@ -33,5 +38,79 @@ class AzureAiSearchEmbeddingStoreTest {
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage()).isEqualTo("index and indexName cannot be both defined");
         }
+    }
+
+    @Test
+    void metadata_from_complex_field_should_map_attributes() {
+        Object rawMetadata = Map.of(
+                "source",
+                "doc.pdf",
+                "attributes",
+                List.of(Map.of("key", "source", "value", "doc.pdf"), Map.of("key", "page", "value", "3")));
+
+        Metadata metadata = metadataFrom(rawMetadata);
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("source", "doc.pdf"), Map.entry("page", "3"));
+    }
+
+    @Test
+    void metadata_from_string_field_should_return_empty_metadata() {
+        Metadata metadata = metadataFrom("arbitrary string from a bring-your-own index");
+
+        assertThat(metadata.toMap()).isEmpty();
+    }
+
+    @Test
+    void metadata_from_null_should_return_empty_metadata() {
+        Metadata metadata = metadataFrom(null);
+
+        assertThat(metadata.toMap()).isEmpty();
+    }
+
+    @Test
+    void metadata_without_attributes_field_should_return_empty_metadata() {
+        Metadata metadata = metadataFrom(Map.of("source", "doc.pdf"));
+
+        assertThat(metadata.toMap()).isEmpty();
+    }
+
+    @Test
+    void metadata_with_non_list_attributes_should_return_empty_metadata() {
+        Metadata metadata = metadataFrom(Map.of("attributes", "not-a-list"));
+
+        assertThat(metadata.toMap()).isEmpty();
+    }
+
+    @Test
+    void metadata_with_non_map_attribute_entry_should_skip_it() {
+        Object rawMetadata = Map.of("attributes", List.of("not-a-map", Map.of("key", "page", "value", "3")));
+
+        Metadata metadata = metadataFrom(rawMetadata);
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("page", "3"));
+    }
+
+    @Test
+    void metadata_attribute_with_null_key_or_value_should_be_skipped() {
+        Map<String, Object> nullKey = new HashMap<>();
+        nullKey.put("key", null);
+        nullKey.put("value", "orphan");
+        Map<String, Object> nullValue = new HashMap<>();
+        nullValue.put("key", "orphan");
+        nullValue.put("value", null);
+        Object rawMetadata = Map.of("attributes", List.of(nullKey, nullValue, Map.of("key", "page", "value", "3")));
+
+        Metadata metadata = metadataFrom(rawMetadata);
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("page", "3"));
+    }
+
+    @Test
+    void metadata_attribute_with_non_string_value_should_be_coerced() {
+        Object rawMetadata = Map.of("attributes", List.of(Map.of("key", "page", "value", 3)));
+
+        Metadata metadata = metadataFrom(rawMetadata);
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("page", "3"));
     }
 }

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
@@ -107,8 +107,11 @@ class AzureAiSearchEmbeddingStoreTest {
 
     @Test
     void metadata_attribute_with_blank_key_should_be_skipped() {
-        Object rawMetadata =
-                Map.of("attributes", List.of(Map.of("key", " ", "value", "orphan"), Map.of("key", "page", "value", "3")));
+        Object rawMetadata = Map.of(
+                "attributes",
+                List.of(
+                        Map.of("key", " ", "value", "orphan"),
+                        Map.of("key", "page", "value", "3")));
 
         Metadata metadata = metadataFrom(rawMetadata);
 


### PR DESCRIPTION
## Issue
Closes #5858

## Change
`getEmbeddingMatches` read each result document's `metadata` field with a hard
`(LinkedHashMap)` cast. That assumes the complex field shape this store writes
(`source` plus an `attributes` key/value collection). Against a bring-your-own index
(`createOrUpdateIndex(false)`) whose `metadata` field has a different type, the cast
throws `ClassCastException` and the query returns nothing.

Extracted the mapping into `metadataFrom(...)`: it maps the `attributes` collection
when the field is the expected complex shape, and returns empty metadata for any other
shape instead of throwing. Reading of indexes this store created is unchanged. This
also removes a latent `NullPointerException` on a complex `metadata` map that has no
`attributes` sub-field.

```
mvn -pl langchain4j-azure-ai-search test
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
