### PR TITLE
fix: Report TOOL_EXECUTION finish reason for Google GenAI tool call responses

### DIFF
--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
@@ -298,10 +298,12 @@ class GoogleGenAiContentMapper {
                 })
                 .orElse(new TokenUsage(0, 0));
 
-        FinishReason finishReason = candidate
-                .finishReason()
-                .map(GoogleGenAiContentMapper::mapFinishReason)
-                .orElseGet(() -> !toolRequests.isEmpty() ? FinishReason.TOOL_EXECUTION : FinishReason.STOP);
+        FinishReason finishReason = !toolRequests.isEmpty()
+                ? FinishReason.TOOL_EXECUTION
+                : candidate
+                        .finishReason()
+                        .map(GoogleGenAiContentMapper::mapFinishReason)
+                        .orElse(FinishReason.STOP);
 
         GoogleGenAiChatResponseMetadata metadata = GoogleGenAiChatResponseMetadata.builder()
                 .modelName(modelName)

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
@@ -390,6 +390,50 @@ class GoogleGenAiContentMapperTest {
     }
 
     @Test
+    void should_return_tool_execution_finish_reason_when_response_contains_function_call() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("city", "London");
+
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(Part.builder()
+                                        .functionCall(FunctionCall.builder()
+                                                .name("getWeather")
+                                                .args(args)
+                                                .build())
+                                        .build())
+                                .build())
+                        .finishReason(
+                                new com.google.genai.types.FinishReason(com.google.genai.types.FinishReason.Known.STOP))
+                        .build()))
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        assertThat(result.finishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
+    }
+
+    @Test
+    void should_keep_reported_finish_reason_when_response_contains_no_function_call() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(Part.builder().text("Hello!").build())
+                                .build())
+                        .finishReason(
+                                new com.google.genai.types.FinishReason(com.google.genai.types.FinishReason.Known.STOP))
+                        .build()))
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        assertThat(result.finishReason()).isEqualTo(FinishReason.STOP);
+    }
+
+    @Test
     void should_handle_response_with_no_content() {
         GenerateContentResponse response = GenerateContentResponse.builder()
                 .candidates(List.of(Candidate.builder().build()))


### PR DESCRIPTION
## Issue

Closes #5945

## Change

`GoogleGenAiContentMapper.toChatResponse()` used `TOOL_EXECUTION` only as a fallback for a missing `finishReason`. Gemini reports `finishReason=STOP` alongside function calls, so tool call responses came back as `STOP`.

Tool execution requests now decide the finish reason first:

```java
FinishReason finishReason = !toolRequests.isEmpty()
        ? FinishReason.TOOL_EXECUTION
        : candidate.finishReason()
                .map(GoogleGenAiContentMapper::mapFinishReason)
                .orElse(FinishReason.STOP);
```

Behaviour change: a response carrying tool execution requests reports `TOOL_EXECUTION` instead of the mapped SDK value, overriding reported reasons such as `MAX_TOKENS` or `UNEXPECTED_TOOL_CALL`. This is the rule already used by this module's streaming path (`GoogleGenAiStreamingChatModel`) and by `BaseGeminiChatModel` in `langchain4j-google-ai-gemini`, and it is what `AbstractBaseChatModelIT` asserts. Responses without tool calls are unaffected.

Tool calling itself was not broken: `AiServices` loops on `AiMessage.hasToolExecutionRequests()`, not on the finish reason. What changes is the value reported through `ChatResponse.metadata().finishReason()` and `Result.finishReason()`.

Tests added to `GoogleGenAiContentMapperTest`: a function call response with `finishReason=STOP` now expects `TOOL_EXECUTION` (fails on `main`), and a text-only response with `finishReason=STOP` still expects `STOP`.

`GoogleGenAiChatModelIT.assertFinishReason()` and `GoogleGenAiStreamingChatModelIT.assertFinishReason()` still return `false`; enabling them needs API keys and widens the scope.

Screenshots: N/A — code-level change, no UI.

## General checklist
- [ ] There are no breaking changes (API, behaviour) — no API change, but the reported finish reason for tool call responses changes as described above
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - unit tests green (`langchain4j-google-genai` 135); `*IT` require API keys and were not run
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - unit tests green (core 1210, 5 skipped; main 1278); `*IT` not run
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- Conditional sections for new maven modules and embedding store integrations are omitted: this PR adds no module and touches no embedding store. -->

