### PR TITLE
fix: parse a bare JSON array in collection output parsers

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/output/ParsingUtils.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/ParsingUtils.java
@@ -1,18 +1,17 @@
 package dev.langchain4j.service.output;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.Utils.quoted;
+import static dev.langchain4j.internal.Utils.toBase64;
+
 import dev.langchain4j.Internal;
 import dev.langchain4j.internal.Json;
-
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.internal.Utils.quoted;
-import static dev.langchain4j.internal.Utils.toBase64;
 
 @Internal
 class ParsingUtils {
@@ -40,15 +39,18 @@ class ParsingUtils {
         }
     }
 
-    static <T, CT extends Collection<T>> CT parseAsStringOrJson(String text,
-                                                                Function<String, T> parser,
-                                                                Supplier<CT> emptyCollectionSupplier,
-                                                                String type) {
+    static <T, CT extends Collection<T>> CT parseAsStringOrJson(
+            String text, Function<String, T> parser, Supplier<CT> emptyCollectionSupplier, String type) {
         if (text == null) {
             throw outputParsingException(text, type, null);
         }
 
-        if (isJson(text)) {
+        if (isJsonArray(text)) {
+            // A bare JSON array, e.g. ["A", "B"] or [{...}, {...}].
+            // This is a common shape returned by LLMs for list-typed results.
+            Collection<?> values = Json.fromJson(text, Collection.class);
+            return parseCollectionValues(values, parser, emptyCollectionSupplier, type);
+        } else if (isJsonObject(text)) {
             Map<?, ?> map = Json.fromJson(text, Map.class);
             if (isNullOrEmpty(map)) {
                 throw outputParsingException(text, type, null);
@@ -59,17 +61,7 @@ class ParsingUtils {
                 throw outputParsingException(text, type, null);
             }
 
-            CT collection = emptyCollectionSupplier.get();
-            for (Object value : ((Collection<?>) values)) {
-                String stringValue;
-                if (value instanceof String string) {
-                    stringValue = string;
-                } else {
-                    stringValue = Json.toJson(value);
-                }
-                collection.add(parse(stringValue, parser, type));
-            }
-            return collection;
+            return parseCollectionValues((Collection<?>) values, parser, emptyCollectionSupplier, type);
         } else {
             CT collection = emptyCollectionSupplier.get();
             for (String line : text.split("\n")) {
@@ -82,8 +74,31 @@ class ParsingUtils {
         }
     }
 
+    private static <T, CT extends Collection<T>> CT parseCollectionValues(
+            Collection<?> values, Function<String, T> parser, Supplier<CT> emptyCollectionSupplier, String type) {
+        CT collection = emptyCollectionSupplier.get();
+        for (Object value : values) {
+            String stringValue;
+            if (value instanceof String string) {
+                stringValue = string;
+            } else {
+                stringValue = Json.toJson(value);
+            }
+            collection.add(parse(stringValue, parser, type));
+        }
+        return collection;
+    }
+
     private static boolean isJson(String text) {
+        return isJsonObject(text);
+    }
+
+    private static boolean isJsonObject(String text) {
         return text.trim().startsWith("{");
+    }
+
+    private static boolean isJsonArray(String text) {
+        return text.trim().startsWith("[");
     }
 
     private static <T> T parse(String text, Function<String, T> parser, Type type) {
@@ -103,7 +118,7 @@ class ParsingUtils {
     }
 
     static OutputParsingException outputParsingException(String text, String type, Throwable cause) {
-        return new OutputParsingException("Failed to parse %s (base64: %s) into %s".formatted(
-                quoted(text), quoted(toBase64(text)), type), cause);
+        return new OutputParsingException(
+                "Failed to parse %s (base64: %s) into %s".formatted(quoted(text), quoted(toBase64(text)), type), cause);
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/ParsingUtils.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/ParsingUtils.java
@@ -22,7 +22,7 @@ class ParsingUtils {
             throw outputParsingException(text, type);
         }
 
-        if (isJson(text)) {
+        if (isJsonObject(text)) {
             Map<?, ?> map = Json.fromJson(text, Map.class);
             if (isNullOrEmpty(map)) {
                 throw outputParsingException(text, type);
@@ -46,10 +46,10 @@ class ParsingUtils {
         }
 
         if (isJsonArray(text)) {
-            // A bare JSON array, e.g. ["A", "B"] or [{...}, {...}].
-            // This is a common shape returned by LLMs for list-typed results.
-            Collection<?> values = Json.fromJson(text, Collection.class);
-            return parseCollectionValues(values, parser, emptyCollectionSupplier, type);
+            Collection<?> values = parseJsonArrayOrNull(text);
+            if (values != null) {
+                return parseCollectionValues(values, parser, emptyCollectionSupplier, type);
+            }
         } else if (isJsonObject(text)) {
             Map<?, ?> map = Json.fromJson(text, Map.class);
             if (isNullOrEmpty(map)) {
@@ -62,16 +62,29 @@ class ParsingUtils {
             }
 
             return parseCollectionValues((Collection<?>) values, parser, emptyCollectionSupplier, type);
-        } else {
-            CT collection = emptyCollectionSupplier.get();
-            for (String line : text.split("\n")) {
-                if (isNullOrBlank(line)) {
-                    continue;
-                }
-                collection.add(parse(line.trim(), parser, type));
-            }
-            return collection;
         }
+
+        return parseLines(text, parser, emptyCollectionSupplier, type);
+    }
+
+    private static Collection<?> parseJsonArrayOrNull(String text) {
+        try {
+            return Json.fromJson(text.trim(), Collection.class);
+        } catch (RuntimeException e) {
+            return null; // the text only looks like a JSON array, e.g. "[apple]\n[banana]"
+        }
+    }
+
+    private static <T, CT extends Collection<T>> CT parseLines(
+            String text, Function<String, T> parser, Supplier<CT> emptyCollectionSupplier, String type) {
+        CT collection = emptyCollectionSupplier.get();
+        for (String line : text.split("\n")) {
+            if (isNullOrBlank(line)) {
+                continue;
+            }
+            collection.add(parse(line.trim(), parser, type));
+        }
+        return collection;
     }
 
     private static <T, CT extends Collection<T>> CT parseCollectionValues(
@@ -89,16 +102,13 @@ class ParsingUtils {
         return collection;
     }
 
-    private static boolean isJson(String text) {
-        return isJsonObject(text);
-    }
-
     private static boolean isJsonObject(String text) {
         return text.trim().startsWith("{");
     }
 
     private static boolean isJsonArray(String text) {
-        return text.trim().startsWith("[");
+        String trimmed = text.trim();
+        return trimmed.startsWith("[") && trimmed.endsWith("]");
     }
 
     private static <T> T parse(String text, Function<String, T> parser, Type type) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/EnumListOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/EnumListOutputParserTest.java
@@ -1,9 +1,17 @@
 package dev.langchain4j.service.output;
 
+import static dev.langchain4j.service.output.EnumListOutputParserTest.Animal.CAT;
+import static dev.langchain4j.service.output.EnumListOutputParserTest.Animal.DOG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -11,19 +19,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import static dev.langchain4j.service.output.EnumListOutputParserTest.Animal.CAT;
-import static dev.langchain4j.service.output.EnumListOutputParserTest.Animal.DOG;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 class EnumListOutputParserTest {
 
     enum Animal {
-        CAT, DOG, BIRD
+        CAT,
+        DOG,
+        BIRD
     }
 
     @ParameterizedTest
@@ -57,8 +58,13 @@ class EnumListOutputParserTest {
                 Arguments.of("{\"values\":[\"CAT\"]}", List.of(CAT)),
                 Arguments.of("{\"values\":[\"CAT\", \"DOG\"]}", List.of(CAT, DOG)),
                 Arguments.of("{\"values\":[]}", List.of()),
-                Arguments.of("  {\"values\":[\"CAT\"]}  ", List.of(CAT))
-        );
+                Arguments.of("  {\"values\":[\"CAT\"]}  ", List.of(CAT)),
+
+                // Bare JSON array (a common shape returned by LLMs)
+                Arguments.of("[\"CAT\"]", List.of(CAT)),
+                Arguments.of("[\"CAT\", \"DOG\"]", List.of(CAT, DOG)),
+                Arguments.of("[]", List.of()),
+                Arguments.of("  [\"CAT\", \"DOG\"]  ", List.of(CAT, DOG)));
     }
 
     @ParameterizedTest
@@ -73,12 +79,7 @@ class EnumListOutputParserTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "BANANA",
-            "{\"values\":[\"BANANA\"]}",
-            "{\"values\":\"CAT\"}",
-            "{\"banana\":[\"CAT\"]}"
-    })
+    @ValueSource(strings = {"BANANA", "{\"values\":[\"BANANA\"]}", "{\"values\":\"CAT\"}", "{\"banana\":[\"CAT\"]}"})
     void should_fail_to_parse_invalid_input(String text) {
 
         // given
@@ -96,7 +97,9 @@ class EnumListOutputParserTest {
 
         // given
         enum MyEnumWithToString {
-            A, B, C;
+            A,
+            B,
+            C;
 
             @Override
             public String toString() {
@@ -112,16 +115,19 @@ class EnumListOutputParserTest {
         Optional<JsonSchema> jsonSchema = parser.jsonSchema();
 
         // then
-        assertThat(jsonSchema).hasValue(JsonSchema.builder()
-                .name("List_of_MyEnumWithToString")
-                .rootElement(JsonObjectSchema.builder()
-                        .addProperty("values", JsonArraySchema.builder()
-                                .items(JsonEnumSchema.builder()
-                                        .enumValues("A", "B", "C")
-                                        .build())
+        assertThat(jsonSchema)
+                .hasValue(JsonSchema.builder()
+                        .name("List_of_MyEnumWithToString")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addProperty(
+                                        "values",
+                                        JsonArraySchema.builder()
+                                                .items(JsonEnumSchema.builder()
+                                                        .enumValues("A", "B", "C")
+                                                        .build())
+                                                .build())
+                                .required("values")
                                 .build())
-                        .required("values")
-                        .build())
-                .build());
+                        .build());
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/EnumListOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/EnumListOutputParserTest.java
@@ -64,7 +64,11 @@ class EnumListOutputParserTest {
                 Arguments.of("[\"CAT\"]", List.of(CAT)),
                 Arguments.of("[\"CAT\", \"DOG\"]", List.of(CAT, DOG)),
                 Arguments.of("[]", List.of()),
-                Arguments.of("  [\"CAT\", \"DOG\"]  ", List.of(CAT, DOG)));
+                Arguments.of("  [\"CAT\", \"DOG\"]  ", List.of(CAT, DOG)),
+
+                // Text that only looks like a bare JSON array: still parsed line by line
+                Arguments.of("[CAT]", List.of(CAT)),
+                Arguments.of("[CAT]\n[DOG]", List.of(CAT, DOG)));
     }
 
     @ParameterizedTest
@@ -79,7 +83,15 @@ class EnumListOutputParserTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"BANANA", "{\"values\":[\"BANANA\"]}", "{\"values\":\"CAT\"}", "{\"banana\":[\"CAT\"]}"})
+    @ValueSource(
+            strings = {
+                "BANANA",
+                "{\"values\":[\"BANANA\"]}",
+                "{\"values\":\"CAT\"}",
+                "{\"banana\":[\"CAT\"]}",
+                "[\"BANANA\"]",
+                "[\"CAT\"",
+            })
     void should_fail_to_parse_invalid_input(String text) {
 
         // given

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/EnumSetOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/EnumSetOutputParserTest.java
@@ -1,5 +1,14 @@
 package dev.langchain4j.service.output;
 
+import static dev.langchain4j.service.output.EnumSetOutputParserTest.Animal.BIRD;
+import static dev.langchain4j.service.output.EnumSetOutputParserTest.Animal.CAT;
+import static dev.langchain4j.service.output.EnumSetOutputParserTest.Animal.DOG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -7,20 +16,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Iterator;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static dev.langchain4j.service.output.EnumSetOutputParserTest.Animal.BIRD;
-import static dev.langchain4j.service.output.EnumSetOutputParserTest.Animal.CAT;
-import static dev.langchain4j.service.output.EnumSetOutputParserTest.Animal.DOG;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 class EnumSetOutputParserTest {
 
     enum Animal {
-        CAT, DOG, BIRD
+        CAT,
+        DOG,
+        BIRD
     }
 
     @ParameterizedTest
@@ -54,8 +55,13 @@ class EnumSetOutputParserTest {
                 Arguments.of("{\"values\":[\"CAT\"]}", Set.of(CAT)),
                 Arguments.of("{\"values\":[\"CAT\", \"DOG\"]}", Set.of(CAT, DOG)),
                 Arguments.of("{\"values\":[]}", Set.of()),
-                Arguments.of("  {\"values\":[\"CAT\"]}  ", Set.of(CAT))
-        );
+                Arguments.of("  {\"values\":[\"CAT\"]}  ", Set.of(CAT)),
+
+                // Bare JSON array (a common shape returned by LLMs)
+                Arguments.of("[\"CAT\"]", Set.of(CAT)),
+                Arguments.of("[\"CAT\", \"DOG\"]", Set.of(CAT, DOG)),
+                Arguments.of("[]", Set.of()),
+                Arguments.of("  [\"CAT\", \"DOG\"]  ", Set.of(CAT, DOG)));
     }
 
     @ParameterizedTest
@@ -70,12 +76,7 @@ class EnumSetOutputParserTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "BANANA",
-            "{\"values\":[\"BANANA\"]}",
-            "{\"values\":\"CAT\"}",
-            "{\"banana\":[\"CAT\"]}"
-    })
+    @ValueSource(strings = {"BANANA", "{\"values\":[\"BANANA\"]}", "{\"values\":\"CAT\"}", "{\"banana\":[\"CAT\"]}"})
     void should_fail_to_parse_invalid_input(String text) {
 
         // given

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PojoListOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PojoListOutputParserTest.java
@@ -116,6 +116,8 @@ class PojoListOutputParserTest {
             strings = {
                 "{\"values\":{\"name\":\"Alice\"}}",
                 "{\"values\":[\"Alice\"]}",
+                "[\"Alice\"]",
+                "[{\"name\":\"Alice\"}] and more",
             })
     void should_fail_to_parse_malformed_json(String malformedJson) {
         assertThatThrownBy(() -> new PojoListOutputParser<>(Person.class).parse(malformedJson))

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PojoListOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PojoListOutputParserTest.java
@@ -35,7 +35,15 @@ class PojoListOutputParserTest {
                 Arguments.of("", List.of()),
                 Arguments.of(" ", List.of()),
                 Arguments.of("{\"values\":[]}", List.of()),
-                Arguments.of(" {\"values\":[{\"name\":\"Klaus\"}]} ", List.of(new Person("Klaus"))));
+                Arguments.of(" {\"values\":[{\"name\":\"Klaus\"}]} ", List.of(new Person("Klaus"))),
+
+                // Bare JSON array (a common shape returned by LLMs)
+                Arguments.of("[{\"name\":\"Klaus\"}]", List.of(new Person("Klaus"))),
+                Arguments.of(
+                        "[{\"name\":\"Klaus\"}, {\"name\":\"Franny\"}]",
+                        List.of(new Person("Klaus"), new Person("Franny"))),
+                Arguments.of("[]", List.of()),
+                Arguments.of(" [{\"name\":\"Klaus\"}] ", List.of(new Person("Klaus"))));
     }
 
     @ParameterizedTest
@@ -107,7 +115,6 @@ class PojoListOutputParserTest {
     @ValueSource(
             strings = {
                 "{\"values\":{\"name\":\"Alice\"}}",
-                "[{\"name\":\"Alice\"}]",
                 "{\"values\":[\"Alice\"]}",
             })
     void should_fail_to_parse_malformed_json(String malformedJson) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PojoSetOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PojoSetOutputParserTest.java
@@ -36,7 +36,15 @@ class PojoSetOutputParserTest {
                 Arguments.of("", Set.of()),
                 Arguments.of(" ", Set.of()),
                 Arguments.of("{\"values\":[]}", Set.of()),
-                Arguments.of(" {\"values\":[{\"name\":\"Klaus\"}]} ", Set.of(new Person("Klaus"))));
+                Arguments.of(" {\"values\":[{\"name\":\"Klaus\"}]} ", Set.of(new Person("Klaus"))),
+
+                // Bare JSON array (a common shape returned by LLMs)
+                Arguments.of("[{\"name\":\"Klaus\"}]", Set.of(new Person("Klaus"))),
+                Arguments.of(
+                        "[{\"name\":\"Klaus\"}, {\"name\":\"Franny\"}]",
+                        Set.of(new Person("Klaus"), new Person("Franny"))),
+                Arguments.of("[]", Set.of()),
+                Arguments.of(" [{\"name\":\"Klaus\"}] ", Set.of(new Person("Klaus"))));
     }
 
     @ParameterizedTest
@@ -59,6 +67,7 @@ class PojoSetOutputParserTest {
                 "{\"values\":[\"banana\"]}",
                 "{\"values\":{\"name\":\"Klaus\"}}",
                 "{\"banana\":[{\"name\":\"Klaus\"}]}",
+                "[\"Klaus\"]",
             })
     void should_fail_to_parse_invalid_input(String text) {
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/StringListOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/StringListOutputParserTest.java
@@ -48,7 +48,14 @@ class StringListOutputParserTest {
                 Arguments.of("[\"CAT\"]", List.of("CAT")),
                 Arguments.of("[\"CAT\", \"DOG\"]", List.of("CAT", "DOG")),
                 Arguments.of("[]", List.of()),
-                Arguments.of("  [\"CAT\", \"DOG\"]  ", List.of("CAT", "DOG")));
+                Arguments.of("  [\"CAT\", \"DOG\"]  ", List.of("CAT", "DOG")),
+                Arguments.of("[\n  \"CAT\",\n  \"DOG\"\n]", List.of("CAT", "DOG")),
+
+                // Text that only looks like a bare JSON array: still parsed line by line
+                Arguments.of("[CAT]\n[DOG]", List.of("[CAT]", "[DOG]")),
+                Arguments.of("[1] CAT\n[2] DOG", List.of("[1] CAT", "[2] DOG")),
+                Arguments.of("[\"CAT\"] and more", List.of("[\"CAT\"] and more")),
+                Arguments.of("[CAT", List.of("[CAT")));
     }
 
     @ParameterizedTest

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/StringListOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/StringListOutputParserTest.java
@@ -1,16 +1,15 @@
 package dev.langchain4j.service.output;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StringListOutputParserTest {
 
@@ -43,8 +42,13 @@ class StringListOutputParserTest {
                 Arguments.of("{\"values\":[\"CAT\"]}", List.of("CAT")),
                 Arguments.of("{\"values\":[\"CAT\",\"DOG\"]}", List.of("CAT", "DOG")),
                 Arguments.of("{\"values\":[]}", List.of()),
-                Arguments.of("  {\"values\":[\"CAT\"]}  ", List.of("CAT"))
-        );
+                Arguments.of("  {\"values\":[\"CAT\"]}  ", List.of("CAT")),
+
+                // Bare JSON array (a common shape returned by LLMs)
+                Arguments.of("[\"CAT\"]", List.of("CAT")),
+                Arguments.of("[\"CAT\", \"DOG\"]", List.of("CAT", "DOG")),
+                Arguments.of("[]", List.of()),
+                Arguments.of("  [\"CAT\", \"DOG\"]  ", List.of("CAT", "DOG")));
     }
 
     @ParameterizedTest
@@ -60,13 +64,14 @@ class StringListOutputParserTest {
 
     @ParameterizedTest
     @NullSource
-    @ValueSource(strings = {
-            "{\"values\": \"\"}",
-            "{\"values\": false}",
-            "{\"values\":\"banana\"}",
-            "{\"values\":{\"name\":\"Klaus\"}}",
-            "{\"banana\":[{\"name\":\"Klaus\"}]}",
-    })
+    @ValueSource(
+            strings = {
+                "{\"values\": \"\"}",
+                "{\"values\": false}",
+                "{\"values\":\"banana\"}",
+                "{\"values\":{\"name\":\"Klaus\"}}",
+                "{\"banana\":[{\"name\":\"Klaus\"}]}",
+            })
     void should_fail_to_parse_invalid_input(String input) {
 
         assertThatThrownBy(() -> new StringListOutputParser().parse(input))

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/StringSetOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/StringSetOutputParserTest.java
@@ -62,7 +62,18 @@ class StringSetOutputParserTest {
                 Arguments.of("{\"values\":[\"CAT\",\"DOG\"]}", Set.of("CAT", "DOG")),
                 Arguments.of("{\"values\":[\"CAT\",\"DOG\",\"CAT\"]}", Set.of("CAT", "DOG")),
                 Arguments.of("{\"values\":[]}", Set.of()),
-                Arguments.of("  {\"values\":[\"CAT\",\"DOG\"]}  ", Set.of("CAT", "DOG")));
+                Arguments.of("  {\"values\":[\"CAT\",\"DOG\"]}  ", Set.of("CAT", "DOG")),
+
+                // Bare JSON array (a common shape returned by LLMs)
+                Arguments.of("[\"CAT\"]", Set.of("CAT")),
+                Arguments.of("[\"CAT\",\"DOG\"]", Set.of("CAT", "DOG")),
+                Arguments.of("[\"CAT\",\"DOG\",\"CAT\"]", Set.of("CAT", "DOG")),
+                Arguments.of("[]", Set.of()),
+                Arguments.of("  [\"CAT\",\"DOG\"]  ", Set.of("CAT", "DOG")),
+
+                // Text that only looks like a bare JSON array: still parsed line by line
+                Arguments.of("[CAT]\n[DOG]", Set.of("[CAT]", "[DOG]")),
+                Arguments.of("[1] CAT\n[2] DOG", Set.of("[1] CAT", "[2] DOG")));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Issue
  Closes #5904

  ## Change

  Collection output parsers (`List`/`Set` of `String`, `Enum`, or POJO) only understood two output shapes:
  1. a JSON **object** with a `values` key: `{"values": ["A", "B"]}`
  2. newline-delimited plain text

  They did **not** handle a bare JSON **array** — `["A", "B"]` — which is one of the most common shapes an LLM returns for a list-typed result, especially when strict JSON-schema response format is not enforced
  (many local/smaller models, older models, or providers/configurations without forced structured output).

  Because `ParsingUtils.isJson()` only recognized objects (`startsWith("{")`), a bare array fell through to the newline-splitting branch, treating the whole single-line array as one element:

  | Return type | LLM output | Before |
  |---|---|---|
  | `List<Enum>` | `["CAT", "DOG"]` | throws `OutputParsingException` |
  | `List<Pojo>` | `[{"name":"Alice"}, {"name":"Bob"}]` | throws `OutputParsingException` |
  | `List<String>` | `["apple", "banana"]` | **silently returns `[["apple", "banana"]]`** (a 1-element list containing the raw JSON string) |

  The fix makes `ParsingUtils.parseAsStringOrJson(...)` (collection variant) recognize a top-level JSON array and parse its elements the same way as the `values` array. The shared element-conversion logic is
  factored into a small `parseCollectionValues(...)` helper reused by both the array and object branches. The scalar (single-value) parser path is unchanged.

  After the fix:
  - `["CAT", "DOG"]` → `[CAT, DOG]`
  - `["apple", "banana"]` → `["apple", "banana"]`
  - `[{"name":"Alice"}]` → `[Person("Alice")]`

  Affected parsers: `EnumCollectionOutputParser` (`EnumListOutputParser`/`EnumSetOutputParser`), `StringCollectionOutputParser` (`StringListOutputParser`/`StringSetOutputParser`), `PojoCollectionOutputParser`
  (`PojoListOutputParser`/`PojoSetOutputParser`).

  ### Text that only *looks* like a JSON array

  Plenty of plain-text output starts with `[` without being JSON, and that output parses fine today via the newline branch. To make sure none of it regresses, the array branch is entered conservatively:

  - the trimmed text must both start with `[` **and** end with `]`. Jackson does not fail on trailing tokens, so without the closing check `[1] apple\n[2] banana` would parse as the array `[1]` and silently
  discard everything after it;
  - if the text turns out not to be valid JSON after all, parsing falls back to the existing line-by-line branch instead of letting a raw `RuntimeException` escape from `Json.fromJson`.

  The fallback deliberately wraps only the JSON parse, so a well-formed array whose *elements* are invalid still fails loudly with `OutputParsingException` (e.g. `["BANANA"]` for a `List<Animal>`).

  Behavior preserved as-is:

  | Input | `List<String>` result |
  |---|---|
  | `[CAT]\n[DOG]` | `["[CAT]", "[DOG]"]` |
  | `[1] CAT\n[2] DOG` | `["[1] CAT", "[2] DOG"]` |
  | `["CAT"] and more` | `["\"CAT\"] and more"]` |
  | `[CAT` | `["[CAT"]` |

  (`EnumOutputParser` already strips surrounding brackets, so `[CAT]` keeps parsing to `CAT`.)

  Note: a pre-existing `PojoListOutputParserTest.should_fail_to_parse_malformed_json` case asserted that the bare array `[{"name":"Alice"}]` should fail — that case is removed, since a bare array of POJOs now
  parses correctly (the whole point of this fix).

  ## General checklist
  - [X] There are no breaking changes (API); the only behavior change is that a previously-failing/mis-parsed input shape now parses correctly
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

  ## Test plan
  - Bare-JSON-array positive cases (single element, multiple elements, empty `[]`, surrounding whitespace, multi-line array) added to `StringListOutputParserTest`, `StringSetOutputParserTest`,
  `EnumListOutputParserTest`, `EnumSetOutputParserTest`, `PojoListOutputParserTest` and `PojoSetOutputParserTest`.
  - Negative cases added for malformed/invalid arrays: `["BANANA"]` and `["CAT"` for enums, `["Alice"]` and `[{"name":"Alice"}] and more` for POJOs.
  - Regression cases added for text that only looks like a JSON array (`[CAT]\n[DOG]`, `[1] CAT\n[2] DOG`, `["CAT"] and more`, `[CAT`), asserting the line-by-line behavior is unchanged.
  - Verified each positive case fails on `main` (`List<Enum>`/`List<Pojo>` throw; `List<String>` returns `[["a","b"]]`) and passes with the fix.
  - Ran all unit tests in `langchain4j-core` and `langchain4j` (1316 tests) — all green.
  - Ran `./mvnw spotless:check` and `./mvnw revapi:check` — both clean.