### PR TITLE
fix: Apply disableParallelToolUse when toolChoice is not set in Anthropic requests

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -202,8 +202,11 @@ Anthropic documentation on tools can be found [here](https://docs.anthropic.com/
 ## Tool Choice
 
 Anthropic's [tool choice](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/implement-tool-use#forcing-tool-use)
-feature is available for both streaming and non-streaming interactions
-by setting `toolChoice(ToolChoice)` or `toolChoiceName(String)`.
+feature is available for both streaming and non-streaming interactions:
+
+- `toolChoice(ToolChoice.REQUIRED)` forces the model to call one of the available tools instead of answering with text.
+- `toolChoiceName("get_weather")` forces the model to call one specific tool. It can be used on its own,
+  and when `toolChoice(ToolChoice)` is set as well, the named tool takes precedence over it.
 
 ## Parallel Tool Use
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -397,8 +397,11 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
-         * Sets the name of the specific tool the model must use when {@link ToolChoice}
-         * is set to {@link ToolChoice#REQUIRED}.
+         * Sets the name of the tool that the model is forced to call.
+         * <p>
+         * It can be set on its own; it does not require {@link #toolChoice(ToolChoice)}.
+         * When {@link #toolChoice(ToolChoice)} is set as well, the named tool takes precedence over it.
+         * It has no effect when the request contains no tools.
          *
          * @param toolChoiceName the name of the tool to force
          * @return {@code this}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -590,8 +590,11 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Sets the name of the specific tool the model must use when {@link ToolChoice}
-         * is set to {@link ToolChoice#REQUIRED}.
+         * Sets the name of the tool that the model is forced to call.
+         * <p>
+         * It can be set on its own; it does not require {@link #toolChoice(ToolChoice)}.
+         * When {@link #toolChoice(ToolChoice)} is set as well, the named tool takes precedence over it.
+         * It has no effect when the request contains no tools.
          *
          * @param toolChoiceName the name of the tool to force
          * @return {@code this}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -161,15 +161,8 @@ class InternalAnthropicHelper {
             requestBuilder.tools(tools);
         }
 
-        if (chatRequest.toolChoice() != null) {
-            requestBuilder.toolChoice(
-                    toAnthropicToolChoice(chatRequest.toolChoice(), toolChoiceName, disableParallelToolUse));
-        } else if (Boolean.TRUE.equals(disableParallelToolUse) && !tools.isEmpty()) {
-            // "disable_parallel_tool_use" is a field of Anthropic's "tool_choice" object, so it can only be sent
-            // inside one. Fall back to "auto", which is the API default when tools are present, so the tool
-            // selection strategy stays the same.
-            requestBuilder.toolChoice(AnthropicToolChoice.from(AnthropicToolChoiceType.AUTO, disableParallelToolUse));
-        }
+        requestBuilder.toolChoice(
+                resolveToolChoice(chatRequest, toolChoiceName, disableParallelToolUse, !tools.isEmpty()));
 
         if (!isNullOrEmpty(userId)) {
             requestBuilder.metadata(AnthropicMetadata.builder().userId(userId).build());
@@ -180,6 +173,30 @@ class InternalAnthropicHelper {
         }
 
         return requestBuilder.build();
+    }
+
+    private static AnthropicToolChoice resolveToolChoice(
+            ChatRequest chatRequest, String toolChoiceName, Boolean disableParallelToolUse, boolean hasTools) {
+
+        if (chatRequest.toolChoice() != null) {
+            return toAnthropicToolChoice(chatRequest.toolChoice(), toolChoiceName, disableParallelToolUse);
+        }
+
+        if (!hasTools) {
+            return null; // without tools Anthropic defaults to "none", and forcing a tool would be rejected
+        }
+
+        if (toolChoiceName != null) {
+            return AnthropicToolChoice.from(toolChoiceName, disableParallelToolUse);
+        }
+
+        if (Boolean.TRUE.equals(disableParallelToolUse)) {
+            // "disable_parallel_tool_use" can only be sent inside "tool_choice", and "auto" is what Anthropic
+            // already applies when tools are present, so the tool selection strategy stays the same
+            return AnthropicToolChoice.from(AnthropicToolChoiceType.AUTO, disableParallelToolUse);
+        }
+
+        return null;
     }
 
     public static AnthropicOutputConfig toAnthropicOutputConfig(ResponseFormat responseFormat) {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -20,6 +20,8 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicMetadata;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicOutputConfig;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicTool;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicToolChoice;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicToolChoiceType;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
@@ -162,6 +164,11 @@ class InternalAnthropicHelper {
         if (chatRequest.toolChoice() != null) {
             requestBuilder.toolChoice(
                     toAnthropicToolChoice(chatRequest.toolChoice(), toolChoiceName, disableParallelToolUse));
+        } else if (Boolean.TRUE.equals(disableParallelToolUse) && !tools.isEmpty()) {
+            // "disable_parallel_tool_use" is a field of Anthropic's "tool_choice" object, so it can only be sent
+            // inside one. Fall back to "auto", which is the API default when tools are present, so the tool
+            // selection strategy stays the same.
+            requestBuilder.toolChoice(AnthropicToolChoice.from(AnthropicToolChoiceType.AUTO, disableParallelToolUse));
         }
 
         if (!isNullOrEmpty(userId)) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
@@ -208,6 +208,57 @@ class AnthropicChatRequestCacheParametersTest {
     }
 
     @Test
+    void should_send_tool_choice_name_when_tool_choice_is_not_set() {
+        AnthropicChatModel model = modelBuilder().toolChoiceName("weather_tool").build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather?"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .toolSpecifications(weatherTool())
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        String body = lastRequestBody();
+        assertThat(body).contains("\"tool_choice\"");
+        assertThat(body).contains("\"type\" : \"tool\"");
+        assertThat(body).contains("\"name\" : \"weather_tool\"");
+    }
+
+    @Test
+    void should_send_tool_choice_name_together_with_disable_parallel_tool_use_when_tool_choice_is_not_set() {
+        AnthropicChatModel model = modelBuilder()
+                .toolChoiceName("weather_tool")
+                .disableParallelToolUse(true)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather?"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .toolSpecifications(weatherTool())
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        String body = lastRequestBody();
+        assertThat(body).contains("\"type\" : \"tool\"");
+        assertThat(body).contains("\"name\" : \"weather_tool\"");
+        assertThat(body).contains("\"disable_parallel_tool_use\" : true");
+    }
+
+    @Test
+    void should_not_send_tool_choice_name_when_no_tools_are_present() {
+        // Anthropic rejects a request that forces a tool which is not in the (here absent) tools list.
+        AnthropicChatModel model = modelBuilder().toolChoiceName("weather_tool").build();
+
+        model.chat(ChatRequest.builder().messages(UserMessage.from("Hi")).build());
+
+        assertThat(lastRequestBody()).doesNotContain("\"tool_choice\"");
+    }
+
+    @Test
     void should_override_user_id_per_request() {
         AnthropicChatModel model = modelBuilder().userId("model-user").build();
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
@@ -178,6 +178,36 @@ class AnthropicChatRequestCacheParametersTest {
     }
 
     @Test
+    void should_send_disable_parallel_tool_use_when_tool_choice_is_not_set() {
+        AnthropicChatModel model = modelBuilder().disableParallelToolUse(true).build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather?"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .toolSpecifications(weatherTool())
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        String body = lastRequestBody();
+        assertThat(body).contains("\"tool_choice\"");
+        assertThat(body).contains("\"type\" : \"auto\"");
+        assertThat(body).contains("\"disable_parallel_tool_use\" : true");
+    }
+
+    @Test
+    void should_not_send_tool_choice_when_no_tools_are_present() {
+        // Anthropic defaults tool_choice to "none" when no tools are sent, so the fallback above must not
+        // add a tool_choice to a request without tools.
+        AnthropicChatModel model = modelBuilder().disableParallelToolUse(true).build();
+
+        model.chat(ChatRequest.builder().messages(UserMessage.from("Hi")).build());
+
+        assertThat(lastRequestBody()).doesNotContain("\"tool_choice\"");
+    }
+
+    @Test
     void should_override_user_id_per_request() {
         AnthropicChatModel model = modelBuilder().userId("model-user").build();
 


### PR DESCRIPTION
## Issue

Closes #5890

## Change

`InternalAnthropicHelper.createAnthropicRequest()` sent `tool_choice` only when `chatRequest.toolChoice()` was set. `disable_parallel_tool_use` is a field of that object, so `disableParallelToolUse(true)` was silently dropped whenever `toolChoice` was unset, which is always the case in AiServices.

Fallback when `toolChoice` is unset, the flag is on and tools are present:

```java
} else if (Boolean.TRUE.equals(disableParallelToolUse) && !tools.isEmpty()) {
    builder.toolChoice(AnthropicToolChoice.from(AnthropicToolChoiceType.AUTO, disableParallelToolUse));
}
```

- Not a behaviour change: the Anthropic tool use docs state `auto` "is the default value when `tools` are provided", so omitting `tool_choice` equals sending `auto`.
- The `!tools.isEmpty()` guard is required: without tools the API default is `none`, so sending `auto` would change behaviour.
- Only users who set `disableParallelToolUse(true)` are affected; it is null by default, and requests with `toolChoice` are unchanged.
- Side effect: changing `tool_choice` invalidates cached message blocks, so affected users may see a one-time prompt cache miss after upgrading.

## Build/test notes

Two cases added to `AnthropicChatRequestCacheParametersTest` (WireMock, no API key): the positive one fails without this fix, the negative one guards the empty-tools path.

`./mvnw -pl langchain4j-anthropic -am clean test`: 178 tests green, whole reactor including `langchain4j-core` and `langchain4j`. The `*IT` classes need an `ANTHROPIC_API_KEY` and were not run.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green — unit tests green; `*IT` not run, they need an API key
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green — unit tests green via the reactor build above; integration tests not run
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- The "new maven module" and "embedding store integration" checklists are omitted: this PR adds no module and touches no embedding store. -->
