### PR TITLE
fix: include Content metadata in equality without changing RRF semantics

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/DefaultContent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/DefaultContent.java
@@ -1,19 +1,16 @@
 package dev.langchain4j.rag.content;
 
-import dev.langchain4j.data.segment.TextSegment;
-
-import java.util.Map;
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.segment.TextSegment;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * A default implementation of a {@link Content}.
  * <br>
  * The class includes optional metadata which can store additional information about the content.
- * This metadata is supplementary and is intentionally excluded from equality and hash calculations.
- * See {@link #equals(Object)} and {@link #hashCode()} for details.
  */
 public class DefaultContent implements Content {
 
@@ -46,34 +43,28 @@ public class DefaultContent implements Content {
     /**
      * Compares this {@code Content} with another object for equality.
      * <br>
-     * The {@code metadata} field is intentionally excluded from the equality check. Metadata is considered
-     * supplementary information and does not contribute to the core identity of the {@code Content}.
+     * Both the {@code textSegment} and {@code metadata} fields contribute to the value of this content.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Content that = (Content) o;
-        return Objects.equals(this.textSegment, that.textSegment());
+        return Objects.equals(this.textSegment, that.textSegment()) && Objects.equals(this.metadata, that.metadata());
     }
 
     /**
      * Computes the hash code for this {@code Content}.
      * <br>
-     * The {@code metadata} field is excluded from the hash code calculation. This ensures that two logically identical
-     * {@code Content} objects with differing metadata produce the same hash code, maintaining consistent behavior in
-     * hash-based collections.
+     * Both the {@code textSegment} and {@code metadata} fields contribute to the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(textSegment);
+        return Objects.hash(textSegment, metadata);
     }
 
     @Override
     public String toString() {
-        return "DefaultContent {" +
-                " textSegment = " + textSegment +
-                ", metadata = " + metadata +
-                " }";
+        return "DefaultContent {" + " textSegment = " + textSegment + ", metadata = " + metadata + " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReciprocalRankFuser.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReciprocalRankFuser.java
@@ -1,15 +1,15 @@
 package dev.langchain4j.rag.content.aggregator;
 
-import dev.langchain4j.rag.content.Content;
+import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
 
 /**
  * Implementation of Reciprocal Rank Fusion.
@@ -48,19 +48,23 @@ public class ReciprocalRankFuser {
     public static List<Content> fuse(Collection<List<Content>> listsOfContents, int k) {
         ensureBetween(k, 1, Integer.MAX_VALUE, "k");
 
-        Map<Content, Double> scores = new LinkedHashMap<>();
+        Map<TextSegment, Double> scores = new LinkedHashMap<>();
+        Map<TextSegment, Content> contents = new LinkedHashMap<>();
         for (List<Content> singleListOfContent : listsOfContents) {
             for (int i = 0; i < singleListOfContent.size(); i++) {
                 Content content = singleListOfContent.get(i);
-                double currentScore = scores.getOrDefault(content, 0.0);
+                TextSegment textSegment = content.textSegment();
+                contents.putIfAbsent(textSegment, content);
+                double currentScore = scores.getOrDefault(textSegment, 0.0);
                 int rank = i + 1;
                 double newScore = currentScore + 1.0 / (k + rank);
-                scores.put(content, newScore);
+                scores.put(textSegment, newScore);
             }
         }
 
-        List<Content> fused = new ArrayList<>(scores.keySet());
-        fused.sort(Comparator.comparingDouble(scores::get).reversed());
+        List<Content> fused = new ArrayList<>(contents.values());
+        fused.sort(Comparator.comparingDouble((Content content) -> scores.get(content.textSegment()))
+                .reversed());
         return fused;
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/ContentTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/ContentTest.java
@@ -62,13 +62,16 @@ class ContentTest {
         Content content1 = Content.from(TextSegment.from("content"), Map.of(SCORE, 1.0));
         Content content2 = Content.from("content 2");
         Content content3 = Content.from("content");
+        Content content4 = Content.from(TextSegment.from("content"), Map.of(SCORE, 1.0));
 
         // then
         assertThat(content1)
                 .isNotEqualTo(content2)
                 .doesNotHaveSameHashCodeAs(content2)
-                .isEqualTo(content3) // Content.metadata() is not taken into account
-                .hasSameHashCodeAs(content3); // Content.metadata() is not taken into account
+                .isNotEqualTo(content3)
+                .doesNotHaveSameHashCodeAs(content3)
+                .isEqualTo(content4)
+                .hasSameHashCodeAs(content4);
     }
 
     @Test
@@ -196,7 +199,7 @@ class ContentTest {
     }
 
     @Test
-    void should_ignore_metadata_in_equality_with_different_metadata() {
+    void should_include_metadata_in_equality() {
         // given
         TextSegment segment = TextSegment.from("test");
         Content content1 = Content.from(segment, Map.of(SCORE, 0.1));
@@ -205,8 +208,9 @@ class ContentTest {
 
         // then
         assertThat(content1).isEqualTo(content2);
-        assertThat(content1).isEqualTo(content3);
-        assertThat(content2).isEqualTo(content3);
+        assertThat(content1).hasSameHashCodeAs(content2);
+        assertThat(content1).isNotEqualTo(content3);
+        assertThat(content2).isNotEqualTo(content3);
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReciprocalRankFuserTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReciprocalRankFuserTest.java
@@ -1,17 +1,20 @@
 package dev.langchain4j.rag.content.aggregator;
 
-import dev.langchain4j.rag.content.Content;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Stream;
-
+import static dev.langchain4j.rag.content.ContentMetadata.SCORE;
 import static dev.langchain4j.rag.content.aggregator.ReciprocalRankFuser.fuse;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ReciprocalRankFuserTest {
 
@@ -26,67 +29,48 @@ class ReciprocalRankFuserTest {
         assertThat(fuse(contents)).isEqualTo(expected);
     }
 
+    @Test
+    void should_fuse_by_text_segment_when_content_metadata_differs() {
+        TextSegment textSegment = TextSegment.from("same text");
+        Content first = Content.from(textSegment, Map.of(SCORE, 0.9));
+        Content second = Content.from(textSegment, Map.of(SCORE, 0.5));
+        Content other = Content.from("other text");
+
+        List<Content> fused = fuse(asList(asList(first, other), asList(second)));
+
+        assertThat(fused).containsExactly(first, other);
+    }
+
     public static Stream<Arguments> should_fuse() {
         return Stream.<Arguments>builder()
 
                 // 0 & 0
-                .add(Arguments.of(
-                        asList(list(), list()),
-                        list()))
+                .add(Arguments.of(asList(list(), list()), list()))
 
                 // 0 & 1
-                .add(Arguments.of(
-                        asList(list(), list(A)),
-                        list(A)))
+                .add(Arguments.of(asList(list(), list(A)), list(A)))
 
                 // 1 & 0
-                .add(Arguments.of(
-                        asList(list(A), list()),
-                        list(A)))
+                .add(Arguments.of(asList(list(A), list()), list(A)))
 
                 // 1 & 1
-                .add(Arguments.of(
-                        asList(list(A), list(A)),
-                        list(A)))
-                .add(Arguments.of(
-                        asList(list(A), list(B)),
-                        asList(A, B)))
+                .add(Arguments.of(asList(list(A), list(A)), list(A)))
+                .add(Arguments.of(asList(list(A), list(B)), asList(A, B)))
 
                 // 1 & 2
-                .add(Arguments.of(
-                        asList(list(A), list(A, B)),
-                        asList(A, B)))
-                .add(Arguments.of(
-                        asList(list(A), list(B, A)),
-                        asList(A, B)))
+                .add(Arguments.of(asList(list(A), list(A, B)), asList(A, B)))
+                .add(Arguments.of(asList(list(A), list(B, A)), asList(A, B)))
 
                 // 2 & 1
-                .add(Arguments.of(
-                        asList(list(A, B), list(A)),
-                        asList(A, B)))
-                .add(Arguments.of(
-                        asList(list(A, B), list(B)),
-                        asList(B, A)))
+                .add(Arguments.of(asList(list(A, B), list(A)), asList(A, B)))
+                .add(Arguments.of(asList(list(A, B), list(B)), asList(B, A)))
 
                 // 2 & 2
-                .add(Arguments.of(
-                        asList(list(A, B), list(A, B)),
-                        asList(A, B)))
-                .add(Arguments.of(
-                        asList(list(A, B), list(B, A)),
-                        asList(A, B)))
-
-                .add(Arguments.of(
-                        asList(list(A, B), list(A, C)),
-                        asList(A, B, C)))
-                .add(Arguments.of(
-                        asList(list(A, B), list(B, C)),
-                        asList(B, A, C)))
-
-                .add(Arguments.of(
-                        asList(list(A, B), list(C, D)),
-                        asList(A, C, B, D)))
-
+                .add(Arguments.of(asList(list(A, B), list(A, B)), asList(A, B)))
+                .add(Arguments.of(asList(list(A, B), list(B, A)), asList(A, B)))
+                .add(Arguments.of(asList(list(A, B), list(A, C)), asList(A, B, C)))
+                .add(Arguments.of(asList(list(A, B), list(B, C)), asList(B, A, C)))
+                .add(Arguments.of(asList(list(A, B), list(C, D)), asList(A, C, B, D)))
                 .build();
     }
 


### PR DESCRIPTION
## Issue
Closes #2314

## Change

`DefaultContent.equals/hashCode` previously ignored content-level metadata. That made two content values compare equal even when their retrieval or reranking metadata differed, and also made `ReciprocalRankFuser` depend implicitly on that incomplete equality contract for deduplication.

This change:

- includes both `TextSegment` and content metadata in `DefaultContent.equals/hashCode`;
- makes `ReciprocalRankFuser` explicitly aggregate scores by `TextSegment`;
- preserves the first encountered `Content` as the representative result when the same text segment appears with different content metadata;
- adds regression coverage for the corrected equality contract and unchanged RRF output semantics;
- updates the relevant Javadocs.

There are no public API signature changes. The `DefaultContent` equality behavior changes intentionally as requested by this issue; RRF deduplication and ranking behavior remain compatible.

## General checklist
- [ ] There are no breaking changes (API, behaviour) — no API changes, but `DefaultContent` equality intentionally changes to include metadata
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — relevant Javadocs updated
- [ ] I have added an example in the examples repo (not applicable)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)

## Verification

- `.\mvnw.cmd -pl langchain4j-core clean test` — 1,211 tests, 0 failures, 0 errors
- `.\mvnw.cmd -pl langchain4j-core,langchain4j test` — core 1,211 tests + main 1,278 tests, 0 failures, 0 errors
- `.\mvnw.cmd -pl langchain4j-core spotless:check`
- `git diff --check`

## AI assistance disclosure

This contribution was prepared with AI coding assistance under the contributor's direction. The contributor reviewed the final diff and validation results.