### PR TITLE
fix: Handle nested Not in ChromaMetadataFilterMapper

### DIFF
--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaMetadataFilterMapper.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaMetadataFilterMapper.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.store.embedding.chroma;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+
 import dev.langchain4j.Internal;
 import dev.langchain4j.store.embedding.filter.Filter;
 import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
@@ -13,11 +16,7 @@ import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
-
 import java.util.Map;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonMap;
 
 @Internal
 class ChromaMetadataFilterMapper {
@@ -52,7 +51,8 @@ class ChromaMetadataFilterMapper {
         } else if (filter instanceof Not) {
             return mapNot((Not) filter);
         } else {
-            throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getName());
+            throw new UnsupportedOperationException(
+                    "Unsupported filter type: " + filter.getClass().getName());
         }
     }
 
@@ -104,15 +104,21 @@ class ChromaMetadataFilterMapper {
         if (expression instanceof IsEqualTo) {
             expression = new IsNotEqualTo(((IsEqualTo) expression).key(), ((IsEqualTo) expression).comparisonValue());
         } else if (expression instanceof IsNotEqualTo) {
-            expression = new IsEqualTo(((IsNotEqualTo) expression).key(), ((IsNotEqualTo) expression).comparisonValue());
+            expression =
+                    new IsEqualTo(((IsNotEqualTo) expression).key(), ((IsNotEqualTo) expression).comparisonValue());
         } else if (expression instanceof IsGreaterThan) {
-            expression = new IsLessThanOrEqualTo(((IsGreaterThan) expression).key(), ((IsGreaterThan) expression).comparisonValue());
+            expression = new IsLessThanOrEqualTo(
+                    ((IsGreaterThan) expression).key(), ((IsGreaterThan) expression).comparisonValue());
         } else if (expression instanceof IsGreaterThanOrEqualTo) {
-            expression = new IsLessThan(((IsGreaterThanOrEqualTo) expression).key(), ((IsGreaterThanOrEqualTo) expression).comparisonValue());
+            expression = new IsLessThan(
+                    ((IsGreaterThanOrEqualTo) expression).key(),
+                    ((IsGreaterThanOrEqualTo) expression).comparisonValue());
         } else if (expression instanceof IsLessThan) {
-            expression = new IsGreaterThanOrEqualTo(((IsLessThan) expression).key(), ((IsLessThan) expression).comparisonValue());
+            expression = new IsGreaterThanOrEqualTo(
+                    ((IsLessThan) expression).key(), ((IsLessThan) expression).comparisonValue());
         } else if (expression instanceof IsLessThanOrEqualTo) {
-            expression = new IsGreaterThan(((IsLessThanOrEqualTo) expression).key(), ((IsLessThanOrEqualTo) expression).comparisonValue());
+            expression = new IsGreaterThan(
+                    ((IsLessThanOrEqualTo) expression).key(), ((IsLessThanOrEqualTo) expression).comparisonValue());
         } else if (expression instanceof IsIn) {
             expression = new IsNotIn(((IsIn) expression).key(), ((IsIn) expression).comparisonValues());
         } else if (expression instanceof IsNotIn) {
@@ -121,8 +127,11 @@ class ChromaMetadataFilterMapper {
             expression = new Or(Filter.not(((And) expression).left()), Filter.not(((And) expression).right()));
         } else if (expression instanceof Or) {
             expression = new And(Filter.not(((Or) expression).left()), Filter.not(((Or) expression).right()));
+        } else if (expression instanceof Not) {
+            expression = ((Not) expression).expression();
         } else {
-            throw new UnsupportedOperationException("Unsupported filter type: " + expression.getClass().getName());
+            throw new UnsupportedOperationException(
+                    "Unsupported filter type: " + expression.getClass().getName());
         }
         return map(expression);
     }

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaMetadataFilterMapperTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaMetadataFilterMapperTest.java
@@ -13,6 +13,7 @@ import dev.langchain4j.store.embedding.filter.comparison.IsLessThanOrEqualTo;
 import dev.langchain4j.store.embedding.filter.comparison.IsNotEqualTo;
 import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
 import dev.langchain4j.store.embedding.filter.logical.And;
+import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
 import java.util.HashSet;
 import java.util.List;
@@ -119,5 +120,46 @@ class ChromaMetadataFilterMapperTest {
         // then
         assertThat(result).containsKey("$and");
         assertThat((List<?>) result.get("$and")).hasSize(2);
+    }
+
+    @Test
+    void should_map_not() {
+        // given
+        Not filter = new Not(new IsEqualTo("key", "value"));
+
+        // when
+        Map<String, Object> result = ChromaMetadataFilterMapper.map(filter);
+
+        // then
+        assertThat(result).isEqualTo(singletonMap("key", singletonMap("$ne", "value")));
+    }
+
+    @Test
+    void should_map_nested_not_by_removing_double_negation() {
+        // given
+        Not filter = new Not(new Not(new IsEqualTo("key", "value")));
+
+        // when
+        Map<String, Object> result = ChromaMetadataFilterMapper.map(filter);
+
+        // then
+        assertThat(result).isEqualTo(singletonMap("key", "value"));
+    }
+
+    @Test
+    void should_map_not_of_and_containing_not() {
+        // given: not(key1 = value1 and not(key2 > 1)) — De Morgan produces a nested Not
+        Not filter = new Not(new And(new IsEqualTo("key1", "value1"), new Not(new IsGreaterThan("key2", 1))));
+
+        // when
+        Map<String, Object> result = ChromaMetadataFilterMapper.map(filter);
+
+        // then: not(A) or B
+        assertThat(result)
+                .isEqualTo(singletonMap(
+                        "$or",
+                        asList(
+                                singletonMap("key1", singletonMap("$ne", "value1")),
+                                singletonMap("key2", singletonMap("$gt", 1)))));
     }
 }


### PR DESCRIPTION
## Issue
Closes #5910

## Change

`ChromaMetadataFilterMapper.mapNot()` inverts the operator a `Not` wraps, but has no branch for a nested `Not`, so it falls through to `throw new UnsupportedOperationException`.

Reaching this does not require a double negation in user code: the `And`/`Or` branches apply De Morgan's law and re-wrap each child in `Filter.not(...)`, so a child that is already a `Not` becomes `Not(Not(...))`. `not(a and not(b))` is enough. `LanguageModelSqlFilterBuilder` can also produce a nested `Not` from an LLM-generated `NOT (... AND NOT ...)` clause.

This adds one branch that drops the double negation:

```java
} else if (expression instanceof Not) {
    expression = ((Not) expression).expression();
}
```

It is evaluated only after every existing branch has failed, so filters that map today are unchanged. `MongoDbMetadataFilterMapper` and `MilvusMetadataFilterMapper` already map `Not` recursively.

`ChromaMetadataFilterMapperTest` had no `Not` coverage. Three tests were added: a single `Not` as a regression net and two nested cases that fail without the fix.

Spotless (`ratchetFrom origin/main`) reformats this file once it is touched, so the diff also carries formatting changes.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- N/A — the change is confined to langchain4j-chroma; core and main modules are not touched. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Documentation and examples to be added after review and approval, per the PR template. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration
<!-- N/A — no stored data format changes; only the in-memory Filter -> Chroma "where" conversion is affected. -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

<!-- "Checklist for adding new maven module" and "Checklist for adding new embedding store integration" sections omitted: this PR neither adds a module nor a new store integration. -->

---

### Testing done

- `./mvnw -pl langchain4j-chroma -am clean test` → BUILD SUCCESS: `ChromaMetadataFilterMapperTest` 15 and `ChromaEmbeddingStoreHttpClientBuilderTest` 4, all green. The reactor also ran `langchain4j-core` green.
- fail-then-pass: with the fix reverted, the two nested-`Not` tests fail with `UnsupportedOperationException`; `should_map_not` passes either way.
- `./mvnw -Pspotless spotless:check -pl langchain4j-chroma` → SUCCESS.
- `*IT` tests not run — they need a ChromaDB container.
