### PR TITLE
fix: use the exact metadata key in Coherence metadata filters

### DIFF
--- a/langchain4j-coherence/src/main/java/dev/langchain4j/store/embedding/coherence/CoherenceMetadataFilterMapper.java
+++ b/langchain4j-coherence/src/main/java/dev/langchain4j/store/embedding/coherence/CoherenceMetadataFilterMapper.java
@@ -4,7 +4,6 @@ import com.oracle.coherence.ai.DocumentChunk;
 import com.tangosol.util.Extractors;
 import com.tangosol.util.Filters;
 import com.tangosol.util.ValueExtractor;
-
 import dev.langchain4j.store.embedding.filter.Filter;
 import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
 import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThan;
@@ -17,7 +16,6 @@ import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
-
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -26,8 +24,7 @@ import java.util.HashSet;
  * {@link com.tangosol.util.Filter Coherence filters} that
  * can be applied to {@link DocumentChunk} metadata.
  */
-class CoherenceMetadataFilterMapper
-    {
+class CoherenceMetadataFilterMapper {
     /**
      * Return the Coherence filter that is equivalent to the
      * specified LangChain4j filter.
@@ -62,12 +59,16 @@ class CoherenceMetadataFilterMapper
         } else if (filter instanceof Or or) {
             return mapOr(or);
         } else {
-            throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getName());
+            throw new UnsupportedOperationException(
+                    "Unsupported filter type: " + filter.getClass().getName());
         }
     }
 
     private static <V> ValueExtractor<DocumentChunk, V> extractor(String field) {
-        return Extractors.chained(ValueExtractor.of(DocumentChunk::metadata), Extractors.extract(field));
+        // Passing the metadata key as a parameter to "get" makes Coherence build a method extractor
+        // that calls Map.get(field). Passing it as the extractor name instead would make Coherence
+        // normalize it to a JavaBean canonical name, which silently rewrites keys such as "isbn".
+        return Extractors.chained(ValueExtractor.of(DocumentChunk::metadata), Extractors.extract("get", field));
     }
 
     private static com.tangosol.util.Filter<DocumentChunk> mapEqual(IsEqualTo isEqualTo) {
@@ -86,7 +87,8 @@ class CoherenceMetadataFilterMapper
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private static com.tangosol.util.Filter<DocumentChunk> mapGreaterThanOrEqual(IsGreaterThanOrEqualTo isGreaterThanOrEqualTo) {
+    private static com.tangosol.util.Filter<DocumentChunk> mapGreaterThanOrEqual(
+            IsGreaterThanOrEqualTo isGreaterThanOrEqualTo) {
         ValueExtractor<DocumentChunk, ? extends Comparable> extractor = extractor(isGreaterThanOrEqualTo.key());
         Comparable value = isGreaterThanOrEqualTo.comparisonValue();
         return Filters.greaterEqual(extractor, value);
@@ -132,4 +134,3 @@ class CoherenceMetadataFilterMapper
         return Filters.any(map(or.left()), map(or.right()));
     }
 }
-

--- a/langchain4j-coherence/src/test/java/dev/langchain4j/store/embedding/coherence/CoherenceMetadataFilterMapperTest.java
+++ b/langchain4j-coherence/src/test/java/dev/langchain4j/store/embedding/coherence/CoherenceMetadataFilterMapperTest.java
@@ -1,0 +1,98 @@
+package dev.langchain4j.store.embedding.coherence;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.oracle.coherence.ai.DocumentChunk;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CoherenceMetadataFilterMapperTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"isbn", "is_active", "getting_started", "isEmbedded"})
+    void should_match_metadata_key_starting_with_bean_accessor_prefix(String key) {
+        // given
+        Map<String, Object> metadata = metadata(key, "expected");
+
+        // then
+        assertThat(matches(metadataKey(key).isEqualTo("expected"), metadata)).isTrue();
+        assertThat(matches(metadataKey(key).isEqualTo("other"), metadata)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"size", "empty", "class", "values"})
+    void should_match_metadata_key_clashing_with_map_method_name(String key) {
+        // given
+        Map<String, Object> metadata = metadata(key, "expected", "city", "Munich");
+
+        // then
+        assertThat(matches(metadataKey(key).isEqualTo("expected"), metadata)).isTrue();
+        assertThat(matches(metadataKey(key).isEqualTo("other"), metadata)).isFalse();
+    }
+
+    @Test
+    void should_not_compare_map_method_result_with_numeric_filter() {
+        // given a metadata key named after a Map method, holding a number
+        Map<String, Object> metadata = metadata("size", 1, "city", "Munich");
+
+        // then the filter must see the metadata value 1, not the entry count 2
+        assertThat(matches(metadataKey("size").isGreaterThan(1), metadata)).isFalse();
+        assertThat(matches(metadataKey("size").isEqualTo(1), metadata)).isTrue();
+    }
+
+    @Test
+    void should_match_in_and_not_in_filters_on_prefixed_key() {
+        // given
+        Map<String, Object> metadata = metadata("is_active", "yes");
+
+        // then
+        assertThat(matches(metadataKey("is_active").isIn("yes", "no"), metadata))
+                .isTrue();
+        assertThat(matches(metadataKey("is_active").isNotIn(List.of("no")), metadata))
+                .isTrue();
+        assertThat(matches(metadataKey("is_active").isIn("no"), metadata)).isFalse();
+    }
+
+    @Test
+    void should_match_ordinary_metadata_keys() {
+        // given
+        Map<String, Object> metadata = metadata("name", "book", "city", "Munich", "age", 42);
+
+        // then
+        assertThat(matches(metadataKey("name").isEqualTo("book"), metadata)).isTrue();
+        assertThat(matches(metadataKey("name").isEqualTo("magazine"), metadata)).isFalse();
+        assertThat(matches(metadataKey("city").isNotEqualTo("Berlin"), metadata))
+                .isTrue();
+        assertThat(matches(metadataKey("age").isGreaterThanOrEqualTo(42), metadata))
+                .isTrue();
+        assertThat(matches(metadataKey("age").isLessThan(42), metadata)).isFalse();
+    }
+
+    @Test
+    void should_not_match_key_that_is_absent_from_metadata() {
+        // given
+        Map<String, Object> metadata = metadata("name", "book");
+
+        // then
+        assertThat(matches(metadataKey("isbn").isEqualTo("978-1"), metadata)).isFalse();
+        assertThat(matches(metadataKey("size").isEqualTo("large"), metadata)).isFalse();
+    }
+
+    private static boolean matches(Filter filter, Map<String, Object> metadata) {
+        return CoherenceMetadataFilterMapper.map(filter).evaluate(new DocumentChunk("text", metadata));
+    }
+
+    private static Map<String, Object> metadata(Object... keysAndValues) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        for (int i = 0; i < keysAndValues.length; i += 2) {
+            metadata.put((String) keysAndValues[i], keysAndValues[i + 1]);
+        }
+        return metadata;
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5906

## Change

`CoherenceMetadataFilterMapper.extractor(field)` built the extractor with `Extractors.extract(field)`, which is a `UniversalExtractor`. Coherence normalizes that name into a JavaBean canonical name before reading the `DocumentChunk` metadata `Map`. Keys starting with `get` or `is` lost the prefix, so `isbn` was looked up as `bn` and never matched. Keys named after a `Map` method were compared against the method result, so `metadataKey("size").isGreaterThan(1)` matched a chunk whose metadata is `{size=1, city=Munich}` because the map has two entries. All eight comparison filters share this extractor, so `search(...)` and `removeAll(Filter)` were both affected.

Passing the key as a parameter skips the name normalization and calls `Map.get(field)` with the key as written:

```java
Extractors.chained(ValueExtractor.of(DocumentChunk::metadata), Extractors.extract("get", field));
```

`CoherenceMetadataFilterMapperTest` evaluates the mapped Coherence filters locally, so it needs no cluster. 10 of its 12 tests fail without the fix.

Two notes:

- This file predates the palantir format, so Spotless reformats parts of it: 5 added and 7 removed lines (blank lines between import groups, the class brace, two line wraps, the trailing newline). The behaviour change itself is one line.
- I ran the module unit tests locally, but not `CoherenceEmbeddingStoreIT`, `CoherenceEmbeddingStoreRemovalIT` or `CoherenceChatMemoryStoreIT`. Those run in the `integration_test` job.

## General checklist

- [X] There are no breaking changes (API, behaviour)
  <!-- The mapper is package-private, so no public API changes. The only behaviour change is the fix itself. -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  <!-- Unit tests only (`./mvnw -pl langchain4j-coherence -am clean test`). I did not run this module's ITs locally. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  <!-- The `-am` build ran the langchain4j-core unit tests (green). I did not run the `langchain4j` module or any ITs. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  <!-- Held back until the PR is reviewed, as the template asks. No documented behaviour changes. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  <!-- N/A - bug fix, not a feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
  <!-- N/A - no configuration or starter surface is involved. -->

<!-- "Checklist for adding new maven module" and "Checklist for adding new embedding store integration" omitted: no new module and no new integration. -->

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `CoherenceEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
  <!-- Not done. Nothing about how chunks are stored changes - only how a filter reads a metadata key at query time. -->

<!-- No screenshots: this change has nothing to show on screen. -->

