### PR TITLE
Avoid NullPointerException when an async agent returns null

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
@@ -9,8 +9,8 @@ import dev.langchain4j.agentic.agent.ChatMessagesAccess;
 import dev.langchain4j.agentic.agent.ErrorContext;
 import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.declarative.TypedKey;
-import dev.langchain4j.agentic.internal.DelayedResponse;
 import dev.langchain4j.agentic.internal.DeferredResponse;
+import dev.langchain4j.agentic.internal.DelayedResponse;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.data.message.AiMessage;
@@ -20,6 +20,7 @@ import dev.langchain4j.internal.Utils;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
+import dev.langchain4j.service.tool.ToolExecution;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,7 +36,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import dev.langchain4j.service.tool.ToolExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +53,8 @@ public class DefaultAgenticScope implements AgenticScope {
 
     private final transient Map<String, Object> agents = new ConcurrentHashMap<>();
     private final transient Map<String, Object> executionContexts = new ConcurrentHashMap<>();
-    private final transient List<CompensableExecution> compensableExecutions = Collections.synchronizedList(new ArrayList<>());
+    private final transient List<CompensableExecution> compensableExecutions =
+            Collections.synchronizedList(new ArrayList<>());
 
     private static final Function<ErrorContext, ErrorRecoveryResult> DEFAULT_ERROR_RECOVERY =
             errorContext -> ErrorRecoveryResult.throwException();
@@ -61,7 +62,8 @@ public class DefaultAgenticScope implements AgenticScope {
     private transient Function<ErrorContext, ErrorRecoveryResult> errorHandler = DEFAULT_ERROR_RECOVERY;
 
     private static Predicate<Object> serializableStateFilter = Predicate.not(DefaultAgenticScope::isProxy)
-            .and(Predicate.not(DefaultAgenticScope::isTokenStream)).and(Predicate.not(DefaultAgenticScope::isFuture));
+            .and(Predicate.not(DefaultAgenticScope::isTokenStream))
+            .and(Predicate.not(DefaultAgenticScope::isFuture));
 
     private static boolean isProxy(Object obj) {
         return Proxy.isProxyClass(obj.getClass());
@@ -226,7 +228,11 @@ public class DefaultAgenticScope implements AgenticScope {
 
     public void rootCallEnded(AgenticScopeRegistry registry, AgentListener agentListener) {
         // ensure that all pending async operations are completed before ending the root call
-        state.replaceAll(this::readStateBlocking);
+        Map.copyOf(state).forEach((key, value) -> {
+            if (value instanceof DelayedResponse<?> pending) {
+                writeState(key, pending.blockingGet());
+            }
+        });
 
         if (kind == Kind.EPHEMERAL) {
             // Ephemeral agenticScope are for single-use and can be evicted immediately
@@ -386,8 +392,11 @@ public class DefaultAgenticScope implements AgenticScope {
             try {
                 compensatingAction.accept(toolExecution());
             } catch (Exception e) {
-                LOG.warn("Cross-agent compensating action failed for tool '{}': {}",
-                        toolExecution().request().name(), e.getMessage(), e);
+                LOG.warn(
+                        "Cross-agent compensating action failed for tool '{}': {}",
+                        toolExecution().request().name(),
+                        e.getMessage(),
+                        e);
             }
         }
     }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AsyncAgentNullReturnParityTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AsyncAgentNullReturnParityTest.java
@@ -1,0 +1,50 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AsyncAgentNullReturnParityTest {
+
+    public static class NullReturningSyncAgent {
+        @Agent(outputKey = "unread")
+        public String run() {
+            return null;
+        }
+    }
+
+    public static class NullReturningAsyncAgent {
+        @Agent(async = true, outputKey = "unread")
+        public String run() {
+            return null;
+        }
+    }
+
+    public static class ResultAgent {
+        @Agent(outputKey = "result")
+        public String run() {
+            return "done";
+        }
+    }
+
+    @Test
+    void sync_agent_returning_null_completes() {
+        UntypedAgent workflow = AgenticServices.sequenceBuilder()
+                .subAgents(new NullReturningSyncAgent(), new ResultAgent())
+                .outputKey("result")
+                .build();
+
+        assertThatCode(() -> workflow.invoke(Map.of())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void async_agent_returning_null_completes_like_sync() {
+        UntypedAgent workflow = AgenticServices.sequenceBuilder()
+                .subAgents(new NullReturningAsyncAgent(), new ResultAgent())
+                .outputKey("result")
+                .build();
+
+        assertThatCode(() -> workflow.invoke(Map.of())).doesNotThrowAnyException();
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/DefaultAgenticScopeRootCallEndedTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/DefaultAgenticScopeRootCallEndedTest.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.agentic.scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.agentic.internal.AsyncResponse;
+import org.junit.jupiter.api.Test;
+
+class DefaultAgenticScopeRootCallEndedTest {
+
+    @Test
+    void resolves_async_state_returning_null_without_throwing() {
+        DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.REGISTERED);
+        scope.writeState("nullOutput", new AsyncResponse<>(() -> null));
+        scope.writeState("realOutput", new AsyncResponse<>(() -> "value"));
+        scope.writeState("plainOutput", "kept");
+
+        assertThatCode(() -> scope.rootCallEnded(null, null)).doesNotThrowAnyException();
+
+        assertThat(scope.readState("nullOutput")).isNull();
+        assertThat(scope.readState("realOutput")).isEqualTo("value");
+        assertThat(scope.readState("plainOutput")).isEqualTo("kept");
+    }
+}


### PR DESCRIPTION

## Issue
Closes #5863

## Change
`DefaultAgenticScope.rootCallEnded` resolved all pending async responses with
`state.replaceAll(this::readStateBlocking)`, which throws `NullPointerException` when a
response resolves to `null` (`ConcurrentHashMap.replaceAll` rejects a null result).
Resolve them over a snapshot and write each result back through `writeState`, which
removes the entry when the value is `null`   matching the synchronous behaviour:

```java
Map.copyOf(state).forEach((key, value) -> {
    if (value instanceof DelayedResponse<?> pending) {
        writeState(key, pending.blockingGet());
    }
});
```

The remaining changes in the file are Spotless formatting (`ratchetFrom origin/main`).

Tests (offline, no model), both fail on the current code with the raw NPE and pass with the change:
- `DefaultAgenticScopeRootCallEndedTest`  -- resolves a mix of async-null, async-value and
  plain state; asserts no throw, the null entry removed, the others preserved.
- `AsyncAgentNullReturnParityTest`  -- a POJO agent returning `null` (output not read
  downstream); the async run completes like the sync run.

```
mvn -pl langchain4j-agentic test
Tests run: 108, Failures: 0, Errors: 0, Skipped: 0
```

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
