### PR TITLE
Do not discard valid JSON preceded by the same opening bracket

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
@@ -16,7 +16,8 @@ public class JsonParsingUtils {
         return extractAndParseJson(text, s -> Json.fromJson(s, type));
     }
 
-    public static <T> ParsedJson<T> extractAndParseJson(String text, ThrowingFunction<String, T> parser) throws Exception {
+    public static <T> ParsedJson<T> extractAndParseJson(String text, ThrowingFunction<String, T> parser)
+            throws Exception {
         Exception parseException = null;
         try {
             return new ParsedJson<>(parser.apply(text), text);
@@ -73,7 +74,11 @@ public class JsonParsingUtils {
             if (c == openingBrace) {
                 braceCount++;
                 if (braceCount == 0) {
-                    return i == 0 || text.charAt(i - 1) != openingBrace ? i : -1;
+                    // This is the opening brace that balances the closing brace at jsonEnd. Return
+                    // it even when the preceding character is the same brace (e.g. "[[1,2]"): the
+                    // caller re-parses and keeps searching if this candidate does not parse, so
+                    // there is no reason to give up and discard an otherwise valid JSON block here.
+                    return i;
                 }
             } else if (c == closingBrace) {
                 braceCount--;

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -3,10 +3,9 @@ package dev.langchain4j.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import java.util.List;
 import java.util.Map;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -77,8 +76,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array() throws Exception {
         String json = "[{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}]";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
         assertThat(result.value()[0].name).isEqualTo("A");
@@ -93,8 +91,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array_with_noise() throws Exception {
         String json = "abc [{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}] xyz";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
     }
@@ -108,8 +105,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_nested_array() throws Exception {
         String json = "[[{\"name\":\"A\",\"age\":1}],[{\"name\":\"B\",\"age\":2}]]";
-        JsonParsingUtils.ParsedJson<MyPojo[][]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
+        JsonParsingUtils.ParsedJson<MyPojo[][]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
         assertThat(result.value()[0][0].name).isEqualTo("A");
@@ -194,8 +190,7 @@ class JsonParsingUtilsTest {
     void extract_json_array_with_nested_objects_and_arrays() throws Exception {
         String json =
                 "[{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]},{\"name\":\"Jerry\",\"age\":20,\"tags\":[\"x\",\"y\"]}]";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value()[1].tags).containsExactly("x", "y");
     }
@@ -211,8 +206,7 @@ class JsonParsingUtilsTest {
                 {"log":"Unexpected character '}' at position 42"}
                 """;
 
-        JsonParsingUtils.ParsedJson<LogEntry> result =
-                JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
+        JsonParsingUtils.ParsedJson<LogEntry> result = JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
 
         assertThat(result.value().log).isEqualTo("Unexpected character '}' at position 42");
     }
@@ -224,8 +218,7 @@ class JsonParsingUtilsTest {
                 {"log":"Error: unexpected ']' found"}
                 """;
 
-        JsonParsingUtils.ParsedJson<LogEntry> result =
-                JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
+        JsonParsingUtils.ParsedJson<LogEntry> result = JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
 
         assertThat(result.value().log).isEqualTo("Error: unexpected ']' found");
     }
@@ -237,11 +230,19 @@ class JsonParsingUtilsTest {
                 [{"log":"missing '}'"},{"log":"ok"}]
                 """;
 
-        JsonParsingUtils.ParsedJson<LogEntry[]> result =
-                JsonParsingUtils.extractAndParseJson(text, LogEntry[].class);
+        JsonParsingUtils.ParsedJson<LogEntry[]> result = JsonParsingUtils.extractAndParseJson(text, LogEntry[].class);
 
         assertThat(result.value()).hasSize(2);
         assertThat(result.value()[0].log).isEqualTo("missing '}'");
         assertThat(result.value()[1].log).isEqualTo("ok");
+    }
+
+    @Test
+    void should_extract_json_array_when_preceded_by_same_opening_bracket() throws Exception {
+        // "[[1,2]" has an unbalanced outer '[' before a valid "[1,2]"; the balanced array must
+        // still be extracted instead of the parser giving up and throwing.
+        JsonParsingUtils.ParsedJson<int[]> result = JsonParsingUtils.extractAndParseJson("output: [[1,2]", int[].class);
+
+        assertThat(result.value()).containsExactly(1, 2);
     }
 }


### PR DESCRIPTION
### Problem

`JsonParsingUtils.findJsonStart` scans backwards for the opening brace that balances a closing one.
When it finds the balancing bracket, it discarded the candidate if the *preceding* character was the
same opening bracket — e.g. for `output: [[1,2]` it gave up and threw instead of extracting the valid
inner array `[1,2]`.

That guard is unnecessary: the caller re-parses each candidate and keeps searching if it does not
parse, so there is no reason to reject an otherwise-valid balanced JSON block here.

### Fix

Return the balancing opening bracket even when the preceding character is the same bracket. Removed
the special-case guard in `findJsonStart`.

### Test

Added `should_extract_json_array_when_preceded_by_same_opening_bracket` (`"output: [[1,2]"` →
`[1, 2]`). Full `JsonParsingUtilsTest` passes (15).
