### PR TITLE
fix: Add missing WHERE clause to filtered vector search in Azure Cosmos DB NoSQL store

### DIFF
--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AbstractAzureCosmosDBNoSqlEmbeddingStore.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AbstractAzureCosmosDBNoSqlEmbeddingStore.java
@@ -417,7 +417,7 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
                         + "VectorDistance(c.%s, @embedding) as score FROM c",
                 embeddingField));
         if (request.filter() != null) {
-            queryBuilder.append(" AND").append(filterMapper.map(request.filter()));
+            queryBuilder.append(" WHERE ").append(filterMapper.map(request.filter()));
         }
         queryBuilder.append(String.format(" ORDER BY VectorDistance(c.%s, @embedding)", embeddingField));
 

--- a/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlSearchQueryTest.java
+++ b/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlSearchQueryTest.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.store.embedding.azure.cosmos.nosql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.azure.cosmos.CosmosAsyncContainer;
+import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.CosmosVectorIndexSpec;
+import com.azure.cosmos.models.IndexingPolicy;
+import com.azure.cosmos.models.SqlQuerySpec;
+import com.azure.cosmos.util.CosmosPagedFlux;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.rag.content.retriever.azure.cosmos.nosql.DefaultAzureCosmosDBNoSqlFilterMapper;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Flux;
+
+/**
+ * Verifies the SQL text that {@link AbstractAzureCosmosDBNoSqlEmbeddingStore#search(EmbeddingSearchRequest)}
+ * sends to Cosmos DB. The container is mocked, so no Azure credentials are required.
+ */
+class AzureCosmosDbNoSqlSearchQueryTest {
+
+    private AbstractAzureCosmosDBNoSqlEmbeddingStore store;
+    private CosmosAsyncContainer container;
+    private ArgumentCaptor<SqlQuerySpec> queryCaptor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        store = new AbstractAzureCosmosDBNoSqlEmbeddingStore();
+        store.filterMapper = new DefaultAzureCosmosDBNoSqlFilterMapper();
+
+        CosmosVectorIndexSpec vectorIndex = new CosmosVectorIndexSpec();
+        vectorIndex.setPath("/embedding");
+        IndexingPolicy indexingPolicy = new IndexingPolicy();
+        indexingPolicy.setVectorIndexes(Collections.singletonList(vectorIndex));
+        setField("indexingPolicy", indexingPolicy);
+        setField("searchQueryType", AzureCosmosDBSearchQueryType.VECTOR);
+
+        container = mock(CosmosAsyncContainer.class);
+        setField("container", container);
+
+        CosmosPagedFlux<AzureCosmosDbNoSqlMatchedDocument> pagedFlux = mock(CosmosPagedFlux.class);
+        when(pagedFlux.byPage()).thenReturn(Flux.empty());
+        queryCaptor = ArgumentCaptor.forClass(SqlQuerySpec.class);
+        when(container.queryItems(
+                        queryCaptor.capture(),
+                        any(CosmosQueryRequestOptions.class),
+                        eq(AzureCosmosDbNoSqlMatchedDocument.class)))
+                .thenReturn(pagedFlux);
+    }
+
+    @Test
+    void should_put_filter_behind_where_keyword() {
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(Embedding.from(new float[] {1.0f, 2.0f}))
+                .filter(new IsEqualTo("category", "electronics"))
+                .build();
+
+        store.search(request);
+
+        assertThat(queryCaptor.getValue().getQueryText())
+                .contains(" FROM c WHERE c.category = \"electronics\" ORDER BY ")
+                .doesNotContain(" FROM c AND");
+    }
+
+    @Test
+    void should_not_add_where_keyword_without_filter() {
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(Embedding.from(new float[] {1.0f, 2.0f}))
+                .build();
+
+        store.search(request);
+
+        assertThat(queryCaptor.getValue().getQueryText()).doesNotContain("WHERE");
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = AbstractAzureCosmosDBNoSqlEmbeddingStore.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(store, value);
+    }
+}


### PR DESCRIPTION

## Issue

Closes #5915

## Change

`AbstractAzureCosmosDBNoSqlEmbeddingStore.search()` appended the metadata filter with `" AND"` and no `WHERE` keyword. `AzureCosmosDBNoSqlFilterMapper.map()` returns a predicate without a leading space, so the query read `... FROM c ANDc.category = "electronics" ORDER BY ...` and Cosmos DB rejected it. Every filtered vector search failed; unfiltered search was unaffected.

```java
queryBuilder.append(" WHERE ").append(filterMapper.map(request.filter()));
```

The filter is the only predicate here, so this mirrors `findRelevantWithFullTextSearch`. The full-text methods use `" WHERE ("` because another predicate follows theirs; #5486 fixed those two and left `search()` unchanged.

The new `AzureCosmosDbNoSqlSearchQueryTest` mocks `CosmosAsyncContainer` and captures the `SqlQuerySpec`, asserting the query text without Azure credentials. It covers the filtered case (`WHERE` present) and the unfiltered case (no `WHERE`). Reverting the production change makes the filtered test fail.

Build notes (JDK 17): `mvn -pl langchain4j-azure-cosmos-nosql clean test` is green — 33 tests, 0 failures, 6 skipped (pre-existing `@EnabledIfEnvironmentVariable` tests). Spotless passes. The `*IT` classes need live Azure Cosmos DB credentials and were not run.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- N/A — change is confined to langchain4j-azure-cosmos-nosql and touches no core or main module code. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A — docs are added after review, per the template note. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — bug fix, not a feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no starter covers this store. -->

<!-- "Checklist for adding new maven module" and "Checklist for adding new embedding store integration" omitted: this PR adds neither. -->

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
<!-- Not verified: requires a live Azure Cosmos DB account. The change only affects query text generation, not the persisted document format. -->

