### PR TITLE
fix(anthropic): apply cache_control to image and pdf content blocks

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
@@ -20,6 +20,11 @@ public class AnthropicImageContent extends AnthropicMessageContent {
         this.source = source;
     }
 
+    public AnthropicImageContent(AnthropicImageContentSource source, AnthropicCacheControl cacheControl) {
+        super("image", cacheControl);
+        this.source = source;
+    }
+
     public AnthropicImageContent(String mediaType, String data) {
         super("image");
         this.source = new AnthropicImageContentSource("base64", mediaType, data);
@@ -31,6 +36,14 @@ public class AnthropicImageContent extends AnthropicMessageContent {
 
     public static AnthropicImageContent fromUrl(String url) {
         return new AnthropicImageContent(AnthropicImageContentSource.fromUrl(url));
+    }
+
+    public static AnthropicImageContent fromBase64(String mediaType, String data, AnthropicCacheControl cacheControl) {
+        return new AnthropicImageContent(AnthropicImageContentSource.fromBase64(mediaType, data), cacheControl);
+    }
+
+    public static AnthropicImageContent fromUrl(String url, AnthropicCacheControl cacheControl) {
+        return new AnthropicImageContent(AnthropicImageContentSource.fromUrl(url), cacheControl);
     }
 
     @Override

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContent.java
@@ -20,6 +20,11 @@ public class AnthropicPdfContent extends AnthropicMessageContent {
         this.source = source;
     }
 
+    public AnthropicPdfContent(AnthropicPdfContentSource source, AnthropicCacheControl cacheControl) {
+        super("document", cacheControl);
+        this.source = source;
+    }
+
     public AnthropicPdfContent(String mediaType, String base64Data) {
         super("document");
         this.source = new AnthropicPdfContentSource("base64", mediaType, base64Data);
@@ -35,6 +40,14 @@ public class AnthropicPdfContent extends AnthropicMessageContent {
 
     public static AnthropicPdfContent fromUrl(String url) {
         return new AnthropicPdfContent(AnthropicPdfContentSource.fromUrl(url));
+    }
+
+    public static AnthropicPdfContent fromBase64(String mediaType, String data, AnthropicCacheControl cacheControl) {
+        return new AnthropicPdfContent(AnthropicPdfContentSource.fromBase64(mediaType, data), cacheControl);
+    }
+
+    public static AnthropicPdfContent fromUrl(String url, AnthropicCacheControl cacheControl) {
+        return new AnthropicPdfContent(AnthropicPdfContentSource.fromUrl(url), cacheControl);
     }
 
     @Override
@@ -53,6 +66,9 @@ public class AnthropicPdfContent extends AnthropicMessageContent {
 
     @Override
     public String toString() {
-        return "AnthropicPdfContent{" + "source=" + source + '}';
+        return "AnthropicPdfContent{" + "source="
+                + source + ", type='"
+                + type + '\'' + ", cacheControl="
+                + cacheControl + '}';
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -194,22 +194,25 @@ public class AnthropicMapper {
                 }
             } else if (content instanceof ImageContent imageContent) {
                 Image image = imageContent.image();
+                AnthropicCacheControl cacheControl = applyCache ? AnthropicCacheType.EPHEMERAL.cacheControl() : null;
                 if (image.url() != null) {
                     anthropicContents.add(
-                            AnthropicImageContent.fromUrl(image.url().toString()));
+                            AnthropicImageContent.fromUrl(image.url().toString(), cacheControl));
                 } else {
                     anthropicContents.add(AnthropicImageContent.fromBase64(
                             ensureNotBlank(image.mimeType(), "mimeType"),
-                            ensureNotBlank(image.base64Data(), "base64Data")));
+                            ensureNotBlank(image.base64Data(), "base64Data"),
+                            cacheControl));
                 }
             } else if (content instanceof PdfFileContent pdfFileContent) {
                 PdfFile pdfFile = pdfFileContent.pdfFile();
+                AnthropicCacheControl cacheControl = applyCache ? AnthropicCacheType.EPHEMERAL.cacheControl() : null;
                 if (pdfFile.url() != null) {
                     anthropicContents.add(
-                            AnthropicPdfContent.fromUrl(pdfFile.url().toString()));
+                            AnthropicPdfContent.fromUrl(pdfFile.url().toString(), cacheControl));
                 } else {
                     anthropicContents.add(AnthropicPdfContent.fromBase64(
-                            pdfFile.mimeType(), ensureNotBlank(pdfFile.base64Data(), "base64Data")));
+                            pdfFile.mimeType(), ensureNotBlank(pdfFile.base64Data(), "base64Data"), cacheControl));
                 }
             } else {
                 throw illegalArgument("Unknown content type: " + content);

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -64,6 +64,10 @@ class AnthropicMapperTest {
     static final String DICE_IMAGE_URL =
             "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png";
 
+    static final String BASE64_IMAGE_DATA = "iVBORw0KGgo=";
+
+    static final String BASE64_PDF_DATA = "JVBERi0xLjQK";
+
     @ParameterizedTest
     @MethodSource
     void test_toAnthropicMessages(List<ChatMessage> messages, List<AnthropicMessage> expectedAnthropicMessages) {
@@ -875,6 +879,179 @@ class AnthropicMapperTest {
         // Then
         assertThat(cacheDiagnostics.cacheMissReasonType()).isEqualTo("system_changed");
         assertThat(cacheDiagnostics.cacheMissedInputTokens()).isEqualTo(41850);
+    }
+
+    @Test
+    void should_apply_cache_control_to_last_content_block_of_user_message_ending_with_image() {
+        // given
+        UserMessage userMessage = UserMessage.from(
+                TextContent.from("What is on this image?"),
+                ImageContent.from(
+                        Image.builder().url(URI.create(DICE_IMAGE_URL)).build()));
+        userMessage.attributes().put("cache_control", "ephemeral");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        AnthropicTextContent textContent =
+                (AnthropicTextContent) anthropicMessages.get(0).content.get(0);
+        assertThat(textContent.cacheControl).isNull();
+
+        AnthropicImageContent imageContent =
+                (AnthropicImageContent) anthropicMessages.get(0).content.get(1);
+        assertThat(imageContent.cacheControl).isNotNull();
+        assertThat(imageContent.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void should_apply_cache_control_to_last_content_block_of_user_message_ending_with_pdf() {
+        // given
+        UserMessage userMessage = UserMessage.from(
+                TextContent.from("What is in this document?"),
+                PdfFileContent.from(URI.create("https://example.com/document.pdf")));
+        userMessage.attributes().put("cache_control", "ephemeral");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        AnthropicTextContent textContent =
+                (AnthropicTextContent) anthropicMessages.get(0).content.get(0);
+        assertThat(textContent.cacheControl).isNull();
+
+        AnthropicPdfContent pdfContent =
+                (AnthropicPdfContent) anthropicMessages.get(0).content.get(1);
+        assertThat(pdfContent.cacheControl).isNotNull();
+        assertThat(pdfContent.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void should_not_apply_cache_control_to_image_content_when_not_last_item() {
+        // given
+        UserMessage userMessage = UserMessage.from(
+                ImageContent.from(
+                        Image.builder().url(URI.create(DICE_IMAGE_URL)).build()),
+                TextContent.from("What is on this image?"));
+        userMessage.attributes().put("cache_control", "ephemeral");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        AnthropicImageContent imageContent =
+                (AnthropicImageContent) anthropicMessages.get(0).content.get(0);
+        assertThat(imageContent.cacheControl).isNull();
+
+        AnthropicTextContent textContent =
+                (AnthropicTextContent) anthropicMessages.get(0).content.get(1);
+        assertThat(textContent.cacheControl).isNotNull();
+    }
+
+    @Test
+    void should_apply_cache_control_to_base64_image_content() {
+        // given
+        UserMessage userMessage = UserMessage.from(ImageContent.from(BASE64_IMAGE_DATA, "image/png"));
+        userMessage.attributes().put("cache_control", "ephemeral");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        AnthropicImageContent imageContent =
+                (AnthropicImageContent) anthropicMessages.get(0).content.get(0);
+        assertThat(imageContent.source.type).isEqualTo("base64");
+        assertThat(imageContent.cacheControl).isNotNull();
+        assertThat(imageContent.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void should_apply_cache_control_to_base64_pdf_content() {
+        // given
+        UserMessage userMessage = UserMessage.from(PdfFileContent.from(BASE64_PDF_DATA, "application/pdf"));
+        userMessage.attributes().put("cache_control", "ephemeral");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        AnthropicPdfContent pdfContent =
+                (AnthropicPdfContent) anthropicMessages.get(0).content.get(0);
+        assertThat(pdfContent.source.type).isEqualTo("base64");
+        assertThat(pdfContent.cacheControl).isNotNull();
+        assertThat(pdfContent.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void should_not_apply_cache_control_to_image_content_without_cache_control_attribute() {
+        // given
+        UserMessage userMessage = UserMessage.from(ImageContent.from(
+                Image.builder().url(URI.create(DICE_IMAGE_URL)).build()));
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        AnthropicImageContent imageContent =
+                (AnthropicImageContent) anthropicMessages.get(0).content.get(0);
+        assertThat(imageContent.cacheControl).isNull();
+    }
+
+    @Test
+    void should_not_apply_cache_control_to_pdf_content_without_cache_control_attribute() {
+        // given
+        UserMessage userMessage = UserMessage.from(PdfFileContent.from(URI.create("https://example.com/document.pdf")));
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        AnthropicPdfContent pdfContent =
+                (AnthropicPdfContent) anthropicMessages.get(0).content.get(0);
+        assertThat(pdfContent.cacheControl).isNull();
+    }
+
+    @Test
+    void should_serialize_image_content_with_cache_control_next_to_source() throws JsonProcessingException {
+        // given
+        UserMessage userMessage = UserMessage.from(ImageContent.from(
+                Image.builder().url(URI.create(DICE_IMAGE_URL)).build()));
+        userMessage.attributes().put("cache_control", "ephemeral");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        String json = new ObjectMapper()
+                .writeValueAsString(anthropicMessages.get(0).content.get(0));
+        assertThat(json).isEqualToIgnoringWhitespace("""
+                        {
+                          "type": "image",
+                          "cache_control": {"type": "ephemeral"},
+                          "source": {"type": "url", "url": "%s"}
+                        }
+                        """.formatted(DICE_IMAGE_URL));
+    }
+
+    @Test
+    void should_serialize_pdf_content_with_cache_control_next_to_source() throws JsonProcessingException {
+        // given
+        UserMessage userMessage = UserMessage.from(PdfFileContent.from(BASE64_PDF_DATA, "application/pdf"));
+        userMessage.attributes().put("cache_control", "ephemeral");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(userMessage));
+
+        // then
+        String json = new ObjectMapper()
+                .writeValueAsString(anthropicMessages.get(0).content.get(0));
+        assertThat(json).isEqualToIgnoringWhitespace("""
+                        {
+                          "type": "document",
+                          "cache_control": {"type": "ephemeral"},
+                          "source": {"type": "base64", "media_type": "application/pdf", "data": "%s"}
+                        }
+                        """.formatted(BASE64_PDF_DATA));
     }
 
     @SafeVarargs


### PR DESCRIPTION
## Issue
Closes #5867 

## Change

`AnthropicMapper` only applied `cache_control=ephemeral` to `TextContent` when a
`UserMessage` was marked for caching, silently dropping it when the last content
item was `ImageContent` or `PdfFileContent`. This contradicts the surrounding
code comment ("apply the cache_control to the last content item") and the
documented behavior in `anthropic.md`.

- Add `cacheControl`-accepting constructors and `from*` overloads to
  `AnthropicImageContent` and `AnthropicPdfContent` (mirrors `AnthropicTextContent`)
- In `AnthropicMapper`, pass `cacheControl` to Image/Pdf content when `applyCache`
- Include `cacheControl` in `AnthropicPdfContent.toString()` (already present on
  `AnthropicImageContent` and `AnthropicTextContent`)

Only the user turn is affected, matching Anthropic's prompt caching restriction.
Nested blocks inside `tool_result` are unchanged — sub-content blocks cannot be
cached directly. Backward compatible: additive overloads; `cacheControl` is null
when absent.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)