### PR TITLE
fix: Mask secret HTTP headers regardless of the JVM default locale

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
@@ -21,18 +21,13 @@ class HttpRequestLogger {
 
     static void log(Logger log, HttpRequest httpRequest) {
         try {
-            log.info(
-                    """
+            log.info("""
                             HTTP request:
                             - method: {}
                             - url: {}
                             - headers: {}
                             - body: {}
-                            """,
-                    httpRequest.method(),
-                    httpRequest.url(),
-                    format(httpRequest.headers()),
-                    httpRequest.body());
+                            """, httpRequest.method(), httpRequest.url(), format(httpRequest.headers()), httpRequest.body());
         } catch (Exception e) {
             log.warn("Exception occurred while logging HTTP request: {}", e.getMessage());
         }

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
@@ -9,6 +9,7 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.http.client.HttpRequest;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -40,8 +41,8 @@ class HttpRequestLogger {
     }
 
     static String format(String headerKey, List<String> headerValues) {
-        if (COMMON_SECRET_HEADERS.contains(headerKey.toLowerCase())
-                || headerKey.toLowerCase().contains("api-key")) {
+        String lowerCaseHeaderKey = headerKey.toLowerCase(Locale.ROOT);
+        if (COMMON_SECRET_HEADERS.contains(lowerCaseHeaderKey) || lowerCaseHeaderKey.contains("api-key")) {
             headerValues =
                     headerValues.stream().map(HttpRequestLogger::maskSecretKey).collect(toList());
         }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/log/HttpRequestLoggerTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/log/HttpRequestLoggerTest.java
@@ -1,0 +1,59 @@
+package dev.langchain4j.http.client.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * and single-threaded to avoid races with the otherwise parallel test suite.
+ * <p>
+ * {@code tr} and {@code az} lowercase {@code 'I'} to the dotless {@code 'ı'} (U+0131),
+ * {@code lt} applies its own dot rules, and {@code en-US} is the baseline.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class HttpRequestLoggerTest {
+
+    private static final String API_KEY = "sk-1234567890abcdef";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ", "lt-LT", "en-US"})
+    void secret_header_should_be_masked_locale_independently(String languageTag) {
+        // Without Locale.ROOT, "X-API-Key".toLowerCase() yields "x-apı-key" under tr/az, which matches
+        // neither COMMON_SECRET_HEADERS nor "api-key", so the key value is logged in clear text.
+        withDefaultLocale(languageTag, () -> {
+            String formatted = HttpRequestLogger.format("X-API-Key", List.of(API_KEY));
+
+            assertThat(formatted).isEqualTo("[X-API-Key: sk-12...ef]").doesNotContain(API_KEY);
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ", "lt-LT", "en-US"})
+    void dotless_header_name_should_not_be_masked_locale_independently(String languageTag) {
+        // The mirror image: a header name spelled with the dotless 'ı' is not a secret header name
+        // in any locale, so its value is rendered unchanged.
+        withDefaultLocale(languageTag, () -> {
+            String formatted = HttpRequestLogger.format("X-APı-Key", List.of(API_KEY));
+
+            assertThat(formatted).isEqualTo("[X-APı-Key: " + API_KEY + "]");
+        });
+    }
+
+    private static void withDefaultLocale(String languageTag, Runnable action) {
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
+            action.run();
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5960

## Change

`HttpRequestLogger.format(String, List)` lowercased the header name with `String#toLowerCase()` (no `Locale`) before matching it against `COMMON_SECRET_HEADERS` and `"api-key"`, so masking depended on the JVM default locale. Under `tr`/`az`, `"X-API-Key".toLowerCase()` becomes `"x-apı-key"` (dotless i) and matches neither check, so the value is logged in clear text at INFO level when `logRequests(true)` is set.

```java
String lowerCaseHeaderKey = headerKey.toLowerCase(Locale.ROOT);
if (COMMON_SECRET_HEADERS.contains(lowerCaseHeaderKey) || lowerCaseHeaderKey.contains("api-key")) {
```

Scope: the header names this repo sends (`Authorization`, `x-api-key`, `x-goog-api-key`) have no uppercase `I` and were never affected. Exposure needs a user-supplied auth header spelled with an uppercase `I`, such as a gateway's `X-API-Key` passed through `customHeaders(...)`. `AwsLoggingInterceptor.maskHeaders()` (#5799) already uses `Locale.ROOT` for the same purpose.

`HttpResponseLogger` reuses this `format()`, so response headers are covered too. Its own `toLowerCase()` in `isTextual()` is left alone: none of the keywords it compares (`json`, `text`, `xml`, ...) contains an `i`.

`HttpRequestLoggerTest` sets and restores the default locale, mirroring `DefaultToolExecutorLocaleTest` (#5778), over `tr-TR`, `az-AZ`, `lt-LT` and `en-US`. On `main` the positive case fails under `tr-TR` and `az-AZ`; the other two stay green as controls.

This file predates the current Spotless formatter, so `ratchetFrom origin/main` reformats the `log()` text block once the file is touched. That reformat is isolated in the first commit, the same split as #5861.

## General checklist
- [X] There are no breaking changes (API, behaviour)
    - No signature, log format or masking policy change. Under `tr`/`az` more header names now match, which is the fix itself.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
    - Unit tests only: `./mvnw -pl langchain4j-http-client -am clean test` → 81 tests, BUILD SUCCESS (JDK 17). No `*IT` ran: `HttpClientIT` and `HttpClientTimeoutIT` are abstract base classes with no runnable subclass in this module.
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
    - Unit tests only: `./mvnw -pl langchain4j-core,langchain4j clean test` → langchain4j-core 1210 (5 skipped), langchain4j 1278, BUILD SUCCESS (JDK 17).
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
    - N/A — internal behaviour fix, no documented API changed.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
    - N/A — not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
    - N/A — no configuration surface changed.

<!-- The "new maven module" and "new/changed embedding store integration" checklists are omitted: this PR adds no module and touches no embedding store. -->

