### PR TITLE
fix: Render non-String metadata values in DefaultContentInjector

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/DefaultContentInjector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/DefaultContentInjector.java
@@ -44,8 +44,7 @@ import java.util.Map;
  */
 public class DefaultContentInjector implements ContentInjector {
 
-    public static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = PromptTemplate.from(
-            """
+    public static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = PromptTemplate.from("""
                     {{userMessage}}
 
                     Answer using the following information:
@@ -117,9 +116,10 @@ public class DefaultContentInjector implements ContentInjector {
     }
 
     protected String format(Metadata metadata) {
+        Map<String, Object> metadataMap = metadata.toMap();
         StringBuilder formattedMetadata = new StringBuilder();
         for (String metadataKey : metadataKeysToInclude) {
-            String metadataValue = metadata.getString(metadataKey);
+            Object metadataValue = metadataMap.get(metadataKey);
             if (metadataValue != null) {
                 if (!formattedMetadata.isEmpty()) {
                     formattedMetadata.append("\n");

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/DefaultContentInjectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/DefaultContentInjectorTest.java
@@ -1,23 +1,23 @@
 package dev.langchain4j.rag.content.injector;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.rag.content.Content;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultContentInjectorTest {
 
@@ -54,10 +54,9 @@ class DefaultContentInjectorTest {
         // then
         assertThat(injected.singleText()).isEqualTo("""
                 Tell me about bananas.
-                
+
                 Answer using the following information:
-                Bananas are awesome!""".stripIndent()
-        );
+                Bananas are awesome!""".stripIndent());
     }
 
     @Test
@@ -73,13 +72,11 @@ class DefaultContentInjectorTest {
         UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
 
         // then
-        assertThat(injected.singleText()).isEqualTo(
-                """
+        assertThat(injected.singleText()).isEqualTo("""
                         Tell me about bananas.
-                        
+
                         Answer using the following information:
-                        Bananas are awesome!"""
-        );
+                        Bananas are awesome!""");
         assertThat(injected.name()).isEqualTo("ape");
     }
 
@@ -89,10 +86,7 @@ class DefaultContentInjectorTest {
         // given
         UserMessage userMessage = UserMessage.from("Tell me about bananas.");
 
-        TextSegment segment = TextSegment.from(
-                "Bananas are awesome!",
-                Metadata.from("source", "trust me bro")
-        );
+        TextSegment segment = TextSegment.from("Bananas are awesome!", Metadata.from("source", "trust me bro"));
         List<Content> contents = singletonList(Content.from(segment));
 
         List<String> metadataKeysToInclude = singletonList("source");
@@ -103,14 +97,75 @@ class DefaultContentInjectorTest {
         UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
 
         // then
-        assertThat(injected.singleText()).isEqualTo(
-                """
+        assertThat(injected.singleText()).isEqualTo("""
                         Tell me about bananas.
-                        
+
                         Answer using the following information:
                         content: Bananas are awesome!
-                        source: trust me bro"""
-        );
+                        source: trust me bro""");
+    }
+
+    @Test
+    void should_inject_single_content_with_non_string_metadata() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Tell me about bananas.");
+
+        UUID documentId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        TextSegment segment = TextSegment.from(
+                "Bananas are awesome!",
+                Metadata.from("source", "trust me bro")
+                        .put("documentId", documentId)
+                        .put("page", 12)
+                        .put("size", 1024L)
+                        .put("score", 0.5f)
+                        .put("relevance", 0.25d));
+        List<Content> contents = singletonList(Content.from(segment));
+
+        List<String> metadataKeysToInclude = asList("source", "documentId", "page", "size", "score", "relevance");
+
+        ContentInjector injector = new DefaultContentInjector(metadataKeysToInclude);
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+                        Tell me about bananas.
+
+                        Answer using the following information:
+                        content: Bananas are awesome!
+                        source: trust me bro
+                        documentId: 11111111-2222-3333-4444-555555555555
+                        page: 12
+                        size: 1024
+                        score: 0.5
+                        relevance: 0.25""");
+    }
+
+    @Test
+    void should_skip_metadata_keys_that_are_absent() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Tell me about bananas.");
+
+        TextSegment segment = TextSegment.from("Bananas are awesome!", Metadata.from("source", "trust me bro"));
+        List<Content> contents = singletonList(Content.from(segment));
+
+        List<String> metadataKeysToInclude = asList("source", "page");
+
+        ContentInjector injector = new DefaultContentInjector(metadataKeysToInclude);
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+                        Tell me about bananas.
+
+                        Answer using the following information:
+                        content: Bananas are awesome!
+                        source: trust me bro""");
     }
 
     @Test
@@ -119,10 +174,7 @@ class DefaultContentInjectorTest {
         // given
         UserMessage userMessage = UserMessage.from("Tell me about bananas.");
 
-        List<Content> contents = asList(
-                Content.from("Bananas are awesome!"),
-                Content.from("Bananas are healthy!")
-        );
+        List<Content> contents = asList(Content.from("Bananas are awesome!"), Content.from("Bananas are healthy!"));
 
         ContentInjector injector = new DefaultContentInjector();
 
@@ -130,36 +182,27 @@ class DefaultContentInjectorTest {
         UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
 
         // then
-        assertThat(injected.singleText()).isEqualTo(
-                """
+        assertThat(injected.singleText()).isEqualTo("""
                         Tell me about bananas.
-                        
+
                         Answer using the following information:
                         Bananas are awesome!
-                        
-                        Bananas are healthy!"""
-        );
+
+                        Bananas are healthy!""");
     }
 
     @ParameterizedTest
     @MethodSource
     void should_inject_multiple_contents_with_multiple_metadata_entries(
-            Function<List<String>, ContentInjector> contentInjectorProvider
-    ) {
+            Function<List<String>, ContentInjector> contentInjectorProvider) {
 
         // given
         UserMessage userMessage = UserMessage.from("Tell me about bananas.");
 
         TextSegment segment1 = TextSegment.from(
-                "Bananas are awesome!",
-                Metadata.from("source", "trust me bro")
-                        .put("date", "today")
-        );
+                "Bananas are awesome!", Metadata.from("source", "trust me bro").put("date", "today"));
         TextSegment segment2 = TextSegment.from(
-                "Bananas are healthy!",
-                Metadata.from("source", "my doctor")
-                        .put("reliability", "100%")
-        );
+                "Bananas are healthy!", Metadata.from("source", "my doctor").put("reliability", "100%"));
         List<Content> contents = asList(Content.from(segment1), Content.from(segment2));
 
         List<String> metadataKeysToInclude = asList("source", "reliability", "date");
@@ -170,32 +213,26 @@ class DefaultContentInjectorTest {
         UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
 
         // then
-        assertThat(injected.singleText()).isEqualTo(
-                """
+        assertThat(injected.singleText()).isEqualTo("""
                         Tell me about bananas.
-                        
+
                         Answer using the following information:
                         content: Bananas are awesome!
                         source: trust me bro
                         date: today
-                        
+
                         content: Bananas are healthy!
                         source: my doctor
-                        reliability: 100%"""
-        );
+                        reliability: 100%""");
     }
 
     static Stream<Arguments> should_inject_multiple_contents_with_multiple_metadata_entries() {
         return Stream.<Arguments>builder()
-                .add(Arguments.of(
-                        (Function<List<String>, ContentInjector>) DefaultContentInjector::new
-                ))
-                .add(Arguments.of(
-                        (Function<List<String>, ContentInjector>)
-                                (metadataKeysToInclude) -> DefaultContentInjector.builder()
-                                        .metadataKeysToInclude(metadataKeysToInclude)
-                                        .build()
-                ))
+                .add(Arguments.of((Function<List<String>, ContentInjector>) DefaultContentInjector::new))
+                .add(Arguments.of((Function<List<String>, ContentInjector>)
+                        (metadataKeysToInclude) -> DefaultContentInjector.builder()
+                                .metadataKeysToInclude(metadataKeysToInclude)
+                                .build()))
                 .build();
     }
 
@@ -208,36 +245,27 @@ class DefaultContentInjectorTest {
         PromptTemplate promptTemplate = PromptTemplate.from("{{userMessage}}\n{{contents}}");
 
         UserMessage userMessage = UserMessage.from("Tell me about bananas.");
-        List<Content> contents = asList(
-                Content.from("Bananas are awesome!"),
-                Content.from("Bananas are healthy!")
-        );
+        List<Content> contents = asList(Content.from("Bananas are awesome!"), Content.from("Bananas are healthy!"));
         ContentInjector injector = contentInjectorProvider.apply(promptTemplate);
 
         // when
         UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
 
         // then
-        assertThat(injected.singleText()).isEqualTo(
-                """
+        assertThat(injected.singleText()).isEqualTo("""
                         Tell me about bananas.
                         Bananas are awesome!
-                        
-                        Bananas are healthy!"""
-        );
+
+                        Bananas are healthy!""");
     }
 
     static Stream<Arguments> should_inject_multiple_contents_with_custom_prompt_template() {
         return Stream.<Arguments>builder()
+                .add(Arguments.of((Function<PromptTemplate, ContentInjector>) DefaultContentInjector::new))
                 .add(Arguments.of(
-                        (Function<PromptTemplate, ContentInjector>) DefaultContentInjector::new
-                ))
-                .add(Arguments.of(
-                        (Function<PromptTemplate, ContentInjector>)
-                                (promptTemplate) -> DefaultContentInjector.builder()
-                                        .promptTemplate(promptTemplate)
-                                        .build()
-                ))
+                        (Function<PromptTemplate, ContentInjector>) (promptTemplate) -> DefaultContentInjector.builder()
+                                .promptTemplate(promptTemplate)
+                                .build()))
                 .build();
     }
 }


### PR DESCRIPTION
## Issue

Closes #5933

## Change

`DefaultContentInjector.format(Metadata)` read values with `Metadata.getString(key)`, which throws for any non-`String` value. `Metadata` officially supports `UUID`, `int`, `long`, `float` and `double`, so listing such a key in `metadataKeysToInclude` made the whole RAG augmentation fail with a `RuntimeException`.

This is a regression from #2505 (`d755ae57d6`), which replaced the deprecated `metadata.get(key)` — it returned `value.toString()` — with `metadata.getString(key)`. Non-String metadata rendered correctly before that commit, and no existing test pins the current exception behaviour.

The fix reads the raw map instead, mirroring `IsEqualTo` and the other metadata filters:

```java
Map<String, Object> metadataMap = metadata.toMap();
Object metadataValue = metadataMap.get(metadataKey);
```

`StringBuilder.append(Object)` renders `String` values exactly as before, so existing output is unchanged.

Reachability: `metadataKeysToInclude` is empty by default, so this needs opt-in configuration. It is a documented builder option, and LangChain4j itself produces non-String metadata — `GcsSource.getMetadataForBlob()` stores `size` as a `long`.

Two tests were added to `DefaultContentInjectorTest`: `UUID`/`int`/`long`/`float`/`double` values render, and absent keys are still skipped. Everything else in the diff of both files is automatic `spotless:apply` reformatting, which the CI ratchet requires once a file is touched.

## General checklist

- [X] There are no breaking changes (API, behaviour)
    The only behaviour change is the fix itself: non-String values render instead of throwing, restoring the pre-#2505 behaviour. String rendering is byte-identical.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
    Unit tests only: `./mvnw -pl langchain4j-core -am clean test` passed (1212 tests). Integration tests were not run because they require provider API keys.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
    Unit tests only: `./mvnw -pl langchain4j-core,langchain4j clean test` passed (2490 tests). Integration tests were not run for the same reason.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
    Not done, per the template note to wait until the PR is reviewed and approved.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
    Not done: this is a small bug fix, not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
    Not applicable: no Spring Boot starter exposes this code path, and no configuration property changed.

<!-- The "new maven module" and "embedding store integration" checklists are omitted: this PR adds no module and touches no embedding store. -->

