### PR TITLE
Stop runaway agent retries from overflowing the stack

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
@@ -5,13 +5,13 @@ import static dev.langchain4j.agentic.scope.DefaultAgenticScope.isSerializable;
 import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.agent.MissingArgumentException;
-import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.scope.AgentInvocation;
+import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.service.TokenStream;
 import java.lang.reflect.Type;
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements AgentInstance, InternalAgent {
 
     private static final Logger LOG = LoggerFactory.getLogger(AgentExecutor.class);
+
+    private static final int MAX_RETRY_ATTEMPTS = 100;
 
     public Object execute(DefaultAgenticScope agenticScope, PlannerExecutor planner) {
         return execute(agenticScope, planner, agentInvoker.async());
@@ -37,7 +39,7 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
 
     private Object execute(DefaultAgenticScope agenticScope, PlannerExecutor planner, boolean async) {
         Object invokedAgent = (agent instanceof AgenticScopeOwner co ? co.withAgenticScope(agenticScope) : agent);
-        return internalExecute(agenticScope, invokedAgent, planner, async);
+        return internalExecute(agenticScope, invokedAgent, planner, async, 0);
     }
 
     private Object handleAgentFailure(
@@ -46,11 +48,21 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
             Object invokedAgent,
             PlannerExecutor planner,
             AgentInvocationArguments args,
-            boolean plannerAlreadyNotified) {
+            boolean plannerAlreadyNotified,
+            int attempt) {
         ErrorRecoveryResult recoveryResult = agenticScope.handleError(agentInvoker.name(), e);
         return switch (recoveryResult.type()) {
             case THROW_EXCEPTION -> throw e;
-            case RETRY -> internalExecute(agenticScope, invokedAgent, planner, false);
+            case RETRY -> {
+                if (attempt >= MAX_RETRY_ATTEMPTS) {
+                    LOG.warn(
+                            "Agent '{}' still failing after {} retries, giving up",
+                            agentInvoker.name(),
+                            MAX_RETRY_ATTEMPTS);
+                    throw e;
+                }
+                yield internalExecute(agenticScope, invokedAgent, planner, false, attempt + 1);
+            }
             case RETURN_RESULT ->
                 plannerAlreadyNotified
                         ? recoveryResult.result()
@@ -59,7 +71,11 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
     }
 
     private Object internalExecute(
-            DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner, boolean async) {
+            DefaultAgenticScope agenticScope,
+            Object invokedAgent,
+            PlannerExecutor planner,
+            boolean async,
+            int attempt) {
         AgentInvocationArguments args = null;
         try {
             try {
@@ -79,7 +95,7 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
                 throw e;
             }
 
-            Object response = agentResponse(agenticScope, invokedAgent, planner, args, async);
+            Object response = agentResponse(agenticScope, invokedAgent, planner, args, async, attempt);
             return completeAgentInvocation(response, agenticScope, invokedAgent, planner, args);
         } catch (AgenticSystemSuspendedException e) {
             if (planner != null) {
@@ -87,7 +103,7 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
             }
             return null;
         } catch (AgentInvocationException e) {
-            return handleAgentFailure(e, agenticScope, invokedAgent, planner, args, false);
+            return handleAgentFailure(e, agenticScope, invokedAgent, planner, args, false, attempt);
         }
     }
 
@@ -116,13 +132,14 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
             Object invokedAgent,
             PlannerExecutor planner,
             AgentInvocationArguments args,
-            boolean async) {
+            boolean async,
+            int attempt) {
         if (async) {
             return new AsyncResponse<>(() -> {
                 try {
                     return agentInvoker.invoke(agenticScope, invokedAgent, args);
                 } catch (AgentInvocationException e) {
-                    return handleAgentFailure(e, agenticScope, invokedAgent, planner, args, true);
+                    return handleAgentFailure(e, agenticScope, invokedAgent, planner, args, true, attempt);
                 }
             });
         }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ErrorRecoveryResultTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ErrorRecoveryResultTest.java
@@ -1,10 +1,12 @@
 package dev.langchain4j.agentic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.ChatModel;
@@ -14,6 +16,7 @@ import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
@@ -105,5 +108,67 @@ class ErrorRecoveryResultTest {
 
         assertThat(failedAgent.get()).isEqualTo("edit");
         assertThat(result).isEqualTo("default story");
+    }
+
+    @Test
+    void error_handler_retrying_within_the_limit_recovers() {
+        AtomicInteger calls = new AtomicInteger();
+        ChatModel flakyModel = new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                if (calls.incrementAndGet() < 3) {
+                    throw new RuntimeException("transient failure");
+                }
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("recovered story"))
+                        .build();
+            }
+        };
+
+        StoryWriter writer = AgenticServices.agentBuilder(StoryWriter.class)
+                .chatModel(flakyModel)
+                .outputKey("story")
+                .build();
+
+        UntypedAgent workflow = AgenticServices.sequenceBuilder()
+                .subAgents(writer)
+                .outputKey("story")
+                .errorHandler(errorContext -> ErrorRecoveryResult.retry())
+                .build();
+
+        Object result =
+                assertTimeoutPreemptively(Duration.ofSeconds(5), () -> workflow.invoke(Map.of("topic", "dragons")));
+
+        assertThat(result).isEqualTo("recovered story");
+        assertThat(calls).hasValue(3);
+    }
+
+    @Test
+    void error_handler_always_retrying_gives_up_and_rethrows_the_agent_failure() {
+        AtomicInteger calls = new AtomicInteger();
+        ChatModel failingModel = new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                calls.incrementAndGet();
+                throw new RuntimeException("permanent failure");
+            }
+        };
+
+        StoryWriter writer = AgenticServices.agentBuilder(StoryWriter.class)
+                .chatModel(failingModel)
+                .outputKey("story")
+                .build();
+
+        UntypedAgent workflow = AgenticServices.sequenceBuilder()
+                .subAgents(writer)
+                .outputKey("story")
+                .errorHandler(errorContext -> ErrorRecoveryResult.retry())
+                .build();
+
+        Throwable thrown = assertTimeoutPreemptively(
+                Duration.ofSeconds(30), () -> catchThrowable(() -> workflow.invoke(Map.of("topic", "dragons"))));
+
+        assertThat(thrown).isInstanceOf(AgentInvocationException.class);
+        assertThat(calls).hasValue(101);
     }
 }


### PR DESCRIPTION
## Issue

Closes #5963

## Change

`AgentExecutor.handleAgentFailure` retried by calling `internalExecute` recursively, so every retry
added stack frames and the retry depth was silently bounded by the stack size. An error handler that
keeps returning `ErrorRecoveryResult.retry()` ended in a `StackOverflowError` after the agent had
been invoked 4049 times locally, and the caller got an `Error` instead of the
`AgentInvocationException` a failing agent is expected to throw.

Retries are now counted and capped. When the cap is reached the original `AgentInvocationException`
is rethrown, so a handler that never stops surfaces the agent's own failure. The counter is passed
down the existing private call chain (`internalExecute` / `handleAgentFailure` / `agentResponse`),
so there is no public API change and no state shared between concurrent executions.

Notes on scope:

- The limit is a safety net, not a retry policy. The handler still decides whether to retry, and 100
  matches `AgentMonitor.DEFAULT_MAX_RETAINED_SESSIONS`, the cap this module already applies to the
  comparable unbounded-growth case. It is well above any realistic retry policy, so a handler that
  stops on its own never reaches it.
- Not made configurable, to keep this a fix rather than a new option. If you want it settable, the
  module's own idiom is `AgentMonitor`'s `volatile` field defaulting to the constant, and I am happy
  to follow that.
- Not rewritten as a loop: without a bound that turns the overflow into a hang, which is harder to
  diagnose than the current crash rather than a fix for it.
- Bounding retries is already possible inside a handler by counting in the `AgenticScope`, so this
  does not add a capability, it stops the framework from crashing when a handler does not stop.

## Build/test notes

Two tests added to `ErrorRecoveryResultTest`, both offline with a stub `ChatModel`:

- a handler that retries and succeeds on the third attempt still recovers (control, passes before and
  after)
- a handler that always retries gives up and rethrows `AgentInvocationException` after the cap

The second fails on main with `StackOverflowError` and passes here.

```
mvn -pl langchain4j-agentic clean verify
```

BUILD SUCCESS: 110 unit tests, 0 failures (2 new), plus `spotless:check` and `revapi:check`. All
changed methods are private, so there is no public API change and no new revapi entry.

```
mvn -o -pl langchain4j-core,langchain4j test
```

1278 tests, 0 failures.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)