### PR TITLE
fix: Check HTTP status in GeminiFiles.listFiles instead of returning an empty list

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFiles.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFiles.java
@@ -134,6 +134,10 @@ public final class GeminiFiles {
                 .build();
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new GeminiUploadFailureException("Failed to list files. Status code: " + response.statusCode());
+        }
+
         GeminiFilesListResponse listResponse = fromJson(response.body(), GeminiFilesListResponse.class);
 
         return listResponse.files() != null ? listResponse.files() : List.of();

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiFilesTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiFilesTest.java
@@ -396,6 +396,25 @@ class GeminiFilesTest {
         }
 
         @Test
+        void should_throwExceptionWhenListFilesReturnsErrorStatusCode() throws IOException, InterruptedException {
+            // Given
+            when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenAnswer(invocation -> createFailedListFilesResponse());
+
+            var subject = GeminiFiles.builder()
+                    .apiKey(TEST_API_KEY)
+                    .httpClient(mockHttpClient)
+                    .baseUrl(TEST_BASE_URL)
+                    .build();
+
+            // When/Then
+            assertThatThrownBy(subject::listFiles)
+                    .isInstanceOf(GeminiUploadFailureException.class)
+                    .hasMessageContaining("Failed to list files")
+                    .hasMessageContaining("403");
+        }
+
+        @Test
         void should_throwGeminiUploadFailureExceptionWhenListFilesThrowsIOException()
                 throws IOException, InterruptedException {
             // Given
@@ -643,8 +662,7 @@ class GeminiFilesTest {
 
     private HttpResponse<String> createFileUploadResponseWithState(
             String uri, String displayName, String mimeType, Long sizeBytes, String state) {
-        var fileJson = String.format(
-                """
+        var fileJson = String.format("""
                         {
                           "file": {
                             "name": "files/%s",
@@ -659,16 +677,14 @@ class GeminiFilesTest {
                             "state": "%s"
                           }
                         }
-                        """,
-                displayName, displayName, mimeType, sizeBytes, uri, state);
+                        """, displayName, displayName, mimeType, sizeBytes, uri, state);
         HttpResponse<String> response = mock(HttpResponse.class);
         when(response.body()).thenReturn(fileJson);
         return response;
     }
 
     private HttpResponse<String> createListFilesResponse() {
-        var json =
-                """
+        var json = """
                 {
                   "files": [
                     {
@@ -699,13 +715,21 @@ class GeminiFilesTest {
                 }
                 """;
         HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
         when(response.body()).thenReturn(json);
         return response;
     }
 
     private HttpResponse<String> createEmptyListFilesResponse() {
         HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
         when(response.body()).thenReturn("{}");
+        return response;
+    }
+
+    private HttpResponse<String> createFailedListFilesResponse() {
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(403);
         return response;
     }
 


### PR DESCRIPTION
## Issue

Closes #5946

## Change

`GeminiFiles.listFiles()` ignored the response status code and deserialized the body straight away. An error response (401, 403, 429, ...) deserializes into a `GeminiFilesListResponse` with `files == null`, so a failed request looked like "no files uploaded".

Nothing else catches it: `GeminiFiles` uses the JDK `java.net.http.HttpClient`, whose `send()` does not throw on 4xx/5xx, and `Json` disables `FAIL_ON_UNKNOWN_PROPERTIES`, so an `{"error": ...}` body deserializes fine.

This adds the check `getMetadata()` and `deleteFile()` already have, reusing their exception and message shape:

```java
if (response.statusCode() != 200) {
    throw new GeminiUploadFailureException("Failed to list files. Status code: " + response.statusCode());
}
```

The 200 path is unchanged.

Notes on the test file:

- New test `should_throwExceptionWhenListFilesReturnsErrorStatusCode` covers a 403 response; it fails without the production change.
- The success fixtures `createListFilesResponse()` and `createEmptyListFilesResponse()` stubbed only `body()`, so `statusCode()` returned Mockito's default `0`. I added `thenReturn(200)` to both, as `createSuccessfulDeleteResponse()` already does. No assertion was changed.
- `spotless:apply` reformatted two text blocks in this file; those hunks are formatting only.

Scope is `listFiles()` alone. `uploadFileBytes()` and `initiateResumableUpload()` skip the same check and are left for a follow-up.

## General checklist
- [X] There are no breaking changes (API, behaviour)
<!-- The public API is unchanged. The only behaviour change is the fix itself: a non-200 response now throws instead of returning an empty list, which is what getMetadata() and deleteFile() already do. -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- All 368 unit tests in langchain4j-google-ai-gemini pass. The *IT classes in this module need GOOGLE_AI_GEMINI_API_KEY and were not run. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Unit tests pass: langchain4j-core (1210) and langchain4j (1278). Their *IT classes were not run. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- Per the PR template, documentation follows once the PR is reviewed and approved. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A - a four-line bug fix, not a feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A - no configuration or starter surface is involved. -->
