### PR TITLE
fix: make Elasticsearch full text and vector search return structurally identical TextSegments

### DIFF
--- a/langchain4j-elasticsearch/revapi.json
+++ b/langchain4j-elasticsearch/revapi.json
@@ -1,0 +1,15 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.store.embedding.EmbeddingMatch",
+          "justification": "AbstractElasticsearchEmbeddingStore.fullTextSearchMatches() returns EmbeddingMatch, the same core type already returned by search() and hybridSearch() via EmbeddingSearchResult"
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
@@ -9,6 +9,7 @@ import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.elasticsearch.AbstractElasticsearchEmbeddingStore;
@@ -103,14 +104,7 @@ public class ElasticsearchContentRetriever extends AbstractElasticsearchEmbeddin
     public List<Content> retrieve(final Query query) {
         if (configuration instanceof ElasticsearchConfigurationFullText) {
             log.debug("Using a full text search query");
-            return this.fullTextSearch(query.text()).stream()
-                    .map(t -> Content.from(
-                            t,
-                            Map.of(
-                                    ContentMetadata.SCORE, t.metadata().getDouble(ContentMetadata.SCORE.name()),
-                                    ContentMetadata.EMBEDDING_ID,
-                                            t.metadata().getString(ContentMetadata.EMBEDDING_ID.name()))))
-                    .toList();
+            return toContentList(this.fullTextSearchMatches(query.text()));
         }
         Embedding referenceEmbedding = embeddingModel.embed(query.text()).content();
         EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
@@ -128,13 +122,18 @@ public class ElasticsearchContentRetriever extends AbstractElasticsearchEmbeddin
     }
 
     private List<Content> mapResultsToContentList(EmbeddingSearchResult<TextSegment> searchResult) {
-        List<Content> result = searchResult.matches().stream()
-                .filter(f -> f.score() >= minScore)
-                .map(m -> Content.from(
-                        m.embedded(),
+        return toContentList(searchResult.matches().stream()
+                .filter(match -> match.score() >= minScore)
+                .toList());
+    }
+
+    private List<Content> toContentList(List<EmbeddingMatch<TextSegment>> matches) {
+        List<Content> result = matches.stream()
+                .map(match -> Content.from(
+                        match.embedded(),
                         Map.of(
-                                ContentMetadata.SCORE, m.score(),
-                                ContentMetadata.EMBEDDING_ID, m.embeddingId())))
+                                ContentMetadata.SCORE, match.score(),
+                                ContentMetadata.EMBEDDING_ID, match.embeddingId())))
                 .toList();
         log.debug("Found [{}] relevant documents in Elasticsearch index [{}].", result.size(), indexName);
         return result;

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
@@ -26,7 +26,6 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
@@ -200,16 +199,33 @@ public abstract class AbstractElasticsearchEmbeddingStore implements EmbeddingSt
         }
     }
 
-    public List<TextSegment> fullTextSearch(String textQuery) {
+    /**
+     * Searches the index with a full text (non-vector) query.
+     *
+     * @param textQuery the text to search for
+     * @return the matching documents, each carrying its Elasticsearch document ID and relevance score
+     */
+    public List<EmbeddingMatch<TextSegment>> fullTextSearchMatches(String textQuery) {
         log.debug("full text search([...{}...])", textQuery.length());
         try {
             SearchResponse<Document> response = this.configuration.fullTextSearch(client, indexName, textQuery);
             log.trace("found [{}] results", response);
 
-            return toTextList(response);
+            return toMatches(response);
         } catch (ElasticsearchException | IOException e) {
             throw new ElasticsearchRequestFailedException(e);
         }
+    }
+
+    /**
+     * @deprecated Use {@link #fullTextSearchMatches(String)} instead. It returns the same text segments,
+     * but also the Elasticsearch document ID and the relevance score of each match.
+     */
+    @Deprecated(forRemoval = true)
+    public List<TextSegment> fullTextSearch(String textQuery) {
+        return fullTextSearchMatches(textQuery).stream()
+                .map(match -> match == null ? null : match.embedded())
+                .collect(toList());
     }
 
     @Override
@@ -361,24 +377,7 @@ public abstract class AbstractElasticsearchEmbeddingStore implements EmbeddingSt
                                         .orElse(new float[] {})),
                                 document.getText() == null
                                         ? null
-                                        : TextSegment.from(
-                                                document.getText(),
-                                                new Metadata(document.getMetadata())
-                                                        .put(ContentMetadata.SCORE.name(), hit.score())
-                                                        .put(ContentMetadata.EMBEDDING_ID.name(), hit.id()))))
-                        .orElse(null))
-                .collect(toList());
-    }
-
-    private List<TextSegment> toTextList(SearchResponse<Document> response) {
-        return response.hits().hits().stream()
-                .map(hit -> Optional.ofNullable(hit.source())
-                        .filter(document -> document.getText() != null)
-                        .map(document -> TextSegment.from(
-                                document.getText(),
-                                new Metadata(document.getMetadata())
-                                        .put(ContentMetadata.SCORE.name(), hit.score())
-                                        .put(ContentMetadata.EMBEDDING_ID.name(), hit.id())))
+                                        : TextSegment.from(document.getText(), new Metadata(document.getMetadata()))))
                         .orElse(null))
                 .collect(toList());
     }

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
@@ -361,7 +361,11 @@ public abstract class AbstractElasticsearchEmbeddingStore implements EmbeddingSt
                                         .orElse(new float[] {})),
                                 document.getText() == null
                                         ? null
-                                        : TextSegment.from(document.getText(), new Metadata(document.getMetadata()))))
+                                        : TextSegment.from(
+                                                document.getText(),
+                                                new Metadata(document.getMetadata())
+                                                        .put(ContentMetadata.SCORE.name(), hit.score())
+                                                        .put(ContentMetadata.EMBEDDING_ID.name(), hit.id()))))
                         .orElse(null))
                 .collect(toList());
     }

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverFusionTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverFusionTest.java
@@ -1,0 +1,174 @@
+package dev.langchain4j.rag.content.retriever.elasticsearch;
+
+import static co.elastic.clients.elasticsearch.core.search.TotalHitsRelation.Eq;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.DefaultTransportOptions;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.ContentMetadata;
+import dev.langchain4j.rag.content.aggregator.ReciprocalRankFuser;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.elasticsearch.Document;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationFullText;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationKnn;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The full text and the vector search paths must produce structurally identical {@link TextSegment}s,
+ * otherwise {@link Content#equals(Object)} sees two different objects for the same document and
+ * {@link ReciprocalRankFuser} cannot fold them. See https://github.com/langchain4j/langchain4j/issues/5974.
+ */
+class ElasticsearchContentRetrieverFusionTest {
+
+    private static final Query QUERY = Query.from("any query");
+
+    @Test
+    void should_not_put_score_and_embedding_id_into_text_segment_metadata() {
+        List<Content> fullText = fullTextRetriever("1", "hello", 12.4).retrieve(QUERY);
+        List<Content> knn = knnRetriever("1", "hello", 0.87).retrieve(QUERY);
+
+        assertThat(fullText).hasSize(1);
+        assertThat(knn).hasSize(1);
+        assertThat(fullText.get(0).textSegment().metadata().toMap()).containsOnlyKeys("key");
+        assertThat(knn.get(0).textSegment().metadata().toMap()).containsOnlyKeys("key");
+    }
+
+    @Test
+    void should_expose_score_and_embedding_id_as_content_metadata_on_both_paths() {
+        Content fullText = fullTextRetriever("1", "hello", 12.4).retrieve(QUERY).get(0);
+        Content knn = knnRetriever("1", "hello", 0.87).retrieve(QUERY).get(0);
+
+        assertThat(fullText.metadata())
+                .containsEntry(ContentMetadata.SCORE, 12.4)
+                .containsEntry(ContentMetadata.EMBEDDING_ID, "1");
+        assertThat(knn.metadata())
+                .containsEntry(ContentMetadata.SCORE, 0.87)
+                .containsEntry(ContentMetadata.EMBEDDING_ID, "1");
+    }
+
+    @Test
+    void should_fuse_the_same_document_retrieved_by_both_paths_despite_different_scores() {
+        List<Content> fullText = fullTextRetriever("1", "hello", 12.4).retrieve(QUERY);
+        List<Content> knn = knnRetriever("1", "hello", 0.87).retrieve(QUERY);
+
+        assertThat(fullText.get(0)).isEqualTo(knn.get(0));
+        assertThat(ReciprocalRankFuser.fuse(List.of(fullText, knn))).hasSize(1);
+    }
+
+    @Test
+    void should_not_fuse_different_documents() {
+        List<Content> fullText = fullTextRetriever("1", "hello", 12.4).retrieve(QUERY);
+        List<Content> knn = knnRetriever("2", "goodbye", 0.87).retrieve(QUERY);
+
+        assertThat(fullText.get(0)).isNotEqualTo(knn.get(0));
+        assertThat(ReciprocalRankFuser.fuse(List.of(fullText, knn))).hasSize(2);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void deprecated_full_text_search_should_return_the_segments_without_score_metadata() {
+        List<TextSegment> segments = fullTextRetriever("1", "hello", 12.4).fullTextSearch("any query");
+
+        assertThat(segments).hasSize(1);
+        assertThat(segments.get(0).text()).isEqualTo("hello");
+        assertThat(segments.get(0).metadata().toMap()).containsOnlyKeys("key");
+    }
+
+    private static ElasticsearchContentRetriever fullTextRetriever(String id, String text, double score) {
+        return retriever(ElasticsearchConfigurationFullText.builder().build(), id, text, score);
+    }
+
+    private static ElasticsearchContentRetriever knnRetriever(String id, String text, double score) {
+        return retriever(ElasticsearchConfigurationKnn.builder().build(), id, text, score);
+    }
+
+    private static ElasticsearchContentRetriever retriever(
+            ElasticsearchConfiguration configuration, String id, String text, double score) {
+        return ElasticsearchContentRetriever.builder()
+                .configuration(configuration)
+                .client(new ElasticsearchClient(new SingleHitTransport(id, text, score)))
+                .indexName("test")
+                .embeddingModel(new FixedEmbeddingModel())
+                .maxResults(3)
+                .build();
+    }
+
+    private static class FixedEmbeddingModel implements EmbeddingModel {
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+            return Response.from(textSegments.stream()
+                    .map(ignored -> Embedding.from(new float[] {0.1f, 0.2f}))
+                    .toList());
+        }
+    }
+
+    private static class SingleHitTransport implements ElasticsearchTransport {
+
+        private final JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+        private final String id;
+        private final String text;
+        private final double score;
+
+        private SingleHitTransport(String id, String text, double score) {
+            this.id = id;
+            this.text = text;
+            this.score = score;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            Hit<Document> hit = Hit.of(h -> h.index("test")
+                    .id(id)
+                    .score(score)
+                    .source(Document.builder()
+                            .vector(new float[] {0.1f, 0.2f})
+                            .text(text)
+                            .metadata(Map.of("key", "value"))
+                            .build()));
+            SearchResponse<Document> response = SearchResponse.of(sr -> sr.took(0)
+                    .timedOut(false)
+                    .shards(s -> s.total(1).successful(1).failed(0))
+                    .hits(h -> h.total(t -> t.value(1).relation(Eq)).hits(singletonList(hit))));
+            return (ResponseT) response;
+        }
+
+        @Override
+        public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            return CompletableFuture.completedFuture(performRequest(request, endpoint, options));
+        }
+
+        @Override
+        public JsonpMapper jsonpMapper() {
+            return jsonpMapper;
+        }
+
+        @Override
+        public TransportOptions options() {
+            return DefaultTransportOptions.EMPTY;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## Issue

  Fixes #5974

  ## Change

  `AbstractElasticsearchEmbeddingStore` produced two different `TextSegment` shapes for the same
  document depending on the retrieval path:

  - `toMatches()` (vector / hybrid search) built the segment from the document's own metadata.
  - `toTextList()` (full text search) additionally wrote `ContentMetadata.SCORE` and
    `ContentMetadata.EMBEDDING_ID` into that metadata.

  `DefaultContent.equals()` compares the embedded `TextSegment`, so the same chunk retrieved by a
  KNN retriever and by a full text retriever produced two unequal `Content` objects, and
  `ReciprocalRankFuser` could not fold them: the fused list contained duplicates and the RRF scores
  were never accumulated.

  Aligning the two methods by *adding* score and embedding id to `toMatches()` does not fix this —
  the two paths use different scoring functions (cosine vs BM25), so the segments would still differ
  by the `SCORE` value. It would also change the metadata of every segment returned by the plain
  `EmbeddingStore.search()` API.

  This PR fixes it from the other side instead:

  - `toTextList()` is removed; the full text path now uses `toMatches()` like every other path, so
    both produce a `TextSegment` carrying only the document's own metadata.
  - `AbstractElasticsearchEmbeddingStore.fullTextSearchMatches(String)` is added. It returns
    `List<EmbeddingMatch<TextSegment>>`, so the Elasticsearch `_id` and `_score` travel next to the
    segment instead of inside it.
  - `ElasticsearchContentRetriever` maps all three paths (full text, vector, hybrid) through the same
    helper, so `Content.metadata()` still exposes `ContentMetadata.SCORE` and
    `ContentMetadata.EMBEDDING_ID` exactly as before.

  `ContentMetadata` is a RAG-layer type; `langchain4j-elasticsearch` was the only module writing it
  into a document-layer `Metadata`. That leak is now gone.

  ## Breaking Changes

  `AbstractElasticsearchEmbeddingStore.fullTextSearch(String)` is deprecated for removal, and the
  `TextSegment`s it returns no longer contain the `SCORE` and `EMBEDDING_ID` metadata entries.
  Only code calling this method directly is affected; `ElasticsearchContentRetriever.retrieve()` is
  unchanged from the caller's point of view.

  Before:

  ```java
  List<TextSegment> segments = store.fullTextSearch("my query");
  for (TextSegment segment : segments) {
      Double score = segment.metadata().getDouble("SCORE");
      String id = segment.metadata().getString("EMBEDDING_ID");
  }
  ```

  After:

  ```java
  List<EmbeddingMatch<TextSegment>> matches = store.fullTextSearchMatches("my query");
  for (EmbeddingMatch<TextSegment> match : matches) {
      Double score = match.score();
      String id = match.embeddingId();
      TextSegment segment = match.embedded();
  }
  ```

  ## General checklist

  - [ ] There are no breaking changes (API, behaviour)  <!-- see the Breaking Changes section above -->
  - [x] I have added unit and/or integration tests for my change
  - [x] The tests cover both positive and negative cases
  - [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
  - [x] I have added/updated the documentation
  - [ ] I have added an example in the examples repo (only for "big" features)
  - [ ] I have added/updated Spring Boot starter(s) (if applicable)

  ## Checklist for changing existing embedding store integration

  - [x] I have manually verified that the `ElasticsearchEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j