### PR TITLE
fix: Use the name of the provided Azure AI Search index when index creation is disabled

### DIFF
--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
@@ -81,7 +81,7 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             // if the indexName is provided, it will be used when creating the default index
             throw new IllegalArgumentException("index and indexName cannot be both defined");
         }
-        if (createOrUpdateIndex && index != null) {
+        if (index != null) {
             this.indexName = index.getName();
         } else {
             this.indexName = getOrDefault(indexName, DEFAULT_INDEX_NAME);

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
@@ -26,6 +26,22 @@ class AzureAiSearchEmbeddingStoreTest {
     }
 
     @Test
+    void provided_index_name_should_be_used_when_the_index_is_not_created() {
+        AzureAiSearchEmbeddingStore store =
+                new AzureAiSearchEmbeddingStore(endpoint, keyCredential, false, index, null, null);
+
+        assertThat(store.searchClient.getIndexName()).isEqualTo(index.getName());
+    }
+
+    @Test
+    void default_index_name_should_be_used_when_no_index_is_provided() {
+        AzureAiSearchEmbeddingStore store =
+                new AzureAiSearchEmbeddingStore(endpoint, keyCredential, false, dimensions, null, null);
+
+        assertThat(store.searchClient.getIndexName()).isEqualTo("vectorsearch");
+    }
+
+    @Test
     void index_and_index_name_should_not_both_be_defined() {
         try {
             new AzureAiSearchEmbeddingStore(endpoint, keyCredential, false, index, indexName, null);


### PR DESCRIPTION
## Issue
Closes #5897

Related to #1098, which reports the same symptom but also asks for field name customisation — out of scope here, so this PR does not close it.

## Change
`AbstractAzureAiSearchEmbeddingStore.initialize()` took the index name from the provided `SearchIndex` only when `createOrUpdateIndex` was `true`:

```java
if (index != null) {   // was: if (createOrUpdateIndex && index != null)
    this.indexName = index.getName();
}
```

The check a few lines above rejects passing both `index` and `indexName`, so with `createOrUpdateIndex(false)` the `indexName` is always null and the store fell through to the default `"vectorsearch"` — passing a `SearchIndex` to connect to an existing index silently queried the wrong one. The comment on that check already says a provided index "has its own name already configured". `AzureAiSearchContentRetriever` shares this method and gets the same fix.

Rejecting the combination instead would leave no way to name the index, since that check forbids `indexName`.

The condition came from #1259; neither that PR nor its issue discusses `createOrUpdateIndex=false`.

Two unit tests were added: one asserts the `SearchClient` is bound to the provided index's name, the other that a store without an `index` still falls back to `"vectorsearch"`. The first fails on `main`. Neither needs network access.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
      An application that passes a `SearchIndex` with `createOrUpdateIndex(false)` and has been reading from `"vectorsearch"` will now read from the name on that index. That is the documented intent, but it is a behaviour change worth calling out.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
      The `createOrUpdateIndex=true` path calls the Azure service and is left to the integration tests.
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
      Unit tests only: `mvn -pl langchain4j-azure-ai-search clean test` — 20/20 green. The integration tests in this module are gated by `@EnabledIfEnvironmentVariable` and need an Azure AI Search endpoint and key, which I do not have.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
      Not run. The change is confined to `langchain4j-azure-ai-search` and does not touch core or main.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
      Will add after review and approval, as the contribution guide asks.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
      Not applicable — this is a bug fix, not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
      Not applicable — no starter passes a `SearchIndex`.

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
      Not verified against a live service — I have no Azure AI Search instance. The stored format is unchanged; only which index the client is bound to changes, and only for the configuration described above.

