### PR TITLE
Add `AnthropicBatchChatModel` for the Anthropic Message Batches API

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -133,6 +133,46 @@ model.chat("Say 'Hello World'", new StreamingChatResponseHandler() {
 
 Identical to the `AnthropicChatModel`, see above.
 
+## Batch API
+
+The [Message Batches API](https://docs.anthropic.com/en/api/creating-message-batches) processes many chat requests
+asynchronously at 50% of the standard per-token price. `AnthropicBatchChatModel` implements the core `BatchChatModel`
+interface (`submit`, `retrieve`, `cancel`, `list`). Each request is submitted with the same parameters an
+`AnthropicChatModel` call would use.
+
+```java
+AnthropicBatchChatModel model = AnthropicBatchChatModel.builder()
+    .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+    .modelName(CLAUDE_3_5_SONNET_20240620)
+    .maxTokens(1024)
+    .build();
+
+// Submit a batch of requests
+BatchResponse<ChatResponse> submitted = model.submit(new BatchRequest<>(List.of(
+    ChatRequest.builder().messages(UserMessage.from("What is the capital of France?")).build(),
+    ChatRequest.builder().messages(UserMessage.from("What is the capital of Germany?")).build())));
+
+String batchId = submitted.batchId();
+
+// Poll until the batch reaches a terminal state (typically well under an hour)
+BatchResponse<ChatResponse> batch = model.retrieve(batchId);
+while (!batch.state().isTerminal()) {
+    Thread.sleep(Duration.ofSeconds(30).toMillis());
+    batch = model.retrieve(batchId);
+}
+
+// Read the per-request results, in submission order
+for (BatchItemResult<ChatResponse> result : batch.results()) {
+    if (result.isSuccess()) {
+        System.out.println(result.response().aiMessage().text());
+    } else {
+        System.out.println("Failed: " + result.error().message());
+    }
+}
+```
+
+Use `model.list(...)` to page through recent batches and `model.cancel(batchId)` to cancel one that is still processing.
+
 ## Tools
 
 Anthropic supports [tools](/tutorials/tools) in both streaming and non-streaming mode.

--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -143,7 +143,7 @@ interface (`submit`, `retrieve`, `cancel`, `list`). Each request is submitted wi
 ```java
 AnthropicBatchChatModel model = AnthropicBatchChatModel.builder()
     .apiKey(System.getenv("ANTHROPIC_API_KEY"))
-    .modelName(CLAUDE_3_5_SONNET_20240620)
+    .modelName("claude-sonnet-4-5")
     .maxTokens(1024)
     .build();
 
@@ -157,7 +157,7 @@ String batchId = submitted.batchId();
 // Poll until the batch reaches a terminal state (typically well under an hour)
 BatchResponse<ChatResponse> batch = model.retrieve(batchId);
 while (!batch.state().isTerminal()) {
-    Thread.sleep(Duration.ofSeconds(30).toMillis());
+    TimeUnit.SECONDS.sleep(30); // throws InterruptedException
     batch = model.retrieve(batchId);
 }
 
@@ -172,6 +172,25 @@ for (BatchItemResult<ChatResponse> result : batch.results()) {
 ```
 
 Use `model.list(...)` to page through recent batches and `model.cancel(batchId)` to cancel one that is still processing.
+A batch that you cancel also finishes in the `ended` state on Anthropic's side, and is reported as `BatchState.CANCELLED`;
+it may still contain results for the requests that completed before the cancellation took effect.
+
+Anthropic-specific options such as thinking or prompt caching are configured through `defaultRequestParameters(...)`,
+exactly as for `AnthropicChatModel`, and can be overridden per request:
+
+```java
+AnthropicBatchChatModel model = AnthropicBatchChatModel.builder()
+    .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+    .modelName("claude-sonnet-4-5")
+    .maxTokens(4096)
+    .defaultRequestParameters(AnthropicChatRequestParameters.builder()
+        .thinkingType("enabled")
+        .thinkingBudgetTokens(2000)
+        .cacheSystemMessages(true)
+        .build())
+    .returnThinking(true) // store the returned thinking in AiMessage.thinking()
+    .build();
+```
 
 ## Tools
 

--- a/langchain4j-anthropic/revapi.json
+++ b/langchain4j-anthropic/revapi.json
@@ -55,6 +55,26 @@
           "old": "method dev.langchain4j.model.chat.request.ChatRequestParameters dev.langchain4j.model.anthropic.AnthropicStreamingChatModel::defaultRequestParameters()",
           "new": "method dev.langchain4j.model.anthropic.AnthropicChatRequestParameters dev.langchain4j.model.anthropic.AnthropicStreamingChatModel::defaultRequestParameters()",
           "justification": "Narrowing the return type to the Anthropic-specific AnthropicChatRequestParameters subtype is source- and binary-compatible"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchPage",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by AnthropicBatchChatModel"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchPagination",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by AnthropicBatchChatModel"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchRequest",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by AnthropicBatchChatModel"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchResponse",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by AnthropicBatchChatModel"
         }
       ]
     }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
@@ -1,0 +1,455 @@
+package dev.langchain4j.model.anthropic;
+
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAiMessage;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toFinishReason;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toTokenUsage;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicBatch;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicBatchResult;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateBatchRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicError;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicListBatchesResponse;
+import dev.langchain4j.model.anthropic.internal.client.AnthropicClient;
+import dev.langchain4j.model.batch.BatchError;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.BatchChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A {@link BatchChatModel} for the Anthropic
+ * <a href="https://docs.anthropic.com/en/api/creating-message-batches">Message Batches API</a>, which processes
+ * multiple chat requests asynchronously at 50% of the standard per-token price.
+ *
+ * <p>Each submitted {@link ChatRequest} is mapped to a request identical to the one
+ * {@link AnthropicChatModel} would send, so per-request parameters (model, tools, thinking, caching, etc.) behave
+ * the same in a batch as in a single call. Requests are submitted inline; the returned {@link BatchResponse} carries
+ * the batch id and its current {@link BatchState}. Results are fetched by {@link #retrieve(String)} once the batch has
+ * ended, preserving submission order.</p>
+ *
+ * @see BatchChatModel
+ * @see BatchResponse
+ */
+@Experimental
+public final class AnthropicBatchChatModel implements BatchChatModel {
+
+    private static final String CUSTOM_ID_PREFIX = "request-";
+
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_CANCELING = "canceling";
+    private static final String STATUS_ENDED = "ended";
+    private static final String RESULT_SUCCEEDED = "succeeded";
+
+    private final AnthropicClient client;
+    private final AnthropicChatRequestParameters defaultRequestParameters;
+    private final int maxRetries;
+
+    public AnthropicBatchChatModel(Builder builder) {
+        this.client = AnthropicClient.builder()
+                .httpClientBuilder(builder.httpClientBuilder)
+                .baseUrl(getOrDefault(builder.baseUrl, "https://api.anthropic.com/v1/"))
+                .apiKey(builder.apiKey)
+                .version(getOrDefault(builder.version, AnthropicChatModel.ANTHROPIC_VERSION))
+                .beta(builder.beta)
+                .timeout(builder.timeout)
+                .logRequests(getOrDefault(builder.logRequests, false))
+                .logResponses(getOrDefault(builder.logResponses, false))
+                .build();
+        this.maxRetries = getOrDefault(builder.maxRetries, 2);
+        this.defaultRequestParameters = AnthropicChatRequestParameters.builder()
+                .modelName(builder.modelName)
+                .maxOutputTokens(getOrDefault(builder.maxTokens, 1024))
+                .temperature(builder.temperature)
+                .topP(builder.topP)
+                .topK(builder.topK)
+                .stopSequences(builder.stopSequences)
+                .build();
+    }
+
+    @Override
+    public BatchResponse<ChatResponse> submit(BatchRequest<ChatRequest> request) {
+        List<ChatRequest> requests = request.requests();
+        List<AnthropicCreateBatchRequest.Request> items = new ArrayList<>();
+        for (int i = 0; i < requests.size(); i++) {
+            items.add(
+                    new AnthropicCreateBatchRequest.Request(CUSTOM_ID_PREFIX + i, toAnthropicRequest(requests.get(i))));
+        }
+        AnthropicCreateBatchRequest batchRequest = new AnthropicCreateBatchRequest(items);
+        AnthropicBatch batch = withRetryMappingExceptions(() -> client.createBatch(batchRequest), maxRetries);
+        return toBatchResponse(batch, List.of());
+    }
+
+    @Override
+    public BatchResponse<ChatResponse> retrieve(String batchId) {
+        AnthropicBatch batch = withRetryMappingExceptions(() -> client.retrieveBatch(batchId), maxRetries);
+        List<BatchItemResult<ChatResponse>> results = List.of();
+        if (STATUS_ENDED.equals(batch.processingStatus)) {
+            List<AnthropicBatchResult> rawResults =
+                    withRetryMappingExceptions(() -> client.retrieveBatchResults(batchId), maxRetries);
+            rawResults.sort(Comparator.comparingInt(this::customIdIndex));
+            results = rawResults.stream().map(this::toBatchItemResult).toList();
+        }
+        return toBatchResponse(batch, results);
+    }
+
+    @Override
+    public void cancel(String batchId) {
+        withRetryMappingExceptions(() -> client.cancelBatch(batchId), maxRetries);
+    }
+
+    @Override
+    public BatchPage<ChatResponse> list(@Nullable BatchPagination pagination) {
+        Integer pageSize = pagination != null ? pagination.pageSize() : null;
+        String pageToken = pagination != null ? pagination.pageToken() : null;
+        AnthropicListBatchesResponse response =
+                withRetryMappingExceptions(() -> client.listBatches(pageSize, pageToken), maxRetries);
+        List<BatchResponse<ChatResponse>> batches = new ArrayList<>();
+        if (response.data != null) {
+            for (AnthropicBatch batch : response.data) {
+                batches.add(toBatchResponse(batch, List.of()));
+            }
+        }
+        String nextPageToken = response.hasMore ? response.lastId : null;
+        return new BatchPage<>(batches, nextPageToken);
+    }
+
+    /**
+     * @return a new {@link Builder} for {@link AnthropicBatchChatModel}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private AnthropicCreateMessageRequest toAnthropicRequest(ChatRequest chatRequest) {
+        ChatRequestParameters merged = defaultRequestParameters.overrideWith(chatRequest.parameters());
+        AnthropicChatRequestParameters parameters = (AnthropicChatRequestParameters) merged;
+        ChatRequest effectiveRequest = ChatRequest.builder()
+                .messages(chatRequest.messages())
+                .parameters(merged)
+                .build();
+        return InternalAnthropicHelper.createAnthropicRequest(
+                effectiveRequest,
+                AnthropicChatModel.toThinking(parameters.thinkingType(), parameters.thinkingBudgetTokens(), null),
+                getOrDefault(parameters.sendThinking(), true),
+                getOrDefault(parameters.midConversationSystemMessages(), false),
+                getOrDefault(parameters.cacheSystemMessages(), false)
+                        ? AnthropicCacheType.EPHEMERAL
+                        : AnthropicCacheType.NO_CACHE,
+                getOrDefault(parameters.cacheTools(), false)
+                        ? AnthropicCacheType.EPHEMERAL
+                        : AnthropicCacheType.NO_CACHE,
+                false,
+                parameters.toolChoiceName(),
+                parameters.disableParallelToolUse(),
+                List.of(),
+                Set.of(),
+                parameters.userId(),
+                List.of(),
+                null,
+                null,
+                getOrDefault(parameters.returnCacheDiagnostics(), false),
+                parameters.previousMessageId());
+    }
+
+    private ChatResponse toChatResponse(AnthropicCreateMessageResponse response) {
+        AnthropicChatResponseMetadata metadata = AnthropicChatResponseMetadata.builder()
+                .id(response.id)
+                .modelName(response.model)
+                .tokenUsage(toTokenUsage(response.usage))
+                .finishReason(toFinishReason(response.stopReason))
+                .build();
+        return ChatResponse.builder()
+                .aiMessage(toAiMessage(response.content, false, false))
+                .metadata(metadata)
+                .build();
+    }
+
+    private BatchResponse<ChatResponse> toBatchResponse(
+            AnthropicBatch batch, List<BatchItemResult<ChatResponse>> results) {
+        return BatchResponse.<ChatResponse>builder()
+                .batchId(batch.id)
+                .state(toBatchState(batch.processingStatus))
+                .results(results)
+                .build();
+    }
+
+    private static BatchState toBatchState(@Nullable String processingStatus) {
+        if (processingStatus == null) {
+            return BatchState.UNSPECIFIED;
+        }
+        return switch (processingStatus) {
+            case STATUS_IN_PROGRESS, STATUS_CANCELING -> BatchState.RUNNING;
+            case STATUS_ENDED -> BatchState.SUCCEEDED;
+            default -> BatchState.UNSPECIFIED;
+        };
+    }
+
+    private BatchItemResult<ChatResponse> toBatchItemResult(AnthropicBatchResult result) {
+        AnthropicBatchResult.Result outcome = result.result;
+        if (outcome != null && RESULT_SUCCEEDED.equals(outcome.type) && outcome.message != null) {
+            return BatchItemResult.success(toChatResponse(outcome.message));
+        }
+        return BatchItemResult.failure(toBatchError(outcome));
+    }
+
+    private static BatchError toBatchError(AnthropicBatchResult.@Nullable Result outcome) {
+        if (outcome == null) {
+            return new BatchError(0, "unknown", null);
+        }
+        if (outcome.error != null && outcome.error.error != null) {
+            AnthropicError error = outcome.error.error;
+            List<Map<String, Object>> details = error.type != null ? List.of(Map.of("type", error.type)) : null;
+            String message = error.message != null ? error.message : outcome.type;
+            return new BatchError(0, message, details);
+        }
+        return new BatchError(0, outcome.type, null);
+    }
+
+    private int customIdIndex(AnthropicBatchResult result) {
+        String customId = result.customId;
+        if (customId != null && customId.startsWith(CUSTOM_ID_PREFIX)) {
+            try {
+                return Integer.parseInt(customId.substring(CUSTOM_ID_PREFIX.length()));
+            } catch (NumberFormatException ignored) {
+                // custom id not produced by this model; keep it last rather than failing
+            }
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    public static final class Builder {
+
+        private HttpClientBuilder httpClientBuilder;
+        private String baseUrl;
+        private String apiKey;
+        private String version;
+        private String beta;
+        private String modelName;
+        private Integer maxTokens;
+        private Double temperature;
+        private Double topP;
+        private Integer topK;
+        private List<String> stopSequences;
+        private Duration timeout;
+        private Integer maxRetries;
+        private Boolean logRequests;
+        private Boolean logResponses;
+
+        private Builder() {}
+
+        /**
+         * Sets a custom {@link HttpClientBuilder} for the underlying HTTP client.
+         * Use this to configure timeouts, proxies, or other HTTP-level settings.
+         *
+         * @param httpClientBuilder the HTTP client builder
+         * @return {@code this}
+         */
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        /**
+         * Sets the base URL of the Anthropic API.
+         * <p>
+         * Defaults to {@code https://api.anthropic.com/v1/}.
+         *
+         * @param baseUrl the base URL
+         * @return {@code this}
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Sets the Anthropic API key used to authenticate requests.
+         *
+         * @param apiKey the API key
+         * @return {@code this}
+         */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Sets the value of the {@code anthropic-version} request header.
+         * <p>
+         * Defaults to {@code 2023-06-01}.
+         * See the <a href="https://docs.anthropic.com/en/api/versioning">Anthropic API versioning docs</a>.
+         *
+         * @param version the API version string
+         * @return {@code this}
+         */
+        public Builder version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        /**
+         * Sets the value of the {@code anthropic-beta} request header to opt into beta features.
+         * <p>
+         * See the <a href="https://docs.anthropic.com/en/api/beta-headers">Anthropic beta headers docs</a>.
+         *
+         * @param beta the beta feature identifier
+         * @return {@code this}
+         */
+        public Builder beta(String beta) {
+            this.beta = beta;
+            return this;
+        }
+
+        /**
+         * Sets the model applied to every batched request, specified as a string model ID.
+         * <p>
+         * See {@link AnthropicChatModelName} for available model constants. It can be overridden per request
+         * via {@link ChatRequestParameters#modelName()}.
+         *
+         * @param modelName the model ID, e.g. {@code "claude-opus-4-5"}
+         * @return {@code this}
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of tokens to generate per batched request.
+         * <p>
+         * Defaults to {@code 1024} if not set.
+         *
+         * @param maxTokens the maximum number of output tokens
+         * @return {@code this}
+         */
+        public Builder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        /**
+         * Sets the sampling temperature in the range {@code [0.0, 1.0]}.
+         * Higher values produce more random output; lower values produce more deterministic output.
+         * <p>
+         * Cannot be used together with {@link #topP(Double)}.
+         *
+         * @param temperature the sampling temperature
+         * @return {@code this}
+         */
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        /**
+         * Sets the nucleus sampling probability (top-p) in the range {@code (0.0, 1.0]}.
+         * Only the tokens whose cumulative probability exceeds this threshold are considered.
+         * <p>
+         * Cannot be used together with {@link #temperature(Double)}.
+         *
+         * @param topP the nucleus sampling threshold
+         * @return {@code this}
+         */
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        /**
+         * Sets the top-K sampling value. Only the {@code topK} most-likely next tokens are considered at each step.
+         * <p>
+         * Recommended for advanced use only; {@link #temperature(Double)} is usually sufficient.
+         *
+         * @param topK the number of top tokens to sample from
+         * @return {@code this}
+         */
+        public Builder topK(Integer topK) {
+            this.topK = topK;
+            return this;
+        }
+
+        /**
+         * Sets sequences that, when generated, will cause the model to stop generating further tokens.
+         *
+         * @param stopSequences the list of stop sequences
+         * @return {@code this}
+         */
+        public Builder stopSequences(List<String> stopSequences) {
+            this.stopSequences = stopSequences;
+            return this;
+        }
+
+        /**
+         * Sets the HTTP request timeout for calls to the Anthropic API.
+         *
+         * @param timeout the request timeout
+         * @return {@code this}
+         */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Sets the number of times to retry a request on transient errors (e.g. rate limits, server errors).
+         * <p>
+         * Defaults to {@code 2}.
+         *
+         * @param maxRetries the maximum number of retry attempts
+         * @return {@code this}
+         */
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * Enables debug logging of HTTP request bodies sent to the Anthropic API.
+         *
+         * @param logRequests whether to log requests
+         * @return {@code this}
+         */
+        public Builder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        /**
+         * Enables debug logging of HTTP response bodies received from the Anthropic API.
+         *
+         * @param logResponses whether to log responses
+         * @return {@code this}
+         */
+        public Builder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        /**
+         * @return a new {@link AnthropicBatchChatModel} configured with this builder's values.
+         */
+        public AnthropicBatchChatModel build() {
+            return new AnthropicBatchChatModel(this);
+        }
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
@@ -1,12 +1,18 @@
 package dev.langchain4j.model.anthropic;
 
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.model.anthropic.InternalAnthropicHelper.validate;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAiMessage;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toFinishReason;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toTokenUsage;
+import static java.util.Arrays.asList;
 
 import dev.langchain4j.Experimental;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicBatch;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicBatchResult;
@@ -27,13 +33,16 @@ import dev.langchain4j.model.batch.BatchState;
 import dev.langchain4j.model.chat.BatchChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -63,6 +72,14 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
     private final AnthropicClient client;
     private final AnthropicChatRequestParameters defaultRequestParameters;
     private final int maxRetries;
+    private final String thinkingDisplay;
+    private final boolean returnThinking;
+    private final boolean returnServerToolResults;
+    private final List<AnthropicServerTool> serverTools;
+    private final Set<String> toolMetadataKeysToSend;
+    private final List<AnthropicSkill> skills;
+    private final Map<String, Object> customParameters;
+    private final Boolean strictTools;
 
     public AnthropicBatchChatModel(Builder builder) {
         this.client = AnthropicClient.builder()
@@ -74,18 +91,63 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
                 .timeout(builder.timeout)
                 .logRequests(getOrDefault(builder.logRequests, false))
                 .logResponses(getOrDefault(builder.logResponses, false))
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
+
+        ChatRequestParameters commonParameters;
+        if (builder.defaultRequestParameters != null) {
+            validate(builder.defaultRequestParameters);
+            commonParameters = builder.defaultRequestParameters;
+        } else {
+            commonParameters = DefaultChatRequestParameters.EMPTY;
+        }
+
+        AnthropicChatRequestParameters anthropicDefaults = commonParameters instanceof AnthropicChatRequestParameters
+                ? (AnthropicChatRequestParameters) commonParameters
+                : AnthropicChatRequestParameters.EMPTY;
+
+        this.thinkingDisplay = builder.thinkingDisplay;
+        this.returnServerToolResults = getOrDefault(builder.returnServerToolResults, false);
+        this.serverTools = copy(builder.serverTools);
+        this.toolMetadataKeysToSend = copy(builder.toolMetadataKeysToSend);
+        this.skills = copy(builder.skills);
+        this.customParameters = copy(builder.customParameters);
+        this.strictTools = builder.strictTools;
+
         this.defaultRequestParameters = AnthropicChatRequestParameters.builder()
-                .modelName(builder.modelName)
-                .maxOutputTokens(getOrDefault(builder.maxTokens, 1024))
-                .temperature(builder.temperature)
-                .topP(builder.topP)
-                .topK(builder.topK)
-                .stopSequences(builder.stopSequences)
+                .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
+                .maxOutputTokens(
+                        getOrDefault(builder.maxTokens, getOrDefault(commonParameters.maxOutputTokens(), 1024)))
+                .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
+                .topP(getOrDefault(builder.topP, commonParameters.topP()))
+                .topK(getOrDefault(builder.topK, commonParameters.topK()))
+                .stopSequences(getOrDefault(builder.stopSequences, commonParameters.stopSequences()))
+                .toolSpecifications(commonParameters.toolSpecifications())
+                .toolChoice(commonParameters.toolChoice())
+                .responseFormat(commonParameters.responseFormat())
+                .cacheSystemMessages(anthropicDefaults.cacheSystemMessages())
+                .cacheTools(anthropicDefaults.cacheTools())
+                .thinkingType(anthropicDefaults.thinkingType())
+                .thinkingBudgetTokens(anthropicDefaults.thinkingBudgetTokens())
+                .sendThinking(anthropicDefaults.sendThinking())
+                .midConversationSystemMessages(anthropicDefaults.midConversationSystemMessages())
+                .returnThinking(getOrDefault(builder.returnThinking, anthropicDefaults.returnThinking()))
+                .toolChoiceName(anthropicDefaults.toolChoiceName())
+                .disableParallelToolUse(anthropicDefaults.disableParallelToolUse())
+                .userId(anthropicDefaults.userId())
+                .returnCacheDiagnostics(anthropicDefaults.returnCacheDiagnostics())
                 .build();
+
+        this.returnThinking = getOrDefault(this.defaultRequestParameters.returnThinking(), false);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>All requests are submitted inline in a single HTTP request, so Anthropic's limits of 100,000 requests
+     * and 256 MB per batch apply. Exceeding either is rejected by the API.</p>
+     */
     @Override
     public BatchResponse<ChatResponse> submit(BatchRequest<ChatRequest> request) {
         List<ChatRequest> requests = request.requests();
@@ -99,6 +161,12 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
         return toBatchResponse(batch, List.of());
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Once the batch has ended, all of its results are downloaded and held in memory. For very large batches
+     * (Anthropic allows up to 100,000 requests per batch) this can require a correspondingly large heap.</p>
+     */
     @Override
     public BatchResponse<ChatResponse> retrieve(String batchId) {
         AnthropicBatch batch = withRetryMappingExceptions(() -> client.retrieveBatch(batchId), maxRetries);
@@ -141,15 +209,16 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
     }
 
     private AnthropicCreateMessageRequest toAnthropicRequest(ChatRequest chatRequest) {
-        ChatRequestParameters merged = defaultRequestParameters.overrideWith(chatRequest.parameters());
-        AnthropicChatRequestParameters parameters = (AnthropicChatRequestParameters) merged;
+        AnthropicChatRequestParameters parameters = defaultRequestParameters.overrideWith(chatRequest.parameters());
+        ensureNotBlank(parameters.modelName(), "modelName");
         ChatRequest effectiveRequest = ChatRequest.builder()
                 .messages(chatRequest.messages())
-                .parameters(merged)
+                .parameters(parameters)
                 .build();
         return InternalAnthropicHelper.createAnthropicRequest(
                 effectiveRequest,
-                AnthropicChatModel.toThinking(parameters.thinkingType(), parameters.thinkingBudgetTokens(), null),
+                AnthropicChatModel.toThinking(
+                        parameters.thinkingType(), parameters.thinkingBudgetTokens(), thinkingDisplay),
                 getOrDefault(parameters.sendThinking(), true),
                 getOrDefault(parameters.midConversationSystemMessages(), false),
                 getOrDefault(parameters.cacheSystemMessages(), false)
@@ -161,12 +230,12 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
                 false,
                 parameters.toolChoiceName(),
                 parameters.disableParallelToolUse(),
-                List.of(),
-                Set.of(),
+                serverTools,
+                toolMetadataKeysToSend,
                 parameters.userId(),
-                List.of(),
-                null,
-                null,
+                skills,
+                customParameters,
+                strictTools,
                 getOrDefault(parameters.returnCacheDiagnostics(), false),
                 parameters.previousMessageId());
     }
@@ -179,7 +248,7 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
                 .finishReason(toFinishReason(response.stopReason))
                 .build();
         return ChatResponse.builder()
-                .aiMessage(toAiMessage(response.content, false, false))
+                .aiMessage(toAiMessage(response.content, returnThinking, returnServerToolResults))
                 .metadata(metadata)
                 .build();
     }
@@ -188,18 +257,19 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
             AnthropicBatch batch, List<BatchItemResult<ChatResponse>> results) {
         return BatchResponse.<ChatResponse>builder()
                 .batchId(batch.id)
-                .state(toBatchState(batch.processingStatus))
+                .state(toBatchState(batch))
                 .results(results)
                 .build();
     }
 
-    private static BatchState toBatchState(@Nullable String processingStatus) {
+    private static BatchState toBatchState(AnthropicBatch batch) {
+        String processingStatus = batch.processingStatus;
         if (processingStatus == null) {
             return BatchState.UNSPECIFIED;
         }
         return switch (processingStatus) {
             case STATUS_IN_PROGRESS, STATUS_CANCELING -> BatchState.RUNNING;
-            case STATUS_ENDED -> BatchState.SUCCEEDED;
+            case STATUS_ENDED -> batch.cancelInitiatedAt != null ? BatchState.CANCELLED : BatchState.SUCCEEDED;
             default -> BatchState.UNSPECIFIED;
         };
     }
@@ -212,6 +282,11 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
         return BatchItemResult.failure(toBatchError(outcome));
     }
 
+    /**
+     * Anthropic reports batch item failures by error type, not by numeric code, so {@link BatchError#code()} is
+     * always {@code 0}; the Anthropic error type is surfaced under the {@code "type"} key of
+     * {@link BatchError#details()} instead.
+     */
     private static BatchError toBatchError(AnthropicBatchResult.@Nullable Result outcome) {
         if (outcome == null) {
             return new BatchError(0, "unknown", null);
@@ -254,6 +329,16 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
         private Integer maxRetries;
         private Boolean logRequests;
         private Boolean logResponses;
+        private ChatRequestParameters defaultRequestParameters;
+        private String thinkingDisplay;
+        private Boolean returnThinking;
+        private Boolean returnServerToolResults;
+        private List<AnthropicServerTool> serverTools;
+        private Set<String> toolMetadataKeysToSend;
+        private List<AnthropicSkill> skills;
+        private Map<String, Object> customParameters;
+        private Boolean strictTools;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         private Builder() {}
 
@@ -331,6 +416,19 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
          */
         public Builder modelName(String modelName) {
             this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * Sets the model applied to every batched request.
+         * <p>
+         * It can be overridden per request via {@link ChatRequestParameters#modelName()}.
+         *
+         * @param modelName the model
+         * @return {@code this}
+         */
+        public Builder modelName(AnthropicChatModelName modelName) {
+            this.modelName = modelName.toString();
             return this;
         }
 
@@ -442,6 +540,170 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
          */
         public Builder logResponses(Boolean logResponses) {
             this.logResponses = logResponses;
+            return this;
+        }
+
+        /**
+         * Sets the default {@link ChatRequestParameters} applied to every batched request.
+         * <p>
+         * Pass {@link AnthropicChatRequestParameters} to configure Anthropic-specific defaults such as thinking,
+         * prompt caching and tool choice. Individual builder methods (e.g. {@link #modelName(String)}) take
+         * precedence over the corresponding value here, and per-request parameters take precedence over both.
+         *
+         * @param parameters the default request parameters
+         * @return {@code this}
+         */
+        public Builder defaultRequestParameters(ChatRequestParameters parameters) {
+            this.defaultRequestParameters = parameters;
+            return this;
+        }
+
+        /**
+         * Controls how thinking is returned by the API, e.g. {@code "summarized"} or {@code "omitted"}.
+         * <p>
+         * Applies only when thinking is enabled via
+         * {@link AnthropicChatRequestParameters.Builder#thinkingType(String)}.
+         *
+         * @param thinkingDisplay the thinking display mode
+         * @return {@code this}
+         * @see #returnThinking(Boolean)
+         */
+        public Builder thinkingDisplay(String thinkingDisplay) {
+            this.thinkingDisplay = thinkingDisplay;
+            return this;
+        }
+
+        /**
+         * Controls whether thinking returned by the API is stored in {@link AiMessage#thinking()}.
+         * <p>
+         * Disabled by default. Unlike {@link AnthropicChatModel}, this is resolved once per model rather than per
+         * request, because results are mapped in {@link #retrieve(String)}, which has no access to the originating
+         * request.
+         *
+         * @param returnThinking whether to return thinking
+         * @return {@code this}
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        /**
+         * Controls whether to return server tool results (e.g. web_search, code_execution)
+         * inside {@link AiMessage#attributes()} under the key "server_tool_results".
+         * <p>
+         * Disabled by default to avoid returning potentially large data.
+         *
+         * @param returnServerToolResults whether to return server tool results
+         * @return {@code this}
+         * @see #serverTools(List)
+         */
+        public Builder returnServerToolResults(Boolean returnServerToolResults) {
+            this.returnServerToolResults = returnServerToolResults;
+            return this;
+        }
+
+        /**
+         * Specifies server tools (e.g. web search, code execution) to be included in every batched request.
+         *
+         * @param serverTools the server tools
+         * @return {@code this}
+         * @see AnthropicChatModel.AnthropicChatModelBuilder#serverTools(List)
+         */
+        public Builder serverTools(List<AnthropicServerTool> serverTools) {
+            this.serverTools = serverTools;
+            return this;
+        }
+
+        /**
+         * @see #serverTools(List)
+         */
+        public Builder serverTools(AnthropicServerTool... serverTools) {
+            return serverTools(asList(serverTools));
+        }
+
+        /**
+         * Enables Anthropic Agent Skills for every batched request.
+         * <p>
+         * The required beta features must be opted into via {@link #beta(String)}.
+         *
+         * @param skills the skills to enable
+         * @return {@code this}
+         * @see AnthropicChatModel.AnthropicChatModelBuilder#skills(List)
+         */
+        public Builder skills(List<AnthropicSkill> skills) {
+            this.skills = skills;
+            return this;
+        }
+
+        /**
+         * @see #skills(List)
+         */
+        public Builder skills(AnthropicSkill... skills) {
+            return skills(asList(skills));
+        }
+
+        /**
+         * Specifies metadata keys from the {@link ToolSpecification#metadata()} to be included in the request.
+         *
+         * @param toolMetadataKeysToSend the metadata keys
+         * @return {@code this}
+         */
+        public Builder toolMetadataKeysToSend(Set<String> toolMetadataKeysToSend) {
+            this.toolMetadataKeysToSend = toolMetadataKeysToSend;
+            return this;
+        }
+
+        /**
+         * @see #toolMetadataKeysToSend(Set)
+         */
+        public Builder toolMetadataKeysToSend(String... toolMetadataKeysToSend) {
+            return toolMetadataKeysToSend(new HashSet<>(asList(toolMetadataKeysToSend)));
+        }
+
+        /**
+         * Enables strict mode for tools, guaranteeing that generated tool arguments match the tool's schema.
+         *
+         * @param strictTools whether tools are strict
+         * @return {@code this}
+         */
+        public Builder strictTools(Boolean strictTools) {
+            this.strictTools = strictTools;
+            return this;
+        }
+
+        /**
+         * Sets additional top-level parameters added verbatim to every batched request body.
+         * Use this to send parameters that are not yet supported by langchain4j.
+         *
+         * @param customParameters the custom parameters
+         * @return {@code this}
+         */
+        public Builder customParameters(Map<String, Object> customParameters) {
+            this.customParameters = customParameters;
+            return this;
+        }
+
+        /**
+         * Sets custom HTTP headers sent with every request to the Anthropic API.
+         *
+         * @param customHeaders a map of header names to values
+         * @return {@code this}
+         */
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier of custom HTTP headers, invoked for every request to the Anthropic API.
+         * Use this when header values need to be refreshed, e.g. for short-lived tokens.
+         *
+         * @param customHeadersSupplier a supplier that returns a map of header names to values
+         * @return {@code this}
+         */
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicBatch.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicBatch.java
@@ -8,9 +8,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
  * Metadata for a batch job returned by the Anthropic Message Batches API
  * (create, retrieve, cancel, and each entry of the list endpoint).
  *
- * <p>{@link #processingStatus} is one of {@code in_progress}, {@code canceling}, or {@code ended}.
- * Per-request outcomes are not carried here; they are fetched separately from the batch's results
- * endpoint once the batch has ended.</p>
+ * <p>{@link #processingStatus} is one of {@code in_progress}, {@code canceling}, or {@code ended}. A canceled
+ * batch also ends as {@code ended}, so {@link #cancelInitiatedAt} is what distinguishes a canceled batch from
+ * one that ran to completion. Per-request outcomes are not carried here; they are fetched separately from the
+ * batch's results endpoint once the batch has ended.</p>
  *
  * <p>Only the fields consumed by {@code AnthropicBatchChatModel} are declared; the remaining
  * response fields are ignored via {@link JsonIgnoreProperties}.</p>
@@ -21,4 +22,5 @@ public class AnthropicBatch {
 
     public String id;
     public String processingStatus;
+    public String cancelInitiatedAt;
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicBatch.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicBatch.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * Metadata for a batch job returned by the Anthropic Message Batches API
+ * (create, retrieve, cancel, and each entry of the list endpoint).
+ *
+ * <p>{@link #processingStatus} is one of {@code in_progress}, {@code canceling}, or {@code ended}.
+ * Per-request outcomes are not carried here; they are fetched separately from the batch's results
+ * endpoint once the batch has ended.</p>
+ *
+ * <p>Only the fields consumed by {@code AnthropicBatchChatModel} are declared; the remaining
+ * response fields are ignored via {@link JsonIgnoreProperties}.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicBatch {
+
+    public String id;
+    public String processingStatus;
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicBatchResult.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicBatchResult.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * A single line of the JSONL document served from a batch's {@code results_url}.
+ *
+ * <p>{@link #customId} correlates the outcome with the originating request. Results are returned
+ * in arbitrary order, so callers must key on {@code custom_id} rather than position.
+ * {@code result.type} is one of {@code succeeded}, {@code errored}, {@code canceled}, or
+ * {@code expired}; {@link Result#message} is populated only for {@code succeeded}.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicBatchResult {
+
+    public String customId;
+    public Result result;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(SnakeCaseStrategy.class)
+    public static class Result {
+
+        public String type;
+        public AnthropicCreateMessageResponse message;
+        public ResultError error;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(SnakeCaseStrategy.class)
+    public static class ResultError {
+
+        public String type;
+        public AnthropicError error;
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateBatchRequest.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateBatchRequest.java
@@ -1,0 +1,45 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+/**
+ * Request body for the Anthropic Message Batches API ({@code POST /v1/messages/batches}).
+ *
+ * <p>Each {@link Request} carries a caller-assigned {@code custom_id} and the same
+ * {@link AnthropicCreateMessageRequest} that a single (non-batch) message request would use.</p>
+ */
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicCreateBatchRequest {
+
+    public List<Request> requests;
+
+    public AnthropicCreateBatchRequest() {}
+
+    public AnthropicCreateBatchRequest(List<Request> requests) {
+        this.requests = requests;
+    }
+
+    @JsonInclude(NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(SnakeCaseStrategy.class)
+    public static class Request {
+
+        public String customId;
+        public AnthropicCreateMessageRequest params;
+
+        public Request() {}
+
+        public Request(String customId, AnthropicCreateMessageRequest params) {
+            this.customId = customId;
+            this.params = params;
+        }
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicListBatchesResponse.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicListBatchesResponse.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+/**
+ * Response body for the list endpoint of the Anthropic Message Batches API
+ * ({@code GET /v1/messages/batches}).
+ *
+ * <p>Uses id-cursor pagination: when {@link #hasMore} is {@code true}, {@link #lastId} is the
+ * cursor to pass back as {@code after_id} to fetch the next page.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicListBatchesResponse {
+
+    public List<AnthropicBatch> data;
+    public boolean hasMore;
+    public String lastId;
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicClient.java
@@ -1,16 +1,22 @@
 package dev.langchain4j.model.anthropic.internal.client;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.http.client.HttpClientBuilderLoader;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicBatch;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicBatchResult;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCountTokensRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateBatchRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicListBatchesResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicModelsListResponse;
 import dev.langchain4j.model.anthropic.internal.api.MessageTokenCountResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.spi.ServiceHelper;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -43,6 +49,26 @@ public abstract class AnthropicClient {
 
     public AnthropicModelsListResponse listModels() {
         throw new UnsupportedOperationException("Model listing is not supported by this client implementation");
+    }
+
+    public AnthropicBatch createBatch(AnthropicCreateBatchRequest request) {
+        throw new UnsupportedFeatureException("Batch creation is not supported by this client implementation");
+    }
+
+    public AnthropicBatch retrieveBatch(String batchId) {
+        throw new UnsupportedFeatureException("Batch retrieval is not supported by this client implementation");
+    }
+
+    public List<AnthropicBatchResult> retrieveBatchResults(String batchId) {
+        throw new UnsupportedFeatureException("Batch results retrieval is not supported by this client implementation");
+    }
+
+    public AnthropicBatch cancelBatch(String batchId) {
+        throw new UnsupportedFeatureException("Batch cancellation is not supported by this client implementation");
+    }
+
+    public AnthropicListBatchesResponse listBatches(Integer limit, String afterId) {
+        throw new UnsupportedFeatureException("Batch listing is not supported by this client implementation");
     }
 
     @SuppressWarnings("rawtypes")

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -44,11 +44,15 @@ import dev.langchain4j.internal.ToolCallBuilder;
 import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
 import dev.langchain4j.model.anthropic.AnthropicServerToolResult;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicBatch;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicBatchResult;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCountTokensRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateBatchRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicDelta;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicDiagnostics;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicListBatchesResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicModelsListResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicResponseMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingData;
@@ -680,6 +684,74 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 .build();
         SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
         return fromJson(successfulHttpResponse.body(), AnthropicModelsListResponse.class);
+    }
+
+    @Override
+    public AnthropicBatch createBatch(AnthropicCreateBatchRequest request) {
+        HttpRequest httpRequest = toHttpRequest(toJson(request), "messages/batches");
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        return fromJson(rawResponse.body(), AnthropicBatch.class);
+    }
+
+    @Override
+    public AnthropicBatch retrieveBatch(String batchId) {
+        SuccessfulHttpResponse rawResponse = httpClient.execute(toBatchGetRequest("messages/batches/" + batchId));
+        return fromJson(rawResponse.body(), AnthropicBatch.class);
+    }
+
+    @Override
+    public List<AnthropicBatchResult> retrieveBatchResults(String batchId) {
+        SuccessfulHttpResponse rawResponse =
+                httpClient.execute(toBatchGetRequest("messages/batches/" + batchId + "/results"));
+        String body = rawResponse.body();
+        List<AnthropicBatchResult> results = new ArrayList<>();
+        if (body != null) {
+            body.lines()
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .forEach(line -> results.add(fromJson(line, AnthropicBatchResult.class)));
+        }
+        return results;
+    }
+
+    @Override
+    public AnthropicBatch cancelBatch(String batchId) {
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(POST)
+                .url(baseUrl, "messages/batches/" + batchId + "/cancel")
+                .addHeader("x-api-key", apiKey)
+                .addHeader("anthropic-version", version)
+                .addHeaders(customHeadersSupplier.get())
+                .build();
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        return fromJson(rawResponse.body(), AnthropicBatch.class);
+    }
+
+    @Override
+    public AnthropicListBatchesResponse listBatches(Integer limit, String afterId) {
+        StringBuilder path = new StringBuilder("messages/batches");
+        List<String> queryParams = new ArrayList<>();
+        if (limit != null) {
+            queryParams.add("limit=" + limit);
+        }
+        if (isNotNullOrBlank(afterId)) {
+            queryParams.add("after_id=" + afterId);
+        }
+        if (!queryParams.isEmpty()) {
+            path.append('?').append(String.join("&", queryParams));
+        }
+        SuccessfulHttpResponse rawResponse = httpClient.execute(toBatchGetRequest(path.toString()));
+        return fromJson(rawResponse.body(), AnthropicListBatchesResponse.class);
+    }
+
+    private HttpRequest toBatchGetRequest(String path) {
+        return HttpRequest.builder()
+                .method(GET)
+                .url(baseUrl, path)
+                .addHeader("x-api-key", apiKey)
+                .addHeader("anthropic-version", version)
+                .addHeaders(customHeadersSupplier.get())
+                .build();
     }
 
     /**

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelIT.java
@@ -1,0 +1,50 @@
+package dev.langchain4j.model.anthropic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+class AnthropicBatchChatModelIT {
+
+    private static final String ANTHROPIC_API_KEY = System.getenv("ANTHROPIC_API_KEY");
+
+    private final AnthropicBatchChatModel model = AnthropicBatchChatModel.builder()
+            .apiKey(ANTHROPIC_API_KEY)
+            .modelName("claude-haiku-4-5-20251001")
+            .maxTokens(16)
+            .build();
+
+    @Test
+    void should_submit_retrieve_and_list_a_batch() {
+        BatchResponse<ChatResponse> submitted = model.submit(new BatchRequest<>(List.of(ChatRequest.builder()
+                .messages(UserMessage.from("What is the capital of France? Answer with one word."))
+                .build())));
+
+        assertThat(submitted.batchId()).isNotBlank();
+        assertThat(submitted.state()).isIn(BatchState.PENDING, BatchState.RUNNING, BatchState.SUCCEEDED);
+
+        BatchResponse<ChatResponse> retrieved = model.retrieve(submitted.batchId());
+        assertThat(retrieved.batchId()).isEqualTo(submitted.batchId());
+        assertThat(retrieved.state()).isNotNull();
+
+        BatchPage<ChatResponse> page = model.list(new BatchPagination(20, null));
+        assertThat(page.batches()).anyMatch(batch -> batch.batchId().equals(submitted.batchId()));
+
+        try {
+            model.cancel(submitted.batchId());
+        } catch (RuntimeException ignored) {
+            // best-effort cleanup; the batch may already have ended and can no longer be cancelled
+        }
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelTest.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.model.anthropic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.batch.BatchItemResult;
 import dev.langchain4j.model.batch.BatchPage;
@@ -50,6 +52,21 @@ class AnthropicBatchChatModelTest {
              "request_counts":{"processing":2,"succeeded":0,"errored":0,"canceled":0,"expired":0}}
             """;
 
+    private static final String CANCEL_INITIATED_ENDED_RESPONSE = """
+            {"id":"msgbatch_cancel_initiated","type":"message_batch","processing_status":"ended",
+             "cancel_initiated_at":"2024-09-24T18:37:24.100435Z",
+             "results_url":"https://example.com/results",
+             "request_counts":{"processing":0,"succeeded":1,"errored":1,"canceled":0,"expired":0}}
+            """;
+
+    private static final String THINKING_RESULTS_JSONL =
+            "{\"custom_id\":\"request-0\",\"result\":{\"type\":\"succeeded\",\"message\":{\"id\":\"msg_0\","
+                    + "\"type\":\"message\",\"role\":\"assistant\",\"content\":["
+                    + "{\"type\":\"thinking\",\"thinking\":\"Paris is the capital.\",\"signature\":\"sig-1\"},"
+                    + "{\"type\":\"text\",\"text\":\"Paris\"}],"
+                    + "\"model\":\"claude-haiku-4-5-20251001\",\"stop_reason\":\"end_turn\","
+                    + "\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}}\n";
+
     private static final String CANCELED_RESULTS_JSONL =
             "{\"custom_id\":\"request-0\",\"result\":{\"type\":\"canceled\"}}\n";
 
@@ -84,7 +101,13 @@ class AnthropicBatchChatModelTest {
                 responseBody = CANCELING_RESPONSE;
             } else if (path.endsWith("/results")) {
                 resultsCalled.set(true);
-                responseBody = path.contains("msgbatch_canceled") ? CANCELED_RESULTS_JSONL : RESULTS_JSONL;
+                if (path.contains("msgbatch_canceled")) {
+                    responseBody = CANCELED_RESULTS_JSONL;
+                } else if (path.contains("msgbatch_thinking")) {
+                    responseBody = THINKING_RESULTS_JSONL;
+                } else {
+                    responseBody = RESULTS_JSONL;
+                }
             } else if (path.equals("/v1/messages/batches") && method.equals("POST")) {
                 capturedCreateBody.set(read(exchange.getRequestBody()));
                 responseBody = CREATE_RESPONSE;
@@ -93,6 +116,8 @@ class AnthropicBatchChatModelTest {
                 responseBody = LIST_RESPONSE;
             } else if (path.endsWith("msgbatch_running")) {
                 responseBody = IN_PROGRESS_RESPONSE;
+            } else if (path.endsWith("msgbatch_cancel_initiated")) {
+                responseBody = CANCEL_INITIATED_ENDED_RESPONSE;
             } else {
                 responseBody = ENDED_RESPONSE;
             }
@@ -192,6 +217,77 @@ class AnthropicBatchChatModelTest {
 
         assertThat(page.batches()).hasSize(1);
         assertThat(capturedListQuery.get()).isNull();
+    }
+
+    @Test
+    void retrieve_maps_ended_batch_with_cancel_initiated_at_to_cancelled() {
+        BatchResponse<ChatResponse> response = model().retrieve("msgbatch_cancel_initiated");
+
+        assertThat(response.state()).isEqualTo(BatchState.CANCELLED);
+        assertThat(response.state().isTerminal()).isTrue();
+        // a cancelled batch may still carry results for requests that completed before cancellation
+        assertThat(response.results()).hasSize(2);
+    }
+
+    @Test
+    void retrieve_does_not_return_thinking_by_default() {
+        BatchResponse<ChatResponse> response = model().retrieve("msgbatch_thinking");
+
+        AiMessage aiMessage = response.results().get(0).response().aiMessage();
+        assertThat(aiMessage.text()).isEqualTo("Paris");
+        assertThat(aiMessage.thinking()).isNull();
+    }
+
+    @Test
+    void retrieve_returns_thinking_when_return_thinking_is_enabled() {
+        AnthropicBatchChatModel model = AnthropicBatchChatModel.builder()
+                .baseUrl(baseUrl)
+                .apiKey("test-key")
+                .modelName("claude-haiku-4-5-20251001")
+                .maxTokens(16)
+                .returnThinking(true)
+                .build();
+
+        BatchResponse<ChatResponse> response = model.retrieve("msgbatch_thinking");
+
+        AiMessage aiMessage = response.results().get(0).response().aiMessage();
+        assertThat(aiMessage.text()).isEqualTo("Paris");
+        assertThat(aiMessage.thinking()).isEqualTo("Paris is the capital.");
+    }
+
+    @Test
+    void submit_applies_anthropic_specific_default_request_parameters() {
+        AnthropicBatchChatModel model = AnthropicBatchChatModel.builder()
+                .baseUrl(baseUrl)
+                .apiKey("test-key")
+                .modelName("claude-haiku-4-5-20251001")
+                .maxTokens(2048)
+                .defaultRequestParameters(AnthropicChatRequestParameters.builder()
+                        .thinkingType("enabled")
+                        .thinkingBudgetTokens(1024)
+                        .build())
+                .build();
+
+        model.submit(new BatchRequest<>(List.of(
+                ChatRequest.builder().messages(UserMessage.from("first")).build())));
+
+        assertThat(capturedCreateBody.get()).contains("\"thinking\"", "\"budget_tokens\" : 1024");
+    }
+
+    @Test
+    void submit_fails_when_model_name_is_not_set() {
+        AnthropicBatchChatModel model = AnthropicBatchChatModel.builder()
+                .baseUrl(baseUrl)
+                .apiKey("test-key")
+                .maxTokens(16)
+                .build();
+
+        BatchRequest<ChatRequest> request = new BatchRequest<>(List.of(
+                ChatRequest.builder().messages(UserMessage.from("first")).build()));
+
+        assertThatThrownBy(() -> model.submit(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("modelName");
     }
 
     private static String read(InputStream inputStream) throws IOException {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelTest.java
@@ -1,0 +1,202 @@
+package dev.langchain4j.model.anthropic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnthropicBatchChatModelTest {
+
+    private static final String CREATE_RESPONSE = """
+            {"id":"msgbatch_1","type":"message_batch","processing_status":"in_progress",
+             "request_counts":{"processing":2,"succeeded":0,"errored":0,"canceled":0,"expired":0}}
+            """;
+
+    private static final String ENDED_RESPONSE = """
+            {"id":"msgbatch_1","type":"message_batch","processing_status":"ended",
+             "results_url":"https://example.com/results",
+             "request_counts":{"processing":0,"succeeded":1,"errored":1,"canceled":0,"expired":0}}
+            """;
+
+    private static final String RESULTS_JSONL =
+            "{\"custom_id\":\"request-1\",\"result\":{\"type\":\"errored\",\"error\":{\"type\":\"error\","
+                    + "\"error\":{\"type\":\"invalid_request_error\",\"message\":\"boom\"}}}}\n"
+                    + "{\"custom_id\":\"request-0\",\"result\":{\"type\":\"succeeded\",\"message\":{\"id\":\"msg_0\","
+                    + "\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"A\"}],"
+                    + "\"model\":\"claude-haiku-4-5-20251001\",\"stop_reason\":\"end_turn\","
+                    + "\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}}\n";
+
+    private static final String IN_PROGRESS_RESPONSE = """
+            {"id":"msgbatch_running","type":"message_batch","processing_status":"in_progress",
+             "request_counts":{"processing":2,"succeeded":0,"errored":0,"canceled":0,"expired":0}}
+            """;
+
+    private static final String CANCELED_RESULTS_JSONL =
+            "{\"custom_id\":\"request-0\",\"result\":{\"type\":\"canceled\"}}\n";
+
+    private static final String CANCELING_RESPONSE = """
+            {"id":"msgbatch_1","type":"message_batch","processing_status":"canceling",
+             "request_counts":{"processing":2,"succeeded":0,"errored":0,"canceled":0,"expired":0}}
+            """;
+
+    private static final String LIST_RESPONSE = """
+            {"data":[{"id":"msgbatch_1","type":"message_batch","processing_status":"ended",
+             "request_counts":{"processing":0,"succeeded":2,"errored":0,"canceled":0,"expired":0}}],
+             "has_more":true,"first_id":"msgbatch_1","last_id":"msgbatch_9"}
+            """;
+
+    private HttpServer server;
+    private String baseUrl;
+    private final AtomicReference<String> capturedCreateBody = new AtomicReference<>();
+    private final AtomicReference<String> capturedListQuery = new AtomicReference<>();
+    private final AtomicBoolean cancelCalled = new AtomicBoolean(false);
+    private final AtomicBoolean resultsCalled = new AtomicBoolean(false);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        server = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
+        server.createContext("/v1/messages/batches", exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            String responseBody;
+            if (path.endsWith("/cancel")) {
+                cancelCalled.set(true);
+                responseBody = CANCELING_RESPONSE;
+            } else if (path.endsWith("/results")) {
+                resultsCalled.set(true);
+                responseBody = path.contains("msgbatch_canceled") ? CANCELED_RESULTS_JSONL : RESULTS_JSONL;
+            } else if (path.equals("/v1/messages/batches") && method.equals("POST")) {
+                capturedCreateBody.set(read(exchange.getRequestBody()));
+                responseBody = CREATE_RESPONSE;
+            } else if (path.equals("/v1/messages/batches")) {
+                capturedListQuery.set(exchange.getRequestURI().getQuery());
+                responseBody = LIST_RESPONSE;
+            } else if (path.endsWith("msgbatch_running")) {
+                responseBody = IN_PROGRESS_RESPONSE;
+            } else {
+                responseBody = ENDED_RESPONSE;
+            }
+            byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.getResponseBody().close();
+        });
+        server.start();
+        baseUrl = "http://" + loopback.getHostAddress() + ":"
+                + server.getAddress().getPort() + "/v1";
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    private AnthropicBatchChatModel model() {
+        return AnthropicBatchChatModel.builder()
+                .baseUrl(baseUrl)
+                .apiKey("test-key")
+                .modelName("claude-haiku-4-5-20251001")
+                .maxTokens(16)
+                .build();
+    }
+
+    @Test
+    void submit_assigns_ordered_custom_ids_and_returns_running_state() {
+        BatchResponse<ChatResponse> response = model().submit(new BatchRequest<>(List.of(
+                ChatRequest.builder().messages(UserMessage.from("first")).build(),
+                ChatRequest.builder().messages(UserMessage.from("second")).build())));
+
+        assertThat(response.batchId()).isEqualTo("msgbatch_1");
+        assertThat(response.state()).isEqualTo(BatchState.RUNNING);
+        assertThat(response.results()).isEmpty();
+        assertThat(capturedCreateBody.get()).contains("\"custom_id\" : \"request-0\"", "\"custom_id\" : \"request-1\"");
+    }
+
+    @Test
+    void retrieve_reorders_results_to_submission_order_and_maps_success_and_error() {
+        BatchResponse<ChatResponse> response = model().retrieve("msgbatch_1");
+
+        assertThat(response.state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(response.results()).hasSize(2);
+
+        BatchItemResult<ChatResponse> first = response.results().get(0);
+        assertThat(first.isSuccess()).isTrue();
+        assertThat(first.response().aiMessage().text()).isEqualTo("A");
+
+        BatchItemResult<ChatResponse> second = response.results().get(1);
+        assertThat(second.isSuccess()).isFalse();
+        assertThat(second.error().message()).isEqualTo("boom");
+
+        assertThat(response.responses()).hasSize(1);
+        assertThat(response.errors()).hasSize(1);
+    }
+
+    @Test
+    void cancel_calls_the_cancel_endpoint() {
+        model().cancel("msgbatch_1");
+        assertThat(cancelCalled).isTrue();
+    }
+
+    @Test
+    void list_maps_pagination_cursor_from_has_more_and_last_id() {
+        BatchPage<ChatResponse> page = model().list(new BatchPagination(10, null));
+
+        assertThat(page.batches()).hasSize(1);
+        assertThat(page.batches().get(0).state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(page.nextPageToken()).isEqualTo("msgbatch_9");
+    }
+
+    @Test
+    void retrieve_while_in_progress_returns_running_and_does_not_fetch_results() {
+        BatchResponse<ChatResponse> response = model().retrieve("msgbatch_running");
+
+        assertThat(response.state()).isEqualTo(BatchState.RUNNING);
+        assertThat(response.results()).isEmpty();
+        assertThat(resultsCalled).isFalse();
+    }
+
+    @Test
+    void retrieve_maps_canceled_result_without_error_to_failure_with_type_as_message() {
+        BatchResponse<ChatResponse> response = model().retrieve("msgbatch_canceled");
+
+        assertThat(response.results()).hasSize(1);
+        BatchItemResult<ChatResponse> result = response.results().get(0);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.error().message()).isEqualTo("canceled");
+    }
+
+    @Test
+    void list_with_null_pagination_sends_no_query_params_and_returns_batches() {
+        BatchPage<ChatResponse> page = model().list(null);
+
+        assertThat(page.batches()).hasSize(1);
+        assertThat(capturedListQuery.get()).isNull();
+    }
+
+    private static String read(InputStream inputStream) throws IOException {
+        try (inputStream) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
Progresses #3916.

## Change

Adds `AnthropicBatchChatModel`, an implementation of the core `BatchChatModel` interface
(`submit` / `retrieve` / `cancel` / `list`) for the [Anthropic Message Batches API](https://docs.anthropic.com/en/docs/build-with-claude/batch-processing), which processes many chat requests asynchronously at 50% of the standard per-token price.

Each request is built through the same `createAnthropicRequest` path as `AnthropicChatModel`, so per-request
parameters (tools, thinking, caching, etc.) behave identically in a batch and in a single call. Results come
back in arbitrary order and are re-sorted to submission order by generated `custom_id`s. Anthropic reports
only `in_progress` / `canceling` / `ended` at the batch level, so `ended` maps to `BatchState.SUCCEEDED` and
the per-request `succeeded` / `errored` / `canceled` / `expired` outcomes are surfaced as `BatchItemResult`s.

The batch endpoints are added to the existing hand-rolled `AnthropicClient` as default methods that throw
`UnsupportedFeatureException`, so existing `AnthropicClient` implementations keep compiling. No new
dependency. Chat requests only.

Covered by unit tests against a mock HTTP server (custom-id ordering, success/error/canceled mapping, the
in-progress case that fetches no results until the batch ends, and pagination). The integration test
`AnthropicBatchChatModelIT` (key-gated on `ANTHROPIC_API_KEY`) was also run against the live Batches API and
passes, exercising submit / retrieve / list / cancel.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [X] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)