### PR TITLE
docs: Fix broken example link and non-existent method in Couchbase docs

### DIFF
--- a/docs/docs/integrations/embedding-stores/couchbase.md
+++ b/docs/docs/integrations/embedding-stores/couchbase.md
@@ -24,7 +24,7 @@ https://www.couchbase.com/
 
 ## Examples
 
-- [CouchbaseEmbeddingStoreExample](https://github.com/langchain4j/langchain4j-examples/blob/main/couchbase-example/src/main/java/CouchbaseEmbeddingStoreExample.java)
+- [CouchbaseEmbeddingSearchExample](https://github.com/langchain4j/langchain4j-examples/blob/main/couchbase-example/src/main/java/CouchbaseEmbeddingSearchExample.java)
 
 ## Couchbase Embedding Store
 Couchbase langchain4j integration stores each embedding in a separate document and uses an FTS vector index to perform
@@ -151,7 +151,7 @@ System.out.println(embeddingMatch.embedded().text()); // I like football.
 ## Deleting Embeddings
 Couchbase embedding store also supports removing embeddings by their identifiers, for example:
 ```java
-embeddingStore.remove(embeddingMatch.id())
+embeddingStore.remove(embeddingMatch.embeddingId());
 ```
 
 Or, to remove all embeddings:


### PR DESCRIPTION
## Issue
Documentation-only fix; no issue filed.

## Change
`docs/docs/integrations/embedding-stores/couchbase.md` has two dead references; two lines change.

- Line 27: the "Examples" link points at `CouchbaseEmbeddingStoreExample.java`, which does not exist in the examples repo, so the link 404s. The only file in `couchbase-example/src/main/java` is `CouchbaseEmbeddingSearchExample.java`; link target and display text now use that name, matching `chroma.md:27` and `qdrant.md:28`.
- Line 154: the "Deleting Embeddings" snippet calls `embeddingMatch.id()`, which `EmbeddingMatch` does not declare, so it does not compile when copied. `embeddingId()` (`EmbeddingMatch.java:52`) returns `String`, the argument type of `EmbeddingStore.remove(String)`.

```java
embeddingStore.remove(embeddingMatch.embeddingId());
```

## Build/test notes
No tests and no Maven or spotless run: the diff is Markdown under `docs/`, with no runtime behaviour. Verified with `gh api` instead — in the examples repo `CouchbaseEmbeddingStoreExample.java` returns 404 and `CouchbaseEmbeddingSearchExample.java` returns 200 — and against `EmbeddingMatch`, whose only accessors are `score()`, `embeddingId()`, `embedding()`, `embedded()`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change <!-- N/A - documentation-only change, no runtime behaviour to test -->
- [ ] The tests cover both positive and negative cases <!-- N/A - no tests added -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- Not done - no module code changed; build skipped for a Markdown-only diff -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- Not done - no module code changed; build skipped for a Markdown-only diff -->
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A - this PR only fixes a link to an example that already exists there -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A - no starter is affected by a docs page fix -->

<!-- Sections omitted: "adding new maven module", "adding new embedding store integration" and "changing existing embedding store integration" - this PR adds no module, adds no integration, and changes no embedding store code. -->
