### PR TITLE
Add Automatic-Module-Name to all published artifacts

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-azure-acads/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-azure-acads/pom.xml
@@ -14,6 +14,10 @@
     <name>LangChain4j :: Integration :: Azure ACADS</name>
     <description>Implementation of a code execution engine using Azure ACA Dynamic Sessions</description>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.codeexecutionengine.azure.acads</automaticModuleNameSource>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/pom.xml
@@ -14,6 +14,7 @@
     <description>Implementation of JavaScript and Python code execution engines and tools using GraalVM Polyglot/Truffle</description>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.codeexecutionengine.graalvm.polyglot</automaticModuleNameSource>
         <graalvm.version>24.1.1</graalvm.version>
     </properties>
 
@@ -36,6 +37,7 @@
             <artifactId>js</artifactId>
             <version>${graalvm.version}</version>
             <type>pom</type>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -43,6 +45,7 @@
             <artifactId>python</artifactId>
             <version>${graalvm.version}</version>
             <type>pom</type>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
@@ -13,6 +13,10 @@
     <name>LangChain4j :: Integration :: Judge0</name>
     <description>Implementation of JavaScript code execution engine and tool using Judge0</description>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.codeexecutionengine.judge0</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -48,7 +52,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/document-loaders/langchain4j-document-loader-amazon-s3/pom.xml
+++ b/document-loaders/langchain4j-document-loader-amazon-s3/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Document Loader :: Amazon S3</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.document.loader.amazons3</automaticModuleNameSource>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
     </properties>
@@ -34,7 +35,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>langchain4j-document-loader-azure-storage-blob</artifactId>
     <name>LangChain4j :: Document Loader :: Azure Blob Storage</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.document.loader.azurestorageblob</automaticModuleNameSource>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/document-loaders/langchain4j-document-loader-google-cloud-storage/pom.xml
+++ b/document-loaders/langchain4j-document-loader-google-cloud-storage/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>langchain4j-document-loader-google-cloud-storage</artifactId>
     <name>LangChain4j :: Document Loader :: Google Cloud Storage</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.document.loader.googlecloudstorage</automaticModuleNameSource>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/document-parsers/langchain4j-document-parser-apache-pdfbox/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-pdfbox/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>langchain4j-document-parser-apache-pdfbox</artifactId>
     <name>LangChain4j :: Document Parser :: Apache PDFBox</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.document.parser.apachepdfbox</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/document-parsers/langchain4j-document-parser-apache-poi/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-poi/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Document Parser :: Apache POI</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.document.parser.apachepoi</automaticModuleNameSource>
         <apache.poi.version>5.5.1</apache.poi.version>
     </properties>
 

--- a/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
@@ -14,6 +14,7 @@
     <name>LangChain4j :: Document Parser :: Apache Tika</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.document.parser.apachetika</automaticModuleNameSource>
         <apache-tika.version>3.2.3</apache-tika.version>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence,requireUpperBoundDeps</enforcer.skipRules>

--- a/document-transformers/langchain4j-document-transformer-jsoup/src/main/java/dev/langchain4j/data/document/transformer/jsoup/HtmlToTextDocumentTransformer.java
+++ b/document-transformers/langchain4j-document-transformer-jsoup/src/main/java/dev/langchain4j/data/document/transformer/jsoup/HtmlToTextDocumentTransformer.java
@@ -4,7 +4,6 @@ import static dev.langchain4j.data.document.Document.URL;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
-import static org.jsoup.internal.StringUtil.in;
 import static org.jsoup.select.NodeTraversor.traverse;
 
 import dev.langchain4j.data.document.Document;
@@ -117,14 +116,22 @@ public class HtmlToTextDocumentTransformer implements DocumentTransformer {
             if (node instanceof TextNode) textBuilder.append(((TextNode) node).text());
             else if (name.equals("li")) textBuilder.append("\n * ");
             else if (name.equals("dt")) textBuilder.append("  ");
-            else if (in(name, "p", "h1", "h2", "h3", "h4", "h5", "h6", "tr")) textBuilder.append("\n");
+            else {
+                switch (name) {
+                    case "p", "h1", "h2", "h3", "h4", "h5", "h6", "tr" -> textBuilder.append("\n");
+                    default -> {}
+                }
+            }
         }
 
         @Override
         public void tail(Node node, int depth) { // hit when all the node's children (if any) have been visited
             String name = node.nodeName();
-            if (in(name, "br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5", "h6")) textBuilder.append("\n");
-            else if (includeLinks && name.equals("a")) {
+            switch (name) {
+                case "br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5", "h6" -> textBuilder.append("\n");
+                default -> {}
+            }
+            if (includeLinks && name.equals("a")) {
                 String link = node.absUrl("href");
                 if (link.isEmpty() && node.baseUri().isEmpty()) {
                     log.warn("No 'URL' metadata found for document. Link will be empty");

--- a/http-clients/langchain4j-http-client-apache/pom.xml
+++ b/http-clients/langchain4j-http-client-apache/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>langchain4j-http-client-apache</artifactId>
     <name>LangChain4j :: HTTP Client :: Apache HttpClient5</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.httpclient.apache</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/http-clients/langchain4j-http-client-jdk/pom.xml
+++ b/http-clients/langchain4j-http-client-jdk/pom.xml
@@ -13,6 +13,10 @@
     <version>1.19.0-SNAPSHOT</version>
     <name>LangChain4j :: HTTP Client :: JDK HttpClient</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.httpclient.jdk</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/http-clients/langchain4j-http-client-okhttp/pom.xml
+++ b/http-clients/langchain4j-http-client-okhttp/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>langchain4j-http-client-okhttp</artifactId>
     <name>LangChain4j :: HTTP Client :: OkHttp</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.httpclient.okhttp</automaticModuleNameSource>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/integration-tests/integration-tests-class-instance-loader/integration-tests-class-instance-loader-quarkus/pom.xml
+++ b/integration-tests/integration-tests-class-instance-loader/integration-tests-class-instance-loader-quarkus/pom.xml
@@ -23,6 +23,7 @@
     </licenses>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.integrationtests.classinstanceloader.quarkus</automaticModuleNameSource>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.26.3</quarkus.platform.version>

--- a/integration-tests/integration-tests-class-instance-loader/integration-tests-class-instance-loader-spring/pom.xml
+++ b/integration-tests/integration-tests-class-instance-loader/integration-tests-class-instance-loader-spring/pom.xml
@@ -23,6 +23,7 @@
     </licenses>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.integrationtests.classinstanceloader.spring</automaticModuleNameSource>
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.16</logback.version>
     </properties>

--- a/integration-tests/integration-tests-class-instance-loader/pom.xml
+++ b/integration-tests/integration-tests-class-instance-loader/pom.xml
@@ -22,6 +22,10 @@
         </license>
     </licenses>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.integrationtests.classinstanceloader</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/integration-tests/integration-tests-class-metadata-provider/integration-tests-class-metadata-provider-spring/pom.xml
+++ b/integration-tests/integration-tests-class-metadata-provider/integration-tests-class-metadata-provider-spring/pom.xml
@@ -23,6 +23,7 @@
     </licenses>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.integrationtests.classmetadataprovider.spring</automaticModuleNameSource>
         <slf4j.version>2.0.16</slf4j.version>
         <logback.version>1.5.16</logback.version>
     </properties>

--- a/integration-tests/integration-tests-class-metadata-provider/pom.xml
+++ b/integration-tests/integration-tests-class-metadata-provider/pom.xml
@@ -22,6 +22,10 @@
         </license>
     </licenses>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.integrationtests.classmetadataprovider</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/integration-tests/integration-tests-guardrails/pom.xml
+++ b/integration-tests/integration-tests-guardrails/pom.xml
@@ -22,6 +22,10 @@
         </license>
     </licenses>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.integrationtests.guardrails</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -33,6 +33,7 @@
     </modules>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.integrationtests.parent</automaticModuleNameSource>
         <!-- Don't want to actually install, deploy, or generate sources/javadocs for any of the artifacts under here -->
         <maven.deploy.file.skip>true</maven.deploy.file.skip>
         <maven.install.skip>true</maven.install.skip>

--- a/internal/langchain4j-docu-chatbot-updater/pom.xml
+++ b/internal/langchain4j-docu-chatbot-updater/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Internal :: Documentation Chatbot Updater</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.docu.chatbotupdater</automaticModuleNameSource>
         <enforcer.skipRules>dependencyConvergence,requireUpperBoundDeps</enforcer.skipRules>
     </properties>
 

--- a/internal/langchain4j-internal-test-retry/pom.xml
+++ b/internal/langchain4j-internal-test-retry/pom.xml
@@ -26,6 +26,7 @@
     </scm>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.internaltest.retry</automaticModuleNameSource>
         <java.version>17</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/langchain4j-azure-ai-search/pom.xml
+++ b/langchain4j-azure-ai-search/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Integration :: Azure AI Search</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.azureai.search</automaticModuleNameSource>
         <skipAzureAiSearchITs>${skipITs}</skipAzureAiSearchITs>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
@@ -45,7 +46,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AbstractAzureCosmosDBNoSqlEmbeddingStore.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AbstractAzureCosmosDBNoSqlEmbeddingStore.java
@@ -17,7 +17,6 @@ import com.azure.cosmos.CosmosAsyncContainer;
 import com.azure.cosmos.CosmosAsyncDatabase;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosException;
-import com.azure.cosmos.implementation.apachecommons.lang.tuple.ImmutablePair;
 import com.azure.cosmos.models.CosmosBulkOperations;
 import com.azure.cosmos.models.CosmosContainerProperties;
 import com.azure.cosmos.models.CosmosFullTextPolicy;
@@ -48,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -235,7 +235,7 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
             }
         }
 
-        List<ImmutablePair<String, CosmosItemOperation>> itemOperationsWithIds = ids.stream()
+        List<Map.Entry<String, CosmosItemOperation>> itemOperationsWithIds = ids.stream()
                 .map(id -> {
                     String partitionKeyValue;
 
@@ -273,13 +273,13 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
                                 new PartitionKey(partitionKeyValue));
                     }
 
-                    return new ImmutablePair<>(id, operation);
+                    return Map.entry(id, operation);
                 })
                 .toList();
 
         try {
             List<CosmosItemOperation> itemOperations =
-                    itemOperationsWithIds.stream().map(ImmutablePair::getValue).collect(toList());
+                    itemOperationsWithIds.stream().map(Map.Entry::getValue).collect(toList());
 
             this.container
                     .executeBulkOperations(Flux.fromIterable(itemOperations))
@@ -291,7 +291,7 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
                                 String documentId = itemOperationsWithIds.stream()
                                         .filter(pair -> pair.getValue().equals(response.getOperation()))
                                         .findFirst()
-                                        .map(ImmutablePair::getKey)
+                                        .map(Map.Entry::getKey)
                                         .orElse("Unknown ID"); // Fallback if the ID can't be found
 
                                 String errorMessage = String.format("Duplicate document id: %s", documentId);

--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/memory/azure/cosmos/nosql/AzureCosmosDBNoSqlMemoryStore.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/memory/azure/cosmos/nosql/AzureCosmosDBNoSqlMemoryStore.java
@@ -11,7 +11,6 @@ import com.azure.cosmos.CosmosAsyncClient;
 import com.azure.cosmos.CosmosAsyncContainer;
 import com.azure.cosmos.CosmosAsyncDatabase;
 import com.azure.cosmos.CosmosClientBuilder;
-import com.azure.cosmos.implementation.guava25.collect.ImmutableList;
 import com.azure.cosmos.models.CosmosContainerProperties;
 import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.ExcludedPath;
@@ -116,7 +115,7 @@ public class AzureCosmosDBNoSqlMemoryStore implements ChatMemoryStore {
         indexingPolicy.setExcludedPaths(singletonList(excludedPath));
         IncludedPath includedPath1 = new IncludedPath("/metadata/?");
         IncludedPath includedPath2 = new IncludedPath("/content/?");
-        indexingPolicy.setIncludedPaths(ImmutableList.of(includedPath1, includedPath2));
+        indexingPolicy.setIncludedPaths(List.of(includedPath1, includedPath2));
         return indexingPolicy;
     }
 

--- a/langchain4j-azure-open-ai/pom.xml
+++ b/langchain4j-azure-open-ai/pom.xml
@@ -23,6 +23,7 @@
     </developers>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.azure.openai</automaticModuleNameSource>
         <azure-ai-openai.version>1.0.0-beta.16</azure-ai-openai.version>
     </properties>
 
@@ -140,5 +141,23 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <configuration>
+                            <legacyMode>true</legacyMode>
+                            <useModulePath>false</useModulePath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/langchain4j-coherence/src/main/java/dev/langchain4j/store/embedding/coherence/CoherenceEmbeddingStore.java
+++ b/langchain4j-coherence/src/main/java/dev/langchain4j/store/embedding/coherence/CoherenceEmbeddingStore.java
@@ -13,11 +13,11 @@ import com.oracle.coherence.ai.Vector;
 import com.oracle.coherence.ai.VectorIndexExtractor;
 import com.oracle.coherence.ai.search.SimilaritySearch;
 import com.oracle.coherence.common.base.Logger;
-import com.tangosol.internal.util.processor.CacheProcessors;
 import com.tangosol.net.Coherence;
 import com.tangosol.net.NamedMap;
 import com.tangosol.net.Session;
 import com.tangosol.util.Filter;
+import com.tangosol.util.Processors;
 import com.tangosol.util.UUID;
 import com.tangosol.util.ValueExtractor;
 import dev.langchain4j.data.document.Metadata;
@@ -121,7 +121,7 @@ public class CoherenceEmbeddingStore implements EmbeddingStore<TextSegment> {
         ensureNotNull(filter, "filter");
 
         Filter<DocumentChunk> chunkFilter = CoherenceMetadataFilterMapper.map(filter);
-        documentChunks.invokeAll(chunkFilter, CacheProcessors.removeBlind());
+        documentChunks.invokeAll(chunkFilter, Processors.remove());
     }
 
     @Override

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/ObservabilityPackage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/ObservabilityPackage.java
@@ -1,0 +1,9 @@
+package dev.langchain4j.observability;
+
+/**
+ * Added to avoid javadoc error for empty package.
+ */
+final class ObservabilityPackage {
+
+    private ObservabilityPackage() {}
+}

--- a/langchain4j-google-ai-gemini/pom.xml
+++ b/langchain4j-google-ai-gemini/pom.xml
@@ -22,6 +22,7 @@
     </developers>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.googleai.gemini</automaticModuleNameSource>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/langchain4j-http-client/pom.xml
+++ b/langchain4j-http-client/pom.xml
@@ -12,6 +12,10 @@
     <version>1.19.0-SNAPSHOT</version>
     <name>LangChain4j :: HTTP Client</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.httpclient</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/langchain4j-infinispan/pom.xml
+++ b/langchain4j-infinispan/pom.xml
@@ -96,6 +96,19 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <configuration>
+                            <legacyMode>true</legacyMode>
+                            <useModulePath>false</useModulePath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/langchain4j-local-ai/pom.xml
+++ b/langchain4j-local-ai/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Integration :: LocalAI</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.localai</automaticModuleNameSource>
         <skipLocalAiITs>${skipITs}</skipLocalAiITs>
     </properties>
 

--- a/langchain4j-micrometer-metrics/pom.xml
+++ b/langchain4j-micrometer-metrics/pom.xml
@@ -14,6 +14,7 @@
     <description>Micrometer implementation for LangChain4j</description>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.micrometermetrics</automaticModuleNameSource>
         <!-- pinned here to avoid surprising upgrades; adjust when updating OTel semconv -->
         <micrometer.version>1.16.5</micrometer.version>
     </properties>

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -21,6 +21,10 @@
         </developer>
     </developers>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.mistralai</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/langchain4j-open-ai-official/pom.xml
+++ b/langchain4j-open-ai-official/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Integration :: OpenAI Official</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.openai.official</automaticModuleNameSource>
         <openai-java.version>4.41.0</openai-java.version>
         <httpclient5.version>5.2.4</httpclient5.version>
         <enforcer.skipRules>requireUpperBoundDeps</enforcer.skipRules>

--- a/langchain4j-open-ai/pom.xml
+++ b/langchain4j-open-ai/pom.xml
@@ -13,6 +13,10 @@
     <version>1.19.0-SNAPSHOT</version>
     <name>LangChain4j :: Integration :: OpenAI</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.openai</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -54,7 +58,6 @@
             <artifactId>jtokkit</artifactId>
             <version>${jtokkit.version}</version>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/langchain4j-ovh-ai/pom.xml
+++ b/langchain4j-ovh-ai/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Integration :: OVHcloud AI</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.ovhai</automaticModuleNameSource>
         <skipOvhAIITs>${skipITs}</skipOvhAIITs>
     </properties>
 
@@ -46,7 +47,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
         <dependency>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -35,6 +35,9 @@
     </scm>
 
     <properties>
+        <!-- Default JPMS module name; submodules can override this property when some artifactId
+             separators are only for readability and should stay grouped in the JPMS name. -->
+        <automaticModuleNameSource>dev.${project.artifactId}</automaticModuleNameSource>
         <langchain4j.beta.version>1.19.0-beta29-SNAPSHOT</langchain4j.beta.version>
         <java.version>17</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
@@ -397,6 +400,15 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.5.0</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <!-- Stable JPMS module name so the jars can be required from the module path.
+                                     Derived from the artifactId by the build-helper execution below. -->
+                                <Automatic-Module-Name>${automaticModuleName}</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -576,6 +588,36 @@
         </pluginManagement>
 
         <plugins>
+
+            <plugin>
+                <!-- Derive the JPMS Automatic-Module-Name from the current automaticModuleNameSource value by
+                     translating remaining '-' separators to '.'. Submodules can override automaticModuleNameSource
+                     directly when some separators are only for readability, e.g. "open-ai" -> "openai". -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>derive-automatic-module-name</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>automaticModuleName</name>
+                            <value>${automaticModuleNameSource}</value>
+                            <regex>-</regex>
+                            <replacement>.</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
 
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/langchain4j-vertex-ai-anthropic/pom.xml
+++ b/langchain4j-vertex-ai-anthropic/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Integration :: Google Vertex AI Anthropic</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.vertexai.anthropic</automaticModuleNameSource>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/langchain4j-vertex-ai-gemini/pom.xml
+++ b/langchain4j-vertex-ai-gemini/pom.xml
@@ -13,6 +13,7 @@
     <name>LangChain4j :: Integration :: Google Vertex AI Gemini</name>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.vertexai.gemini</automaticModuleNameSource>
         <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 

--- a/langchain4j-vertex-ai/pom.xml
+++ b/langchain4j-vertex-ai/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>langchain4j-vertex-ai</artifactId>
     <name>LangChain4j :: Integration :: Google Vertex AI</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.vertexai</automaticModuleNameSource>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -44,7 +48,6 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-discoveryengine</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/langchain4j-voyage-ai/pom.xml
+++ b/langchain4j-voyage-ai/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>langchain4j-voyage-ai</artifactId>
     <name>LangChain4j :: Integration :: Voyage AI</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.voyageai</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -14,6 +14,10 @@
 
     <name>LangChain4j :: Integration :: CloudFlare Workers AI</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.workersai</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/web-search-engines/langchain4j-web-search-engine-google-custom/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-google-custom/pom.xml
@@ -16,6 +16,7 @@
     <description>Implementation of Google Custom Search API for LangChain4j</description>
 
     <properties>
+        <automaticModuleNameSource>dev.langchain4j.websearchengine.google.custom</automaticModuleNameSource>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence,requireUpperBoundDeps</enforcer.skipRules>
     </properties>
@@ -38,7 +39,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
@@ -14,6 +14,10 @@
 
     <name>LangChain4j :: Web Search Engine :: SearchApi</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.websearchengine.searchapi</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -39,7 +43,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
@@ -14,6 +14,10 @@
 
     <name>LangChain4j :: Web Search Engine :: Tavily</name>
 
+    <properties>
+        <automaticModuleNameSource>dev.langchain4j.websearchengine.tavily</automaticModuleNameSource>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -39,7 +43,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 


### PR DESCRIPTION
Derive a stable JPMS module name for every published module from its artifactId in the parent POM: dev.<artifactId with '-' as '.'> — so langchain4j-open-ai -> dev.langchain4j.open.ai, langchain4j-core -> dev.langchain4j.core, langchain4j -> dev.langchain4j. Every published artifactId begins with 'langchain4j', so the 'dev.' prefix reproduces the dev.langchain4j group namespace, and new modules are covered automatically with no per-module change. This lets the jars be required from the module path instead of relying on filename-derived automatic names.

A build-helper regex-property execution computes the name; the maven-jar-plugin writes it to the manifest; a properties default covers the dash-less 'langchain4j' artifact.

Also avoids one use of internal API which is not available when Oracle Coherence is placed on the module path.

Suggested names:

langchain4j-code-execution-engine-azure-acads -> dev.langchain4j.codeexecutionengine.azure.acads
langchain4j-code-execution-engine-graalvm-polyglot -> dev.langchain4j.codeexecutionengine.graalvm.polyglot
langchain4j-code-execution-engine-judge0 -> dev.langchain4j.codeexecutionengine.judge0
langchain4j-document-loader-amazon-s3 -> dev.langchain4j.document.loader.amazons3
langchain4j-document-loader-azure-storage-blob -> dev.langchain4j.document.loader.azurestorageblob
langchain4j-document-loader-github -> dev.langchain4j.document.loader.github
langchain4j-document-loader-google-cloud-storage -> dev.langchain4j.document.loader.googlecloudstorage
langchain4j-document-loader-playwright -> dev.langchain4j.document.loader.playwright
langchain4j-document-loader-selenium -> dev.langchain4j.document.loader.selenium
langchain4j-document-loader-tencent-cos -> dev.langchain4j.document.loader.tencent.cos
langchain4j-document-parser-apache-pdfbox -> dev.langchain4j.document.parser.apachepdfbox
langchain4j-document-parser-apache-poi -> dev.langchain4j.document.parser.apachepoi
langchain4j-document-parser-apache-tika -> dev.langchain4j.document.parser.apachetika
langchain4j-document-parser-docling -> dev.langchain4j.document.parser.docling
langchain4j-document-parser-markdown -> dev.langchain4j.document.parser.markdown
langchain4j-document-parser-yaml -> dev.langchain4j.document.parser.yaml
langchain4j-document-transformer-jsoup -> dev.langchain4j.document.transformer.jsoup
langchain4j-embedding-store-filter-parser-sql -> dev.langchain4j.embedding.store.filter.parser.sql
langchain4j-embeddings -> dev.langchain4j.embeddings
langchain4j-embeddings-all-minilm-l6-v2 -> dev.langchain4j.embeddings.all.minilm.l6.v2
langchain4j-embeddings-all-minilm-l6-v2-q -> dev.langchain4j.embeddings.all.minilm.l6.v2.q
langchain4j-embeddings-bge-small-en -> dev.langchain4j.embeddings.bge.small.en
langchain4j-embeddings-bge-small-en-q -> dev.langchain4j.embeddings.bge.small.en.q
langchain4j-embeddings-bge-small-en-v15 -> dev.langchain4j.embeddings.bge.small.en.v15
langchain4j-embeddings-bge-small-en-v15-q -> dev.langchain4j.embeddings.bge.small.en.v15.q
langchain4j-embeddings-bge-small-zh-v15 -> dev.langchain4j.embeddings.bge.small.zh.v15
langchain4j-embeddings-bge-small-zh-v15-q -> dev.langchain4j.embeddings.bge.small.zh.v15.q
langchain4j-embeddings-e5-small-v2 -> dev.langchain4j.embeddings.e5.small.v2
langchain4j-embeddings-e5-small-v2-q -> dev.langchain4j.embeddings.e5.small.v2.q
langchain4j-experimental-hibernate -> dev.langchain4j.experimental.hibernate
langchain4j-experimental-skills-shell -> dev.langchain4j.experimental.skills.shell
langchain4j-experimental-sql -> dev.langchain4j.experimental.sql
langchain4j-http-client-apache -> dev.langchain4j.httpclient.apache
langchain4j-http-client-jdk -> dev.langchain4j.httpclient.jdk
langchain4j-http-client-okhttp -> dev.langchain4j.httpclient.okhttp
langchain4j-integration-tests-class-instance-loader-quarkus -> dev.langchain4j.integrationtests.classinstanceloader.quarkus
langchain4j-integration-tests-class-instance-loader-spring -> dev.langchain4j.integrationtests.classinstanceloader.spring
langchain4j-integration-tests-class-instance-loader -> dev.langchain4j.integrationtests.classinstanceloader
langchain4j-integration-tests-class-metadata-provider-spring -> dev.langchain4j.integrationtests.classmetadataprovider.spring
langchain4j-integration-tests-class-metadata-provider -> dev.langchain4j.integrationtests.classmetadataprovider
langchain4j-integration-tests-guardrails -> dev.langchain4j.integrationtests.guardrails
langchain4j-integration-tests-parent -> dev.langchain4j.integrationtests.parent
langchain4j-docu-chatbot-updater -> dev.langchain4j.docu.chatbotupdater
langchain4j-internal-test-retry -> dev.langchain4j.internaltest.retry
langchain4j -> dev.langchain4j
langchain4j-agentic -> dev.langchain4j.agentic
langchain4j-agentic-a2a -> dev.langchain4j.agentic.a2a
langchain4j-agentic-mcp -> dev.langchain4j.agentic.mcp
langchain4j-agentic-patterns -> dev.langchain4j.agentic.patterns
langchain4j-anthropic -> dev.langchain4j.anthropic
langchain4j-azure-ai-search -> dev.langchain4j.azureai.search
langchain4j-azure-cosmos-mongo-vcore -> dev.langchain4j.azure.cosmos.mongo.vcore
langchain4j-azure-cosmos-nosql -> dev.langchain4j.azure.cosmos.nosql
langchain4j-azure-open-ai -> dev.langchain4j.azure.openai
langchain4j-bedrock -> dev.langchain4j.bedrock
langchain4j-bom -> dev.langchain4j.bom
langchain4j-cassandra -> dev.langchain4j.cassandra
langchain4j-chroma -> dev.langchain4j.chroma
langchain4j-cohere -> dev.langchain4j.cohere
langchain4j-coherence -> dev.langchain4j.coherence
langchain4j-core -> dev.langchain4j.core
langchain4j-couchbase -> dev.langchain4j.couchbase
langchain4j-easy-rag -> dev.langchain4j.easy.rag
langchain4j-elasticsearch -> dev.langchain4j.elasticsearch
langchain4j-github-models -> dev.langchain4j.github.models
langchain4j-google-ai-gemini -> dev.langchain4j.googleai.gemini
langchain4j-google-genai -> dev.langchain4j.google.genai
langchain4j-gpu-llama3 -> dev.langchain4j.gpu.llama3
langchain4j-guardrails -> dev.langchain4j.guardrails
langchain4j-hibernate -> dev.langchain4j.hibernate
langchain4j-http-client -> dev.langchain4j.httpclient
langchain4j-hugging-face -> dev.langchain4j.hugging.face
langchain4j-infinispan -> dev.langchain4j.infinispan
langchain4j-jina -> dev.langchain4j.jina
langchain4j-jlama -> dev.langchain4j.jlama
langchain4j-kotlin -> dev.langchain4j.kotlin
langchain4j-local-ai -> dev.langchain4j.localai
langchain4j-mariadb -> dev.langchain4j.mariadb
langchain4j-mcp -> dev.langchain4j.mcp
langchain4j-mcp-docker -> dev.langchain4j.mcp.docker
langchain4j-micrometer-metrics -> dev.langchain4j.micrometermetrics
langchain4j-milvus -> dev.langchain4j.milvus
langchain4j-milvus-v2 -> dev.langchain4j.milvus.v2
langchain4j-mistral-ai -> dev.langchain4j.mistralai
langchain4j-mongodb-atlas -> dev.langchain4j.mongodb.atlas
langchain4j-nomic -> dev.langchain4j.nomic
langchain4j-observation -> dev.langchain4j.observation
langchain4j-ollama -> dev.langchain4j.ollama
langchain4j-onnx-scoring -> dev.langchain4j.onnx.scoring
langchain4j-open-ai -> dev.langchain4j.openai
langchain4j-open-ai-official -> dev.langchain4j.openai.official
langchain4j-opensearch -> dev.langchain4j.opensearch
langchain4j-oracle -> dev.langchain4j.oracle
langchain4j-ovh-ai -> dev.langchain4j.ovhai
langchain4j-parent -> dev.langchain4j.parent
langchain4j-pgvector -> dev.langchain4j.pgvector
langchain4j-pinecone -> dev.langchain4j.pinecone
langchain4j-qdrant -> dev.langchain4j.qdrant
langchain4j-skills -> dev.langchain4j.skills
langchain4j-tablestore -> dev.langchain4j.tablestore
langchain4j-test -> dev.langchain4j.test
langchain4j-vertex-ai -> dev.langchain4j.vertexai
langchain4j-vertex-ai-anthropic -> dev.langchain4j.vertexai.anthropic
langchain4j-vertex-ai-gemini -> dev.langchain4j.vertexai.gemini
langchain4j-vespa -> dev.langchain4j.vespa
langchain4j-voyage-ai -> dev.langchain4j.voyageai
langchain4j-watsonx -> dev.langchain4j.watsonx
langchain4j-weaviate -> dev.langchain4j.weaviate
langchain4j-workers-ai -> dev.langchain4j.workersai
langchain4j-aggregator -> dev.langchain4j.aggregator
langchain4j-web-search-engine-google-custom -> dev.langchain4j.websearchengine.google.custom
langchain4j-web-search-engine-searchapi -> dev.langchain4j.websearchengine.searchapi
langchain4j-web-search-engine-tavily -> dev.langchain4j.websearchengine.tavily