### PR TITLE
Fix Milvus V2 L2 relevance score mapping

### DIFF
--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/Mapper.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/Mapper.java
@@ -19,6 +19,7 @@ import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.RelevanceScore;
 import io.milvus.v2.client.MilvusClientV2;
 import io.milvus.v2.common.ConsistencyLevel;
+import io.milvus.v2.common.IndexParam;
 import io.milvus.v2.service.vector.response.QueryResp;
 import io.milvus.v2.service.vector.response.SearchResp;
 import java.lang.reflect.Type;
@@ -81,7 +82,8 @@ class Mapper {
             String collectionName,
             FieldDefinition fieldDefinition,
             ConsistencyLevel consistencyLevel,
-            boolean queryForVectorOnSearch) {
+            boolean queryForVectorOnSearch,
+            IndexParam.MetricType metricType) {
         List<EmbeddingMatch<TextSegment>> matches = new ArrayList<>();
 
         Map<String, Embedding> idToEmbedding = new HashMap<>();
@@ -126,11 +128,19 @@ class Mapper {
             TextSegment textSegment =
                     toTextSegment(searchResp.getSearchResults().get(0).get(i), fieldDefinition);
             EmbeddingMatch<TextSegment> embeddingMatch =
-                    new EmbeddingMatch<>(RelevanceScore.fromCosineSimilarity(score), rowId, embedding, textSegment);
+                    new EmbeddingMatch<>(toRelevanceScore(score, metricType), rowId, embedding, textSegment);
             matches.add(embeddingMatch);
         }
 
         return matches;
+    }
+
+    static double toRelevanceScore(double score, IndexParam.MetricType metricType) {
+        if (metricType == IndexParam.MetricType.L2) {
+            return 1.0 / (1.0 + score);
+        }
+
+        return RelevanceScore.fromCosineSimilarity(score);
     }
 
     private static TextSegment toTextSegment(SearchResp.SearchResult searchResult, FieldDefinition fieldDefinition) {

--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStore.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStore.java
@@ -260,7 +260,8 @@ public class MilvusV2EmbeddingStore implements EmbeddingStore<TextSegment> {
                 collectionName,
                 fieldDefinition,
                 consistencyLevel,
-                retrieveEmbeddingsOnSearch);
+                retrieveEmbeddingsOnSearch,
+                metricType);
 
         List<EmbeddingMatch<TextSegment>> result = matches.stream()
                 .filter(match -> match.score() >= embeddingSearchRequest.minScore())
@@ -315,8 +316,9 @@ public class MilvusV2EmbeddingStore implements EmbeddingStore<TextSegment> {
             throw new IllegalStateException("Built-in sparse mode does not accept client-provided sparse vectors.");
         }
         if (this.dimension == null) {
-            throw new IllegalStateException("dimension must be set (via .dimension(...)) to insert sparse-only vectors, "
-                    + "because a zero-filled dense placeholder vector of that dimension is required.");
+            throw new IllegalStateException(
+                    "dimension must be set (via .dimension(...)) to insert sparse-only vectors, "
+                            + "because a zero-filled dense placeholder vector of that dimension is required.");
         }
 
         List<String> textScalars = toScalars(textSegments, ids.size());

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MapperTest.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MapperTest.java
@@ -1,9 +1,12 @@
 package dev.langchain4j.store.embedding.milvus.v2;
 
+import static dev.langchain4j.store.embedding.milvus.v2.Mapper.toRelevanceScore;
 import static dev.langchain4j.store.embedding.milvus.v2.Mapper.toSparseVectors;
 import static dev.langchain4j.store.embedding.milvus.v2.Mapper.toVectors;
 
 import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.store.embedding.RelevanceScore;
+import io.milvus.v2.common.IndexParam;
 import java.util.Arrays;
 import java.util.List;
 import java.util.SortedMap;
@@ -132,5 +135,45 @@ class MapperTest implements WithAssertions {
         assertThat(vector.get(-1L)).isEqualTo(-0.1f);
         assertThat(vector.get(0L)).isEqualTo(0.0f);
         assertThat(vector.get(1L)).isEqualTo(0.1f);
+    }
+
+    @Test
+    void should_convert_l2_distance_to_relevance_score() {
+        double identical = toRelevanceScore(0.0, IndexParam.MetricType.L2);
+        double near = toRelevanceScore(1.0, IndexParam.MetricType.L2);
+        double far = toRelevanceScore(3.0, IndexParam.MetricType.L2);
+
+        assertThat(identical).isEqualTo(1.0);
+        assertThat(near).isEqualTo(0.5);
+        assertThat(far).isEqualTo(0.25);
+    }
+
+    @Test
+    void should_rank_a_smaller_l2_distance_higher() {
+        double near = toRelevanceScore(0.5, IndexParam.MetricType.L2);
+        double far = toRelevanceScore(2.0, IndexParam.MetricType.L2);
+
+        assertThat(near).isGreaterThan(far);
+        assertThat(near).isBetween(0.0, 1.0);
+        assertThat(far).isBetween(0.0, 1.0);
+    }
+
+    @Test
+    void should_not_treat_an_l2_distance_as_a_cosine_similarity() {
+        double relevanceScore = toRelevanceScore(3.0, IndexParam.MetricType.L2);
+
+        assertThat(relevanceScore).isNotEqualTo(RelevanceScore.fromCosineSimilarity(3.0));
+        assertThat(relevanceScore).isBetween(0.0, 1.0);
+    }
+
+    @Test
+    void should_use_cosine_conversion_for_non_l2_metrics() {
+        double cosine = toRelevanceScore(0.6, IndexParam.MetricType.COSINE);
+        double innerProduct = toRelevanceScore(0.6, IndexParam.MetricType.IP);
+        double bm25 = toRelevanceScore(0.6, IndexParam.MetricType.BM25);
+
+        assertThat(cosine).isEqualTo(RelevanceScore.fromCosineSimilarity(0.6));
+        assertThat(innerProduct).isEqualTo(RelevanceScore.fromCosineSimilarity(0.6));
+        assertThat(bm25).isEqualTo(RelevanceScore.fromCosineSimilarity(0.6));
     }
 }


### PR DESCRIPTION
Closes #5251

#5251 was filed against `langchain4j-milvus`. #5428 fixed that module but left the issue open, and
`langchain4j-milvus-v2`, added later in #3311, still has the same bug.

## Change

`MilvusV2EmbeddingStore` lets callers pick the metric type via `metricType(...)`, but
`Mapper.toEmbeddingMatches` always converted the raw Milvus score with `RelevanceScore.fromCosineSimilarity`,
which is `(score + 1) / 2` and expects a similarity in `[-1, 1]`. With `L2` the raw score is a distance in
`[0, +inf)` where lower is more similar, so the ranking was inverted and the score could leave the `[0, 1]`
range. `search()` filters matches on that value, so `minScore` was affected too.

| raw `L2` distance | before | after |
|---|---|---|
| 0.0 (identical) | 0.5 | 1.0 |
| 1.0 | 1.0 | 0.5 |
| 3.0 | 2.0 | 0.25 |

Fix:
- pass the configured `IndexParam.MetricType` into result mapping;
- convert `L2` distances with `1 / (1 + distance)`, leaving every other metric type on the existing cosine
  conversion.

This is the same conversion `langchain4j-milvus` already uses in `Mapper.toRelevanceScore`. The default
`COSINE` behaviour is unchanged, and the new method is package-private, so there is no public API change
(revapi clean).

I kept this to `L2` to match `langchain4j-milvus`. `IP` is not a cosine similarity either, and in
`SearchMode.HYBRID` the score comes from the reranker rather than from a single metric. Happy to handle
either in a follow-up if you prefer.

## Tests

Added four tests to `MapperTest`. The first three fail on `main` and pass with the fix; the fourth pins the
paths that must not move:
- `should_convert_l2_distance_to_relevance_score`
- `should_rank_a_smaller_l2_distance_higher`
- `should_not_treat_an_l2_distance_as_a_cosine_similarity`
- `should_use_cosine_conversion_for_non_l2_metrics` (`COSINE`, `IP` and `BM25` unchanged)

```
mvn -pl langchain4j-milvus-v2 verify -DskipITs   # 26 unit tests, 0 failures; spotless + revapi green
mvn -pl langchain4j-core,langchain4j test        # core 1201, main 1278, 0 failures
```

The module's ITs are skipped in CI via `-DskipMilvusITs` and need a local Docker/Testcontainers run, which I
was not able to do. Nothing else in the module uses `MetricType.L2`, so the branch this change adds is
covered by the new unit tests, and every existing test and IT continues to exercise the unchanged cosine
path.

Note: Spotless (`ratchetFrom`) reformats a file on first touch, so `MilvusV2EmbeddingStore.java` contains one
reformatted `throw` statement unrelated to this fix; the functional change there is the added `metricType`
argument.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `MilvusV2EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
