### PR TITLE
Complete A2A response future exceptionally on interrupted task states

### DIFF
--- a/langchain4j-agentic-a2a/revapi.json
+++ b/langchain4j-agentic-a2a/revapi.json
@@ -12,6 +12,12 @@
         },
         {
           "ignore": true,
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class org.a2aproject.sdk.spec.TaskState",
+          "justification": "A2ATaskInterruptedException deliberately reports the A2A task state it was interrupted in; like AgentCard above, this module exposes A2A protocol types as part of its integration API"
+        },
+        {
+          "ignore": true,
           "code": "java.method.returnTypeChanged",
           "old": "method io.a2a.spec.AgentCard dev.langchain4j.agentic.a2a.A2AClientInstance::agentCard()",
           "new": "method org.a2aproject.sdk.spec.AgentCard dev.langchain4j.agentic.a2a.A2AClientInstance::agentCard()",

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
@@ -13,7 +13,9 @@ import org.a2aproject.sdk.spec.TaskState;
  *
  * @since 1.19.0
  */
-public class A2ATaskInterruptedException extends RuntimeException {
+import dev.langchain4j.exception.LangChain4jException;
+
+public class A2ATaskInterruptedException extends LangChain4jException {
 
     private final String taskId;
     private final TaskState state;

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
@@ -2,6 +2,8 @@ package dev.langchain4j.agentic.a2a;
 
 import org.a2aproject.sdk.spec.TaskState;
 
+import dev.langchain4j.exception.LangChain4jException;
+
 /**
  * Thrown when an A2A task enters an interrupted state ({@code input-required} or
  * {@code auth-required}) instead of completing.
@@ -13,8 +15,6 @@ import org.a2aproject.sdk.spec.TaskState;
  *
  * @since 1.19.0
  */
-import dev.langchain4j.exception.LangChain4jException;
-
 public class A2ATaskInterruptedException extends LangChain4jException {
 
     private final String taskId;

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.agentic.a2a;
+
+import org.a2aproject.sdk.spec.TaskState;
+
+/**
+ * Thrown when an A2A task enters an interrupted state ({@code input-required} or
+ * {@code auth-required}) instead of completing.
+ * <p>
+ * The remote agent has paused the task and is waiting for additional input or
+ * authentication before it can continue. The A2A server will not advance the task on
+ * its own, so the {@link java.util.concurrent.CompletableFuture} backing the invocation
+ * is completed exceptionally with this exception rather than left pending indefinitely.
+ *
+ * @since 1.19.0
+ */
+public class A2ATaskInterruptedException extends RuntimeException {
+
+    private final String taskId;
+    private final TaskState state;
+
+    public A2ATaskInterruptedException(String taskId, TaskState state, String reason) {
+        super("A2A task " + taskId + " is interrupted in state " + state.name()
+                + (reason == null || reason.isEmpty() ? "" : ": " + reason));
+        this.taskId = taskId;
+        this.state = state;
+    }
+
+    /**
+     * The id of the task that was interrupted.
+     *
+     * @since 1.19.0
+     */
+    public String taskId() {
+        return taskId;
+    }
+
+    /**
+     * The interrupted state the task is in, either {@code TASK_STATE_INPUT_REQUIRED} or
+     * {@code TASK_STATE_AUTH_REQUIRED}.
+     *
+     * @since 1.19.0
+     */
+    public TaskState state() {
+        return state;
+    }
+}

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
@@ -1,8 +1,7 @@
 package dev.langchain4j.agentic.a2a;
 
-import org.a2aproject.sdk.spec.TaskState;
-
 import dev.langchain4j.exception.LangChain4jException;
+import org.a2aproject.sdk.spec.TaskState;
 
 /**
  * Thrown when an A2A task enters an interrupted state ({@code input-required} or

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2ATaskInterruptedException.java
@@ -17,12 +17,14 @@ public class A2ATaskInterruptedException extends RuntimeException {
 
     private final String taskId;
     private final TaskState state;
+    private final String reason;
 
     public A2ATaskInterruptedException(String taskId, TaskState state, String reason) {
-        super("A2A task " + taskId + " is interrupted in state " + state.name()
-                + (reason == null || reason.isEmpty() ? "" : ": " + reason));
+        super("A2A task " + taskId + " is interrupted in state " + state.name() + ": "
+                + (reason == null || reason.isEmpty() ? defaultReason(state) : reason));
         this.taskId = taskId;
         this.state = state;
+        this.reason = reason == null || reason.isEmpty() ? null : reason;
     }
 
     /**
@@ -42,5 +44,23 @@ public class A2ATaskInterruptedException extends RuntimeException {
      */
     public TaskState state() {
         return state;
+    }
+
+    /**
+     * The status message sent by the remote agent when it interrupted the task — typically the
+     * question asking for the missing input, or the authentication challenge. Returns {@code null}
+     * when the remote agent interrupted the task without sending one; the generic description used
+     * in {@link #getMessage()} in that case is not reported here, so callers can tell the two apart.
+     *
+     * @since 1.19.0
+     */
+    public String reason() {
+        return reason;
+    }
+
+    private static String defaultReason(TaskState state) {
+        return state == TaskState.TASK_STATE_AUTH_REQUIRED
+                ? "waiting for authentication"
+                : "waiting for additional input";
     }
 }

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
@@ -278,6 +278,14 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
 
     static void completeFromTask(Task task, CompletableFuture<String> messageResponse) {
         TaskState state = task.status().state();
+        if (state.isInterrupted()) {
+            // The remote agent paused the task (input-required/auth-required) and will not advance it
+            // on its own, so this must complete exceptionally rather than being left pending forever.
+            Message statusMessage = task.status().message();
+            String reason = statusMessage != null ? extractTextFromParts(statusMessage.parts()) : "";
+            messageResponse.completeExceptionally(new A2ATaskInterruptedException(task.id(), state, reason));
+            return;
+        }
         if (!isTerminalState(state) && task.artifacts().isEmpty()) {
             return;
         }

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
@@ -81,6 +81,7 @@ class DefaultA2AClientBuilderTest {
         A2ATaskInterruptedException cause = (A2ATaskInterruptedException) getCause(future);
         assertThat(cause.taskId()).isEqualTo("task-111");
         assertThat(cause.state()).isEqualTo(TaskState.TASK_STATE_INPUT_REQUIRED);
+        assertThat(cause.reason()).isEqualTo("What is your email address?");
     }
 
     @Test
@@ -99,10 +100,33 @@ class DefaultA2AClientBuilderTest {
         assertThatThrownBy(future::get)
                 .hasCauseInstanceOf(A2ATaskInterruptedException.class)
                 .hasMessageContaining("task-222")
-                .hasMessageContaining("TASK_STATE_AUTH_REQUIRED");
+                .hasMessageContaining("TASK_STATE_AUTH_REQUIRED")
+                .hasMessageContaining("waiting for authentication");
         A2ATaskInterruptedException cause = (A2ATaskInterruptedException) getCause(future);
         assertThat(cause.taskId()).isEqualTo("task-222");
         assertThat(cause.state()).isEqualTo(TaskState.TASK_STATE_AUTH_REQUIRED);
+        // The fallback description only goes into the exception message; reason() stays null so
+        // callers can tell "the agent sent no prompt" apart from a prompt it actually sent.
+        assertThat(cause.reason()).isNull();
+    }
+
+    @Test
+    void completeFromTask_inputRequiredWithoutReason_fallsBackToStateSpecificDescription() {
+        Task interruptedTask = Task.builder()
+                .id("task-444")
+                .contextId("ctx-8")
+                .status(new TaskStatus(TaskState.TASK_STATE_INPUT_REQUIRED))
+                .artifacts(List.of())
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(interruptedTask, future);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get)
+                .hasCauseInstanceOf(A2ATaskInterruptedException.class)
+                .hasMessageContaining("task-444")
+                .hasMessageContaining("waiting for additional input");
     }
 
     @Test

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
@@ -57,6 +57,76 @@ class DefaultA2AClientBuilderTest {
     }
 
     @Test
+    void completeFromTask_inputRequiredWithReason_completesExceptionallyWithInterruptedException() {
+        Message inputRequiredMessage = Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .parts(List.of(new TextPart("What is your email address?")))
+                .build();
+        Task interruptedTask = Task.builder()
+                .id("task-111")
+                .contextId("ctx-5")
+                .status(new TaskStatus(TaskState.TASK_STATE_INPUT_REQUIRED, inputRequiredMessage, null))
+                .artifacts(List.of())
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(interruptedTask, future);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get)
+                .hasCauseInstanceOf(A2ATaskInterruptedException.class)
+                .hasMessageContaining("task-111")
+                .hasMessageContaining("TASK_STATE_INPUT_REQUIRED")
+                .hasMessageContaining("What is your email address?");
+        A2ATaskInterruptedException cause = (A2ATaskInterruptedException) getCause(future);
+        assertThat(cause.taskId()).isEqualTo("task-111");
+        assertThat(cause.state()).isEqualTo(TaskState.TASK_STATE_INPUT_REQUIRED);
+    }
+
+    @Test
+    void completeFromTask_authRequiredWithoutReason_completesExceptionallyWithInterruptedException() {
+        Task interruptedTask = Task.builder()
+                .id("task-222")
+                .contextId("ctx-6")
+                .status(new TaskStatus(TaskState.TASK_STATE_AUTH_REQUIRED))
+                .artifacts(List.of())
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(interruptedTask, future);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get)
+                .hasCauseInstanceOf(A2ATaskInterruptedException.class)
+                .hasMessageContaining("task-222")
+                .hasMessageContaining("TASK_STATE_AUTH_REQUIRED");
+        A2ATaskInterruptedException cause = (A2ATaskInterruptedException) getCause(future);
+        assertThat(cause.taskId()).isEqualTo("task-222");
+        assertThat(cause.state()).isEqualTo(TaskState.TASK_STATE_AUTH_REQUIRED);
+    }
+
+    @Test
+    void completeFromTask_inputRequiredWithArtifacts_stillCompletesExceptionally() {
+        Artifact artifact = Artifact.builder()
+                .artifactId("artifact-partial")
+                .parts(List.<Part<?>>of(new TextPart("partial answer")))
+                .build();
+        Task interruptedTask = Task.builder()
+                .id("task-333")
+                .contextId("ctx-7")
+                .status(new TaskStatus(TaskState.TASK_STATE_INPUT_REQUIRED))
+                .artifacts(List.of(artifact))
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(interruptedTask, future);
+
+        // Even though artifacts are present, an interrupted task must not be treated as complete.
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get).hasCauseInstanceOf(A2ATaskInterruptedException.class);
+    }
+
+    @Test
     void completeFromTask_completedTaskWithArtifact_completesNormally() throws Exception {
         Artifact artifact = Artifact.builder()
                 .artifactId("artifact-1")
@@ -133,5 +203,14 @@ class DefaultA2AClientBuilderTest {
 
         assertThat(future).isCompleted();
         assertThat(future.get()).isEqualTo("the answer");
+    }
+
+    private static Throwable getCause(CompletableFuture<?> future) {
+        try {
+            future.get();
+            throw new AssertionError("Expected future to be completed exceptionally");
+        } catch (Exception e) {
+            return e.getCause();
+        }
     }
 }


### PR DESCRIPTION
## Issue
No dedicated issue. This is the follow-up explicitly called out by the author of #5850 in the merged commit message:

> "Follow-up: interrupted task states (`input-required`, `auth-required`) go in a separate PR that delays completion further, so this one should land first."

## Change

#5850 fixed `messageResponse` hanging forever when an A2A SSE stream ended normally without producing a result. `completeFromTask(...)` has the same class of bug for a different trigger: when a task enters an **interrupted** state (`TASK_STATE_INPUT_REQUIRED` or `TASK_STATE_AUTH_REQUIRED`), the remote agent has paused the task and will not advance it further on its own — but the existing check only treats `isTerminalState(state) == false && artifacts empty` as "keep waiting", so the future is left pending indefinitely (until/unless the stream later closes and `handleStreamEnd` steps in with a generic message).

The A2A SDK's `TaskState` enum already exposes this exact semantic via `state.isInterrupted()` (true only for `INPUT_REQUIRED`/`AUTH_REQUIRED`), so this doesn't need a hand-maintained list of state names — it stays correct if the SDK adds another interrupted state later.

`completeFromTask` now checks `state.isInterrupted()` first and completes the future exceptionally with a new `A2ATaskInterruptedException`, carrying the task id, the specific state, and — reusing the same message-extraction pattern already used for the failure branch — the remote agent's status message when present (often the actual question/prompt asking for the missing input). This check runs before the artifacts check, so a task that is interrupted but happens to carry partial artifacts is still reported as interrupted rather than silently treated as a successful (partial) completion.

`isTerminalState`/`isFailureState` are unchanged — this PR only addresses the specific follow-up called out in #5850, not other edge cases (e.g. `UNRECOGNIZED`), to keep the diff minimal and focused.

### New class
- `A2ATaskInterruptedException`: unchecked exception exposing `taskId()`, `state()` and `reason()`, following the existing convention in the agentic module (e.g. `MissingArgumentException`, `AgenticSystemSuspendedException`) of a dedicated exception type over a generic `RuntimeException`. `reason()` returns the remote agent's status message and stays `null` when the agent sent none, so callers can tell that apart from the generic description used in `getMessage()`.

### Tests
Four new cases in `DefaultA2AClientBuilderTest`, mirroring the existing style (direct calls to the package-visible static method, `Task.builder()` fixtures, assertions on the resulting future):
- `input-required` with a status message → exceptional completion, message contains the task id and the extracted reason, `reason()` returns the prompt
- `auth-required` without a status message → exceptional completion, message says "waiting for authentication", `reason()` returns `null`
- `input-required` without a status message → message falls back to "waiting for additional input"
- `input-required` with non-empty artifacts → still completes exceptionally (not silently treated as done)

### revapi
Exposing the SDK's `TaskState` on the new exception trips `java.class.externalClassExposedInAPI` ("missing-class org.a2aproject.sdk.spec.TaskState"), which failed the `integration_test` job. Added an ignore to `langchain4j-agentic-a2a/revapi.json`, alongside the entry already there for `org.a2aproject.sdk.spec.AgentCard` — this module deliberately surfaces A2A protocol types as part of its integration API (`A2AClientInstance::agentCard()` already does). Reproduced and verified locally with `mvn -pl langchain4j-agentic-a2a package revapi:check`.

## General checklist
- [X] There are no breaking changes (API, behaviour) — this only changes behavior for a previously-hanging case (never completed → now completes exceptionally); no existing passing test relied on the old hang
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules — ran the full `langchain4j-agentic-a2a` module (16 tests, all green) + `spotless:check` + `revapi:check` pass. Did not run `A2AAgentIT`, which needs a live A2A server, consistent with #5850.
- [ ] I have added/updated the documentation — not applicable (internal error-handling behavior, no public API surface beyond the new exception type)
- [ ] I have added an example in the examples repo — not applicable
- [ ] I have added/updated Spring Boot starter(s) — not applicable

## Verification
```
mvn -pl langchain4j-agentic-a2a package revapi:check spotless:check
# Tests run: 16, Failures: 0, Errors: 0
# revapi:check   BUILD SUCCESS
# spotless:check BUILD SUCCESS
```

