### PR TITLE
Surface parallel agent failures as AgentInvocationException

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -329,8 +329,7 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
             return;
         }
         crossAgentCompensationEnabled = true;
-        subagents.stream().map(InternalAgent.class::cast)
-                .forEach(InternalAgent::enableCrossAgentCompensation);
+        subagents.stream().map(InternalAgent.class::cast).forEach(InternalAgent::enableCrossAgentCompensation);
     }
 
     @Override
@@ -492,7 +491,14 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             } catch (ExecutionException e) {
-                throw new RuntimeException(e);
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException runtimeException) {
+                    throw runtimeException;
+                }
+                if (cause instanceof Error error) {
+                    throw error;
+                }
+                throw new RuntimeException(cause);
             }
         }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ParallelAgentExceptionParityTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ParallelAgentExceptionParityTest.java
@@ -1,0 +1,103 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import dev.langchain4j.agentic.agent.AgentInvocationException;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ParallelAgentExceptionParityTest {
+
+    static final Map<String, Object> INPUT = Map.of("topic", "dragons");
+
+    static final ChatModel FAILING_MODEL = new ChatModel() {
+        @Override
+        public ChatResponse chat(ChatRequest chatRequest) {
+            throw new RuntimeException("model failure");
+        }
+    };
+
+    public interface Writer {
+
+        @UserMessage("Write about {{topic}}")
+        @Agent(outputKey = "story")
+        String write(@V("topic") String topic);
+    }
+
+    public interface Reviewer {
+
+        @UserMessage("Review {{topic}}")
+        @Agent(outputKey = "review")
+        String review(@V("topic") String topic);
+    }
+
+    private static ChatModel countingModel(AtomicInteger counter) {
+        return new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                counter.incrementAndGet();
+                return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
+            }
+        };
+    }
+
+    private static Writer writer(ChatModel model) {
+        return AgenticServices.agentBuilder(Writer.class)
+                .chatModel(model)
+                .outputKey("story")
+                .build();
+    }
+
+    private static Reviewer reviewer(ChatModel model) {
+        return AgenticServices.agentBuilder(Reviewer.class)
+                .chatModel(model)
+                .outputKey("review")
+                .build();
+    }
+
+    private static UntypedAgent sequentialWorkflow(ChatModel model) {
+        return AgenticServices.sequenceBuilder()
+                .subAgents(writer(model), reviewer(model))
+                .build();
+    }
+
+    private static UntypedAgent parallelWorkflow(ChatModel model) {
+        return AgenticServices.parallelBuilder()
+                .subAgents(writer(model), reviewer(model))
+                .build();
+    }
+
+    private static Throwable failureOf(UntypedAgent workflow) {
+        return catchThrowable(() -> workflow.invoke(INPUT));
+    }
+
+    @Test
+    void sequential_agent_failure_throws_agentInvocationException() {
+        assertThat(failureOf(sequentialWorkflow(FAILING_MODEL))).isExactlyInstanceOf(AgentInvocationException.class);
+    }
+
+    @Test
+    void parallel_agent_failure_throws_same_type_as_sequential() {
+        assertThat(failureOf(parallelWorkflow(FAILING_MODEL)))
+                .isExactlyInstanceOf(AgentInvocationException.class)
+                .hasSameClassAs(failureOf(sequentialWorkflow(FAILING_MODEL)));
+    }
+
+    @Test
+    void parallel_agents_without_failure_are_all_invoked() {
+        AtomicInteger invocations = new AtomicInteger();
+
+        assertThatCode(() -> parallelWorkflow(countingModel(invocations)).invoke(INPUT))
+                .doesNotThrowAnyException();
+        assertThat(invocations).hasValue(2);
+    }
+}


### PR DESCRIPTION
Closes #5941

## Change

A sub-agent failing in a parallel workflow reached the caller as
`RuntimeException(ExecutionException(AgentInvocationException))`, while the sequential path throws
`AgentInvocationException` directly. So `catch (AgentInvocationException e)` handled a sequence but
missed the equivalent parallel failure.

`PlannerLoop.parallelExecution` blocks on `allOf(tasks).get()`, which reports a failure as
`ExecutionException`, and the catch re-wrapped it in a new `RuntimeException`. It now rethrows the
cause when unchecked, matching the `DelayedResponse.join` helper added for the async path in #5746.
A checked cause cannot be rethrown from an unchecked method and is still wrapped.

`AgentInvocationException` extends `RuntimeException`, so existing `catch (RuntimeException e)` code
is unaffected.

This affects any planner that returns more than one agent for a step: `parallelBuilder`,
`parallelMapper`, `supervisorBuilder`, `plannerBuilder` and custom planners. Workflows that call a
single agent per step are unaffected, since they take the `case 1` branch of `loop()` and never reach
`parallelExecution`.

Notes on scope:

- The `InterruptedException` branch is untouched, so the wait stays interruptible. That is why this
  repeats `join`'s unwrapping rather than calling it: `join()` is not interruptible like `get()`.
  Happy to extract a shared helper if you prefer.
- Cancelling the remaining futures on failure is left out. `CompletableFuture.cancel` does not
  interrupt a task that is already running, so cancelling would let agents keep mutating the
  `AgenticScope` after the exception has propagated. Separate question.
- `spotless:apply` also reformats one pre-existing line (329); `spotless:check` fails without it.

## Build/test notes

`ParallelAgentExceptionParityTest` (offline, stub `ChatModel`): sequential failure type as control,
parallel failure is exactly `AgentInvocationException` and the same class as the sequential one, and
a non-failing parallel workflow still invokes both sub-agents. The parity test fails on main and
passes here; the other two pass either way.

```
mvn -pl langchain4j-agentic clean verify
```

BUILD SUCCESS: 111 unit tests, 0 failures (3 new), plus `spotless:check` and `revapi:check`. The
change is a private method body, so no public API change and no new revapi entry.

```
mvn -o -pl langchain4j-core,langchain4j test
```

1278 tests, 0 failures.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
