### PR TITLE
Fix parallel agent failures surfacing as RuntimeException instead of AgentInvocationException

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -329,8 +329,7 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
             return;
         }
         crossAgentCompensationEnabled = true;
-        subagents.stream().map(InternalAgent.class::cast)
-                .forEach(InternalAgent::enableCrossAgentCompensation);
+        subagents.stream().map(InternalAgent.class::cast).forEach(InternalAgent::enableCrossAgentCompensation);
     }
 
     @Override
@@ -492,7 +491,14 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             } catch (ExecutionException e) {
-                throw new RuntimeException(e);
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException runtimeException) {
+                    throw runtimeException;
+                }
+                if (cause instanceof Error error) {
+                    throw error;
+                }
+                throw new RuntimeException(cause);
             }
         }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ParallelAgentExceptionParityTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ParallelAgentExceptionParityTest.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agentic.agent.AgentInvocationException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+class ParallelAgentExceptionParityTest {
+
+    static final ChatModel FAILING_MODEL = new ChatModel() {
+        @Override
+        public ChatResponse chat(ChatRequest chatRequest) {
+            throw new RuntimeException("model failure");
+        }
+    };
+
+    public interface Writer {
+
+        @UserMessage("Write about {{topic}}")
+        @Agent(outputKey = "story")
+        String write(@V("topic") String topic);
+    }
+
+    public interface Reviewer {
+
+        @UserMessage("Review {{topic}}")
+        @Agent(outputKey = "review")
+        String review(@V("topic") String topic);
+    }
+
+    private UntypedAgent sequentialWorkflow() {
+        return AgenticServices.sequenceBuilder()
+                .subAgents(writer(), reviewer())
+                .outputKey("story")
+                .build();
+    }
+
+    private UntypedAgent parallelWorkflow() {
+        return AgenticServices.parallelBuilder()
+                .subAgents(writer(), reviewer())
+                .outputKey("story")
+                .build();
+    }
+
+    private Writer writer() {
+        return AgenticServices.agentBuilder(Writer.class)
+                .chatModel(FAILING_MODEL)
+                .outputKey("story")
+                .build();
+    }
+
+    private Reviewer reviewer() {
+        return AgenticServices.agentBuilder(Reviewer.class)
+                .chatModel(FAILING_MODEL)
+                .outputKey("review")
+                .build();
+    }
+
+    @Test
+    void sequential_agent_failure_throws_agentInvocationException() {
+        assertThatThrownBy(() -> sequentialWorkflow().invoke(Map.of("topic", "dragons")))
+                .isInstanceOf(AgentInvocationException.class);
+    }
+
+    @Test
+    void parallel_agent_failure_throws_same_type_as_sequential() {
+        assertThatThrownBy(() -> parallelWorkflow().invoke(Map.of("topic", "dragons")))
+                .isInstanceOf(AgentInvocationException.class)
+                .isNotInstanceOf(ExecutionException.class)
+                .isNotInstanceOf(CompletionException.class);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5941

## Change

`PlannerLoop.parallelExecution` blocked on `CompletableFuture.allOf(tasks).get()` and re-wrapped the
resulting `ExecutionException` in a `RuntimeException`, so a failing sub-agent surfaced as
`RuntimeException(ExecutionException(AgentInvocationException))`. The single-agent branch of the same
`loop()` switch calls `execute(...)` directly and throws `AgentInvocationException`, so
`catch (AgentInvocationException e)` handled a sequence but missed the parallel case.

The `ExecutionException` handler now rethrows the cause, matching the behaviour that
`DelayedResponse.join` already provides for the async/streaming/deferred paths in the same package.

This affects any workflow whose planner returns more than one agent for a step (`parallelBuilder`,
`parallelMapper`, `supervisorBuilder`, `plannerBuilder`, custom planners). Workflows that call one
agent per step are unaffected, since they take the `case 1` branch.

I kept `.get()` rather than reusing `DelayedResponse.join(CompletableFuture.allOf(tasks))`, which would
have been a smaller diff: `join()` does not propagate interrupts, so reusing it would have silently
dropped the existing `Thread.currentThread().interrupt()` branch and made parallel workflows
uncancellable.

The one-line change at `PlannerBasedInvocationHandler:329` is unrelated to the fix. It is produced by
`spotless:apply`, because `<ratchetFrom>origin/main</ratchetFrom>` brings the whole touched file into
formatting scope. Reverting that line makes `./mvnw spotless:check` fail.

### Tests

`ParallelAgentExceptionParityTest` mirrors the existing `AsyncAgentExceptionParityTest` and needs no
API key, using an inline `ChatModel` that throws. Two sub-agents are required to reach
`parallelExecution`, as a single sub-agent takes the `case 1` branch.

- Negative case: without the fix, `parallel_agent_failure_throws_same_type_as_sequential` fails with
  `RuntimeException(ExecutionException(AgentInvocationException))`, reproducing the stack trace in the issue.
- Positive case: `sequential_agent_failure_throws_agentInvocationException` passes both before and after,
  demonstrating the asymmetry the fix removes.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Unit tests run with `./mvnw -pl langchain4j-core,langchain4j,langchain4j-agentic -am test`: 1210 in core,
1278 in main, 110 in agentic, 0 failures. Integration tests requiring provider API keys were not run.
Documentation is unchanged as this is an internal behaviour fix with no API surface change.
