### PR TITLE
fix: Return generated text when GPULlama3 generation stops at maxTokens

### DIFF
--- a/langchain4j-gpu-llama3/src/main/java/dev/langchain4j/model/gpullama3/GPULlama3BaseModel.java
+++ b/langchain4j-gpu-llama3/src/main/java/dev/langchain4j/model/gpullama3/GPULlama3BaseModel.java
@@ -153,10 +153,13 @@ abstract class GPULlama3BaseModel implements AutoCloseable {
         }
 
         if (stopToken == null) {
-            return "Ran out of context length...\n Increase context length with by passing to llama-tornado --max-tokens XXX";
-        } else {
-            return responseText;
+            log.warn(
+                    "Generation stopped after reaching maxTokens ({}), so the response is truncated. "
+                            + "Increase maxTokens(...) on the model builder to get a complete response.",
+                    maxTokens);
         }
+
+        return responseText;
     }
     // @formatter:on
 

--- a/langchain4j-gpu-llama3/src/test/java/dev/langchain4j/model/gpullama3/GPULlama3BaseModelTest.java
+++ b/langchain4j-gpu-llama3/src/test/java/dev/langchain4j/model/gpullama3/GPULlama3BaseModelTest.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.model.gpullama3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.beehive.gpullama3.model.Model;
+import org.beehive.gpullama3.model.format.ChatFormat;
+import org.beehive.gpullama3.tokenizer.Tokenizer;
+import org.junit.jupiter.api.Test;
+
+class GPULlama3BaseModelTest {
+
+    private static final int STOP_TOKEN = 9;
+
+    /** Minimal concrete subclass of the abstract base class; it adds no behaviour of its own. */
+    private static class TestModel extends GPULlama3BaseModel {}
+
+    @Test
+    void should_return_generated_text_when_generation_stops_at_max_tokens() throws Exception {
+        // No stop token is configured, so generation ends because maxTokens is exhausted.
+        TestModel model = newModel(Set.of(), new ArrayList<>(List.of(1, 2, 3)), "truncated answer");
+
+        String response = model.modelResponse(chatRequest(), null);
+
+        assertThat(response).isEqualTo("truncated answer");
+    }
+
+    @Test
+    void should_return_generated_text_when_generation_stops_at_stop_token() throws Exception {
+        TestModel model = newModel(Set.of(STOP_TOKEN), new ArrayList<>(List.of(1, 2, STOP_TOKEN)), "complete answer");
+
+        String response = model.modelResponse(chatRequest(), null);
+
+        assertThat(response).isEqualTo("complete answer");
+    }
+
+    private static ChatRequest chatRequest() {
+        return ChatRequest.builder().messages(UserMessage.from("hi")).build();
+    }
+
+    private static TestModel newModel(Set<Integer> stopTokens, List<Integer> responseTokens, String decodedText)
+            throws Exception {
+        Tokenizer tokenizer = mock(Tokenizer.class);
+        when(tokenizer.decode(anyList())).thenReturn(decodedText);
+
+        Model llama = mock(Model.class);
+        when(llama.tokenizer()).thenReturn(tokenizer);
+        when(llama.generateTokens(any(), anyInt(), anyList(), anySet(), anyInt(), any(), anyBoolean(), any()))
+                .thenReturn(responseTokens);
+
+        ChatFormat chatFormat = mock(ChatFormat.class);
+        when(chatFormat.getStopTokens()).thenReturn(stopTokens);
+
+        TestModel model = new TestModel();
+        model.chatFormat = chatFormat;
+        // model, maxTokens and onGPU are private and are only ever assigned by init(), which loads a GGUF
+        // file from disk and, on the GPU path, a TornadoVM plan. Setting them reflectively lets this test
+        // exercise modelResponse() without a model file or a GPU.
+        setField(model, "model", llama);
+        setField(model, "maxTokens", 512);
+        setField(model, "onGPU", Boolean.FALSE);
+        return model;
+    }
+
+    private static void setField(GPULlama3BaseModel target, String name, Object value) throws Exception {
+        Field field = GPULlama3BaseModel.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5957

## Change

`GPULlama3BaseModel.modelResponse()` decoded `responseText`, then discarded it whenever generation ended without a stop token and returned a fixed notice instead. The notice reached callers as `AiMessage.text()`, and in streaming it contradicted the tokens already sent to `onPartialResponse`. It now always returns `responseText` and logs the truncation with the class's existing SLF4J logger, naming `maxTokens(...)` instead of the `llama-tornado` CLI flag.

```java
if (stopToken == null) {
    log.warn("Generation stopped after reaching maxTokens ({}), so the response is truncated. "
            + "Increase maxTokens(...) on the model builder to get a complete response.", maxTokens);
}
return responseText;
```

Upstream, this sentence is a `System.err.println` + `break` in CLI REPL `Model.runInteractive()`; `runInstructOnceLangChain4J()` on the same interface always returns `responseText`. Nothing else references the string.

### Relationship to #5876

#5876 rewrites parts of this file, but its `modelResponse()` hunks (`@@ -108,9 +117,16 @@`, `@@ -161,7 +177,7 @@`) miss this branch. Happy to fold this in or rebase once it lands.

### Test execution

The new tests do not run in CI: this module's pom hardcodes test skips, and the module is only in the reactor under the root `jdk25` profile — same as `GPULlama3ResponseParserTest` (merged in #5517). The truncation test fails on `main`. The existing ITs use `maxTokens(2048)`, so they miss this branch too.

## General checklist
- [X] There are no breaking changes (API, behaviour) <!-- No signature, field, or public API change. The returned value differs only on the defective branch, which is the fix itself. -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases <!-- stop token present -> responseText; stop token absent -> responseText, not the notice string. -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - 7 unit tests green (2 new + 5 existing `GPULlama3ResponseParserTest`), run with the JUnit Platform Console Launcher on JDK 25. `GPULlama3ChatModelIT` and `GPULlama3CStreamingChatModelIT` were not run: they need a GPU, TornadoVM and a local GGUF model.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - `mvn -pl langchain4j-core,langchain4j clean test`: langchain4j-core 1210 tests, langchain4j 1278 tests, 0 failures and 0 errors in both. The `*IT` classes in those modules need API keys and were not run.
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- Not required: no documented behaviour changes. The integration docs never mentioned the notice string. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- Not a big feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- Not applicable; there is no Spring Boot starter for this integration. -->

<!-- The "new maven module" and "embedding store integration" checklists are omitted: this PR adds no module and touches no embedding store. -->

