### PR TITLE
feat(http-client): add default User-Agent: LangChain4j header in shared HTTP clients

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -226,6 +226,10 @@ public class ApacheHttpClient implements HttpClient {
             }
         });
 
+        if (request.headers().keySet().stream().noneMatch(k -> k.equalsIgnoreCase("User-Agent"))) {
+            apacheRequest.addHeader("User-Agent", "LangChain4j");
+        }
+
         return apacheRequest;
     }
 
@@ -265,6 +269,10 @@ public class ApacheHttpClient implements HttpClient {
                 }
             }
         });
+
+        if (request.headers().keySet().stream().noneMatch(k -> k.equalsIgnoreCase("User-Agent"))) {
+            builder.addHeader("User-Agent", "LangChain4j");
+        }
 
         return builder.build();
     }

--- a/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientUserAgentTest.java
+++ b/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientUserAgentTest.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.http.client.apache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApacheHttpClientUserAgentTest {
+
+    private HttpServer server;
+    private String baseUrl;
+    private final AtomicReference<String> capturedUserAgent = new AtomicReference<>();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/test", exchange -> {
+            capturedUserAgent.set(exchange.getRequestHeaders().getFirst("User-Agent"));
+            byte[] response = new byte[0];
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        });
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void should_send_langchain4j_user_agent_by_default() throws Exception {
+        ApacheHttpClient.builder().build().execute(request(null));
+
+        assertThat(capturedUserAgent.get()).isEqualTo("LangChain4j");
+    }
+
+    @Test
+    void should_allow_caller_to_override_user_agent() throws Exception {
+        ApacheHttpClient.builder().build().execute(request("my-app/1.0"));
+
+        assertThat(capturedUserAgent.get()).isEqualTo("my-app/1.0");
+    }
+
+    private HttpRequest request(String userAgent) {
+        HttpRequest.Builder builder =
+                HttpRequest.builder().method(HttpMethod.GET).url(baseUrl + "/test");
+        if (userAgent != null) {
+            builder.addHeader("User-Agent", userAgent);
+        }
+        return builder.build();
+    }
+}

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -106,6 +106,10 @@ public class JdkHttpClient implements HttpClient {
             }
         });
 
+        if (request.headers().keySet().stream().noneMatch(k -> k.equalsIgnoreCase("User-Agent"))) {
+            builder.header("User-Agent", "LangChain4j");
+        }
+
         BodyPublisher bodyPublisher;
         if (request.formDataFields().isEmpty() && request.formDataFiles().isEmpty()) {
             if (request.body() != null) {

--- a/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/JdkHttpClientUserAgentTest.java
+++ b/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/JdkHttpClientUserAgentTest.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.http.client.jdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JdkHttpClientUserAgentTest {
+
+    private HttpServer server;
+    private String baseUrl;
+    private final AtomicReference<String> capturedUserAgent = new AtomicReference<>();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/test", exchange -> {
+            capturedUserAgent.set(exchange.getRequestHeaders().getFirst("User-Agent"));
+            byte[] response = new byte[0];
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        });
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void should_send_langchain4j_user_agent_by_default() throws Exception {
+        JdkHttpClient.builder().build().execute(request(null));
+
+        assertThat(capturedUserAgent.get()).isEqualTo("LangChain4j");
+    }
+
+    @Test
+    void should_allow_caller_to_override_user_agent() throws Exception {
+        JdkHttpClient.builder().build().execute(request("my-app/1.0"));
+
+        assertThat(capturedUserAgent.get()).isEqualTo("my-app/1.0");
+    }
+
+    private HttpRequest request(String userAgent) {
+        HttpRequest.Builder builder =
+                HttpRequest.builder().method(HttpMethod.GET).url(baseUrl + "/test");
+        if (userAgent != null) {
+            builder.addHeader("User-Agent", userAgent);
+        }
+        return builder.build();
+    }
+}

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
@@ -153,6 +153,10 @@ public class OkHttpClient implements HttpClient {
             }
         });
 
+        if (request.headers().keySet().stream().noneMatch(k -> k.equalsIgnoreCase("User-Agent"))) {
+            builder.header("User-Agent", "LangChain4j");
+        }
+
         RequestBody body = buildRequestBody(request);
 
         switch (request.method()) {

--- a/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientUserAgentTest.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientUserAgentTest.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.http.client.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OkHttpClientUserAgentTest {
+
+    private HttpServer server;
+    private String baseUrl;
+    private final AtomicReference<String> capturedUserAgent = new AtomicReference<>();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/test", exchange -> {
+            capturedUserAgent.set(exchange.getRequestHeaders().getFirst("User-Agent"));
+            byte[] response = new byte[0];
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        });
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void should_send_langchain4j_user_agent_by_default() throws Exception {
+        OkHttpClient.builder().build().execute(request(null));
+
+        assertThat(capturedUserAgent.get()).isEqualTo("LangChain4j");
+    }
+
+    @Test
+    void should_allow_caller_to_override_user_agent() throws Exception {
+        OkHttpClient.builder().build().execute(request("my-app/1.0"));
+
+        assertThat(capturedUserAgent.get()).isEqualTo("my-app/1.0");
+    }
+
+    private HttpRequest request(String userAgent) {
+        HttpRequest.Builder builder =
+                HttpRequest.builder().method(HttpMethod.GET).url(baseUrl + "/test");
+        if (userAgent != null) {
+            builder.addHeader("User-Agent", userAgent);
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a default `User-Agent: LangChain4j` header to all three shared HTTP
client implementations — JDK, OkHttp, and Apache.

The header is injected only when the caller has not already set a
`User-Agent`, so per-module or per-request overrides continue to work
transparently.

**Why here instead of per module:** These three clients are the shared
transport layer used by the majority of provider modules. A single change
here covers the whole library, rather than requiring a separate PR for each
module as was started in #5707.

## Changes
- `JdkHttpClient`: set `User-Agent: LangChain4j` in `toJdkRequest()`
- `OkHttpClient`: set `User-Agent: LangChain4j` in `toOkHttpRequest()`
- `ApacheHttpClient`: set `User-Agent: LangChain4j` in both
  `toApacheRequest()` and `toSimpleApacheRequest()`

## Tests
Each client has a new `*UserAgentTest` that uses an embedded HTTP server
to verify:
- the default `LangChain4j` header is sent when the caller sets none
- a caller-supplied `User-Agent` is respected (not overwritten)

All 29 existing + new tests pass.

Relates to #967.