### PR TITLE
fix: Accept any memoryId type in CassandraChatMemoryStore

### DIFF
--- a/langchain4j-cassandra/src/main/java/dev/langchain4j/store/memory/chat/cassandra/CassandraChatMemoryStore.java
+++ b/langchain4j-cassandra/src/main/java/dev/langchain4j/store/memory/chat/cassandra/CassandraChatMemoryStore.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.store.memory.chat.cassandra;
 
+import static java.util.stream.Collectors.toList;
+
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.uuid.Uuids;
@@ -11,15 +13,12 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageDeserializer;
 import dev.langchain4j.data.message.ChatMessageSerializer;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
-import org.jspecify.annotations.NonNull;
-
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-
-import static java.util.stream.Collectors.toList;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Implementation of {@link ChatMemoryStore} using Astra DB Vector Search.
@@ -103,9 +102,7 @@ public class CassandraChatMemoryStore implements ChatMemoryStore {
          * for the full history. Instead of changing the multipurpose table
          * we reverse the list.
          */
-        List<ChatMessage> latestFirstList = messageTable
-                .findPartition(getMemoryId(memoryId))
-                .stream()
+        List<ChatMessage> latestFirstList = messageTable.findPartition(getMemoryId(memoryId)).stream()
                 .map(this::toChatMessage)
                 .collect(toList());
         Collections.reverse(latestFirstList);
@@ -171,10 +168,7 @@ public class CassandraChatMemoryStore implements ChatMemoryStore {
     }
 
     private String getMemoryId(Object memoryId) {
-        if (!(memoryId instanceof String)) {
-            throw new IllegalArgumentException("memoryId must be a String");
-        }
-        return (String) memoryId;
+        return memoryId.toString();
     }
 
     public static class Builder {
@@ -222,13 +216,11 @@ public class CassandraChatMemoryStore implements ChatMemoryStore {
             return this;
         }
 
-        public Builder() {
-        }
+        public Builder() {}
 
         public CassandraChatMemoryStore build() {
-            CqlSessionBuilder builder = CqlSession.builder()
-                    .withKeyspace(keyspace)
-                    .withLocalDatacenter(localDataCenter);
+            CqlSessionBuilder builder =
+                    CqlSession.builder().withKeyspace(keyspace).withLocalDatacenter(localDataCenter);
             if (userName != null && password != null) {
                 builder.withAuthCredentials(userName, password);
             }
@@ -288,5 +280,4 @@ public class CassandraChatMemoryStore implements ChatMemoryStore {
             return new CassandraChatMemoryStore(cqlSession, tableName);
         }
     }
-
 }

--- a/langchain4j-cassandra/src/test/java/dev/langchain4j/store/memory/chat/cassandra/CassandraChatMemoryStoreTest.java
+++ b/langchain4j-cassandra/src/test/java/dev/langchain4j/store/memory/chat/cassandra/CassandraChatMemoryStoreTest.java
@@ -1,0 +1,81 @@
+package dev.langchain4j.store.memory.chat.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CassandraChatMemoryStoreTest {
+
+    private PreparedStatement preparedStatement;
+    private CassandraChatMemoryStore store;
+
+    @BeforeEach
+    void setUp() {
+        CqlSession session = mock(CqlSession.class);
+        when(session.getKeyspace()).thenReturn(Optional.of(CqlIdentifier.fromCql("ks")));
+        preparedStatement = mock(PreparedStatement.class);
+        when(session.prepare(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.bind(any(Object[].class))).thenReturn(mock(BoundStatement.class));
+        when(session.execute(any(Statement.class))).thenReturn(mock(ResultSet.class));
+        store = new CassandraChatMemoryStore(session, "message_store");
+    }
+
+    @Test
+    void getMessages_accepts_integer_memory_id() {
+        assertThat(store.getMessages(42)).isEmpty();
+        verify(preparedStatement).bind("42");
+    }
+
+    @Test
+    void getMessages_accepts_uuid_memory_id() {
+        UUID memoryId = UUID.randomUUID();
+
+        assertThat(store.getMessages(memoryId)).isEmpty();
+        verify(preparedStatement).bind(memoryId.toString());
+    }
+
+    @Test
+    void getMessages_still_accepts_string_memory_id() {
+        assertThat(store.getMessages("chat-1")).isEmpty();
+        verify(preparedStatement).bind("chat-1");
+    }
+
+    @Test
+    void updateMessages_accepts_integer_memory_id() {
+        store.updateMessages(42, List.of(UserMessage.from("hello")));
+
+        verify(preparedStatement).bind(eq("42"), any(UUID.class), anyString());
+    }
+
+    @Test
+    void deleteMessages_accepts_integer_memory_id() {
+        store.deleteMessages(42);
+
+        verify(preparedStatement).bind("42");
+    }
+
+    @Test
+    void getMessages_rejects_null_memory_id() {
+        assertThatThrownBy(() -> store.getMessages(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("'memoryId' must not be null");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5914

## Change

`CassandraChatMemoryStore.getMemoryId(Object)` threw `IllegalArgumentException` unless the id was a `String`, so all three store methods failed for any other type. It now derives the partition key from `memoryId.toString()`:

```java
private String getMemoryId(Object memoryId) {
    return memoryId.toString();
}
```

`ChatMemoryStore` declares `Object memoryId`, and the `@MemoryId` Javadoc says a parameter "can be of any type". The value reaches the store unchanged: `DefaultAiServices.findMemoryId()` -> `ChatMemoryService` -> `MessageWindowChatMemory(Object id)` -> `store.getMessages(Object)`. The AI Services example in `docs/docs/tutorials/ai-services.md` uses `@MemoryId int` and takes exactly that path.

Cassandra was the only one of the seven `ChatMemoryStore` implementations restricting the type; `TablestoreChatMemoryStore` already uses `memoryId.toString()` for the same kind of string partition key.

`String` ids keep producing the same partition key, and `null` is still rejected by the existing `Objects.requireNonNull` checks.

Build/test notes: new `CassandraChatMemoryStoreTest` (6 tests, mocked `CqlSession`, no Docker or credentials); 4 of them fail on the unpatched code with `memoryId must be a String`. `./mvnw -pl langchain4j-cassandra -am clean test` is green on JDK 17 (9/9 in this module). `CassandraChatMemoryStoreDockerIT` and `CassandraEmbeddingStoreIT` were not run (Docker/API key). Spotless `ratchetFrom=origin/main` reformats every file a branch touches, which adds 20 formatting-only lines to this diff.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Unit tests only (9/9 green): the module's *IT tests need Docker or an Astra token. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Their unit tests ran green as part of `-pl langchain4j-cassandra -am clean test`; their integration tests were not run. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- Deferred until the PR is reviewed, per the template note. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — not a big feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no starter exposes this behaviour. -->

<!-- The three embedding-store / new-module checklist sections are omitted: this changes a chat memory store, adds no module, and adds no embedding store. -->

