### PR TITLE
fix: Repair toBuilder() copy constructors in observability events

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/AiServiceCompletedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/AiServiceCompletedEvent.java
@@ -50,7 +50,7 @@ public interface AiServiceCompletedEvent extends AiServiceEvent {
          */
         protected AiServiceCompletedEventBuilder(AiServiceCompletedEvent src) {
             super(src);
-            result(src.result());
+            result(src.result().orElse(null));
         }
 
         /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/ToolExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/ToolExecutedEvent.java
@@ -6,7 +6,6 @@ import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.observability.event.DefaultToolExecutedEvent;
-
 import java.util.List;
 
 /**
@@ -70,7 +69,6 @@ public interface ToolExecutedEvent extends AiServiceEvent {
         protected ToolExecutedEventBuilder(ToolExecutedEvent src) {
             super(src);
             request(src.request());
-            resultText(src.resultText());
             resultContents(src.resultContents());
         }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/observability/api/event/AiServiceCompletedEventTests.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/observability/api/event/AiServiceCompletedEventTests.java
@@ -1,0 +1,52 @@
+package dev.langchain4j.observability.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.invocation.InvocationContext;
+import org.junit.jupiter.api.Test;
+
+class AiServiceCompletedEventTests {
+
+    private static final InvocationContext INVOCATION_CONTEXT = InvocationContext.builder()
+            .interfaceName("SomeInterface")
+            .methodName("someMethod")
+            .build();
+
+    @Test
+    void toBuilderRoundTripsPresentResult() {
+        final AiServiceCompletedEvent event = AiServiceCompletedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .result("hello")
+                .build();
+
+        final AiServiceCompletedEvent copy = event.toBuilder().build();
+
+        assertThat(copy.invocationContext()).isEqualTo(event.invocationContext());
+        assertThat(copy.result()).contains("hello");
+    }
+
+    @Test
+    void toBuilderRoundTripsAbsentResult() {
+        final AiServiceCompletedEvent event = AiServiceCompletedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .build();
+
+        final AiServiceCompletedEvent copy = event.toBuilder().build();
+
+        assertThat(event.result()).isEmpty();
+        assertThat(copy.result()).isEmpty();
+    }
+
+    @Test
+    void toBuilderAllowsOverridingResult() {
+        final AiServiceCompletedEvent event = AiServiceCompletedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .result("hello")
+                .build();
+
+        final AiServiceCompletedEvent copy = event.toBuilder().result("bye").build();
+
+        assertThat(copy.result()).contains("bye");
+        assertThat(event.result()).contains("hello");
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/observability/api/event/ToolExecutedEventTests.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/observability/api/event/ToolExecutedEventTests.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.observability.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.invocation.InvocationContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ToolExecutedEventTests {
+
+    private static final InvocationContext INVOCATION_CONTEXT = InvocationContext.builder()
+            .interfaceName("SomeInterface")
+            .methodName("someMethod")
+            .build();
+
+    private static final ToolExecutionRequest TOOL_EXECUTION_REQUEST =
+            ToolExecutionRequest.builder().name("someTool").arguments("{}").build();
+
+    @Test
+    void toBuilderRoundTripsEventBuiltFromResultText() {
+        final ToolExecutedEvent event = ToolExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .request(TOOL_EXECUTION_REQUEST)
+                .resultText("ok")
+                .build();
+
+        final ToolExecutedEvent copy = event.toBuilder().build();
+
+        assertThat(copy.invocationContext()).isEqualTo(event.invocationContext());
+        assertThat(copy.request()).isEqualTo(event.request());
+        assertThat(copy.resultText()).isEqualTo("ok");
+        assertThat(copy.resultContents()).isEqualTo(event.resultContents());
+    }
+
+    @Test
+    void toBuilderRoundTripsEventBuiltFromResultContents() {
+        final List<Content> resultContents =
+                List.of(TextContent.from("look"), ImageContent.from("http://localhost/image.png"));
+
+        final ToolExecutedEvent event = ToolExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .request(TOOL_EXECUTION_REQUEST)
+                .resultContents(resultContents)
+                .build();
+
+        final ToolExecutedEvent copy = event.toBuilder().build();
+
+        assertThat(copy.invocationContext()).isEqualTo(event.invocationContext());
+        assertThat(copy.request()).isEqualTo(event.request());
+        assertThat(copy.resultContents()).isEqualTo(resultContents);
+    }
+
+    @Test
+    void toBuilderAllowsOverridingResultContents() {
+        final ToolExecutedEvent event = ToolExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .request(TOOL_EXECUTION_REQUEST)
+                .resultText("ok")
+                .build();
+
+        final ToolExecutedEvent copy = event.toBuilder()
+                .resultContents(List.of(TextContent.from("changed")))
+                .build();
+
+        assertThat(copy.resultText()).isEqualTo("changed");
+        assertThat(event.resultText()).isEqualTo("ok");
+    }
+
+    @Test
+    void buildStillRejectsBothResultTextAndResultContents() {
+        assertThatThrownBy(() -> ToolExecutedEvent.builder()
+                        .invocationContext(INVOCATION_CONTEXT)
+                        .request(TOOL_EXECUTION_REQUEST)
+                        .resultText("ok")
+                        .resultContents(List.of(TextContent.from("ok")))
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("resultText and resultContents are mutually exclusive");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5934

## Change

Two `toBuilder()` copy constructors in `observability/api/event/` cannot reconstruct their source event. One defect class, two one-line fixes.

`ToolExecutedEvent.toBuilder()` always throws. Its copy constructor sets both `resultText` and `resultContents`, which `DefaultToolExecutedEvent` rejects as mutually exclusive. This is a regression from #4851 (`8ff282f12`), which added the `resultContents` line without removing the existing `resultText` line; the copy constructor before it worked. That PR declared no breaking changes, so this restores prior behaviour rather than changing a contract.

`AiServiceCompletedEvent.toBuilder()` passes `src.result()` (an `Optional`) into the `Object` setter, so the round trip returns `Optional[Optional[...]]` and an absent result flips to present. The fix mirrors the sibling `AiServiceStartedEvent`, which already unwraps with `orElse(null)`.

```java
// ToolExecutedEvent
 request(src.request());
-resultText(src.resultText());
 resultContents(src.resultContents());

// AiServiceCompletedEvent
-result(src.result());
+result(src.result().orElse(null));
```

Reachability: `AiServiceEvent` documents `toBuilder()` as allowing "modification of the existing properties and reconstruction of the event". Product code builds these exact objects and fires them to user listeners (`ToolService.java:839`, `AiServiceStreamingResponseHandler.java:252,259`, `DefaultAiServices.java:453`), so a listener holding one cannot call `toBuilder()` at all.

No existing test pins the current behaviour. Seven new tests cover both round trips and confirm the mutual-exclusion check still rejects both fields.

`spotless:apply` also removed one blank line between the imports of `ToolExecutedEvent.java` — the only formatting-only change.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
    All unit tests in `langchain4j-core` pass (1217 tests, 0 failures). Integration tests (`*IT`) were not run because they require API keys.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
    All unit tests in `langchain4j-core` and `langchain4j` pass (2495 tests, 0 failures). Integration tests (`*IT`) were not run because they require API keys.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
    No documentation change: the public API and its documented behaviour are unchanged.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
    Not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
    Not applicable: no configuration surface changed.

<!-- The "new maven module", "new embedding store integration" and "changing existing embedding store integration" sections are omitted: this is neither a new module nor an embedding store change. -->

