### PR TITLE
fix: report Amazon Bedrock provider and model name from BedrockCohereEmbeddingModel

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
@@ -11,6 +11,7 @@ import static software.amazon.awssdk.regions.Region.US_EAST_1;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
@@ -91,6 +92,16 @@ public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
         }
 
         return Response.from(embeddings, tokenUsageFrom(inputTokenCount));
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return ModelProvider.AMAZON_BEDROCK;
+    }
+
+    @Override
+    public String modelName() {
+        return model;
     }
 
     private Optional<Integer> inputTokenCountFrom(InvokeModelResponse response) {

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
@@ -6,6 +6,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.embedding.request.EmbeddingRequest;
+import dev.langchain4j.model.embedding.response.EmbeddingResponse;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import java.util.ArrayDeque;
@@ -82,6 +85,35 @@ class BedrockCohereEmbeddingModelTest {
         assertThat(response.tokenUsage().inputTokenCount()).isEqualTo(5);
         assertThat(response.tokenUsage().outputTokenCount()).isNull();
         assertThat(response.tokenUsage().totalTokenCount()).isEqualTo(5);
+    }
+
+    @Test
+    void should_report_amazon_bedrock_as_provider() {
+        BedrockCohereEmbeddingModel model = BedrockCohereEmbeddingModel.builder()
+                .client(clientReturning(new ArrayDeque<>()))
+                .model(COHERE_EMBED_MULTILINGUAL_V3)
+                .inputType(SEARCH_QUERY)
+                .build();
+
+        assertThat(model.provider()).isEqualTo(ModelProvider.AMAZON_BEDROCK);
+    }
+
+    @Test
+    void should_report_model_name_in_response_metadata() {
+        Queue<InvokeModelResponse> responses = new ArrayDeque<>(List.of(invokeModelResponse("[0.1,0.2]", "3")));
+
+        BedrockCohereEmbeddingModel model = BedrockCohereEmbeddingModel.builder()
+                .client(clientReturning(responses))
+                .model(COHERE_EMBED_MULTILINGUAL_V3)
+                .inputType(SEARCH_QUERY)
+                .build();
+
+        assertThat(model.modelName()).isEqualTo("cohere.embed-multilingual-v3");
+
+        EmbeddingResponse response =
+                model.embed(EmbeddingRequest.builder().input("hello").build());
+
+        assertThat(response.metadata().modelName()).isEqualTo("cohere.embed-multilingual-v3");
     }
 
     private static BedrockRuntimeClient clientReturning(Queue<InvokeModelResponse> responses) {


### PR DESCRIPTION
## Issue
Closes #5908

## Change

`BedrockCohereEmbeddingModel` extends `DimensionAwareEmbeddingModel` rather than `AbstractBedrockEmbeddingModel`, so it did not pick up the `provider()` / `modelName()` overrides added by #5735. On a successful call it reported `ModelProvider.OTHER` to listeners and `"unknown"` as `EmbeddingResponse.metadata().modelName()`.

Override both methods, mirroring `AbstractBedrockEmbeddingModel`:

```java
@Override
public ModelProvider provider() {
    return ModelProvider.AMAZON_BEDROCK;
}

@Override
public String modelName() {
    return model;
}
```

`listeners()` is left out: it would need a new builder field. `addListener(...)` already works, since `ListeningEmbeddingModel` delegates `provider()` and `modelName()` to the wrapped model.

No `revapi.json` entry is needed. `revapi:check` on the module passes — `ModelProvider` is already part of this module's public API through `BedrockChatModel.provider()`.

Two tests were added to `BedrockCohereEmbeddingModelTest`, one per reported value, so each defect fails on its own without the fix:

- `should_report_amazon_bedrock_as_provider` — `expected: AMAZON_BEDROCK but was: OTHER`
- `should_report_model_name_in_response_metadata` — `expected: "cohere.embed-multilingual-v3" but was: "unknown"`

`BedrockCohereEmbeddingModelIT` was not run; it needs AWS credentials.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
<!-- The change has no failure branch — both tests assert the reported values. -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- All 193 unit tests in langchain4j-bedrock are green. The *IT classes need AWS credentials and were not run. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Unit tests are green in both: `./mvnw -pl langchain4j-core,langchain4j clean test` (1210 and 1278 tests). Their ITs were not run. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- Per CONTRIBUTING.md, documentation is added after review and approval. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — bug fix, not a feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no starter surface is affected. -->

<!-- The "new maven module", "new embedding store integration" and "changing existing embedding store integration" sections are omitted: this PR adds no module and touches no embedding store. -->
<!-- Screenshots: N/A — no visual surface. -->

