### PR TITLE
fix: Correct mislabeled safeSearch field in WebSearchRequest toString

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/web/search/WebSearchRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/web/search/WebSearchRequest.java
@@ -1,11 +1,11 @@
 package dev.langchain4j.web.search;
 
-import java.util.Map;
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a search request that can be made by the user to perform searches in any implementation of {@link WebSearchEngine}.
@@ -39,14 +39,14 @@ public class WebSearchRequest {
     private final Boolean safeSearch;
     private final Map<String, Object> additionalParams;
 
-    private WebSearchRequest(Builder builder){
-        this.searchTerms = ensureNotBlank(builder.searchTerms,"searchTerms");
+    private WebSearchRequest(Builder builder) {
+        this.searchTerms = ensureNotBlank(builder.searchTerms, "searchTerms");
         this.maxResults = builder.maxResults;
         this.language = builder.language;
         this.geoLocation = builder.geoLocation;
-        this.startPage = getOrDefault(builder.startPage,1);
+        this.startPage = getOrDefault(builder.startPage, 1);
         this.startIndex = builder.startIndex;
-        this.safeSearch = getOrDefault(builder.safeSearch,true);
+        this.safeSearch = getOrDefault(builder.safeSearch, true);
         this.additionalParams = copy(builder.additionalParams);
     }
 
@@ -125,11 +125,10 @@ public class WebSearchRequest {
     @Override
     public boolean equals(Object another) {
         if (this == another) return true;
-        return another instanceof WebSearchRequest wsr
-                && equalTo(wsr);
+        return another instanceof WebSearchRequest wsr && equalTo(wsr);
     }
 
-    private boolean equalTo(WebSearchRequest another){
+    private boolean equalTo(WebSearchRequest another) {
         return Objects.equals(searchTerms, another.searchTerms)
                 && Objects.equals(maxResults, another.maxResults)
                 && Objects.equals(language, another.language)
@@ -156,16 +155,15 @@ public class WebSearchRequest {
 
     @Override
     public String toString() {
-        return "WebSearchRequest{" +
-                "searchTerms='" + searchTerms + '\'' +
-                ", maxResults=" + maxResults +
-                ", language='" + language + '\'' +
-                ", geoLocation='" + geoLocation + '\'' +
-                ", startPage=" + startPage +
-                ", startIndex=" + startIndex +
-                ", siteRestrict=" + safeSearch +
-                ", additionalParams=" + additionalParams +
-                '}';
+        return "WebSearchRequest{" + "searchTerms='"
+                + searchTerms + '\'' + ", maxResults="
+                + maxResults + ", language='"
+                + language + '\'' + ", geoLocation='"
+                + geoLocation + '\'' + ", startPage="
+                + startPage + ", startIndex="
+                + startIndex + ", safeSearch="
+                + safeSearch + ", additionalParams="
+                + additionalParams + '}';
     }
 
     /**
@@ -188,8 +186,7 @@ public class WebSearchRequest {
         private Boolean safeSearch;
         private Map<String, Object> additionalParams;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         /**
          * Set the search terms.
@@ -307,6 +304,9 @@ public class WebSearchRequest {
      * @return The web search request.
      */
     public static WebSearchRequest from(String searchTerms, Integer maxResults) {
-        return WebSearchRequest.builder().searchTerms(searchTerms).maxResults(maxResults).build();
+        return WebSearchRequest.builder()
+                .searchTerms(searchTerms)
+                .maxResults(maxResults)
+                .build();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/web/search/WebSearchRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/web/search/WebSearchRequestTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.web.search;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class WebSearchRequestTest {
@@ -22,7 +23,7 @@ class WebSearchRequestTest {
 
         assertThat(webSearchRequest)
                 .hasToString(
-                        "WebSearchRequest{searchTerms='query', maxResults=null, language='null', geoLocation='null', startPage=1, startIndex=null, siteRestrict=true, additionalParams={}}");
+                        "WebSearchRequest{searchTerms='query', maxResults=null, language='null', geoLocation='null', startPage=1, startIndex=null, safeSearch=true, additionalParams={}}");
     }
 
     @Test
@@ -41,7 +42,7 @@ class WebSearchRequestTest {
 
         assertThat(webSearchRequest)
                 .hasToString(
-                        "WebSearchRequest{searchTerms='query', maxResults=null, language='null', geoLocation='null', startPage=1, startIndex=null, siteRestrict=true, additionalParams={}}");
+                        "WebSearchRequest{searchTerms='query', maxResults=null, language='null', geoLocation='null', startPage=1, startIndex=null, safeSearch=true, additionalParams={}}");
     }
 
     @Test
@@ -59,7 +60,7 @@ class WebSearchRequestTest {
 
         assertThat(webSearchRequest)
                 .hasToString(
-                        "WebSearchRequest{searchTerms='query', maxResults=10, language='null', geoLocation='null', startPage=1, startIndex=null, siteRestrict=true, additionalParams={}}");
+                        "WebSearchRequest{searchTerms='query', maxResults=10, language='null', geoLocation='null', startPage=1, startIndex=null, safeSearch=true, additionalParams={}}");
     }
 
     @Test
@@ -78,7 +79,32 @@ class WebSearchRequestTest {
 
         assertThat(webSearchRequest)
                 .hasToString(
-                        "WebSearchRequest{searchTerms='query', maxResults=10, language='null', geoLocation='null', startPage=1, startIndex=null, siteRestrict=true, additionalParams={}}");
+                        "WebSearchRequest{searchTerms='query', maxResults=10, language='null', geoLocation='null', startPage=1, startIndex=null, safeSearch=true, additionalParams={}}");
+    }
+
+    @Test
+    void should_label_every_field_in_toString_with_its_own_name() {
+        WebSearchRequest webSearchRequest = WebSearchRequest.builder()
+                .searchTerms("query")
+                .maxResults(10)
+                .language("en")
+                .geoLocation("us")
+                .startPage(2)
+                .startIndex(3)
+                .safeSearch(false)
+                .additionalParams(Map.of("key", "value"))
+                .build();
+
+        assertThat(webSearchRequest.toString())
+                .contains("searchTerms='query'")
+                .contains("maxResults=10")
+                .contains("language='en'")
+                .contains("geoLocation='us'")
+                .contains("startPage=2")
+                .contains("startIndex=3")
+                .contains("safeSearch=false")
+                .contains("additionalParams={key=value}")
+                .doesNotContain("siteRestrict=");
     }
 
     @Test


### PR DESCRIPTION
## Issue

Closes #5935

## Change

`WebSearchRequest.toString()` printed the `safeSearch` field under the label `siteRestrict`. This class has no `siteRestrict` field, getter, or builder method. `siteRestrict` is a separate, real option in `langchain4j-web-search-engine-google-custom`, so a public value object was reporting a field name that does not exist on it.

```java
-                ", siteRestrict=" + safeSearch +
+                ", safeSearch=" + safeSearch +
```

Four `hasToString(...)` assertions in `WebSearchRequestTest` were updated. They were not changed to make the build green: with only the production line fixed, that test reports `Tests run: 6, Failures: 4`; after updating the four assertions, all pass. They were implementation snapshots rather than a contract - the same test calls `assertThat(webSearchRequest.safeSearch()).isTrue()` one line before asserting `siteRestrict=true`.

This is not a breaking change: no Javadoc documents the `toString()` format, and no code in the repository parses this string. The line is unchanged since `d28f5ab47` (#642).

One test was added that pins every label in `toString()` to its own field name.

`spotless:apply` reformatted `WebSearchRequest.java` as a whole (23 insertions / 23 deletions): the file was not in palantir format before, and the ratchet covers any touched file.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
    The added test asserts both the expected labels and the absence of the old one.
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
    Unit tests only: `./mvnw -pl langchain4j-core -am clean test` passed (1211 tests). Integration tests (`*IT`) were not run because they require API keys.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
    Unit tests only: `./mvnw -pl langchain4j-core,langchain4j clean test` passed (2489 tests). Integration tests were not run for the same reason.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
    No documentation change: the `toString()` output is not documented anywhere.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
    Not applicable: this is a one-line bug fix, not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
    Not applicable: no configuration or starter surface is affected.

<!-- The "new maven module", "new embedding store integration", and "changing existing embedding store integration" checklists were omitted: this PR adds no module and touches no embedding store. -->

