### PR TITLE
fix: Honor custom filter mapper in Azure Cosmos DB NoSQL token credential constructor

### DIFF
--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStore.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStore.java
@@ -60,7 +60,7 @@ public class AzureCosmosDbNoSqlEmbeddingStore extends AbstractAzureCosmosDBNoSql
             CosmosFullTextPolicy cosmosFullTextPolicy,
             Integer vectorStoreThroughput,
             AzureCosmosDBSearchQueryType azureCosmosDBSearchQueryType,
-            AzureCosmosDBNoSqlFilterMapper filterMappe) {
+            AzureCosmosDBNoSqlFilterMapper filterMapper) {
         this.initialize(
                 endpoint,
                 null,

--- a/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStoreConstructorTest.java
+++ b/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStoreConstructorTest.java
@@ -1,0 +1,95 @@
+package dev.langchain4j.store.embedding.azure.cosmos.nosql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.cosmos.models.CosmosFullTextPolicy;
+import com.azure.cosmos.models.CosmosVectorEmbeddingPolicy;
+import com.azure.cosmos.models.IndexingPolicy;
+import dev.langchain4j.rag.content.retriever.azure.cosmos.nosql.AzureCosmosDBNoSqlFilterMapper;
+import dev.langchain4j.store.embedding.filter.Filter;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+/**
+ * Verifies that both constructors hand the caller-supplied filter mapper over to
+ * {@link AbstractAzureCosmosDBNoSqlEmbeddingStore#initialize}. Connecting to Cosmos DB is avoided by
+ * overriding {@code initialize}, so no credentials are required.
+ */
+class AzureCosmosDbNoSqlEmbeddingStoreConstructorTest {
+
+    private static final AzureCosmosDBNoSqlFilterMapper CUSTOM_MAPPER = new AzureCosmosDBNoSqlFilterMapper() {
+        @Override
+        public String map(Filter filter) {
+            return "custom";
+        }
+    };
+
+    @Test
+    void should_pass_filter_mapper_from_token_credential_constructor() {
+        RecordingStore store = new RecordingStore("https://localhost", (TokenCredential) request -> Mono.empty());
+
+        assertThat(store.receivedFilterMapper).isSameAs(CUSTOM_MAPPER);
+    }
+
+    @Test
+    void should_pass_filter_mapper_from_key_credential_constructor() {
+        RecordingStore store = new RecordingStore("https://localhost", new AzureKeyCredential("test-key"));
+
+        assertThat(store.receivedFilterMapper).isSameAs(CUSTOM_MAPPER);
+    }
+
+    /** Records what the constructor forwards instead of opening a Cosmos DB client. */
+    private static class RecordingStore extends AzureCosmosDbNoSqlEmbeddingStore {
+
+        private AzureCosmosDBNoSqlFilterMapper receivedFilterMapper;
+
+        RecordingStore(String endpoint, TokenCredential tokenCredential) {
+            super(
+                    endpoint,
+                    tokenCredential,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    AzureCosmosDBSearchQueryType.VECTOR,
+                    CUSTOM_MAPPER);
+        }
+
+        RecordingStore(String endpoint, AzureKeyCredential keyCredential) {
+            super(
+                    endpoint,
+                    keyCredential,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    AzureCosmosDBSearchQueryType.VECTOR,
+                    CUSTOM_MAPPER);
+        }
+
+        @Override
+        protected void initialize(
+                String endpoint,
+                AzureKeyCredential keyCredential,
+                TokenCredential tokenCredential,
+                String databaseName,
+                String containerName,
+                String partitionKeyPath,
+                IndexingPolicy indexingPolicy,
+                CosmosVectorEmbeddingPolicy cosmosVectorEmbeddingPolicy,
+                CosmosFullTextPolicy cosmosFullTextPolicy,
+                Integer vectorStoreThroughput,
+                AzureCosmosDBSearchQueryType searchQueryType,
+                AzureCosmosDBNoSqlFilterMapper filterMapper) {
+            this.receivedFilterMapper = filterMapper;
+        }
+    }
+}


### PR DESCRIPTION

## Issue

Closes #5917

## Change

The `TokenCredential` constructor of `AzureCosmosDbNoSqlEmbeddingStore` declared its last parameter as `filterMappe`, while the body passed `filterMapper`. That name resolved to the inherited `protected filterMapper` field of `AbstractAzureCosmosDBNoSqlEmbeddingStore`, which is `null` at that point, so the code compiled and the caller's mapper was dropped. `initialize()` replaces a `null` mapper with `DefaultAzureCosmosDBNoSqlFilterMapper`, so nothing failed — the custom mapper was silently ignored.

```java
AzureCosmosDBNoSqlFilterMapper filterMapper) {
```

`Builder.build()` calls this constructor whenever `keyCredential` is null, so `builder().tokenCredential(cred).filterMapper(custom).build()` was affected. The `AzureKeyCredential` constructor already passed its parameter correctly.

The new `AzureCosmosDbNoSqlEmbeddingStoreConstructorTest` subclasses the store and overrides `initialize()` to record the forwarded mapper, so it needs no Azure credentials or network access. It asserts both constructors, and restoring the typo makes the token credential case fail.

Build notes (JDK 17): `mvn -pl langchain4j-azure-cosmos-nosql clean test` is green — 33 tests, 0 failures, 6 skipped (pre-existing `@EnabledIfEnvironmentVariable` tests). Spotless passes. The `*IT` classes need live Azure Cosmos DB credentials and were not run.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- N/A — change is confined to langchain4j-azure-cosmos-nosql and touches no core or main module code. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A — docs are added after review, per the template note. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — bug fix, not a feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no starter covers this store. -->

<!-- "Checklist for adding new maven module" and "Checklist for adding new embedding store integration" omitted: this PR adds neither. -->

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
<!-- Not verified: requires a live Azure Cosmos DB account. The change only affects which filter mapper instance is used, not the persisted document format. -->

