### PR TITLE
fix: Include cache token fields in AnthropicTokenUsage equals and hashCode

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicTokenUsage.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicTokenUsage.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.anthropic;
 
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.Objects;
 
 public class AnthropicTokenUsage extends TokenUsage {
 
@@ -62,14 +63,28 @@ public class AnthropicTokenUsage extends TokenUsage {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        AnthropicTokenUsage that = (AnthropicTokenUsage) o;
+        return Objects.equals(cacheCreationInputTokens, that.cacheCreationInputTokens)
+                && Objects.equals(cacheReadInputTokens, that.cacheReadInputTokens);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cacheCreationInputTokens, cacheReadInputTokens);
+    }
+
+    @Override
     public String toString() {
-        return "AnthropicTokenUsage {" +
-                " inputTokenCount = " + inputTokenCount() +
-                ", outputTokenCount = " + outputTokenCount() +
-                ", totalTokenCount = " + totalTokenCount() +
-                ", cacheCreationInputTokens = " + cacheCreationInputTokens +
-                ", cacheReadInputTokens = " + cacheReadInputTokens +
-                " }";
+        return "AnthropicTokenUsage {" + " inputTokenCount = "
+                + inputTokenCount() + ", outputTokenCount = "
+                + outputTokenCount() + ", totalTokenCount = "
+                + totalTokenCount() + ", cacheCreationInputTokens = "
+                + cacheCreationInputTokens + ", cacheReadInputTokens = "
+                + cacheReadInputTokens + " }";
     }
 
     public static Builder builder() {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicTokenUsageTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicTokenUsageTest.java
@@ -1,0 +1,151 @@
+package dev.langchain4j.model.anthropic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.output.TokenUsage;
+import org.junit.jupiter.api.Test;
+
+class AnthropicTokenUsageTest {
+
+    @Test
+    void should_be_equal_when_all_fields_match() {
+        AnthropicTokenUsage usage1 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        AnthropicTokenUsage usage2 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        assertThat(usage1).isEqualTo(usage2);
+        assertThat(usage2).isEqualTo(usage1);
+        assertThat(usage1).hasSameHashCodeAs(usage2);
+    }
+
+    @Test
+    void should_not_be_equal_when_cache_creation_input_tokens_differ() {
+        AnthropicTokenUsage usage1 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        AnthropicTokenUsage usage2 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(90)
+                .cacheReadInputTokens(20)
+                .build();
+
+        assertThat(usage1).isNotEqualTo(usage2);
+        assertThat(usage1.hashCode()).isNotEqualTo(usage2.hashCode());
+    }
+
+    @Test
+    void should_not_be_equal_when_cache_read_input_tokens_differ() {
+        AnthropicTokenUsage usage1 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        AnthropicTokenUsage usage2 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(30)
+                .build();
+
+        assertThat(usage1).isNotEqualTo(usage2);
+        assertThat(usage1.hashCode()).isNotEqualTo(usage2.hashCode());
+    }
+
+    @Test
+    void should_not_be_equal_when_parent_fields_differ() {
+        AnthropicTokenUsage usage1 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        AnthropicTokenUsage usage2 = AnthropicTokenUsage.builder()
+                .inputTokenCount(200)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        assertThat(usage1).isNotEqualTo(usage2);
+    }
+
+    @Test
+    void should_be_equal_when_both_have_null_cache_fields() {
+        AnthropicTokenUsage usage1 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(null)
+                .cacheReadInputTokens(null)
+                .build();
+
+        AnthropicTokenUsage usage2 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .build();
+
+        assertThat(usage1).isEqualTo(usage2);
+        assertThat(usage1).hasSameHashCodeAs(usage2);
+    }
+
+    @Test
+    void should_not_be_equal_when_only_one_has_null_cache_fields() {
+        AnthropicTokenUsage usage1 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .build();
+
+        AnthropicTokenUsage usage2 = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        assertThat(usage1).isNotEqualTo(usage2);
+        assertThat(usage2).isNotEqualTo(usage1);
+    }
+
+    @Test
+    void should_not_be_equal_to_parent_token_usage() {
+        AnthropicTokenUsage anthropicTokenUsage = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .build();
+
+        TokenUsage tokenUsage = new TokenUsage(100, 50);
+
+        assertThat(anthropicTokenUsage).isNotEqualTo(tokenUsage);
+        assertThat(tokenUsage).isNotEqualTo(anthropicTokenUsage);
+    }
+
+    @Test
+    void should_be_reflexively_equal_and_not_equal_to_null() {
+        AnthropicTokenUsage usage = AnthropicTokenUsage.builder()
+                .inputTokenCount(100)
+                .outputTokenCount(50)
+                .cacheCreationInputTokens(80)
+                .cacheReadInputTokens(20)
+                .build();
+
+        assertThat(usage).isEqualTo(usage);
+        assertThat(usage).isNotEqualTo(null);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5891

## Change

`AnthropicTokenUsage` carries `cacheCreationInputTokens` and `cacheReadInputTokens` but did not override `equals`/`hashCode`. The inherited `TokenUsage.equals()` compares only input, output and total counts, so two usages differing only in cache tokens compared as equal.

`ChatResponseMetadata.equals()` compares `tokenUsage`, so this propagates to `ChatResponse` equality: a cache-read response and a cache-write one compare as equal when their input/output counts match.

The four other `TokenUsage` subclasses (`BedrockTokenUsage`, `OpenAiTokenUsage`, `OpenAiOfficialTokenUsage`, `GoogleAiGeminiTokenUsage`) override both methods; Anthropic was the only one that did not. This mirrors `BedrockTokenUsage`:

```java
// equals(), after the getClass() check
return super.equals(o)
        && Objects.equals(cacheCreationInputTokens, that.cacheCreationInputTokens)
        && Objects.equals(cacheReadInputTokens, that.cacheReadInputTokens);
```

`equals` becomes stricter. Nothing in the repository compares these instances with `equals` or uses them as map/set keys, and the class is not serializable, so nothing else breaks.

## Build/test notes

`AnthropicTokenUsageTest` adds 8 unit tests, no API key needed; three fail without the fix.

`./mvnw -pl langchain4j-anthropic -am clean test`: 184 tests green, whole reactor (including `langchain4j-core` and `langchain4j`) successful. The `*IT` classes need API keys and were not run.

Formatting: the file predates the Palantir format, so the ratchet also rewraps the existing `toString` — the only unrelated hunk, kept in this commit.

## General checklist
- [X] There are no breaking changes (API, behaviour) — no API change; `equals` becomes stricter, which is the fix itself
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green — unit tests green (184 tests in `langchain4j-anthropic`); `*IT` not run locally, they need API keys
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green — unit tests green via `./mvnw -pl langchain4j-anthropic -am clean test`; integration tests not run
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- Sections for adding a new maven module and for embedding store integrations are omitted: this PR touches neither. -->
