### PR TITLE
fix: Add missing Gemini finish reasons to prevent response deserialization failure

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FinishReasonMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FinishReasonMapper.java
@@ -7,10 +7,26 @@ class FinishReasonMapper {
     static FinishReason fromGFinishReasonToFinishReason(GeminiFinishReason geminiFinishReason) {
         return switch (geminiFinishReason) {
             case STOP -> FinishReason.STOP;
-            case BLOCKLIST, PROHIBITED_CONTENT, RECITATION, IMAGE_RECITATION, SPII, SAFETY, LANGUAGE ->
-                FinishReason.CONTENT_FILTER;
+            case BLOCKLIST,
+                    PROHIBITED_CONTENT,
+                    RECITATION,
+                    IMAGE_RECITATION,
+                    IMAGE_SAFETY,
+                    IMAGE_PROHIBITED_CONTENT,
+                    SPII,
+                    SAFETY,
+                    LANGUAGE -> FinishReason.CONTENT_FILTER;
             case MAX_TOKENS -> FinishReason.LENGTH;
-            case MALFORMED_FUNCTION_CALL, FINISH_REASON_UNSPECIFIED, OTHER -> FinishReason.OTHER;
+            case MALFORMED_FUNCTION_CALL,
+                    FINISH_REASON_UNSPECIFIED,
+                    OTHER,
+                    IMAGE_OTHER,
+                    NO_IMAGE,
+                    UNEXPECTED_TOOL_CALL,
+                    TOO_MANY_TOOL_CALLS,
+                    MISSING_THOUGHT_SIGNATURE,
+                    MALFORMED_RESPONSE,
+                    ESCALATION -> FinishReason.OTHER;
         };
     }
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
@@ -30,7 +30,16 @@ record GeminiGenerateContentResponse(
             PROHIBITED_CONTENT,
             SPII,
             MALFORMED_FUNCTION_CALL,
-            IMAGE_RECITATION
+            IMAGE_RECITATION,
+            IMAGE_SAFETY,
+            IMAGE_PROHIBITED_CONTENT,
+            IMAGE_OTHER,
+            NO_IMAGE,
+            UNEXPECTED_TOOL_CALL,
+            TOO_MANY_TOOL_CALLS,
+            MISSING_THOUGHT_SIGNATURE,
+            MALFORMED_RESPONSE,
+            ESCALATION
         }
     }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/FinishReasonMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/FinishReasonMapperTest.java
@@ -26,6 +26,9 @@ class FinishReasonMapperTest {
             GeminiFinishReason.BLOCKLIST,
             GeminiFinishReason.PROHIBITED_CONTENT,
             GeminiFinishReason.RECITATION,
+            GeminiFinishReason.IMAGE_RECITATION,
+            GeminiFinishReason.IMAGE_SAFETY,
+            GeminiFinishReason.IMAGE_PROHIBITED_CONTENT,
             GeminiFinishReason.SPII,
             GeminiFinishReason.SAFETY,
             GeminiFinishReason.LANGUAGE
@@ -42,7 +45,14 @@ class FinishReasonMapperTest {
         GeminiFinishReason[] otherReasons = {
             GeminiFinishReason.MALFORMED_FUNCTION_CALL,
             GeminiFinishReason.FINISH_REASON_UNSPECIFIED,
-            GeminiFinishReason.OTHER
+            GeminiFinishReason.OTHER,
+            GeminiFinishReason.IMAGE_OTHER,
+            GeminiFinishReason.NO_IMAGE,
+            GeminiFinishReason.UNEXPECTED_TOOL_CALL,
+            GeminiFinishReason.TOO_MANY_TOOL_CALLS,
+            GeminiFinishReason.MISSING_THOUGHT_SIGNATURE,
+            GeminiFinishReason.MALFORMED_RESPONSE,
+            GeminiFinishReason.ESCALATION
         };
         for (GeminiFinishReason reason : otherReasons) {
             assertThat(FinishReasonMapper.fromGFinishReasonToFinishReason(reason))
@@ -57,6 +67,27 @@ class FinishReasonMapperTest {
             assertThat(FinishReasonMapper.fromGFinishReasonToFinishReason(reason))
                     .as("mapping for %s", reason)
                     .isNotNull();
+        }
+    }
+
+    @Test
+    void should_deserialize_image_safety_finish_reason() {
+        GeminiGenerateContentResponse response = Json.fromJson(
+                "{\"candidates\":[{\"finishReason\":\"IMAGE_SAFETY\"}]}", GeminiGenerateContentResponse.class);
+
+        assertThat(response.candidates().get(0).finishReason()).hasToString("IMAGE_SAFETY");
+    }
+
+    @Test
+    void should_deserialize_every_gemini_finish_reason() {
+        for (GeminiFinishReason reason : GeminiFinishReason.values()) {
+            GeminiGenerateContentResponse response = Json.fromJson(
+                    "{\"candidates\":[{\"finishReason\":\"" + reason.name() + "\"}]}",
+                    GeminiGenerateContentResponse.class);
+
+            assertThat(response.candidates().get(0).finishReason())
+                    .as("deserialization of %s", reason)
+                    .isEqualTo(reason);
         }
     }
 }


### PR DESCRIPTION
## Issue

Closes #5944

## Change

`GeminiFinishReason` declared 12 constants. The Gemini `v1beta` discovery document (revision `20260803`, `schemas.Candidate.properties.finishReason.enum`) declares 21. A response carrying one of the 9 missing values failed enum deserialization with `InvalidFormatException`, which `Json.fromJson` rewraps as `RuntimeException`, so the entire HTTP 200 body was lost.

This adds the 9 values and routes them through `FinishReasonMapper`:

```java
case BLOCKLIST, PROHIBITED_CONTENT, RECITATION, IMAGE_RECITATION,
        IMAGE_SAFETY, IMAGE_PROHIBITED_CONTENT, SPII, SAFETY, LANGUAGE -> FinishReason.CONTENT_FILTER;
```

The remaining seven map to `FinishReason.OTHER`, matching the sibling `GoogleGenAiContentMapper.mapFinishReason`. `TOO_MANY_TOOL_CALLS` deliberately does not map to `TOOL_EXECUTION`: in LangChain4j that value means the response carries tool calls to execute, and `BaseGeminiChatModel` sets it itself.

Both files change together because the switch is exhaustive with no `default`. That is kept on purpose — the compiler flags the next added constant.

`should_deserialize_image_safety_finish_reason` asserts on the raw wire value, so it compiles against `main` and fails there with the `InvalidFormatException` above.

Scope note: enabling `READ_UNKNOWN_ENUM_VALUES_AS_NULL` was rejected. It makes `finishReason` null, and `BaseGeminiChatModel` passes it into the exhaustive switch without a null check, which converts the parse failure into an NPE. Handling future values needs a separate design.

PR #5256 fixed this same failure for `IMAGE_RECITATION` alone; this covers the rest.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- All 369 unit tests in langchain4j-google-ai-gemini pass. The *IT classes in this module need GOOGLE_AI_GEMINI_API_KEY and were not run. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Unit tests pass: langchain4j-core (1210) and langchain4j (1278). Their *IT classes were not run. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A - an internal enum fix with no documented surface. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A - a bug fix, not a "big" feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A - no starter or configuration surface is involved. -->
