### PR TITLE
fix: Default ElasticsearchContentRetriever maxResults to 3 as documented

### DIFF
--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 public class ElasticsearchContentRetriever extends AbstractElasticsearchEmbeddingStore implements ContentRetriever {
 
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchContentRetriever.class);
+    private static final int DEFAULT_MAX_RESULTS = 3;
     private final EmbeddingModel embeddingModel;
     private final int maxResults;
     private final double minScore;
@@ -152,7 +153,7 @@ public class ElasticsearchContentRetriever extends AbstractElasticsearchEmbeddin
         private ElasticsearchConfiguration configuration =
                 ElasticsearchConfigurationKnn.builder().build();
         private EmbeddingModel embeddingModel;
-        private int maxResults;
+        private int maxResults = DEFAULT_MAX_RESULTS;
         private double minScore;
         private Filter filter;
 

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverDefaultMaxResultsTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverDefaultMaxResultsTest.java
@@ -1,0 +1,123 @@
+package dev.langchain4j.rag.content.retriever.elasticsearch;
+
+import static co.elastic.clients.elasticsearch.core.search.TotalHitsRelation.Eq;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.DefaultTransportOptions;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.elasticsearch.Document;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchContentRetrieverDefaultMaxResultsTest {
+
+    /**
+     * The documentation states that {@code maxResults} defaults to 3 and that a builder without it
+     * is equivalent to one calling {@code maxResults(3)}. Leaving the field at the {@code int}
+     * default of 0 instead made that documented call fail, because
+     * {@code EmbeddingSearchRequest} rejects a non-positive {@code maxResults}.
+     */
+    @Test
+    void should_default_max_results_to_three_when_not_set() {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchClient client = new ElasticsearchClient(transport);
+
+        ElasticsearchContentRetriever retriever = ElasticsearchContentRetriever.builder()
+                .client(client)
+                .indexName("test")
+                .embeddingModel(new FixedEmbeddingModel())
+                .build();
+
+        retriever.retrieve(Query.from("any query"));
+
+        assertThat(transport.capturedRequest.size()).isEqualTo(3);
+    }
+
+    @Test
+    void should_use_max_results_when_set() {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchClient client = new ElasticsearchClient(transport);
+
+        ElasticsearchContentRetriever retriever = ElasticsearchContentRetriever.builder()
+                .client(client)
+                .indexName("test")
+                .embeddingModel(new FixedEmbeddingModel())
+                .maxResults(7)
+                .build();
+
+        retriever.retrieve(Query.from("any query"));
+
+        assertThat(transport.capturedRequest.size()).isEqualTo(7);
+    }
+
+    private static class FixedEmbeddingModel implements EmbeddingModel {
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+            return Response.from(textSegments.stream()
+                    .map(ignored -> Embedding.from(new float[] {0.1f, 0.2f}))
+                    .toList());
+        }
+    }
+
+    private static class CapturingTransport implements ElasticsearchTransport {
+
+        private final JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+        private SearchRequest capturedRequest;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            capturedRequest = (SearchRequest) request;
+            Hit<Document> hit = Hit.of(h -> h.index("test")
+                    .id("1")
+                    .score(1.0)
+                    .source(Document.builder()
+                            .vector(new float[] {0.1f, 0.2f})
+                            .text("hello")
+                            .metadata(Map.of())
+                            .build()));
+            SearchResponse<Document> response = SearchResponse.of(sr -> sr.took(0)
+                    .timedOut(false)
+                    .shards(s -> s.total(1).successful(1).failed(0))
+                    .hits(h -> h.total(t -> t.value(1).relation(Eq)).hits(singletonList(hit))));
+            return (ResponseT) response;
+        }
+
+        @Override
+        public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            return CompletableFuture.completedFuture(performRequest(request, endpoint, options));
+        }
+
+        @Override
+        public JsonpMapper jsonpMapper() {
+            return jsonpMapper;
+        }
+
+        @Override
+        public TransportOptions options() {
+            return DefaultTransportOptions.EMPTY;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5931

## Change

`ElasticsearchContentRetriever.Builder` declares `maxResults` as a primitive `int`, so it stays `0` when the caller does not set it. `retrieve()` passes that `0` to `EmbeddingSearchRequest`, which rejects non-positive values, so the documented minimal example throws `IllegalArgumentException: maxResults must be greater than zero, but is: 0`.

`EmbeddingSearchRequest` cannot supply its own default of 3 here, because `getOrDefault` only substitutes `null` and a primitive `int` is never `null`.

This initialises the builder field instead:

```java
private static final int DEFAULT_MAX_RESULTS = 3;
...
private int maxResults = DEFAULT_MAX_RESULTS;
```

The value matches what the [documentation](https://docs.langchain4j.dev/integrations/embedding-stores/elasticsearch) already states ("Default is `3`") and what `EmbeddingSearchRequest` uses. The retriever and that documentation both arrived in #4069; only the code side was missing.

The public constructors are untouched, so an explicitly passed `maxResults` still wins.

## Testing

`ElasticsearchContentRetrieverDefaultMaxResultsTest` captures the outgoing `SearchRequest` through a stub `ElasticsearchTransport`, following the existing `ElasticsearchContentRetrieverMinScoreTest`. No Elasticsearch instance is required.

- omitting `maxResults` sends `size=3` (fails on `main` with the exception above)
- setting `maxResults(7)` still sends `size=7`

All 5 module unit tests are green on JDK 17. The `*IT` classes need a live Elasticsearch (Testcontainers) and were not run or modified.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
      <!-- Left unchecked deliberately: the API is unchanged, but the observable behaviour is. A builder without maxResults used to throw and now returns 3 results, which is what the documentation already promised. -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
      <!-- Unit tests only; the *IT classes require a live Elasticsearch. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
      <!-- Neither module is touched. langchain4j-core was built and tested as a dependency of this module and is green; the langchain4j module was not run. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
      <!-- N/A — the documentation already describes this default; the code now matches it. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
      <!-- N/A — not a feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
      <!-- N/A — no starter exposes this builder field. -->

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
      <!-- N/A — no stored data format or query semantics change; only an unset builder default. -->

---

