### PR TITLE
Add generateContentConfigCustomizer to GoogleGenAiBatchChatModel

### DIFF
--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -67,6 +68,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
     private final Map<String, String> labels;
     private final String cachedContent;
     private final ChatRequestParameters defaultRequestParameters;
+    private final Consumer<GenerateContentConfig.Builder> generateContentConfigCustomizer;
 
     private GoogleGenAiBatchChatModel(Builder builder) {
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
@@ -83,6 +85,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
         this.labels = builder.labels != null ? new HashMap<>(builder.labels) : null;
         this.cachedContent = builder.cachedContent;
         this.defaultRequestParameters = builder.defaultRequestParameters;
+        this.generateContentConfigCustomizer = builder.generateContentConfigCustomizer;
 
         this.client = builder.client != null
                 ? builder.client
@@ -204,7 +207,8 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
                 allowedFunctionNames,
                 vertexSearchDatastore,
                 labels,
-                cachedContent);
+                cachedContent,
+                generateContentConfigCustomizer);
 
         return InlinedRequest.builder().contents(contents).config(config).build();
     }
@@ -277,6 +281,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
         private String apiEndpoint;
         private Map<String, String> customHeaders;
         private String cachedContent;
+        private Consumer<GenerateContentConfig.Builder> generateContentConfigCustomizer;
 
         public Builder client(Client client) {
             this.client = client;
@@ -396,6 +401,20 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
 
         public Builder cachedContent(String cachedContent) {
             this.cachedContent = cachedContent;
+            return this;
+        }
+
+        /**
+         * Registers a customizer applied to the {@link GenerateContentConfig.Builder} after this integration has
+         * populated it (generation parameters, tools, system instruction, etc.), so it can set any underlying
+         * Google Gen AI SDK option that is not exposed here, or override a value set above.
+         *
+         * @param generateContentConfigCustomizer a consumer that mutates the {@link GenerateContentConfig.Builder}
+         * @see GenerateContentConfig
+         */
+        public Builder generateContentConfigCustomizer(
+                Consumer<GenerateContentConfig.Builder> generateContentConfigCustomizer) {
+            this.generateContentConfigCustomizer = generateContentConfigCustomizer;
             return this;
         }
 

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModelTest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.google.genai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -13,10 +14,13 @@ import com.google.genai.types.BatchJob;
 import com.google.genai.types.JobState;
 import com.google.genai.types.JobState.Known;
 import com.google.genai.types.ListBatchJobsConfig;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.batch.BatchPage;
 import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -60,5 +64,25 @@ class GoogleGenAiBatchChatModelTest {
         assertThat(response.batches()).hasSize(1);
         assertThat(response.batches().get(0).batchId()).isEqualTo("batches/1");
         assertThat(response.nextPageToken()).isEqualTo("token-123");
+    }
+
+    @Test
+    void should_invoke_generate_content_config_customizer_when_building_the_request() {
+        RuntimeException fromCustomizer = new RuntimeException("customizer invoked");
+        GoogleGenAiBatchChatModel batchModel = GoogleGenAiBatchChatModel.builder()
+                .apiKey("test-key")
+                .modelName("gemini-2.5-flash")
+                .generateContentConfigCustomizer(config -> {
+                    throw fromCustomizer;
+                })
+                .build();
+
+        // customizer runs while assembling the inlined request, before any network access
+        assertThatThrownBy(() -> batchModel.submit(
+                        "test-batch",
+                        List.of(ChatRequest.builder()
+                                .messages(UserMessage.from("hello"))
+                                .build())))
+                .isSameAs(fromCustomizer);
     }
 }


### PR DESCRIPTION
## Issue
No dedicated issue. This is the follow-up explicitly suggested by the author of #5646 in the merged commit message:

> "Scope: this covers the sync and streaming chat models. `GoogleGenAiBatchChatModel` is left as is; happy to extend the same option to it in a follow-up if that's wanted."

## Change

#5646 added `generateContentConfigCustomizer(Consumer<GenerateContentConfig.Builder>)` to `GoogleGenAiChatModel` and `GoogleGenAiStreamingChatModel`, an escape hatch that lets callers set any underlying Google Gen AI SDK option not otherwise exposed, applied after the integration has populated the config (generation parameters, tools, system instruction, etc.).

`GoogleGenAiBatchChatModel` builds its per-request `GenerateContentConfig` through the same shared `GoogleGenAiConfigBuilder.buildConfig(...)`, but was calling the 14-arg overload (without a customizer), so the option wasn't available there.

This PR mirrors the existing implementation:

- `GoogleGenAiBatchChatModel`: add the `generateContentConfigCustomizer` field, pass it through to the 15-arg `buildConfig(...)` overload when assembling each `InlinedRequest`.
- `Builder`: add the `generateContentConfigCustomizer(...)` method (same Javadoc as the sync/streaming builders).
- Unit test: mirrors the existing `should_invoke_generate_content_config_customizer_when_building_the_request` test on `GoogleGenAiChatModelTest` — a customizer that throws proves it's invoked while assembling the request, before any network access.

The customizer-application logic itself (apply / override / preserve tools / null no-op) is already covered by `GoogleGenAiConfigBuilderTest`, since all three models share the same `buildConfig` method — no need to duplicate those cases here.

## General checklist
- [X] There are no breaking changes (API, behaviour) — purely additive; the new option defaults to no-op
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases — covered by shared `GoogleGenAiConfigBuilderTest` + this model-specific invocation test
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules — ran the full `langchain4j-google-genai` module (132 tests, all green) + `spotless:check` passes
- [ ] I have added/updated the documentation — not applicable (mirrors an already-documented option on the sync/streaming models)
- [ ] I have added an example in the examples repo — not applicable
- [ ] I have added/updated Spring Boot starter(s) — not applicable

## Verification
```
mvn -pl langchain4j-google-genai test
# Tests run: 132, Failures: 0, Errors: 0
mvn -pl langchain4j-google-genai spotless:check
# BUILD SUCCESS
```
