### PR TITLE
fix: Validate ids/embeddings/textSegments size in ChromaEmbeddingStore.addAll

### DIFF
--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
@@ -1,9 +1,11 @@
 package dev.langchain4j.store.embedding.chroma;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.Utils.randomUUID;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
 import static dev.langchain4j.store.embedding.chroma.ChromaApiVersion.*;
 import static java.time.Duration.ofSeconds;
 import static java.util.Collections.singletonList;
@@ -257,6 +259,14 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     @Override
     public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> textSegments) {
+        if (isNullOrEmpty(ids) || isNullOrEmpty(embeddings)) {
+            return;
+        }
+        ensureTrue(ids.size() == embeddings.size(), "ids size is not equal to embeddings size");
+        ensureTrue(
+                textSegments == null || embeddings.size() == textSegments.size(),
+                "embeddings size is not equal to textSegments size");
+
         int size = embeddings.size();
 
         List<Map<String, Object>> metadatas;

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
@@ -3,9 +3,9 @@ package dev.langchain4j.store.embedding.chroma;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.internal.ValidationUtils.ensureConsistentSizes;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
 import static dev.langchain4j.store.embedding.chroma.ChromaApiVersion.*;
 import static java.time.Duration.ofSeconds;
 import static java.util.Collections.singletonList;
@@ -259,13 +259,10 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     @Override
     public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> textSegments) {
-        if (isNullOrEmpty(ids) || isNullOrEmpty(embeddings)) {
+        ensureConsistentSizes(ids, embeddings, textSegments);
+        if (isNullOrEmpty(embeddings)) {
             return;
         }
-        ensureTrue(ids.size() == embeddings.size(), "ids size is not equal to embeddings size");
-        ensureTrue(
-                textSegments == null || embeddings.size() == textSegments.size(),
-                "embeddings size is not equal to textSegments size");
 
         int size = embeddings.size();
 

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CapturingHttpClient.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CapturingHttpClient.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.store.embedding.chroma;
+
+import static java.util.Collections.emptyMap;
+
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An {@link HttpClient} that records every request it receives and answers with a canned Chroma response,
+ * so that {@link ChromaEmbeddingStore} can be tested without a running Chroma server.
+ */
+class CapturingHttpClient implements HttpClient {
+
+    private final List<HttpRequest> requests = new ArrayList<>();
+
+    List<HttpRequest> requests() {
+        return requests;
+    }
+
+    @Override
+    public SuccessfulHttpResponse execute(HttpRequest request) {
+        requests.add(request);
+        return SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .headers(emptyMap())
+                .body(bodyFor(request.url()))
+                .build();
+    }
+
+    @Override
+    public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+        throw new UnsupportedOperationException("SSE is not used by ChromaEmbeddingStore");
+    }
+
+    private static String bodyFor(String url) {
+        if (url.endsWith("/api/v2/tenants/default")) {
+            return "{\"name\":\"default\"}";
+        }
+        if (url.endsWith("/api/v2/tenants/default/databases/default")) {
+            return "{\"name\":\"default\"}";
+        }
+        if (url.endsWith("/add")) {
+            return "true";
+        }
+        if (url.endsWith("/api/v1/collections")) {
+            return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
+        }
+        if (url.contains("/collections/test")) {
+            return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
+        }
+        throw new IllegalArgumentException("Unexpected URL: " + url);
+    }
+}

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreHttpClientBuilderTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreHttpClientBuilderTest.java
@@ -3,19 +3,12 @@ package dev.langchain4j.store.embedding.chroma;
 import static dev.langchain4j.http.client.HttpMethod.DELETE;
 import static dev.langchain4j.http.client.HttpMethod.GET;
 import static dev.langchain4j.http.client.HttpMethod.POST;
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.http.client.HttpClient;
-import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.http.client.HttpRequest;
-import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
-import dev.langchain4j.http.client.sse.ServerSentEventListener;
-import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -106,83 +99,6 @@ class ChromaEmbeddingStoreHttpClientBuilderTest {
 
         // then
         assertThat(httpClient.requests()).hasSize(1);
-    }
-
-    private static class TestHttpClientBuilder implements HttpClientBuilder {
-
-        private final HttpClient httpClient;
-
-        private TestHttpClientBuilder(HttpClient httpClient) {
-            this.httpClient = httpClient;
-        }
-
-        @Override
-        public Duration connectTimeout() {
-            return null;
-        }
-
-        @Override
-        public HttpClientBuilder connectTimeout(Duration timeout) {
-            return this;
-        }
-
-        @Override
-        public Duration readTimeout() {
-            return null;
-        }
-
-        @Override
-        public HttpClientBuilder readTimeout(Duration timeout) {
-            return this;
-        }
-
-        @Override
-        public HttpClient build() {
-            return httpClient;
-        }
-    }
-
-    private static class CapturingHttpClient implements HttpClient {
-
-        private final List<HttpRequest> requests = new ArrayList<>();
-
-        private List<HttpRequest> requests() {
-            return requests;
-        }
-
-        @Override
-        public SuccessfulHttpResponse execute(HttpRequest request) {
-            requests.add(request);
-            return SuccessfulHttpResponse.builder()
-                    .statusCode(200)
-                    .headers(emptyMap())
-                    .body(bodyFor(request.url()))
-                    .build();
-        }
-
-        @Override
-        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
-            throw new UnsupportedOperationException("SSE is not used by ChromaEmbeddingStore");
-        }
-
-        private static String bodyFor(String url) {
-            if (url.endsWith("/api/v2/tenants/default")) {
-                return "{\"name\":\"default\"}";
-            }
-            if (url.endsWith("/api/v2/tenants/default/databases/default")) {
-                return "{\"name\":\"default\"}";
-            }
-            if (url.endsWith("/add")) {
-                return "true";
-            }
-            if (url.endsWith("/api/v1/collections")) {
-                return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
-            }
-            if (url.contains("/collections/test")) {
-                return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
-            }
-            throw new IllegalArgumentException("Unexpected URL: " + url);
-        }
     }
 
     private void assertStaticHeaders(HttpRequest request) {

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
@@ -1,19 +1,14 @@
 package dev.langchain4j.store.embedding.chroma;
 
-import static java.util.Collections.emptyMap;
+import static dev.langchain4j.http.client.HttpMethod.POST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.http.client.HttpClient;
-import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.http.client.HttpRequest;
-import dev.langchain4j.http.client.SuccessfulHttpResponse;
-import dev.langchain4j.http.client.sse.ServerSentEventListener;
-import dev.langchain4j.http.client.sse.ServerSentEventParser;
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -23,22 +18,62 @@ class ChromaEmbeddingStoreTest {
     private static final Embedding EMBEDDING_2 = Embedding.from(List.of(4f, 5f, 6f));
 
     @Test
+    void should_add_all_when_sizes_match() throws Exception {
+        // given
+        CapturingHttpClient httpClient = new CapturingHttpClient();
+        ChromaEmbeddingStore store = store(httpClient);
+        int requestsAfterInit = httpClient.requests().size();
+
+        // when
+        store.addAll(
+                List.of("id1", "id2"),
+                List.of(EMBEDDING_1, EMBEDDING_2),
+                List.of(TextSegment.from("first"), TextSegment.from("second")));
+
+        // then
+        assertThat(httpClient.requests()).hasSize(requestsAfterInit + 1);
+
+        HttpRequest addRequest = httpClient.requests().get(requestsAfterInit);
+        assertThat(addRequest.method()).isEqualTo(POST);
+        assertThat(addRequest.url()).endsWith("/add");
+
+        JsonNode body = new ObjectMapper().readTree(addRequest.body());
+        assertThat(body.get("ids")).map(JsonNode::asText).containsExactly("id1", "id2");
+        assertThat(body.get("documents")).map(JsonNode::asText).containsExactly("first", "second");
+        assertThat(body.get("embeddings")).map(JsonNode::toString).containsExactly("[1.0,2.0,3.0]", "[4.0,5.0,6.0]");
+        assertThat(body.get("metadatas")).hasSize(2);
+    }
+
+    @Test
     void should_throw_when_ids_and_embeddings_have_different_sizes() {
         // given
-        RecordingHttpClient httpClient = new RecordingHttpClient();
-        ChromaEmbeddingStore store = store(httpClient);
+        ChromaEmbeddingStore store = store(new CapturingHttpClient());
 
         // when + then
         assertThatThrownBy(() -> store.addAll(List.of("id1"), List.of(EMBEDDING_1, EMBEDDING_2), null))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("ids size is not equal to embeddings size");
+                .hasMessage("ids size (1) is not equal to embeddings size (2)");
+    }
+
+    @Test
+    void should_throw_when_embeddings_are_provided_without_ids() {
+        // given
+        ChromaEmbeddingStore store = store(new CapturingHttpClient());
+
+        // when + then
+        assertThatThrownBy(() -> store.addAll(List.of(), List.of(EMBEDDING_1), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids size (0) is not equal to embeddings size (1)");
+
+        assertThatThrownBy(() -> store.addAll(null, List.of(EMBEDDING_1), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids size (0) is not equal to embeddings size (1)");
     }
 
     @Test
     void should_throw_when_embeddings_and_text_segments_have_different_sizes() {
         // given
-        RecordingHttpClient httpClient = new RecordingHttpClient();
-        ChromaEmbeddingStore store = store(httpClient);
+        ChromaEmbeddingStore store = store(new CapturingHttpClient());
 
         // when + then
         assertThatThrownBy(() -> store.addAll(
@@ -46,79 +81,29 @@ class ChromaEmbeddingStoreTest {
                         List.of(EMBEDDING_1, EMBEDDING_2),
                         List.of(TextSegment.from("only one segment"))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("embeddings size is not equal to textSegments size");
+                .hasMessage("embeddings size (2) is not equal to embedded size (1)");
     }
 
     @Test
     void should_not_call_server_when_input_is_empty() {
         // given
-        RecordingHttpClient httpClient = new RecordingHttpClient();
+        CapturingHttpClient httpClient = new CapturingHttpClient();
         ChromaEmbeddingStore store = store(httpClient);
-        int requestsAfterInit = httpClient.requests.size();
+        int requestsAfterInit = httpClient.requests().size();
 
         // when
         store.addAll(List.of(), List.of(), null);
+        store.addAll(null, null, null);
 
         // then
-        assertThat(httpClient.requests).hasSize(requestsAfterInit);
+        assertThat(httpClient.requests()).hasSize(requestsAfterInit);
     }
 
-    private static ChromaEmbeddingStore store(HttpClient httpClient) {
+    private static ChromaEmbeddingStore store(CapturingHttpClient httpClient) {
         return ChromaEmbeddingStore.builder()
                 .baseUrl("http://localhost:8000")
                 .collectionName("test")
-                .httpClientBuilder(new FixedHttpClientBuilder(httpClient))
+                .httpClientBuilder(new TestHttpClientBuilder(httpClient))
                 .build();
-    }
-
-    private record FixedHttpClientBuilder(HttpClient httpClient) implements HttpClientBuilder {
-
-        @Override
-        public Duration connectTimeout() {
-            return null;
-        }
-
-        @Override
-        public HttpClientBuilder connectTimeout(Duration timeout) {
-            return this;
-        }
-
-        @Override
-        public Duration readTimeout() {
-            return null;
-        }
-
-        @Override
-        public HttpClientBuilder readTimeout(Duration timeout) {
-            return this;
-        }
-
-        @Override
-        public HttpClient build() {
-            return httpClient;
-        }
-    }
-
-    private static class RecordingHttpClient implements HttpClient {
-
-        private final List<HttpRequest> requests = new ArrayList<>();
-
-        @Override
-        public SuccessfulHttpResponse execute(HttpRequest request) {
-            requests.add(request);
-            String body = request.url().endsWith("/add")
-                    ? "true"
-                    : "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
-            return SuccessfulHttpResponse.builder()
-                    .statusCode(200)
-                    .headers(emptyMap())
-                    .body(body)
-                    .build();
-        }
-
-        @Override
-        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
-            throw new UnsupportedOperationException("SSE is not used by ChromaEmbeddingStore");
-        }
     }
 }

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
@@ -1,0 +1,124 @@
+package dev.langchain4j.store.embedding.chroma;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChromaEmbeddingStoreTest {
+
+    private static final Embedding EMBEDDING_1 = Embedding.from(List.of(1f, 2f, 3f));
+    private static final Embedding EMBEDDING_2 = Embedding.from(List.of(4f, 5f, 6f));
+
+    @Test
+    void should_throw_when_ids_and_embeddings_have_different_sizes() {
+        // given
+        RecordingHttpClient httpClient = new RecordingHttpClient();
+        ChromaEmbeddingStore store = store(httpClient);
+
+        // when + then
+        assertThatThrownBy(() -> store.addAll(List.of("id1"), List.of(EMBEDDING_1, EMBEDDING_2), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ids size is not equal to embeddings size");
+    }
+
+    @Test
+    void should_throw_when_embeddings_and_text_segments_have_different_sizes() {
+        // given
+        RecordingHttpClient httpClient = new RecordingHttpClient();
+        ChromaEmbeddingStore store = store(httpClient);
+
+        // when + then
+        assertThatThrownBy(() -> store.addAll(
+                        List.of("id1", "id2"),
+                        List.of(EMBEDDING_1, EMBEDDING_2),
+                        List.of(TextSegment.from("only one segment"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("embeddings size is not equal to textSegments size");
+    }
+
+    @Test
+    void should_not_call_server_when_input_is_empty() {
+        // given
+        RecordingHttpClient httpClient = new RecordingHttpClient();
+        ChromaEmbeddingStore store = store(httpClient);
+        int requestsAfterInit = httpClient.requests.size();
+
+        // when
+        store.addAll(List.of(), List.of(), null);
+
+        // then
+        assertThat(httpClient.requests).hasSize(requestsAfterInit);
+    }
+
+    private static ChromaEmbeddingStore store(HttpClient httpClient) {
+        return ChromaEmbeddingStore.builder()
+                .baseUrl("http://localhost:8000")
+                .collectionName("test")
+                .httpClientBuilder(new FixedHttpClientBuilder(httpClient))
+                .build();
+    }
+
+    private record FixedHttpClientBuilder(HttpClient httpClient) implements HttpClientBuilder {
+
+        @Override
+        public Duration connectTimeout() {
+            return null;
+        }
+
+        @Override
+        public HttpClientBuilder connectTimeout(Duration timeout) {
+            return this;
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return null;
+        }
+
+        @Override
+        public HttpClientBuilder readTimeout(Duration timeout) {
+            return this;
+        }
+
+        @Override
+        public HttpClient build() {
+            return httpClient;
+        }
+    }
+
+    private static class RecordingHttpClient implements HttpClient {
+
+        private final List<HttpRequest> requests = new ArrayList<>();
+
+        @Override
+        public SuccessfulHttpResponse execute(HttpRequest request) {
+            requests.add(request);
+            String body = request.url().endsWith("/add")
+                    ? "true"
+                    : "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
+            return SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .headers(emptyMap())
+                    .body(body)
+                    .build();
+        }
+
+        @Override
+        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+            throw new UnsupportedOperationException("SSE is not used by ChromaEmbeddingStore");
+        }
+    }
+}

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/TestHttpClientBuilder.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/TestHttpClientBuilder.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.store.embedding.chroma;
+
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import java.time.Duration;
+
+/**
+ * An {@link HttpClientBuilder} that always builds the given {@link HttpClient} and ignores the timeouts.
+ */
+record TestHttpClientBuilder(HttpClient httpClient) implements HttpClientBuilder {
+
+    @Override
+    public Duration connectTimeout() {
+        return null;
+    }
+
+    @Override
+    public HttpClientBuilder connectTimeout(Duration timeout) {
+        return this;
+    }
+
+    @Override
+    public Duration readTimeout() {
+        return null;
+    }
+
+    @Override
+    public HttpClientBuilder readTimeout(Duration timeout) {
+        return this;
+    }
+
+    @Override
+    public HttpClient build() {
+        return httpClient;
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/ValidationUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/ValidationUtils.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 
 import dev.langchain4j.Internal;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -27,6 +28,40 @@ public class ValidationUtils {
     public static void ensureEq(Object lhs, Object rhs, String format, Object... args) {
         if (!Objects.equals(lhs, rhs)) {
             throw illegalArgument(format, args);
+        }
+    }
+
+    /**
+     * Ensures that the IDs, embeddings and embedded contents passed to
+     * {@link dev.langchain4j.store.embedding.EmbeddingStore#addAll(java.util.List, java.util.List, java.util.List)}
+     * describe the same number of entries.
+     *
+     * <p>The three lists are positional: the i-th ID, the i-th embedding and the i-th embedded content belong
+     * together. An embedding store cannot store entries whose lists disagree in size, so this method rejects such
+     * input before any of it reaches the store.
+     *
+     * <p>A {@code null} list of IDs or embeddings counts as an empty list, so that passing embeddings without IDs
+     * (or the other way around) is reported as a mismatch rather than silently ignored. A {@code null} list of
+     * embedded contents means that no contents were provided at all and is always accepted; an empty one is not,
+     * unless there are no embeddings either.
+     *
+     * @param ids        The IDs, or {@code null}.
+     * @param embeddings The embeddings, or {@code null}.
+     * @param embedded   The embedded contents, or {@code null} if they were not provided.
+     * @throws IllegalArgumentException if the sizes do not match.
+     */
+    public static void ensureConsistentSizes(List<?> ids, List<?> embeddings, List<?> embedded) {
+        int idsSize = ids == null ? 0 : ids.size();
+        int embeddingsSize = embeddings == null ? 0 : embeddings.size();
+        ensureEq(
+                idsSize, embeddingsSize, "ids size (%s) is not equal to embeddings size (%s)", idsSize, embeddingsSize);
+        if (embedded != null) {
+            ensureEq(
+                    embeddingsSize,
+                    embedded.size(),
+                    "embeddings size (%s) is not equal to embedded size (%s)",
+                    embeddingsSize,
+                    embedded.size());
         }
     }
 
@@ -275,7 +310,7 @@ public class ValidationUtils {
         }
         return i;
     }
-    
+
     /**
      * Ensures that the given integer is either null or greater than zero.
      *

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/ValidationUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/ValidationUtilsTest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.internal;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
+import static dev.langchain4j.internal.ValidationUtils.ensureConsistentSizes;
 import static dev.langchain4j.internal.ValidationUtils.ensureEq;
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNegative;
@@ -258,5 +259,51 @@ class ValidationUtilsTest implements WithAssertions {
                     .isThrownBy(() -> ValidationUtils.ensureBetween(-1L, 0, 1, "test"))
                     .withMessageContaining("test must be between 0 and 1, but is: -1");
         }
+    }
+
+    @Test
+    void ensure_consistent_sizes_accepts_matching_sizes() {
+        ensureConsistentSizes(List.of("id1", "id2"), List.of("e1", "e2"), List.of("s1", "s2"));
+        ensureConsistentSizes(List.of("id1", "id2"), List.of("e1", "e2"), null);
+    }
+
+    @Test
+    void ensure_consistent_sizes_accepts_empty_input() {
+        ensureConsistentSizes(List.of(), List.of(), List.of());
+        ensureConsistentSizes(List.of(), List.of(), null);
+        ensureConsistentSizes(null, null, null);
+    }
+
+    @Test
+    void ensure_consistent_sizes_rejects_ids_size_mismatch() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ensureConsistentSizes(List.of("id1"), List.of("e1", "e2"), null))
+                .withMessage("ids size (1) is not equal to embeddings size (2)");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ensureConsistentSizes(List.of("id1", "id2"), List.of("e1"), null))
+                .withMessage("ids size (2) is not equal to embeddings size (1)");
+    }
+
+    @Test
+    void ensure_consistent_sizes_treats_null_ids_and_embeddings_as_empty() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ensureConsistentSizes(null, List.of("e1"), null))
+                .withMessage("ids size (0) is not equal to embeddings size (1)");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ensureConsistentSizes(List.of("id1"), null, null))
+                .withMessage("ids size (1) is not equal to embeddings size (0)");
+    }
+
+    @Test
+    void ensure_consistent_sizes_rejects_embedded_size_mismatch() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ensureConsistentSizes(List.of("id1", "id2"), List.of("e1", "e2"), List.of("s1")))
+                .withMessage("embeddings size (2) is not equal to embedded size (1)");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ensureConsistentSizes(List.of("id1"), List.of("e1"), List.of()))
+                .withMessage("embeddings size (1) is not equal to embedded size (0)");
     }
 }


### PR DESCRIPTION
## Issue
Closes #5911

## Change

`ChromaEmbeddingStore.addAll(ids, embeddings, textSegments)` derives its length from `embeddings` alone. `ids` is passed through untouched and `metadatas`/`documents` are built from `textSegments`, so lists of different sizes produce an add request whose arrays disagree in length. It reaches Chroma and fails there, without naming the wrong list. Empty input is unguarded too, so an ingestion yielding no segments still performs an HTTP round trip.

This adds an empty-input guard and two size checks:

```java
ensureTrue(ids.size() == embeddings.size(), "ids size is not equal to embeddings size");
ensureTrue(
        textSegments == null || embeddings.size() == textSegments.size(),
        "embeddings size is not equal to textSegments size");
```

The wording matches `PineconeEmbeddingStore` (#5593); `VespaEmbeddingStore` (#5632) and `AbstractElasticsearchEmbeddingStore` validate the same way. Most stores already guard this method; Chroma is one of the few with none.

Matching lists behave as before. Two things change: a mismatch fails fast with `IllegalArgumentException` instead of reaching the server, and empty input returns without a request — both as in the two PRs above.

Added `ChromaEmbeddingStoreTest` with a fake `HttpClientBuilder`, so no container is needed.

## General checklist
<!-- Behaviour change is intentional and mirrors #5593/#5632: input that previously produced a failing/needless server request is now rejected or skipped client-side. Box left unchecked for that reason. -->
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- N/A — the change is confined to langchain4j-chroma; core and main modules are not touched. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Documentation and examples to be added after review and approval, per the PR template. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration
<!-- N/A — no stored data format changes; only input validation is added before the add request is built. -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

<!-- "Checklist for adding new maven module" and "Checklist for adding new embedding store integration" sections omitted: this PR neither adds a module nor a new store integration. -->

---

### Testing done

- `./mvnw -pl langchain4j-chroma -am clean test` → BUILD SUCCESS: `ChromaEmbeddingStoreTest` 3, `ChromaMetadataFilterMapperTest` 12 and `ChromaEmbeddingStoreHttpClientBuilderTest` 4, all green. The reactor also ran `langchain4j-core` green.
- fail-then-pass: with the guard reverted, all three new tests fail — the mismatch cases send the request instead of throwing, the empty case records an extra `/add`.
- `./mvnw -Pspotless spotless:check -pl langchain4j-chroma` → SUCCESS.
- `*IT` tests not run — they need a ChromaDB container.
