### PR TITLE
fix: Escape single quotes in Azure AI Search metadata filter expressions

### DIFF
--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapper.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapper.java
@@ -1,15 +1,14 @@
 package dev.langchain4j.rag.content.retriever.azure.search;
 
+import static java.lang.String.format;
+
 import dev.langchain4j.store.embedding.filter.*;
 import dev.langchain4j.store.embedding.filter.comparison.*;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
-
 import java.util.Collection;
 import java.util.stream.Collectors;
-
-import static java.lang.String.format;
 
 /**
  * Maps {@link Filter} objects to Azure AI Search filter strings.
@@ -17,8 +16,7 @@ import static java.lang.String.format;
  */
 public class DefaultAzureAiSearchFilterMapper implements AzureAiSearchFilterMapper {
 
-    public DefaultAzureAiSearchFilterMapper() {
-    }
+    public DefaultAzureAiSearchFilterMapper() {}
 
     public String map(Filter filter) {
         if (filter == null) return "";
@@ -29,13 +27,15 @@ public class DefaultAzureAiSearchFilterMapper implements AzureAiSearchFilterMapp
             return mapComparisonFilter(filter);
         }
     }
-    
-    
+
     private String mapLogicalOperator(Filter operator) {
-        if (operator instanceof And) return  format(getLogicalFormat(operator), map(((And) operator).left()), map(((And) operator).right()));
-        if (operator instanceof Or) return format(getLogicalFormat(operator), map(((Or) operator).left()), map(((Or) operator).right()));
+        if (operator instanceof And)
+            return format(getLogicalFormat(operator), map(((And) operator).left()), map(((And) operator).right()));
+        if (operator instanceof Or)
+            return format(getLogicalFormat(operator), map(((Or) operator).left()), map(((Or) operator).right()));
         if (operator instanceof Not) return format(getLogicalFormat(operator), map(((Not) operator).expression()));
-        throw new UnsupportedOperationException("Unsupported filter type: " + operator.getClass().getName());
+        throw new UnsupportedOperationException(
+                "Unsupported filter type: " + operator.getClass().getName());
     }
 
     private boolean isLogicalOperator(Filter filter) {
@@ -51,28 +51,31 @@ public class DefaultAzureAiSearchFilterMapper implements AzureAiSearchFilterMapp
         if (filter instanceof IsLessThanOrEqualTo) return mapIsLessThanOrEqualTo((IsLessThanOrEqualTo) filter);
         if (filter instanceof IsIn) return mapIsIn((IsIn) filter);
         if (filter instanceof IsNotIn) return mapIsNotIn((IsNotIn) filter);
-        throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getName());
+        throw new UnsupportedOperationException(
+                "Unsupported filter type: " + filter.getClass().getName());
     }
 
     private String getLogicalFormat(Filter filter) {
         if (filter instanceof And) return "(%s and %s)";
         if (filter instanceof Or) return "(%s or %s)";
         if (filter instanceof Not) return "(not %s)";
-        throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getName());
+        throw new UnsupportedOperationException(
+                "Unsupported filter type: " + filter.getClass().getName());
     }
 
     private String getComparisonFormat(Filter filter) {
         if (filter instanceof IsEqualTo) return "k/value eq '%s'";
-// not use, it raplace by Not ( isEqualTo )
-//        if (filter instanceof IsNotEqualTo) return "k/value ne '%s'";
+        // not use, it raplace by Not ( isEqualTo )
+        //        if (filter instanceof IsNotEqualTo) return "k/value ne '%s'";
         if (filter instanceof IsGreaterThan) return "k/value gt '%s'";
         if (filter instanceof IsGreaterThanOrEqualTo) return "k/value ge '%s'";
         if (filter instanceof IsLessThan) return "k/value lt '%s'";
         if (filter instanceof IsLessThanOrEqualTo) return "k/value le '%s'";
         if (filter instanceof IsIn) return "search.in(k/value, ('%s'))";
-// not use, it raplace by Not ( IsIn )
-//        if (filter instanceof IsNotIn) return "not search.in(k/value, ('%s'))";
-        throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getName());
+        // not use, it raplace by Not ( IsIn )
+        //        if (filter instanceof IsNotIn) return "not search.in(k/value, ('%s'))";
+        throw new UnsupportedOperationException(
+                "Unsupported filter type: " + filter.getClass().getName());
     }
 
     private String mapIsNotIn(IsNotIn filter) {
@@ -80,7 +83,8 @@ public class DefaultAzureAiSearchFilterMapper implements AzureAiSearchFilterMapp
     }
 
     private String mapIsIn(IsIn filter) {
-        return formatComparisonFilter(filter.key(), mapSearchInValues(filter.comparisonValues()), getComparisonFormat(filter));
+        return formatComparisonFilter(
+                filter.key(), mapSearchInValues(filter.comparisonValues()), getComparisonFormat(filter));
     }
 
     private String mapIsLessThanOrEqualTo(IsLessThanOrEqualTo filter) {

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapper.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapper.java
@@ -116,6 +116,14 @@ public class DefaultAzureAiSearchFilterMapper implements AzureAiSearchFilterMapp
     }
 
     private String formatComparisonFilter(String key, String value, String format) {
-        return format("metadata/attributes/any(k: k/key eq '%s' and " + format + ")", key, value);
+        return format("metadata/attributes/any(k: k/key eq '%s' and " + format + ")", escape(key), escape(value));
+    }
+
+    /**
+     * Escapes single quotes in an OData string literal by doubling them,
+     * as required by the Azure AI Search OData syntax.
+     */
+    private static String escape(String value) {
+        return value.replace("'", "''");
     }
 }

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapperTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapperTest.java
@@ -1,20 +1,19 @@
 package dev.langchain4j.rag.content.retriever.azure.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
 import dev.langchain4j.store.embedding.filter.Filter;
 import dev.langchain4j.store.embedding.filter.comparison.*;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Or;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import org.junit.jupiter.api.Test;
 
 class DefaultAzureAiSearchFilterMapperTest {
 
     private final AzureAiSearchFilterMapper mapper = new DefaultAzureAiSearchFilterMapper();
-    
+
     @Test
     void map_nullFilter() {
         String result = mapper.map(null);
@@ -53,26 +52,28 @@ class DefaultAzureAiSearchFilterMapperTest {
     void map_handlesIsIn() {
         IsIn isInFilter = new IsIn("key1", Arrays.asList("value1", "value2"));
         String result = mapper.map(isInFilter);
-        assertThat(result).isEqualTo("metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1, value2')))");
+        assertThat(result)
+                .isEqualTo("metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1, value2')))");
     }
 
     @Test
     void map_handlesIsNotIn() {
         IsNotIn isNotInFilter = new IsNotIn("key1", Arrays.asList("value1", "value2"));
         String result = mapper.map(isNotInFilter);
-        assertThat(result).isEqualTo("(not metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1, value2'))))");
+        assertThat(result)
+                .isEqualTo(
+                        "(not metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1, value2'))))");
     }
 
     @Test
     void map_handlesComplexFilter() {
         And filter = new And(
                 new IsEqualTo("key1", "value1"),
-                new Or(
-                        new IsNotIn("key2", Arrays.asList("value2", "value3")),
-                        new IsGreaterThan("key3", "100"))
-        );
+                new Or(new IsNotIn("key2", Arrays.asList("value2", "value3")), new IsGreaterThan("key3", "100")));
         String result = mapper.map(filter);
-        assertThat(result).isEqualTo("(metadata/attributes/any(k: k/key eq 'key1' and k/value eq 'value1') and ((not metadata/attributes/any(k: k/key eq 'key2' and search.in(k/value, ('value2, value3')))) or metadata/attributes/any(k: k/key eq 'key3' and k/value gt '100')))");
+        assertThat(result)
+                .isEqualTo(
+                        "(metadata/attributes/any(k: k/key eq 'key1' and k/value eq 'value1') and ((not metadata/attributes/any(k: k/key eq 'key2' and search.in(k/value, ('value2, value3')))) or metadata/attributes/any(k: k/key eq 'key3' and k/value gt '100')))");
     }
 
     @Test

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapperTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapperTest.java
@@ -66,6 +66,29 @@ class DefaultAzureAiSearchFilterMapperTest {
     }
 
     @Test
+    void map_escapesSingleQuoteInValue() {
+        IsEqualTo isEqualToFilter = new IsEqualTo("key1", "O'Brien");
+        String result = mapper.map(isEqualToFilter);
+        assertThat(result).isEqualTo("metadata/attributes/any(k: k/key eq 'key1' and k/value eq 'O''Brien')");
+    }
+
+    @Test
+    void map_escapesSingleQuoteInKey() {
+        IsEqualTo isEqualToFilter = new IsEqualTo("o'clock", "value1");
+        String result = mapper.map(isEqualToFilter);
+        assertThat(result).isEqualTo("metadata/attributes/any(k: k/key eq 'o''clock' and k/value eq 'value1')");
+    }
+
+    @Test
+    void map_escapesSingleQuoteInIsIn() {
+        IsIn isInFilter = new IsIn("key1", Arrays.asList("O'Brien", "D'Angelo"));
+        String result = mapper.map(isInFilter);
+        assertThat(result)
+                .isEqualTo(
+                        "metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('D''Angelo, O''Brien')))");
+    }
+
+    @Test
     void map_handlesComplexFilter() {
         And filter = new And(
                 new IsEqualTo("key1", "value1"),


### PR DESCRIPTION
## Issue
Closes #5896

## Change
`DefaultAzureAiSearchFilterMapper` built the OData `$filter` string by interpolating metadata keys and values directly. The Azure AI Search OData grammar defines a string literal as `"'"([^'] | "''")*"'"`, so a single quote inside a literal must be doubled. A metadata value like `O'Brien` produced `k/value eq 'O'Brien'`, which the service rejects.

Every comparison mapping funnels through `formatComparisonFilter`, so escaping both arguments there covers keys, comparison values, and the joined `search.in` values in one place:

```java
private static String escape(String value) {
    return value.replace("'", "''");
}
```

Three unit tests were added, covering a quoted value, a quoted key, and quoted `IsIn` values. They fail on `main`. The nine existing tests use quote-free values and are unchanged, so they guard that ordinary filters still render identically.

Only single-quote escaping is in scope. `search.in` also splits on its default delimiters, so values containing a comma or a space are still split incorrectly; fixing that means choosing an explicit delimiter, a separate behaviour change.

The file had never been formatted, so Spotless `ratchetFrom origin/main` reformats it entirely; that is isolated in the first commit.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
      The rendered filter changes only for keys and values that contain a single quote, where the previous output was invalid OData. An application that already worked around this by pre-doubling quotes itself would now send doubly escaped literals and match nothing.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
      Unit tests only: `mvn -pl langchain4j-azure-ai-search clean test` — 21/21 green. The integration tests in this module are gated by `@EnabledIfEnvironmentVariable` and need an Azure AI Search endpoint and key, which I do not have.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
      Not run. The change is confined to one mapper in `langchain4j-azure-ai-search` and does not touch core or main.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
      Will add after review and approval, as the contribution guide asks.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
      Not applicable — this is a bug fix, not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
      Not applicable — no starter exposes this mapper.

## Checklist for changing existing embedding store integration
- [X] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
      Nothing is persisted or read differently: the change only affects how a query filter is rendered. Index schema and stored documents are untouched.

