### PR TITLE
fix: Do not require dimensions when the Azure AI Search index is not created

### DIFF
--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStore.java
@@ -172,7 +172,9 @@ public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingS
             ensureNotNull(endpoint, "endpoint");
             ensureTrue(
                     keyCredential != null || tokenCredential != null, "either apiKey or tokenCredential must be set");
-            ensureTrue(dimensions > 0 || index != null, "either dimensions or index must be set");
+            ensureTrue(
+                    !createOrUpdateIndex || dimensions > 0 || index != null,
+                    "either dimensions or index must be set when createOrUpdateIndex is true");
             if (keyCredential == null) {
                 if (index == null) {
                     return new AzureAiSearchEmbeddingStore(

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStore.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.store.embedding.azure.search;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
+
 import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.search.documents.indexes.models.SearchIndex;
@@ -7,27 +10,50 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.rag.content.retriever.azure.search.AzureAiSearchFilterMapper;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
-
 /**
  * Azure AI Search EmbeddingStore Implementation
  */
-public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
+public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingStore
+        implements EmbeddingStore<TextSegment> {
 
-    public AzureAiSearchEmbeddingStore(String endpoint, AzureKeyCredential keyCredential, boolean createOrUpdateIndex, int dimensions, String indexName, AzureAiSearchFilterMapper filterMapper) {
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            AzureKeyCredential keyCredential,
+            boolean createOrUpdateIndex,
+            int dimensions,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
         this.initialize(endpoint, keyCredential, null, createOrUpdateIndex, dimensions, null, indexName, filterMapper);
     }
 
-    public AzureAiSearchEmbeddingStore(String endpoint, AzureKeyCredential keyCredential, boolean createOrUpdateIndex, SearchIndex index, String indexName, AzureAiSearchFilterMapper filterMapper) {
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            AzureKeyCredential keyCredential,
+            boolean createOrUpdateIndex,
+            SearchIndex index,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
         this.initialize(endpoint, keyCredential, null, createOrUpdateIndex, 0, index, indexName, filterMapper);
     }
 
-    public AzureAiSearchEmbeddingStore(String endpoint, TokenCredential tokenCredential, boolean createOrUpdateIndex, int dimensions, String indexName, AzureAiSearchFilterMapper filterMapper) {
-        this.initialize(endpoint, null, tokenCredential, createOrUpdateIndex, dimensions, null, indexName, filterMapper);
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            TokenCredential tokenCredential,
+            boolean createOrUpdateIndex,
+            int dimensions,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
+        this.initialize(
+                endpoint, null, tokenCredential, createOrUpdateIndex, dimensions, null, indexName, filterMapper);
     }
 
-    public AzureAiSearchEmbeddingStore(String endpoint, TokenCredential tokenCredential, boolean createOrUpdateIndex, SearchIndex index, String indexName, AzureAiSearchFilterMapper filterMapper) {
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            TokenCredential tokenCredential,
+            boolean createOrUpdateIndex,
+            SearchIndex index,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
         this.initialize(endpoint, null, tokenCredential, createOrUpdateIndex, 0, index, indexName, filterMapper);
     }
 
@@ -144,19 +170,24 @@ public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingS
 
         public AzureAiSearchEmbeddingStore build() {
             ensureNotNull(endpoint, "endpoint");
-            ensureTrue(keyCredential != null || tokenCredential != null, "either apiKey or tokenCredential must be set");
+            ensureTrue(
+                    keyCredential != null || tokenCredential != null, "either apiKey or tokenCredential must be set");
             ensureTrue(dimensions > 0 || index != null, "either dimensions or index must be set");
             if (keyCredential == null) {
                 if (index == null) {
-                    return new AzureAiSearchEmbeddingStore(endpoint, tokenCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
+                    return new AzureAiSearchEmbeddingStore(
+                            endpoint, tokenCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
                 } else {
-                    return new AzureAiSearchEmbeddingStore(endpoint, tokenCredential, createOrUpdateIndex, index, indexName, filterMapper);
+                    return new AzureAiSearchEmbeddingStore(
+                            endpoint, tokenCredential, createOrUpdateIndex, index, indexName, filterMapper);
                 }
             } else {
                 if (index == null) {
-                    return new AzureAiSearchEmbeddingStore(endpoint, keyCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
+                    return new AzureAiSearchEmbeddingStore(
+                            endpoint, keyCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
                 } else {
-                    return new AzureAiSearchEmbeddingStore(endpoint, keyCredential, createOrUpdateIndex, index, indexName, filterMapper);
+                    return new AzureAiSearchEmbeddingStore(
+                            endpoint, keyCredential, createOrUpdateIndex, index, indexName, filterMapper);
                 }
             }
         }

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
@@ -26,6 +26,34 @@ class AzureAiSearchEmbeddingStoreTest {
     }
 
     @Test
+    void dimensions_should_not_be_required_when_the_index_is_not_created() {
+        AzureAiSearchEmbeddingStore store = AzureAiSearchEmbeddingStore.builder()
+                .endpoint(endpoint)
+                .apiKey("TEST")
+                .createOrUpdateIndex(false)
+                .indexName(indexName)
+                .build();
+
+        assertThat(store).isNotNull();
+    }
+
+    @Test
+    void dimensions_should_still_be_required_when_the_index_is_created() {
+        try {
+            AzureAiSearchEmbeddingStore.builder()
+                    .endpoint(endpoint)
+                    .apiKey("TEST")
+                    .createOrUpdateIndex(true)
+                    .indexName(indexName)
+                    .build();
+            fail("Expected IllegalArgumentException to be thrown");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage())
+                    .isEqualTo("either dimensions or index must be set when createOrUpdateIndex is true");
+        }
+    }
+
+    @Test
     void index_and_index_name_should_not_both_be_defined() {
         try {
             new AzureAiSearchEmbeddingStore(endpoint, keyCredential, false, index, indexName, null);


### PR DESCRIPTION
## Issue
Closes #2884

## Change
`AzureAiSearchEmbeddingStore.Builder.build()` required `dimensions` or `index` unconditionally, but `dimensions` is only read inside the `if (createOrUpdateIndex)` block of `AbstractAzureAiSearchEmbeddingStore.initialize()`. With `createOrUpdateIndex(false)` it is never used, so callers connecting to an existing index had to pass a meaningless number. The public constructors of the same class already accept that combination, so the builder was stricter than the constructor it delegates to.

The check now applies only when the index is created, and the message states the condition:

```java
ensureTrue(
        !createOrUpdateIndex || dimensions > 0 || index != null,
        "either dimensions or index must be set when createOrUpdateIndex is true");
```

Two unit tests were added: one builds a store with `createOrUpdateIndex(false)` and no `dimensions`, the other asserts the requirement still holds when `createOrUpdateIndex` is `true`. Both fail on `main`.

`AzureAiSearchEmbeddingStore.java` had never been formatted, so Spotless `ratchetFrom origin/main` reformats the whole file. That reformatting is isolated in the first commit; the second commit holds the fix and the tests.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
      Unit tests only: `mvn -pl langchain4j-azure-ai-search clean test` — 20/20 green. The integration tests in this module are gated by `@EnabledIfEnvironmentVariable` and need an Azure AI Search endpoint and key, which I do not have.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
      Not run. This change is confined to one builder in `langchain4j-azure-ai-search` and does not touch core or main.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
      Will add after review and approval, as the contribution guide asks.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
      Not applicable — this is a small validation fix, not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
      Not applicable — no starter exposes this builder validation.

## Checklist for changing existing embedding store integration
- [X] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
      Nothing is persisted or read differently: the change only relaxes a builder-side argument check. Index name, schema and documents are untouched.

