### PR TITLE
Keep generated images from every streamed chunk

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.model.googleai;
 
+import static dev.langchain4j.data.message.AiMessage.GENERATED_IMAGES_KEY;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.model.googleai.FinishReasonMapper.fromGFinishReasonToFinishReason;
+import static dev.langchain4j.model.googleai.PartsAndContentsMapper.THINKING_SIGNATURE_KEY;
 import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromGPartsToAiMessage;
 import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
 
@@ -137,10 +139,28 @@ class GeminiStreamingResponseBuilder {
     private void updateContentAndFunctionCalls(AiMessage message) {
         Optional.ofNullable(message.text()).ifPresent(contentBuilder::append);
         Optional.ofNullable(message.thinking()).ifPresent(thoughtBuilder::append);
-        attributes.putAll(message.attributes());
+        mergeAttributes(message.attributes());
         if (message.hasToolExecutionRequests()) {
             functionCalls.addAll(message.toolExecutionRequests());
         }
+    }
+
+    private void mergeAttributes(Map<String, Object> partialAttributes) {
+        partialAttributes.forEach((key, value) -> {
+            if (GENERATED_IMAGES_KEY.equals(key)) {
+                attributes.merge(key, value, GeminiStreamingResponseBuilder::concatenate);
+            } else if (THINKING_SIGNATURE_KEY.equals(key)) {
+                attributes.merge(key, value, (existing, added) -> existing + "\n\n" + added);
+            } else {
+                attributes.put(key, value);
+            }
+        });
+    }
+
+    private static Object concatenate(Object existing, Object added) {
+        List<Object> concatenated = new ArrayList<>((List<?>) existing);
+        concatenated.addAll((List<?>) added);
+        return concatenated;
     }
 
     private AiMessage createAiMessage() {

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.googleai;
 import static dev.langchain4j.data.message.AiMessage.GENERATED_IMAGES_KEY;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.model.googleai.FinishReasonMapper.fromGFinishReasonToFinishReason;
-import static dev.langchain4j.model.googleai.PartsAndContentsMapper.THINKING_SIGNATURE_KEY;
 import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromGPartsToAiMessage;
 import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
 
@@ -149,8 +148,6 @@ class GeminiStreamingResponseBuilder {
         partialAttributes.forEach((key, value) -> {
             if (GENERATED_IMAGES_KEY.equals(key)) {
                 attributes.merge(key, value, GeminiStreamingResponseBuilder::concatenate);
-            } else if (THINKING_SIGNATURE_KEY.equals(key)) {
-                attributes.merge(key, value, (existing, added) -> existing + "\n\n" + added);
             } else {
                 attributes.put(key, value);
             }

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.model.googleai;
 
-import static dev.langchain4j.model.googleai.PartsAndContentsMapper.THINKING_SIGNATURE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.image.Image;
@@ -85,17 +84,6 @@ class GeminiStreamingResponseBuilderTest {
     }
 
     @Test
-    void should_join_thinking_signatures_from_every_chunk() {
-        GeminiStreamingResponseBuilder thinkingBuilder = new GeminiStreamingResponseBuilder(false, true);
-        thinkingBuilder.append(chunkWith(thoughtPart("thinking about it", "sig-1")));
-        thinkingBuilder.append(chunkWith(thoughtPart("still thinking", "sig-2")));
-
-        AiMessage aiMessage = thinkingBuilder.build().aiMessage();
-
-        assertThat(aiMessage.attributes()).containsEntry(THINKING_SIGNATURE_KEY, "sig-1\n\nsig-2");
-    }
-
-    @Test
     void should_keep_accumulating_text_and_tools_across_chunks() {
         builder.append(chunkWith(GeminiPart.ofText("Hello ")));
         builder.append(chunkWith(imagePart("AAAA")));
@@ -110,10 +98,6 @@ class GeminiStreamingResponseBuilderTest {
     private static GeminiPart imagePart(String base64Data) {
         return new GeminiPart(
                 null, new GeminiBlob("image/png", base64Data), null, null, null, null, null, null, null, null);
-    }
-
-    private static GeminiPart thoughtPart(String thinking, String signature) {
-        return new GeminiPart(thinking, null, null, null, null, null, null, true, signature, null);
     }
 
     private static GeminiGenerateContentResponse chunkWith(GeminiPart part) {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
@@ -1,7 +1,12 @@
 package dev.langchain4j.model.googleai;
 
+import static dev.langchain4j.model.googleai.PartsAndContentsMapper.THINKING_SIGNATURE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.googleai.GeminiContent.GeminiPart;
+import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiBlob;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate;
 import dev.langchain4j.model.googleai.GeminiStreamingResponseBuilder.TextAndTools;
 import java.util.Collections;
@@ -57,5 +62,63 @@ class GeminiStreamingResponseBuilderTest {
 
         assertThat(result.maybeText()).hasValue("Hello");
         assertThat(result.tools()).isEmpty();
+    }
+
+    @Test
+    void should_keep_generated_images_from_every_chunk() {
+        builder.append(chunkWith(imagePart("AAAA")));
+        builder.append(chunkWith(imagePart("BBBB")));
+
+        AiMessage aiMessage = builder.build().aiMessage();
+
+        assertThat(aiMessage.images()).extracting(Image::base64Data).containsExactly("AAAA", "BBBB");
+    }
+
+    @Test
+    void should_keep_generated_images_when_only_one_chunk_has_them() {
+        builder.append(chunkWith(GeminiPart.ofText("Hello")));
+        builder.append(chunkWith(imagePart("AAAA")));
+
+        AiMessage aiMessage = builder.build().aiMessage();
+
+        assertThat(aiMessage.images()).extracting(Image::base64Data).containsExactly("AAAA");
+    }
+
+    @Test
+    void should_join_thinking_signatures_from_every_chunk() {
+        GeminiStreamingResponseBuilder thinkingBuilder = new GeminiStreamingResponseBuilder(false, true);
+        thinkingBuilder.append(chunkWith(thoughtPart("thinking about it", "sig-1")));
+        thinkingBuilder.append(chunkWith(thoughtPart("still thinking", "sig-2")));
+
+        AiMessage aiMessage = thinkingBuilder.build().aiMessage();
+
+        assertThat(aiMessage.attributes()).containsEntry(THINKING_SIGNATURE_KEY, "sig-1\n\nsig-2");
+    }
+
+    @Test
+    void should_keep_accumulating_text_and_tools_across_chunks() {
+        builder.append(chunkWith(GeminiPart.ofText("Hello ")));
+        builder.append(chunkWith(imagePart("AAAA")));
+        builder.append(chunkWith(GeminiPart.ofText("world")));
+
+        AiMessage aiMessage = builder.build().aiMessage();
+
+        assertThat(aiMessage.text()).isEqualTo("Hello world");
+        assertThat(aiMessage.images()).hasSize(1);
+    }
+
+    private static GeminiPart imagePart(String base64Data) {
+        return new GeminiPart(
+                null, new GeminiBlob("image/png", base64Data), null, null, null, null, null, null, null, null);
+    }
+
+    private static GeminiPart thoughtPart(String thinking, String signature) {
+        return new GeminiPart(thinking, null, null, null, null, null, null, true, signature, null);
+    }
+
+    private static GeminiGenerateContentResponse chunkWith(GeminiPart part) {
+        GeminiContent content = new GeminiContent(List.of(part), "model");
+        GeminiCandidate candidate = new GeminiCandidate(content, null, null, null);
+        return new GeminiGenerateContentResponse("id-1", "gemini-pro", List.of(candidate), null, null);
     }
 }


### PR DESCRIPTION
## Issue

  Closes #5971

  ## Change

  `GeminiStreamingResponseBuilder.updateContentAndFunctionCalls` accumulates text, thinking and tool
  execution requests across chunks, but merged the attributes with `putAll`, which replaces a key rather
  than combining it:

  ```java
  Optional.ofNullable(message.text()).ifPresent(contentBuilder::append);      // appended
  Optional.ofNullable(message.thinking()).ifPresent(thoughtBuilder::append);  // appended
  attributes.putAll(message.attributes());                                    // replaced
  functionCalls.addAll(message.toolExecutionRequests());                      // accumulated
  ```

  `fromGPartsToAiMessage` builds each chunk's attributes from that chunk's parts alone, so
  `GENERATED_IMAGES_KEY` holds only the images in that chunk. Every chunk carrying an image replaced the
  images collected earlier and only the last chunk's survived into the completed response, with no error.

  Fix: merge `GENERATED_IMAGES_KEY` instead of overwriting it. Generated images are concatenated in
  arrival order; every other attribute keeps the previous last-one-wins behaviour.

  ## Why thinking signatures are not changed here

  An earlier revision of this PR also joined `THINKING_SIGNATURE_KEY` across chunks with a blank line, to
  match what `PartsAndContentsMapper` does for a non-streamed response. That has been dropped.

  The stored signature is not only read by the caller: `PartsAndContentsMapper` reads it back and
  `toGeminiParts` attaches it as the `thoughtSignature` of the first function call part when
  `sendThinking` is enabled. A thought signature is an opaque blob, and a blank-line-joined concatenation
  of several of them is not a signature the model can decrypt. Keeping the last chunk's signature at least
  sends back an intact one, so joining would have been a regression for streaming + thinking + tools,
  rather than a fix.

  The non-streaming join looks like the side that is actually wrong, and `langchain4j-google-genai`
  already shows the better shape: it stores signatures per tool call id (`thought_signature_<id>`) instead
  of collapsing them into one value. Aligning `langchain4j-google-ai-gemini` with that is worth doing, but
  it is a separate change with its own behaviour discussion, so it is left out of this bug fix.

  ## Tests

  Three tests added to `GeminiStreamingResponseBuilderTest`:
  - images from two image-bearing chunks are both present, in order;
  - images survive when only one chunk carries them;
  - text still accumulates across chunks when an image chunk is interleaved.

  The first fails on `main`. The other two guard the behaviour that must not change.

  ```
  mvn -pl langchain4j-google-ai-gemini test      # 370 tests, 0 failures
  mvn -pl langchain4j-google-ai-gemini verify    # green, including revapi
  ```

  ## General checklist
  - [x] There are no breaking changes (API, behaviour)
  - [x] I have added unit and/or integration tests for my change
  - [x] The tests cover both positive and negative cases
  - [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)