### PR TITLE
Add batch-level tool execution hooks to AiServices

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -1061,6 +1061,32 @@ tokenStream
     .start();
 ```
 
+### Observing Tool Executions
+
+When building an AI Service, you can register callbacks that are invoked around tool executions:
+```java
+Assistant assistant = AiServices.builder(Assistant.class)
+        .chatModel(model)
+        .tools(new Tools())
+        // invoked before each tool is executed
+        .beforeToolExecution((BeforeToolExecution before) -> System.out.println(before.request()))
+        // invoked after each tool is executed
+        .afterToolExecution((ToolExecution execution) -> System.out.println(execution.result()))
+        // invoked once per tool-calling round, with all tool execution requests of that round,
+        // before the first tool starts executing
+        .beforeAllToolExecutions((BeforeAllToolExecutions before) -> System.out.println(before.requests()))
+        // invoked once per tool-calling round, with all tool executions of that round,
+        // after the last tool has finished executing
+        .afterAllToolExecutions((List<ToolExecution> executions) -> System.out.println(executions))
+        .build();
+```
+
+The batch-level callbacks (`beforeAllToolExecutions` and `afterAllToolExecutions`) receive the whole batch
+of tool calls requested by the LLM in a single response, both when tools are executed sequentially
+and when they are executed [concurrently](/tutorials/tools#executing-tools-concurrently).
+They are useful, for example, for emitting ordered observability events or for batch-level tracing.
+These callbacks are invoked only for synchronous AI Services.
+
 ### Specifying Tools Programmatically
 
 When using AI Services, tools can also be specified programmatically.

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -1126,6 +1126,32 @@ Attributes are also stored for every message, so avoid putting large values ther
 if the conversation is persisted.
 :::
 
+### Observing Tool Executions
+
+When building an AI Service, you can register callbacks that are invoked around tool executions:
+```java
+Assistant assistant = AiServices.builder(Assistant.class)
+        .chatModel(model)
+        .tools(new Tools())
+        // invoked before each tool is executed
+        .beforeToolExecution((BeforeToolExecution before) -> System.out.println(before.request()))
+        // invoked after each tool is executed
+        .afterToolExecution((ToolExecution execution) -> System.out.println(execution.result()))
+        // invoked once per tool-calling round, with all tool execution requests of that round,
+        // before the first tool starts executing
+        .beforeAllToolExecutions((BeforeAllToolExecutions before) -> System.out.println(before.requests()))
+        // invoked once per tool-calling round, with all tool executions of that round,
+        // after the last tool has finished executing
+        .afterAllToolExecutions((List<ToolExecution> executions) -> System.out.println(executions))
+        .build();
+```
+
+The batch-level callbacks (`beforeAllToolExecutions` and `afterAllToolExecutions`) receive the whole batch
+of tool calls requested by the LLM in a single response, both when tools are executed sequentially
+and when they are executed [concurrently](/tutorials/tools#executing-tools-concurrently).
+They are useful, for example, for emitting ordered observability events or for batch-level tracing.
+These callbacks are invoked only for synchronous AI Services.
+
 ### Specifying Tools Programmatically
 
 When using AI Services, tools can also be specified programmatically.

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -42,6 +42,7 @@ import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.service.tool.AiServiceTool;
+import dev.langchain4j.service.tool.BeforeAllToolExecutions;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.DefaultToolExecutor;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
@@ -713,6 +714,46 @@ public abstract class AiServices<T> {
      */
     public AiServices<T> afterToolExecution(Consumer<ToolExecution> afterToolExecution) {
         context.toolService.afterToolExecution(afterToolExecution);
+        return this;
+    }
+
+    /**
+     * Configures a callback to be invoked once per tool-calling round, before any of the requested tools is executed.
+     * <p>
+     * When the LLM requests multiple tool executions at once, this callback receives all of them together,
+     * before the first tool starts executing, regardless of whether the tools are executed sequentially
+     * or {@linkplain #executeToolsConcurrently() concurrently}.
+     * It complements {@link #beforeToolExecution(Consumer)}, which is invoked for each tool execution individually.
+     * <p>
+     * This callback is invoked only for synchronous AI Services.
+     *
+     * @param beforeAllToolExecutions A {@link Consumer} that accepts a {@link BeforeAllToolExecutions}
+     *                                containing all tool execution requests of the current tool-calling round.
+     * @return builder
+     * @since 1.19.0
+     */
+    public AiServices<T> beforeAllToolExecutions(Consumer<BeforeAllToolExecutions> beforeAllToolExecutions) {
+        context.toolService.beforeAllToolExecutions(beforeAllToolExecutions);
+        return this;
+    }
+
+    /**
+     * Configures a callback to be invoked once per tool-calling round, after all requested tools have been executed.
+     * <p>
+     * When the LLM requests multiple tool executions at once, this callback receives all of them together,
+     * after the last tool has finished executing, regardless of whether the tools are executed sequentially
+     * or {@linkplain #executeToolsConcurrently() concurrently}.
+     * It complements {@link #afterToolExecution(Consumer)}, which is invoked for each tool execution individually.
+     * <p>
+     * This callback is invoked only for synchronous AI Services.
+     *
+     * @param afterAllToolExecutions A {@link Consumer} that accepts all {@link ToolExecution}s
+     *                               of the current tool-calling round, in the order they were requested by the LLM.
+     * @return builder
+     * @since 1.19.0
+     */
+    public AiServices<T> afterAllToolExecutions(Consumer<List<ToolExecution>> afterAllToolExecutions) {
+        context.toolService.afterAllToolExecutions(afterAllToolExecutions);
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -42,6 +42,7 @@ import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.service.tool.AiServiceTool;
+import dev.langchain4j.service.tool.BeforeAllToolExecutions;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.DefaultToolExecutor;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
@@ -712,6 +713,46 @@ public abstract class AiServices<T> {
      */
     public AiServices<T> afterToolExecution(Consumer<ToolExecution> afterToolExecution) {
         context.toolService.afterToolExecution(afterToolExecution);
+        return this;
+    }
+
+    /**
+     * Configures a callback to be invoked once per tool-calling round, before any of the requested tools is executed.
+     * <p>
+     * When the LLM requests multiple tool executions at once, this callback receives all of them together,
+     * before the first tool starts executing, regardless of whether the tools are executed sequentially
+     * or {@linkplain #executeToolsConcurrently() concurrently}.
+     * It complements {@link #beforeToolExecution(Consumer)}, which is invoked for each tool execution individually.
+     * <p>
+     * This callback is invoked only for synchronous AI Services.
+     *
+     * @param beforeAllToolExecutions A {@link Consumer} that accepts a {@link BeforeAllToolExecutions}
+     *                                containing all tool execution requests of the current tool-calling round.
+     * @return builder
+     * @since 1.19.0
+     */
+    public AiServices<T> beforeAllToolExecutions(Consumer<BeforeAllToolExecutions> beforeAllToolExecutions) {
+        context.toolService.beforeAllToolExecutions(beforeAllToolExecutions);
+        return this;
+    }
+
+    /**
+     * Configures a callback to be invoked once per tool-calling round, after all requested tools have been executed.
+     * <p>
+     * When the LLM requests multiple tool executions at once, this callback receives all of them together,
+     * after the last tool has finished executing, regardless of whether the tools are executed sequentially
+     * or {@linkplain #executeToolsConcurrently() concurrently}.
+     * It complements {@link #afterToolExecution(Consumer)}, which is invoked for each tool execution individually.
+     * <p>
+     * This callback is invoked only for synchronous AI Services.
+     *
+     * @param afterAllToolExecutions A {@link Consumer} that accepts all {@link ToolExecution}s
+     *                               of the current tool-calling round, in the order they were requested by the LLM.
+     * @return builder
+     * @since 1.19.0
+     */
+    public AiServices<T> afterAllToolExecutions(Consumer<List<ToolExecution>> afterAllToolExecutions) {
+        context.toolService.afterAllToolExecutions(afterAllToolExecutions);
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeAllToolExecutions.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeAllToolExecutions.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.service.tool;
+
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents all tool execution requests of a single tool-calling round, before any of them is executed.
+ *
+ * @since 1.19.0
+ */
+@Experimental
+public class BeforeAllToolExecutions {
+
+    private final List<ToolExecutionRequest> requests;
+    private final InvocationContext invocationContext;
+
+    private BeforeAllToolExecutions(Builder builder) {
+        this.requests = copy(ensureNotEmpty(builder.requests, "requests"));
+        this.invocationContext = ensureNotNull(builder.invocationContext, "invocationContext");
+    }
+
+    /**
+     * Returns all tool execution requests of the current tool-calling round,
+     * in the order they were requested by the LLM. Never empty.
+     *
+     * @return the tool execution requests
+     */
+    public List<ToolExecutionRequest> requests() {
+        return requests;
+    }
+
+    /**
+     * Returns the invocation context of the tool requests that are about to be executed.
+     */
+    public InvocationContext invocationContext() {
+        return invocationContext;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        BeforeAllToolExecutions that = (BeforeAllToolExecutions) obj;
+        return Objects.equals(requests, that.requests);
+    }
+
+    @Override
+    public String toString() {
+        return "BeforeAllToolExecutions {" + " requests = " + requests + " }";
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 5381;
+        h += (h << 5) + Objects.hashCode(requests);
+        return h;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<ToolExecutionRequest> requests;
+        private InvocationContext invocationContext;
+
+        private Builder() {}
+
+        public Builder requests(List<ToolExecutionRequest> requests) {
+            this.requests = requests;
+            return this;
+        }
+
+        public Builder invocationContext(InvocationContext invocationContext) {
+            this.invocationContext = invocationContext;
+            return this;
+        }
+
+        public BeforeAllToolExecutions build() {
+            return new BeforeAllToolExecutions(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -105,6 +105,8 @@ public class ToolService {
 
     private Consumer<BeforeToolExecution> beforeToolExecution = null;
     private Consumer<ToolExecution> afterToolExecution = null;
+    private Consumer<BeforeAllToolExecutions> beforeAllToolExecutions = null;
+    private Consumer<List<ToolExecution>> afterAllToolExecutions = null;
     private BiConsumer<ToolExecution, Consumer<ToolExecution>> onCompensableToolExecution = null;
     private Consumer<InvocationContext> onToolExecutionError = null;
 
@@ -276,7 +278,8 @@ public class ToolService {
         }
 
         for (Method candidateMethod : allConcreteMethods(objectWithTools.getClass())) {
-            Method method = getAnnotatedMethod(candidateMethod, CompensateFor.class).orElse(null);
+            Method method =
+                    getAnnotatedMethod(candidateMethod, CompensateFor.class).orElse(null);
             if (method != null) {
                 CompensateFor compensateFor = method.getAnnotation(CompensateFor.class);
                 String toolName = compensateFor.value();
@@ -335,8 +338,10 @@ public class ToolService {
                             .methodToInvoke(method)
                             .propagateToolExecutionExceptions(true)
                             .build();
-                    compensatingActions.put(toolName, toolExecution ->
-                            executor.executeWithContext(toolExecution.request(), toolExecution.invocationContext()));
+                    compensatingActions.put(
+                            toolName,
+                            toolExecution -> executor.executeWithContext(
+                                    toolExecution.request(), toolExecution.invocationContext()));
                 }
             }
         }
@@ -409,7 +414,36 @@ public class ToolService {
         return afterToolExecution;
     }
 
-    public void onCompensableToolExecution(BiConsumer<ToolExecution, Consumer<ToolExecution>> onCompensableToolExecution) {
+    /**
+     * @since 1.19.0
+     */
+    public void beforeAllToolExecutions(Consumer<BeforeAllToolExecutions> beforeAllToolExecutions) {
+        this.beforeAllToolExecutions = beforeAllToolExecutions;
+    }
+
+    /**
+     * @since 1.19.0
+     */
+    public Consumer<BeforeAllToolExecutions> beforeAllToolExecutions() {
+        return beforeAllToolExecutions;
+    }
+
+    /**
+     * @since 1.19.0
+     */
+    public void afterAllToolExecutions(Consumer<List<ToolExecution>> afterAllToolExecutions) {
+        this.afterAllToolExecutions = afterAllToolExecutions;
+    }
+
+    /**
+     * @since 1.19.0
+     */
+    public Consumer<List<ToolExecution>> afterAllToolExecutions() {
+        return afterAllToolExecutions;
+    }
+
+    public void onCompensableToolExecution(
+            BiConsumer<ToolExecution, Consumer<ToolExecution>> onCompensableToolExecution) {
         if (compensatingToolMisconfiguration != null) {
             throw compensatingToolMisconfiguration;
         }
@@ -586,6 +620,14 @@ public class ToolService {
             intermediateResponses.add(chatResponse);
 
             List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+
+            if (beforeAllToolExecutions != null) {
+                beforeAllToolExecutions.accept(BeforeAllToolExecutions.builder()
+                        .requests(toolExecutionRequests)
+                        .invocationContext(invocationContext)
+                        .build());
+            }
+
             Map<ToolExecutionRequest, ToolExecutionResult> toolResults =
                     execute(toolExecutionRequests, toolServiceContext.toolExecutors(), invocationContext);
 
@@ -593,6 +635,7 @@ public class ToolService {
             String failedToolName = null;
             List<ReturnBehavior> returnBehaviors = new ArrayList<>(toolExecutionRequests.size());
             List<ToolExecutionResultMessage> resultMessages = new ArrayList<>(toolExecutionRequests.size());
+            List<ToolExecution> roundToolExecutions = new ArrayList<>(toolExecutionRequests.size());
 
             for (ToolExecutionRequest request : toolExecutionRequests) {
                 ToolExecutionResult result = toolResults.get(request);
@@ -604,7 +647,7 @@ public class ToolService {
                         .result(result)
                         .invocationContext(invocationContext)
                         .build();
-                toolExecutions.add(toolExecution);
+                roundToolExecutions.add(toolExecution);
 
                 fireToolExecutedEvent(invocationContext, request, toolExecution, context.eventListenerRegistrar);
 
@@ -622,6 +665,12 @@ public class ToolService {
                 }
                 anyToolErrored = anyToolErrored || result.isError();
                 returnBehaviors.add(toolServiceContext.returnBehavior(request.name()));
+            }
+
+            toolExecutions.addAll(roundToolExecutions);
+
+            if (afterAllToolExecutions != null) {
+                afterAllToolExecutions.accept(copy(roundToolExecutions));
             }
 
             if (anyToolErrored && compensableExecutions != null && !compensableExecutions.isEmpty()) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -105,6 +105,8 @@ public class ToolService {
 
     private Consumer<BeforeToolExecution> beforeToolExecution = null;
     private Consumer<ToolExecution> afterToolExecution = null;
+    private Consumer<BeforeAllToolExecutions> beforeAllToolExecutions = null;
+    private Consumer<List<ToolExecution>> afterAllToolExecutions = null;
     private BiConsumer<ToolExecution, Consumer<ToolExecution>> onCompensableToolExecution = null;
     private Consumer<InvocationContext> onToolExecutionError = null;
 
@@ -334,8 +336,10 @@ public class ToolService {
                             .methodToInvoke(method)
                             .propagateToolExecutionExceptions(true)
                             .build();
-                    compensatingActions.put(toolName, toolExecution ->
-                            executor.executeWithContext(toolExecution.request(), toolExecution.invocationContext()));
+                    compensatingActions.put(
+                            toolName,
+                            toolExecution -> executor.executeWithContext(
+                                    toolExecution.request(), toolExecution.invocationContext()));
                 }
             }
         }
@@ -408,7 +412,36 @@ public class ToolService {
         return afterToolExecution;
     }
 
-    public void onCompensableToolExecution(BiConsumer<ToolExecution, Consumer<ToolExecution>> onCompensableToolExecution) {
+    /**
+     * @since 1.19.0
+     */
+    public void beforeAllToolExecutions(Consumer<BeforeAllToolExecutions> beforeAllToolExecutions) {
+        this.beforeAllToolExecutions = beforeAllToolExecutions;
+    }
+
+    /**
+     * @since 1.19.0
+     */
+    public Consumer<BeforeAllToolExecutions> beforeAllToolExecutions() {
+        return beforeAllToolExecutions;
+    }
+
+    /**
+     * @since 1.19.0
+     */
+    public void afterAllToolExecutions(Consumer<List<ToolExecution>> afterAllToolExecutions) {
+        this.afterAllToolExecutions = afterAllToolExecutions;
+    }
+
+    /**
+     * @since 1.19.0
+     */
+    public Consumer<List<ToolExecution>> afterAllToolExecutions() {
+        return afterAllToolExecutions;
+    }
+
+    public void onCompensableToolExecution(
+            BiConsumer<ToolExecution, Consumer<ToolExecution>> onCompensableToolExecution) {
         if (compensatingToolMisconfiguration != null) {
             throw compensatingToolMisconfiguration;
         }
@@ -585,6 +618,14 @@ public class ToolService {
             intermediateResponses.add(chatResponse);
 
             List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+
+            if (beforeAllToolExecutions != null) {
+                beforeAllToolExecutions.accept(BeforeAllToolExecutions.builder()
+                        .requests(toolExecutionRequests)
+                        .invocationContext(invocationContext)
+                        .build());
+            }
+
             Map<ToolExecutionRequest, ToolExecutionResult> toolResults =
                     execute(toolExecutionRequests, toolServiceContext.toolExecutors(), invocationContext);
 
@@ -592,6 +633,7 @@ public class ToolService {
             String failedToolName = null;
             List<ReturnBehavior> returnBehaviors = new ArrayList<>(toolExecutionRequests.size());
             List<ToolExecutionResultMessage> resultMessages = new ArrayList<>(toolExecutionRequests.size());
+            List<ToolExecution> roundToolExecutions = new ArrayList<>(toolExecutionRequests.size());
 
             for (ToolExecutionRequest request : toolExecutionRequests) {
                 ToolExecutionResult result = toolResults.get(request);
@@ -603,7 +645,7 @@ public class ToolService {
                         .result(result)
                         .invocationContext(invocationContext)
                         .build();
-                toolExecutions.add(toolExecution);
+                roundToolExecutions.add(toolExecution);
 
                 fireToolExecutedEvent(invocationContext, request, toolExecution, context.eventListenerRegistrar);
 
@@ -621,6 +663,12 @@ public class ToolService {
                 }
                 anyToolErrored = anyToolErrored || result.isError();
                 returnBehaviors.add(toolServiceContext.returnBehavior(request.name()));
+            }
+
+            toolExecutions.addAll(roundToolExecutions);
+
+            if (afterAllToolExecutions != null) {
+                afterAllToolExecutions.accept(copy(roundToolExecutions));
             }
 
             if (anyToolErrored && compensableExecutions != null && !compensableExecutions.isEmpty()) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithAllToolExecutionsHooksTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithAllToolExecutionsHooksTest.java
@@ -1,0 +1,423 @@
+package dev.langchain4j.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.tool.BeforeAllToolExecutions;
+import dev.langchain4j.service.tool.ToolExecution;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AiServicesWithAllToolExecutionsHooksTest {
+
+    private static final ToolExecutionRequest GET_TIME_REQUEST = ToolExecutionRequest.builder()
+            .id("1")
+            .name("getCurrentTime")
+            .arguments("{\"arg0\":\"Munich\"}")
+            .build();
+
+    private static final ToolExecutionRequest GET_TEMPERATURE_REQUEST = ToolExecutionRequest.builder()
+            .id("2")
+            .name("getCurrentTemperature")
+            .arguments("{\"arg0\":\"Munich\"}")
+            .build();
+
+    interface Assistant {
+
+        String chat(String userMessage);
+    }
+
+    static class Tools {
+
+        static final String CURRENT_TIME = "16:35";
+        static final String CURRENT_TEMPERATURE = "17 degrees";
+
+        final AtomicInteger executedToolCount = new AtomicInteger();
+
+        @Tool
+        String getCurrentTime(String city) {
+            executedToolCount.incrementAndGet();
+            return CURRENT_TIME;
+        }
+
+        @Tool
+        String getCurrentTemperature(String city) {
+            executedToolCount.incrementAndGet();
+            return CURRENT_TEMPERATURE;
+        }
+    }
+
+    static class FailingTools {
+
+        static final RuntimeException TIME_FAILURE = new RuntimeException("time service is down");
+        static final String CURRENT_TEMPERATURE = "17 degrees";
+
+        @Tool
+        String getCurrentTime(String city) {
+            throw TIME_FAILURE;
+        }
+
+        @Tool
+        String getCurrentTemperature(String city) {
+            return CURRENT_TEMPERATURE;
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void should_invoke_beforeAllToolExecutions_with_all_requests_before_any_tool_is_executed(
+            boolean executeToolsConcurrently) {
+
+        // given
+        Tools tools = new Tools();
+
+        List<BeforeAllToolExecutions> hookInvocations = new CopyOnWriteArrayList<>();
+        AtomicInteger executedToolsWhenHookFired = new AtomicInteger(-1);
+        AtomicReference<Thread> hookThread = new AtomicReference<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        AiServices<Assistant> assistantBuilder = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .beforeAllToolExecutions(before -> {
+                    hookInvocations.add(before);
+                    executedToolsWhenHookFired.set(tools.executedToolCount.get());
+                    hookThread.set(Thread.currentThread());
+                });
+        if (executeToolsConcurrently) {
+            assistantBuilder.executeToolsConcurrently();
+        }
+        Assistant assistant = assistantBuilder.build();
+
+        // when
+        assistant.chat("What is the current time and temperature in Munich?");
+
+        // then
+        assertThat(hookInvocations).hasSize(1);
+
+        BeforeAllToolExecutions beforeAllToolExecutions = hookInvocations.get(0);
+        assertThat(beforeAllToolExecutions.requests()).containsExactly(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST);
+        assertThat(beforeAllToolExecutions.invocationContext()).isNotNull();
+
+        assertThat(executedToolsWhenHookFired).hasValue(0);
+        assertThat(tools.executedToolCount).hasValue(2);
+        assertThat(hookThread).hasValue(Thread.currentThread());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void should_invoke_afterAllToolExecutions_once_after_all_tools_are_executed(boolean executeToolsConcurrently) {
+
+        // given
+        Tools tools = new Tools();
+
+        List<List<ToolExecution>> hookInvocations = new CopyOnWriteArrayList<>();
+        AtomicInteger executedToolsWhenHookFired = new AtomicInteger(-1);
+        AtomicReference<Thread> hookThread = new AtomicReference<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        AiServices<Assistant> assistantBuilder = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .afterAllToolExecutions(executions -> {
+                    hookInvocations.add(executions);
+                    executedToolsWhenHookFired.set(tools.executedToolCount.get());
+                    hookThread.set(Thread.currentThread());
+                });
+        if (executeToolsConcurrently) {
+            assistantBuilder.executeToolsConcurrently();
+        }
+        Assistant assistant = assistantBuilder.build();
+
+        // when
+        assistant.chat("What is the current time and temperature in Munich?");
+
+        // then
+        assertThat(hookInvocations).hasSize(1);
+
+        List<ToolExecution> toolExecutions = hookInvocations.get(0);
+        assertThat(toolExecutions).hasSize(2);
+        assertThat(toolExecutions.get(0).request()).isEqualTo(GET_TIME_REQUEST);
+        assertThat(toolExecutions.get(0).result()).isEqualTo(Tools.CURRENT_TIME);
+        assertThat(toolExecutions.get(1).request()).isEqualTo(GET_TEMPERATURE_REQUEST);
+        assertThat(toolExecutions.get(1).result()).isEqualTo(Tools.CURRENT_TEMPERATURE);
+
+        assertThat(executedToolsWhenHookFired).hasValue(2);
+        assertThat(hookThread).hasValue(Thread.currentThread());
+    }
+
+    @Test
+    void should_invoke_batch_hooks_and_per_call_hooks_in_order() {
+
+        // given
+        Tools tools = new Tools();
+
+        List<String> events = new ArrayList<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .beforeAllToolExecutions(before -> events.add("beforeAll"))
+                .beforeToolExecution(
+                        before -> events.add("before " + before.request().name()))
+                .afterToolExecution(
+                        after -> events.add("after " + after.request().name()))
+                .afterAllToolExecutions(executions -> events.add("afterAll"))
+                .build();
+
+        // when
+        assistant.chat("What is the current time and temperature in Munich?");
+
+        // then
+        assertThat(events)
+                .containsExactly(
+                        "beforeAll",
+                        "before getCurrentTime",
+                        "after getCurrentTime",
+                        "before getCurrentTemperature",
+                        "after getCurrentTemperature",
+                        "afterAll");
+    }
+
+    @Test
+    void should_invoke_batch_hooks_around_per_call_hooks_when_executing_tools_concurrently() {
+
+        // given
+        Tools tools = new Tools();
+
+        List<String> events = new CopyOnWriteArrayList<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .executeToolsConcurrently()
+                .beforeAllToolExecutions(before -> events.add("beforeAll"))
+                .beforeToolExecution(
+                        before -> events.add("before " + before.request().name()))
+                .afterToolExecution(
+                        after -> events.add("after " + after.request().name()))
+                .afterAllToolExecutions(executions -> events.add("afterAll"))
+                .build();
+
+        // when
+        assistant.chat("What is the current time and temperature in Munich?");
+
+        // then
+        assertThat(events).hasSize(6);
+        assertThat(events.get(0)).isEqualTo("beforeAll");
+        assertThat(events.get(5)).isEqualTo("afterAll");
+        assertThat(events.subList(1, 5))
+                .containsExactlyInAnyOrder(
+                        "before getCurrentTime",
+                        "after getCurrentTime",
+                        "before getCurrentTemperature",
+                        "after getCurrentTemperature");
+    }
+
+    @Test
+    void should_invoke_batch_hooks_once_per_tool_calling_round() {
+
+        // given
+        Tools tools = new Tools();
+
+        List<BeforeAllToolExecutions> beforeInvocations = new ArrayList<>();
+        List<List<ToolExecution>> afterInvocations = new ArrayList<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST), AiMessage.from(GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .beforeAllToolExecutions(beforeInvocations::add)
+                .afterAllToolExecutions(afterInvocations::add)
+                .build();
+
+        // when
+        assistant.chat("What is the current time and temperature in Munich?");
+
+        // then
+        assertThat(beforeInvocations).hasSize(2);
+        assertThat(beforeInvocations.get(0).requests()).containsExactly(GET_TIME_REQUEST);
+        assertThat(beforeInvocations.get(1).requests()).containsExactly(GET_TEMPERATURE_REQUEST);
+
+        assertThat(afterInvocations).hasSize(2);
+        assertThat(afterInvocations.get(0)).hasSize(1);
+        assertThat(afterInvocations.get(0).get(0).request()).isEqualTo(GET_TIME_REQUEST);
+        assertThat(afterInvocations.get(1)).hasSize(1);
+        assertThat(afterInvocations.get(1).get(0).request()).isEqualTo(GET_TEMPERATURE_REQUEST);
+    }
+
+    @Test
+    void should_not_invoke_batch_hooks_when_no_tools_are_requested() {
+
+        // given
+        Tools tools = new Tools();
+
+        List<BeforeAllToolExecutions> beforeInvocations = new ArrayList<>();
+        List<List<ToolExecution>> afterInvocations = new ArrayList<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .beforeAllToolExecutions(beforeInvocations::add)
+                .afterAllToolExecutions(afterInvocations::add)
+                .build();
+
+        // when
+        assistant.chat("Hello");
+
+        // then
+        assertThat(beforeInvocations).isEmpty();
+        assertThat(afterInvocations).isEmpty();
+        assertThat(tools.executedToolCount).hasValue(0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void should_propagate_exception_thrown_from_beforeAllToolExecutions(boolean executeToolsConcurrently) {
+
+        // given
+        Tools tools = new Tools();
+
+        RuntimeException hookException = new RuntimeException("beforeAllToolExecutions failed");
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        AiServices<Assistant> assistantBuilder = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .beforeAllToolExecutions(before -> {
+                    throw hookException;
+                });
+        if (executeToolsConcurrently) {
+            assistantBuilder.executeToolsConcurrently();
+        }
+        Assistant assistant = assistantBuilder.build();
+
+        // when-then
+        assertThatThrownBy(() -> assistant.chat("What is the current time and temperature in Munich?"))
+                .isSameAs(hookException);
+        assertThat(tools.executedToolCount).hasValue(0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void should_propagate_exception_thrown_from_afterAllToolExecutions(boolean executeToolsConcurrently) {
+
+        // given
+        Tools tools = new Tools();
+
+        RuntimeException hookException = new RuntimeException("afterAllToolExecutions failed");
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        AiServices<Assistant> assistantBuilder = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .afterAllToolExecutions(executions -> {
+                    throw hookException;
+                });
+        if (executeToolsConcurrently) {
+            assistantBuilder.executeToolsConcurrently();
+        }
+        Assistant assistant = assistantBuilder.build();
+
+        // when-then
+        assertThatThrownBy(() -> assistant.chat("What is the current time and temperature in Munich?"))
+                .isSameAs(hookException);
+        assertThat(tools.executedToolCount).hasValue(2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void should_invoke_afterAllToolExecutions_with_error_result_when_tool_fails(boolean executeToolsConcurrently) {
+
+        // given
+        List<List<ToolExecution>> hookInvocations = new CopyOnWriteArrayList<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        AiServices<Assistant> assistantBuilder = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(new FailingTools())
+                .afterAllToolExecutions(hookInvocations::add);
+        if (executeToolsConcurrently) {
+            assistantBuilder.executeToolsConcurrently();
+        }
+        Assistant assistant = assistantBuilder.build();
+
+        // when
+        assistant.chat("What is the current time and temperature in Munich?");
+
+        // then
+        assertThat(hookInvocations).hasSize(1);
+
+        List<ToolExecution> toolExecutions = hookInvocations.get(0);
+        assertThat(toolExecutions).hasSize(2);
+        assertThat(toolExecutions.get(0).request()).isEqualTo(GET_TIME_REQUEST);
+        assertThat(toolExecutions.get(0).hasFailed()).isTrue();
+        assertThat(toolExecutions.get(0).result()).isEqualTo(FailingTools.TIME_FAILURE.getMessage());
+        assertThat(toolExecutions.get(1).request()).isEqualTo(GET_TEMPERATURE_REQUEST);
+        assertThat(toolExecutions.get(1).hasFailed()).isFalse();
+        assertThat(toolExecutions.get(1).result()).isEqualTo(FailingTools.CURRENT_TEMPERATURE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void should_not_invoke_afterAllToolExecutions_when_tool_exception_propagates(boolean executeToolsConcurrently) {
+
+        // given
+        List<BeforeAllToolExecutions> beforeInvocations = new CopyOnWriteArrayList<>();
+        List<List<ToolExecution>> afterInvocations = new CopyOnWriteArrayList<>();
+
+        ChatModel model = ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(GET_TIME_REQUEST, GET_TEMPERATURE_REQUEST), AiMessage.from("done"));
+
+        AiServices<Assistant> assistantBuilder = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(new FailingTools())
+                .toolExecutionErrorHandler((error, context) -> {
+                    throw (RuntimeException) error;
+                })
+                .beforeAllToolExecutions(beforeInvocations::add)
+                .afterAllToolExecutions(afterInvocations::add);
+        if (executeToolsConcurrently) {
+            assistantBuilder.executeToolsConcurrently();
+        }
+        Assistant assistant = assistantBuilder.build();
+
+        // when-then
+        assertThatThrownBy(() -> assistant.chat("What is the current time and temperature in Munich?"))
+                .isSameAs(FailingTools.TIME_FAILURE);
+
+        assertThat(beforeInvocations).hasSize(1);
+        assertThat(afterInvocations).isEmpty();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
@@ -79,9 +79,14 @@ class ToolServiceTest {
     void findTools_should_execute_tool_through_overriding_method() {
         InterceptedDateTool objectWithTools = new InterceptedDateTool();
 
-        ToolExecutor toolExecutor = ToolService.findTools(objectWithTools).get(0).toolExecutor();
+        ToolExecutor toolExecutor =
+                ToolService.findTools(objectWithTools).get(0).toolExecutor();
         String result = toolExecutor.execute(
-                ToolExecutionRequest.builder().name("getCurrentDate").arguments("{}").build(), null);
+                ToolExecutionRequest.builder()
+                        .name("getCurrentDate")
+                        .arguments("{}")
+                        .build(),
+                null);
 
         assertThat(result).isEqualTo("2024-04-29");
         assertThat(objectWithTools.intercepted).isTrue();
@@ -208,10 +213,28 @@ class ToolServiceTest {
     }
 
     @Test
+    void beforeAllToolExecutions_getter() {
+        ToolService toolService = new ToolService();
+        Consumer<BeforeAllToolExecutions> callback = before -> {};
+        toolService.beforeAllToolExecutions(callback);
+        assertThat(toolService.beforeAllToolExecutions()).isSameAs(callback);
+    }
+
+    @Test
+    void afterAllToolExecutions_getter() {
+        ToolService toolService = new ToolService();
+        Consumer<List<ToolExecution>> callback = after -> {};
+        toolService.afterAllToolExecutions(callback);
+        assertThat(toolService.afterAllToolExecutions()).isSameAs(callback);
+    }
+
+    @Test
     void callbacks_null_by_default() {
         ToolService toolService = new ToolService();
         assertThat(toolService.beforeToolExecution()).isNull();
         assertThat(toolService.afterToolExecution()).isNull();
+        assertThat(toolService.beforeAllToolExecutions()).isNull();
+        assertThat(toolService.afterAllToolExecutions()).isNull();
     }
 
     // --- refreshDynamicProviders ---

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
@@ -162,10 +162,28 @@ class ToolServiceTest {
     }
 
     @Test
+    void beforeAllToolExecutions_getter() {
+        ToolService toolService = new ToolService();
+        Consumer<BeforeAllToolExecutions> callback = before -> {};
+        toolService.beforeAllToolExecutions(callback);
+        assertThat(toolService.beforeAllToolExecutions()).isSameAs(callback);
+    }
+
+    @Test
+    void afterAllToolExecutions_getter() {
+        ToolService toolService = new ToolService();
+        Consumer<List<ToolExecution>> callback = after -> {};
+        toolService.afterAllToolExecutions(callback);
+        assertThat(toolService.afterAllToolExecutions()).isSameAs(callback);
+    }
+
+    @Test
     void callbacks_null_by_default() {
         ToolService toolService = new ToolService();
         assertThat(toolService.beforeToolExecution()).isNull();
         assertThat(toolService.afterToolExecution()).isNull();
+        assertThat(toolService.beforeAllToolExecutions()).isNull();
+        assertThat(toolService.afterAllToolExecutions()).isNull();
     }
 
     // --- refreshDynamicProviders ---


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #5749

## Change
<!-- Please describe the changes you made. -->

Adds batch-level tool execution hooks to the `AiServices` builder, complementing the existing per-call `beforeToolExecution`/`afterToolExecution`:

- `beforeAllToolExecutions(Consumer<BeforeAllToolExecutions>)` - invoked once per tool-calling round, with all `ToolExecutionRequest`s of that round, before the first tool starts executing
- `afterAllToolExecutions(Consumer<List<ToolExecution>>)` - invoked once per round, after all requested tools have finished, with the same `ToolExecution` objects that end up in `Result.toolExecutions()`

Naming as suggested in the issue thread. Sync AI Services only, as agreed there (in streaming mode tools start executing before the full batch is known).

Both hooks fire on the caller thread, for sequential and `executeToolsConcurrently()` execution, in this order per round: `beforeAllToolExecutions`, then the per-call hooks, then `afterAllToolExecutions`. `BeforeAllToolExecutions` mirrors the existing `BeforeToolExecution` (`@Experimental`, builder). The hooks are wired in `ToolService.executeInferenceAndToolsLoop`, which collects the full request list before dispatching; the streaming path is untouched. The spotless ratchet also reformatted two pre-existing statements in `ToolService.java`; no behavior changes there.

Testing: new `AiServicesWithAllToolExecutionsHooksTest` (mock-based, runs without API keys) covers: before receives the full list before any tool executes, after fires once with all results, ordering relative to per-call hooks, sequential and concurrent paths, multiple rounds, the no-tools case, exception propagation from both hooks, a failing tool whose error is returned to the LLM (the after hook receives the execution with the error result), and a tool exception rethrown by the error handler (the exception propagates and the after hook is not invoked, matching per-call hook behavior). The tests were verified to fail without the `ToolService` change. `mvn verify` on langchain4j-core and langchain4j passes: 1210 + 1296 unit tests, 588 integration tests, 0 failures, coverage checks met. Integration tests that require provider API keys were skipped.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
