### PR TITLE
Fix agent using a summarizedContext with scope-dependent @ChatModelSupplier

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
@@ -219,7 +219,11 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
                 aiServices.chatRequestTransformer(
                         new Context.AgenticScopeContextGenerator(agenticScope, contextProvider));
             } else {
-                aiServices.chatRequestTransformer(new Context.Summarizer(agenticScope, model, contextProvidingAgents));
+                ChatModel summarizerModel = model;
+                if (summarizerModel == null && chatModelProvider != null) {
+                    summarizerModel = chatModelProvider.apply(agenticScope);
+                }
+                aiServices.chatRequestTransformer(new Context.Summarizer(agenticScope, summarizerModel, contextProvidingAgents));
             }
         }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/DeclarativeAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/DeclarativeAgentIT.java
@@ -1193,4 +1193,48 @@ public class DeclarativeAgentIT {
         assertThat(result.agenticScope().readState("cityData", "")).contains("Rome");
         assertThat(result.result()).containsIgnoringCase("Rome");
     }
+
+    public interface ProducerAgent {
+
+        @UserMessage("Provide a brief analysis of: {{request}}")
+        @Agent(description = "A producer agent", outputKey = "analysis")
+        String produce(@V("request") String request);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return baseModel();
+        }
+    }
+
+    public interface ConsumerWithScopeDependentSupplier {
+
+        @UserMessage("You are an expert. The user request is {{request}}.")
+        @Agent(
+                description = "An expert that summarizes context from other agents",
+                outputKey = "response",
+                summarizedContext = {"produce"})
+        String consume(@V("request") String request);
+
+        @ChatModelSupplier
+        static ChatModel chatModel(AgenticScope scope) {
+            return baseModel();
+        }
+    }
+
+    public interface SummarizedContextWithScopeSupplierPipeline {
+
+        @SequenceAgent(
+                outputKey = "response",
+                subAgents = {ProducerAgent.class, ConsumerWithScopeDependentSupplier.class})
+        String process(@V("request") String request);
+    }
+
+    @Test
+    void summarizedContext_with_scope_dependent_chatModelSupplier_should_not_throw() {
+        SummarizedContextWithScopeSupplierPipeline pipeline =
+                AgenticServices.createAgenticSystem(SummarizedContextWithScopeSupplierPipeline.class);
+
+        String response = pipeline.process("test request");
+        assertThat(response).isNotBlank();
+    }
 }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change

Resolve the `ChatModel` through `chatModelProvider` when creating the `Summarizer` in `AgentBuilder.build()`. When an agent declares both `summarizedContext` and a `@ChatModelSupplier` that takes an `AgenticScope` parameter, the model is stored as `chatModelProvider` (a `Function<AgenticScope, ChatModel>`) rather than as the model field directly. The `Summarizer` was only reading model, which is null in this case, causing `IllegalConfigurationException: Please specify either chatModel or streamingChatModel` at invocation time.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
