### PR TITLE
fix(google-ai-gemini): recover empty functionResponse name from prior tool call

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
@@ -376,9 +376,8 @@ final class PartsAndContentsMapper {
                         } else if (content instanceof ImageContent imageContent) {
                             toolParts.add(fromContentToGPart(imageContent, mediaResolutionPerPartEnabled));
                         } else {
-                            throw new UnsupportedFeatureException(
-                                    "Google AI Gemini does not support content type '" + content.type()
-                                            + "' in tool results.");
+                            throw new UnsupportedFeatureException("Google AI Gemini does not support content type '"
+                                    + content.type() + "' in tool results.");
                         }
                     }
                     if (responseMap.isEmpty()) {
@@ -439,7 +438,8 @@ final class PartsAndContentsMapper {
                 toolResultOffset++;
             }
         }
-        if (toolResultOffset < requests.size() && !isNullOrBlank(requests.get(toolResultOffset).name())) {
+        if (toolResultOffset < requests.size()
+                && !isNullOrBlank(requests.get(toolResultOffset).name())) {
             return requests.get(toolResultOffset).name();
         }
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
@@ -288,109 +288,172 @@ final class PartsAndContentsMapper {
             GeminiContent systemInstruction,
             boolean sendThinking,
             boolean mediaResolutionPerPartEnabled) {
-        return messages.stream()
-                .map(msg -> {
-                    switch (msg.type()) {
-                        case SYSTEM:
-                            SystemMessage systemMessage = (SystemMessage) msg;
+        List<GeminiContent> contents = new ArrayList<>();
+        for (int messageIndex = 0; messageIndex < messages.size(); messageIndex++) {
+            ChatMessage msg = messages.get(messageIndex);
+            GeminiContent content = toGeminiContent(
+                    msg, messages, messageIndex, systemInstruction, sendThinking, mediaResolutionPerPartEnabled);
+            if (content != null) {
+                contents.add(content);
+            }
+        }
+        return contents;
+    }
 
-                            if (systemInstruction != null) {
-                                systemInstruction.addPart(GeminiContent.GeminiPart.builder()
-                                        .text(systemMessage.text())
-                                        .build());
-                                return null;
-                            }
+    private static GeminiContent toGeminiContent(
+            ChatMessage msg,
+            List<ChatMessage> messages,
+            int messageIndex,
+            GeminiContent systemInstruction,
+            boolean sendThinking,
+            boolean mediaResolutionPerPartEnabled) {
+        switch (msg.type()) {
+            case SYSTEM:
+                SystemMessage systemMessage = (SystemMessage) msg;
 
-                            if (isNotNullOrEmpty(systemMessage.text())) {
-                                return new GeminiContent(
-                                        List.of(GeminiContent.GeminiPart.builder()
-                                                .text(systemMessage.text())
-                                                .build()),
-                                        GeminiRole.MODEL.toString());
-                            }
+                if (systemInstruction != null) {
+                    systemInstruction.addPart(GeminiContent.GeminiPart.builder()
+                            .text(systemMessage.text())
+                            .build());
+                    return null;
+                }
 
-                            return null;
-                        case AI:
-                            AiMessage aiMessage = (AiMessage) msg;
+                if (isNotNullOrEmpty(systemMessage.text())) {
+                    return new GeminiContent(
+                            List.of(GeminiContent.GeminiPart.builder()
+                                    .text(systemMessage.text())
+                                    .build()),
+                            GeminiRole.MODEL.toString());
+                }
 
-                            List<GeminiContent.GeminiPart> parts = new ArrayList<>();
+                return null;
+            case AI:
+                AiMessage aiMessage = (AiMessage) msg;
 
-                            if (sendThinking && isNotNullOrEmpty(aiMessage.thinking())) {
-                                parts.add(GeminiContent.GeminiPart.builder()
-                                        .text(aiMessage.thinking())
-                                        .thought(true)
-                                        .build());
-                            }
+                List<GeminiContent.GeminiPart> parts = new ArrayList<>();
 
-                            if (isNotNullOrEmpty(aiMessage.text())) {
-                                parts.add(GeminiContent.GeminiPart.builder()
-                                        .text(aiMessage.text())
-                                        .build());
-                            }
+                if (sendThinking && isNotNullOrEmpty(aiMessage.thinking())) {
+                    parts.add(GeminiContent.GeminiPart.builder()
+                            .text(aiMessage.thinking())
+                            .thought(true)
+                            .build());
+                }
 
-                            if (aiMessage.hasToolExecutionRequests()) {
-                                String thoughtSignature = null;
-                                if (sendThinking) {
-                                    thoughtSignature = aiMessage.attribute(THINKING_SIGNATURE_KEY, String.class);
-                                }
-                                parts.addAll(toGeminiParts(aiMessage.toolExecutionRequests(), thoughtSignature));
-                            }
+                if (isNotNullOrEmpty(aiMessage.text())) {
+                    parts.add(GeminiContent.GeminiPart.builder()
+                            .text(aiMessage.text())
+                            .build());
+                }
 
-                            return new GeminiContent(parts, GeminiRole.MODEL.toString());
-
-                        case USER:
-                            UserMessage userMessage = (UserMessage) msg;
-
-                            return new GeminiContent(
-                                    userMessage.contents().stream()
-                                            .map(content -> fromContentToGPart(content, mediaResolutionPerPartEnabled))
-                                            .collect(Collectors.toList()),
-                                    GeminiRole.USER.toString());
-                        case TOOL_EXECUTION_RESULT:
-                            ToolExecutionResultMessage toolResultMessage = (ToolExecutionResultMessage) msg;
-
-                            if (!toolResultMessage.hasSingleText()) {
-                                List<GeminiContent.GeminiPart> toolParts = new ArrayList<>();
-                                Map<String, String> responseMap = new HashMap<>();
-                                for (dev.langchain4j.data.message.Content content : toolResultMessage.contents()) {
-                                    if (content instanceof TextContent textContent) {
-                                        responseMap.put("response", textContent.text());
-                                    } else if (content instanceof ImageContent imageContent) {
-                                        toolParts.add(fromContentToGPart(imageContent, mediaResolutionPerPartEnabled));
-                                    } else {
-                                        throw new UnsupportedFeatureException(
-                                                "Google AI Gemini does not support content type '" + content.type()
-                                                        + "' in tool results.");
-                                    }
-                                }
-                                if (responseMap.isEmpty()) {
-                                    responseMap.put("response", "");
-                                }
-                                toolParts.add(
-                                        0,
-                                        GeminiContent.GeminiPart.builder()
-                                                .functionResponse(new GeminiFunctionResponse(
-                                                        toolResultMessage.id(),
-                                                        toolResultMessage.toolName(),
-                                                        responseMap))
-                                                .build());
-                                return new GeminiContent(toolParts, GeminiRole.USER.toString());
-                            }
-
-                            return new GeminiContent(
-                                    List.of(GeminiContent.GeminiPart.builder()
-                                            .functionResponse(new GeminiFunctionResponse(
-                                                    toolResultMessage.id(),
-                                                    toolResultMessage.toolName(),
-                                                    Map.of("response", toolResultMessage.text())))
-                                            .build()),
-                                    GeminiRole.USER.toString());
-                        default:
-                            return null;
+                if (aiMessage.hasToolExecutionRequests()) {
+                    String thoughtSignature = null;
+                    if (sendThinking) {
+                        thoughtSignature = aiMessage.attribute(THINKING_SIGNATURE_KEY, String.class);
                     }
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                    parts.addAll(toGeminiParts(aiMessage.toolExecutionRequests(), thoughtSignature));
+                }
+
+                return new GeminiContent(parts, GeminiRole.MODEL.toString());
+
+            case USER:
+                UserMessage userMessage = (UserMessage) msg;
+
+                return new GeminiContent(
+                        userMessage.contents().stream()
+                                .map(content -> fromContentToGPart(content, mediaResolutionPerPartEnabled))
+                                .collect(Collectors.toList()),
+                        GeminiRole.USER.toString());
+            case TOOL_EXECUTION_RESULT:
+                ToolExecutionResultMessage toolResultMessage = (ToolExecutionResultMessage) msg;
+                String functionName = resolveFunctionResponseName(messages, messageIndex, toolResultMessage);
+
+                if (!toolResultMessage.hasSingleText()) {
+                    List<GeminiContent.GeminiPart> toolParts = new ArrayList<>();
+                    Map<String, String> responseMap = new HashMap<>();
+                    for (dev.langchain4j.data.message.Content content : toolResultMessage.contents()) {
+                        if (content instanceof TextContent textContent) {
+                            responseMap.put("response", textContent.text());
+                        } else if (content instanceof ImageContent imageContent) {
+                            toolParts.add(fromContentToGPart(imageContent, mediaResolutionPerPartEnabled));
+                        } else {
+                            throw new UnsupportedFeatureException(
+                                    "Google AI Gemini does not support content type '" + content.type()
+                                            + "' in tool results.");
+                        }
+                    }
+                    if (responseMap.isEmpty()) {
+                        responseMap.put("response", "");
+                    }
+                    toolParts.add(
+                            0,
+                            GeminiContent.GeminiPart.builder()
+                                    .functionResponse(new GeminiFunctionResponse(
+                                            toolResultMessage.id(), functionName, responseMap))
+                                    .build());
+                    return new GeminiContent(toolParts, GeminiRole.USER.toString());
+                }
+
+                return new GeminiContent(
+                        List.of(GeminiContent.GeminiPart.builder()
+                                .functionResponse(new GeminiFunctionResponse(
+                                        toolResultMessage.id(),
+                                        functionName,
+                                        Map.of("response", toolResultMessage.text())))
+                                .build()),
+                        GeminiRole.USER.toString());
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Gemini requires {@code functionResponse.name} to be non-empty. Prefer the name on the tool result
+     * message; when it is blank (e.g. only tool call id was stored), recover the name from the nearest
+     * preceding {@link AiMessage} tool execution requests by id, then by order.
+     */
+    static String resolveFunctionResponseName(
+            List<ChatMessage> messages, int toolResultIndex, ToolExecutionResultMessage toolResultMessage) {
+        if (!isNullOrBlank(toolResultMessage.toolName())) {
+            return toolResultMessage.toolName();
+        }
+
+        int aiMessageIndex = findPrecedingAiMessageIndexWithToolRequests(messages, toolResultIndex);
+        if (aiMessageIndex < 0) {
+            return toolResultMessage.toolName();
+        }
+
+        AiMessage precedingAiMessage = (AiMessage) messages.get(aiMessageIndex);
+        List<ToolExecutionRequest> requests = precedingAiMessage.toolExecutionRequests();
+
+        if (!isNullOrBlank(toolResultMessage.id())) {
+            for (ToolExecutionRequest request : requests) {
+                if (toolResultMessage.id().equals(request.id()) && !isNullOrBlank(request.name())) {
+                    return request.name();
+                }
+            }
+        }
+
+        int toolResultOffset = 0;
+        for (int i = aiMessageIndex + 1; i < toolResultIndex; i++) {
+            if (messages.get(i) instanceof ToolExecutionResultMessage) {
+                toolResultOffset++;
+            }
+        }
+        if (toolResultOffset < requests.size() && !isNullOrBlank(requests.get(toolResultOffset).name())) {
+            return requests.get(toolResultOffset).name();
+        }
+
+        return toolResultMessage.toolName();
+    }
+
+    private static int findPrecedingAiMessageIndexWithToolRequests(List<ChatMessage> messages, int fromIndex) {
+        for (int i = fromIndex - 1; i >= 0; i--) {
+            ChatMessage message = messages.get(i);
+            if (message instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
@@ -338,8 +338,7 @@ class PartsAndContentsMapperTest {
                 .arguments("{}")
                 .build();
         AiMessage aiMessage = AiMessage.from(toolRequest);
-        ToolExecutionResultMessage toolResult =
-                ToolExecutionResultMessage.from("call-1", "explicit_name", "ok");
+        ToolExecutionResultMessage toolResult = ToolExecutionResultMessage.from("call-1", "explicit_name", "ok");
 
         List<GeminiContent> result =
                 PartsAndContentsMapper.fromMessageToGContent(List.of(aiMessage, toolResult), null, false);

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
@@ -287,6 +287,67 @@ class PartsAndContentsMapperTest {
     }
 
     @Test
+    void fromMessageToGContent_recoversEmptyFunctionResponseNameByToolCallId() {
+        // Gemini rejects functionResponse with empty name (e.g. when only id was stored on the result).
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("get_current_time")
+                .arguments("{\"timezone\":\"Asia/Shanghai\"}")
+                .build();
+        AiMessage aiMessage = AiMessage.from(toolRequest);
+        ToolExecutionResultMessage toolResult =
+                ToolExecutionResultMessage.from("call-1", "", "{\"timezone\":\"Asia/Shanghai\"}");
+
+        List<GeminiContent> result =
+                PartsAndContentsMapper.fromMessageToGContent(List.of(aiMessage, toolResult), null, false);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).parts().get(0).functionCall().name()).isEqualTo("get_current_time");
+        assertThat(result.get(1).parts().get(0).functionResponse().name()).isEqualTo("get_current_time");
+        assertThat(result.get(1).parts().get(0).functionResponse().id()).isEqualTo("call-1");
+    }
+
+    @Test
+    void fromMessageToGContent_recoversEmptyFunctionResponseNameByOrderWhenIdsMissing() {
+        // Gemini often omits function call ids; recover name by position among tool results.
+        ToolExecutionRequest first = ToolExecutionRequest.builder()
+                .name("get_current_time")
+                .arguments("{\"timezone\":\"Asia/Shanghai\"}")
+                .build();
+        ToolExecutionRequest second = ToolExecutionRequest.builder()
+                .name("convert_time")
+                .arguments("{\"time\":\"12:00\"}")
+                .build();
+        AiMessage aiMessage = AiMessage.from(first, second);
+        ToolExecutionResultMessage firstResult = ToolExecutionResultMessage.from(null, "", "now");
+        ToolExecutionResultMessage secondResult = ToolExecutionResultMessage.from(null, "", "later");
+
+        List<GeminiContent> result = PartsAndContentsMapper.fromMessageToGContent(
+                List.of(aiMessage, firstResult, secondResult), null, false);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(1).parts().get(0).functionResponse().name()).isEqualTo("get_current_time");
+        assertThat(result.get(2).parts().get(0).functionResponse().name()).isEqualTo("convert_time");
+    }
+
+    @Test
+    void fromMessageToGContent_keepsExplicitFunctionResponseNameWhenPresent() {
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("get_current_time")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessage = AiMessage.from(toolRequest);
+        ToolExecutionResultMessage toolResult =
+                ToolExecutionResultMessage.from("call-1", "explicit_name", "ok");
+
+        List<GeminiContent> result =
+                PartsAndContentsMapper.fromMessageToGContent(List.of(aiMessage, toolResult), null, false);
+
+        assertThat(result.get(1).parts().get(0).functionResponse().name()).isEqualTo("explicit_name");
+    }
+
+    @Test
     void fromMessageToGContent_systemMessageWithText() {
         SystemMessage msg = new SystemMessage("system text");
         List<GeminiContent> result = PartsAndContentsMapper.fromMessageToGContent(List.of(msg), null, false);


### PR DESCRIPTION
## Issue
Fixes #3468

## Change
Google AI Gemini rejects `GenerateContentRequest` when `functionResponse.name` is empty (`Name cannot be empty`).

When mapping `ToolExecutionResultMessage` to Gemini content, if `toolName` is blank, recover the function name from the nearest preceding `AiMessage` tool execution requests:
1. Match by tool call id when present
2. Otherwise match by order among consecutive tool results

This keeps existing behavior when `toolName` is already set, and unblocks MCP / tool loops that only carry a blank name on the result message (while the model turn still has the real tool name).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

## Test plan
- [X] `./mvnw -pl langchain4j-google-ai-gemini -Dtest=PartsAndContentsMapperTest,FunctionMapperTest test` (49 tests green, JDK 21)