### PR TITLE
fix: return null instead of throwing NPE for URIs without a file name

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.internal;
 
 import dev.langchain4j.Internal;
-
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,61 +35,62 @@ import java.util.Map;
 public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
 
     private static final Map<String, String> defaultMappings = new HashMap<>();
+
     static {
-        defaultMappings.put("pdf",   "application/pdf");
-        defaultMappings.put("yml",   "text/yaml");
-        defaultMappings.put("yaml",  "text/yaml");
-        defaultMappings.put("json",  "application/json");
-        defaultMappings.put("js",    "text/javascript");
-        defaultMappings.put("mjs",   "text/javascript");
-        defaultMappings.put("ts",    "text/x.typescript");
-        defaultMappings.put("txt",   "text/plain");
-        defaultMappings.put("xml",   "application/xml");
-        defaultMappings.put("svg",   "image/svg+xml");
+        defaultMappings.put("pdf", "application/pdf");
+        defaultMappings.put("yml", "text/yaml");
+        defaultMappings.put("yaml", "text/yaml");
+        defaultMappings.put("json", "application/json");
+        defaultMappings.put("js", "text/javascript");
+        defaultMappings.put("mjs", "text/javascript");
+        defaultMappings.put("ts", "text/x.typescript");
+        defaultMappings.put("txt", "text/plain");
+        defaultMappings.put("xml", "application/xml");
+        defaultMappings.put("svg", "image/svg+xml");
         defaultMappings.put("xhtml", "application/xhtml+xml");
-        defaultMappings.put("html",  "text/html");
-        defaultMappings.put("htm",   "text/html");
-        defaultMappings.put("css",   "text/css");
-        defaultMappings.put("csv",   "text/csv");
-        defaultMappings.put("tsv",   "text/tsv");
-        defaultMappings.put("md",    "text/x-markdown");
+        defaultMappings.put("html", "text/html");
+        defaultMappings.put("htm", "text/html");
+        defaultMappings.put("css", "text/css");
+        defaultMappings.put("csv", "text/csv");
+        defaultMappings.put("tsv", "text/tsv");
+        defaultMappings.put("md", "text/x-markdown");
 
         // Mime types from image requirements for Vertex AI Gemini
         // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-understanding#image-requirements
         defaultMappings.put("avif", "image/avif");
-        defaultMappings.put("bmp",  "image/bmp");
-        defaultMappings.put("gif",  "image/gif");
-        defaultMappings.put("jpe",  "image/jpeg");
+        defaultMappings.put("bmp", "image/bmp");
+        defaultMappings.put("gif", "image/gif");
+        defaultMappings.put("jpe", "image/jpeg");
         defaultMappings.put("jpeg", "image/jpeg");
-        defaultMappings.put("jpg",  "image/jpeg");
-        defaultMappings.put("png",  "image/png");
-        defaultMappings.put("tif",  "image/tiff");
+        defaultMappings.put("jpg", "image/jpeg");
+        defaultMappings.put("png", "image/png");
+        defaultMappings.put("tif", "image/tiff");
         defaultMappings.put("tiff", "image/tiff");
         defaultMappings.put("webp", "image/webp");
 
         // Mime types from audio requirements for Vertex AI Gemini
         // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding
-        defaultMappings.put("mp3",  "audio/mp3");
-        defaultMappings.put("wav",  "audio/wav");
-        defaultMappings.put("aac",  "audio/aac");
+        defaultMappings.put("mp3", "audio/mp3");
+        defaultMappings.put("wav", "audio/wav");
+        defaultMappings.put("aac", "audio/aac");
         defaultMappings.put("flac", "audio/flac");
-        defaultMappings.put("mpa",  "audio/m4a");
+        defaultMappings.put("mpa", "audio/m4a");
         defaultMappings.put("mpga", "audio/mpga");
         defaultMappings.put("opus", "audio/opus");
-        defaultMappings.put("pcm",  "audio/pcm");
+        defaultMappings.put("pcm", "audio/pcm");
 
         // Mime types from video requirements for Vertex AI Gemini
         // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding
-        defaultMappings.put("mp4",    "video/mp4");
-        defaultMappings.put("mpeg",   "video/mpeg");
-        defaultMappings.put("mpg",    "video/mpg");
+        defaultMappings.put("mp4", "video/mp4");
+        defaultMappings.put("mpeg", "video/mpeg");
+        defaultMappings.put("mpg", "video/mpg");
         defaultMappings.put("mpegps", "video/mpegps");
-        defaultMappings.put("mov",    "video/mov");
-        defaultMappings.put("avi",    "video/avi");
-        defaultMappings.put("flv",    "video/x-flv");
-        defaultMappings.put("webm",   "video/webm");
+        defaultMappings.put("mov", "video/mov");
+        defaultMappings.put("avi", "video/avi");
+        defaultMappings.put("flv", "video/x-flv");
+        defaultMappings.put("webm", "video/webm");
         defaultMappings.put("wmv", "video/wmv");
-        defaultMappings.put("3gpp",   "video/3gpp");
+        defaultMappings.put("3gpp", "video/3gpp");
     }
 
     private final Map<String, String> mappings;
@@ -150,15 +150,29 @@ public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
      *     returns null if no mapping was found.
      */
     public String probeContentType(URI uri) {
+        // Opaque URIs (e.g. "data:image/png;base64,...", "mailto:...") have no path component,
+        // and URIs such as "https://example.com" have an empty one. Neither carries a file name.
+        String uriPath = uri.getPath();
+        if (uriPath == null || uriPath.isEmpty()) {
+            return null;
+        }
+
         // First let's try to guess via the Path
-        Path path = Path.of(uri.getPath());
+        Path path = Path.of(uriPath);
+
+        // Paths that denote a root (e.g. "https://example.com/") have no file name either
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            return null;
+        }
+
         String mimeTypeFromPath = probeContentType(path);
         if (mimeTypeFromPath != null) {
             return mimeTypeFromPath;
         }
 
         // Second, let's see if URLConnection can guess from the file name
-        String mimeTypeGuessedFromUrlCon = URLConnection.guessContentTypeFromName(path.getFileName().toString());
+        String mimeTypeGuessedFromUrlCon = URLConnection.guessContentTypeFromName(fileName.toString());
         if (mimeTypeGuessedFromUrlCon != null) {
             return mimeTypeGuessedFromUrlCon;
         }
@@ -166,8 +180,7 @@ public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
         // Third, the most costly network-hop approach to check
         // the content-type returned when opening a stream
         // Inspired from langchain4j-dashscope module: in EnhancedFileTypeDetector
-        try (InputStream in = new BufferedInputStream(
-            Files.newInputStream(path, StandardOpenOption.READ))) {
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(path, StandardOpenOption.READ))) {
             return URLConnection.guessContentTypeFromStream(in);
         } catch (IOException e) {
             return null;
@@ -175,7 +188,12 @@ public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
     }
 
     static String extension(Path path) {
-        String fileName = path.getFileName().toFile().toString();
+        Path fileNamePath = path.getFileName();
+        if (fileNamePath == null) {
+            // e.g. a root path such as "/"
+            return "";
+        }
+        String fileName = fileNamePath.toString();
         int lastDotPosition = fileName.lastIndexOf('.');
         return lastDotPosition > 0 ? fileName.substring(lastDotPosition + 1) : "";
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.net.MalformedURLException;
@@ -337,5 +338,68 @@ class CustomMimeTypesFileTypeDetectorTest {
 
         // then
         assertThat(mimeType).isEqualTo("text/css");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "https://example.com/", // path is "/", which has no file name
+                "https://example.com", // no path at all
+                "gs://my-bucket" // no path at all
+            })
+    void should_return_null_for_uri_without_file_name(String url) {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType(URI.create(url));
+
+        // then
+        assertThat(mimeType).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "data:image/png;base64,iVBORw0KGgo=", // opaque URI: getPath() is null
+                "mailto:someone@example.com",
+                "urn:isbn:0451450523"
+            })
+    void should_return_null_for_opaque_uri(String url) {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType(URI.create(url));
+
+        // then
+        assertThat(mimeType).isNull();
+    }
+
+    @Test
+    void should_still_detect_mime_type_for_uri_with_file_name() {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType(URI.create("gs://my-bucket/audio.mp3"));
+
+        // then
+        assertThat(mimeType).isEqualTo("audio/mp3");
+    }
+
+    @Test
+    void should_return_empty_extension_for_path_without_file_name() {
+        // when/then
+        assertThat(CustomMimeTypesFileTypeDetector.extension(Path.of("/"))).isEmpty();
+    }
+
+    @Test
+    void should_not_throw_for_path_without_file_name() {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when/then
+        assertThatCode(() -> detector.probeContentType(Path.of("/"))).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## Issue
Closes #5976

## Change

`CustomMimeTypesFileTypeDetector` threw a `NullPointerException` for valid URIs and paths that have no file-name component, instead of returning `null` as its Javadoc promises ("returns null if no mapping was found").

Two guards were missing:

- **`probeContentType(URI)`** — `URI.getPath()` returns `null` for opaque URIs (`data:`, `mailto:`, `urn:`) and `""` for URIs with no path, so `Path.of(uri.getPath())` threw. It now returns `null` for both.
- **`extension(Path)`** — `Path.getFileName()` returns `null` for a root path such as `/`, which is exactly what `URI.getPath()` yields for `https://example.com/`. It now returns an empty extension instead of dereferencing `null`.

The `URLConnection` fallback in `probeContentType(URI)` reused `path.getFileName()` and had the same defect; it now reuses the already-null-checked local.

Behaviour that deliberately did **not** change:
- `probeContentType(null)` still throws `NullPointerException` — existing tests assert this.
- Every URI/path that previously resolved to a mime type still resolves to the same one.
- Inputs that previously returned `null` by falling all the way through the chain still return `null`; the new guards just short-circuit before touching the filesystem.

While the detector is `@Internal`, it is reachable from user-facing code: `PartsAndContentsMapper` in `langchain4j-google-ai-gemini` calls `probeContentType(URI)` when mapping image/audio/video/PDF content to Gemini parts.

### Tests

Six new cases in `CustomMimeTypesFileTypeDetectorTest`, covering both directions:

| Test | Covers |
|---|---|
| `should_return_null_for_uri_without_file_name` | negative — `https://example.com/`, `https://example.com`, `gs://my-bucket` |
| `should_return_null_for_opaque_uri` | negative — `data:`, `mailto:`, `urn:` |
| `should_still_detect_mime_type_for_uri_with_file_name` | positive — `gs://my-bucket/audio.mp3` → `audio/mp3` |
| `should_return_empty_extension_for_path_without_file_name` | negative — `extension(Path.of("/"))` |
| `should_not_throw_for_path_without_file_name` | negative — `probeContentType(Path.of("/"))` |

I verified these fail on unmodified `main` before the fix (1 failure + 5 errors, all `NullPointerException`) and pass with it. Full `langchain4j-core` suite: **1219 tests, 0 failures, 0 errors**.

> **A note on the diff size:** the logical change is ~30 lines, but `spotless` is configured with `ratchetFrom origin/main`, so touching this file requires the whole file to be reformatted — mostly the de-alignment of the `defaultMappings.put(...)` block. That reformatting is `spotless:apply`'s output, not a hand edit; CI's spotless job fails without it. `git diff -w` shows the real change.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — not applicable, no public API or behaviour change to document
- [x] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) — not applicable
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) — not applicable
