### PR TITLE
Add watsonx.ai Model Gateway support and dedicated Deployment chat models

### DIFF
--- a/docs/docs/integrations/embedding-models/watsonx.md
+++ b/docs/docs/integrations/embedding-models/watsonx.md
@@ -6,6 +6,7 @@ sidebar_position: 23
 
 - [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings)
 - [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
+- [watsonx.ai Java SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/services/embedding-service)
 
 ## Maven Dependency
 

--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -6,6 +6,9 @@ sidebar_position: 22
 
 - [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#chat-completions)
 - [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
+- [watsonx.ai Java SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/)
+
+This integration is built on top of the **IBM watsonx.ai Java SDK**: every model described below wraps one of its services. When you need details on a behavior that is not specific to LangChain4j — token caching, retries, HTTP client tuning — the [SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/) is the reference.
 
 ## Maven Dependency
 
@@ -28,6 +31,8 @@ This allows you to use different authentication mechanisms depending on your dep
 - **Custom authenticators** – any implementation of the `Authenticator` interface can be used.
 
 The `WatsonxChatModel`, `WatsonxStreamingChatModel`, and other service builders accept either a shortcut via `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
+
+Token caching and renewal are handled transparently: a token is fetched on the first request, cached, and refreshed before it expires — you never manage its lifecycle. Passing the same `Authenticator` instance to several models lets them share a single cached token. See the [SDK authentication guide](https://ibm.github.io/watsonx-ai-java-sdk/authentication) for the full list of authenticators and their parameters.
 
 ### Example
 ```java
@@ -89,6 +94,8 @@ EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
 
 > **Note:** When using a custom `HttpClient` with Cloud Pak for Data, make sure to set it on both the service builder and the authenticator builder to ensure consistent HTTP behavior across all requests.
 
+> 🔗 [SDK guide to the HTTP client](https://ibm.github.io/watsonx-ai-java-sdk/advanced/http-client), including how to build an `SSLContext` from a private truststore.
+
 #### Disabling SSL verification
 
 If you only need to disable SSL certificate verification, you can use the `verifySsl(false)` option instead of providing a custom `HttpClient`:
@@ -131,17 +138,11 @@ To create an instance, you must specify the mandatory parameters:
 - `projectId(...)` – IBM Cloud Project ID (or use `spaceId(...)`);
 - `modelName(...)` – Foundation model ID for inference;
 
-Alternatively, you can use a **deployed model** by specifying:
-
-- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
-- `apiKey(...)` – IBM Cloud IAM API key;
-- `deploymentId(...)` – Deployment ID of the on-demand deployed model;
-
 > You can authenticate using either `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
 
-### Example
+> To call a model you have deployed on-demand, use [`WatsonxDeploymentChatModel`](#deployed-models-on-demand-deployment) instead.
 
-#### Using a foundation model from the catalog
+### Example
 
 ```java
 import dev.langchain4j.model.chat.ChatModel;
@@ -161,32 +162,7 @@ String answer = chatModel.chat("Hello from watsonx.ai");
 System.out.println(answer);
 ```
 
-#### Using a deployed model (on-demand deployment)
-
-IBM watsonx.ai allows you to deploy foundation models on-demand on dedicated hardware for exclusive use by your organization. These deployed models can be accessed using their `deploymentId`.
-
-```java
-import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.watsonx.WatsonxChatModel;
-import com.ibm.watsonx.ai.CloudRegion;
-
-ChatModel chatModel = WatsonxChatModel.builder()
-    .baseUrl(CloudRegion.FRANKFURT)
-    .apiKey("your-api-key")
-    .deploymentId("your-deployment-id")
-    .temperature(0.7)
-    .maxOutputTokens(0)
-    .build();
-
-String answer = chatModel.chat("Hello from watsonx.ai");
-System.out.println(answer);
-```
-
-> **Note:** When using `deploymentId`, you don't need to specify `projectId`, `spaceId`, or `modelName` as the deployment already contains this information.
-
 > 🔗 [View available models](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx#ibm-provided)
-
-> 🔗 [Learn more about deploying models on-demand](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/deploy-on-demand-overview.html?context=wx&audience=wdp)
 
 ## WatsonxStreamingChatModel
 
@@ -194,9 +170,9 @@ The `WatsonxStreamingChatModel` provides streaming support for IBM watsonx.ai wi
 
 Streaming uses the same configuration structure and parameters as the non-streaming [`WatsonxChatModel`](#watsonxchatmodel). The main difference is that responses are delivered incrementally through a handler interface.
 
-### Example
+> To call a model you have deployed on-demand, use [`WatsonxDeploymentStreamingChatModel`](#deployed-models-on-demand-deployment) instead.
 
-#### Using a foundation model from the catalog
+### Example
 
 ```java
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -232,16 +208,51 @@ model.chat("What is the capital of Italy?", new StreamingChatResponseHandler() {
 });
 ```
 
-#### Using a deployed model (on-demand deployment)
+> 🔗 [View available models](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx#ibm-provided)
+
+## Deployed models (on-demand deployment)
+
+IBM watsonx.ai allows you to deploy foundation models on-demand on dedicated hardware for exclusive use by your organization. These deployed models are addressed by their `deploymentId` and are served by a different watsonx.ai endpoint than the foundation-model catalog, so LangChain4j exposes them through their own pair of classes: `WatsonxDeploymentChatModel` and `WatsonxDeploymentStreamingChatModel`.
+
+To create an instance, you must specify:
+
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
+- `apiKey(...)` – IBM Cloud IAM API key;
+- `deploymentId(...)` – Deployment ID of the on-demand deployed model;
+
+A deployment already targets a specific model within a project or space, so these builders expose neither `modelName(...)` nor `projectId(...)`/`spaceId(...)`. Every other generation parameter (`temperature`, `maxOutputTokens`, `thinking`, tools, `responseFormat`, …) works exactly as it does on `WatsonxChatModel`.
+
+> **Note:** `deploymentId` is a connection-level setting fixed when the model is built — it selects the deployment endpoint, so it cannot be overridden per request through `WatsonxChatRequestParameters`.
+
+### WatsonxDeploymentChatModel
+
+```java
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
+import com.ibm.watsonx.ai.CloudRegion;
+
+ChatModel chatModel = WatsonxDeploymentChatModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .deploymentId("your-deployment-id")
+    .temperature(0.7)
+    .maxOutputTokens(0)
+    .build();
+
+String answer = chatModel.chat("Hello from watsonx.ai");
+System.out.println(answer);
+```
+
+### WatsonxDeploymentStreamingChatModel
 
 ```java
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.ChatResponse;
-import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
+import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
 import com.ibm.watsonx.ai.CloudRegion;
 
-StreamingChatModel model = WatsonxStreamingChatModel.builder()
+StreamingChatModel model = WatsonxDeploymentStreamingChatModel.builder()
     .baseUrl(CloudRegion.FRANKFURT)
     .apiKey("your-api-key")
     .deploymentId("your-deployment-id")
@@ -267,17 +278,146 @@ model.chat("What is the capital of Italy?", new StreamingChatResponseHandler() {
 });
 ```
 
-> **Note:** When using `deploymentId`, you don't need to specify `projectId`, `spaceId`, or `modelName` as the deployment already contains this information.
-
-> 🔗 [View available models](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx#ibm-provided)
-
 > 🔗 [Learn more about deploying models on-demand](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/deploy-on-demand-overview.html?context=wx&audience=wdp)
+
+## Model Gateway
+
+The IBM watsonx.ai **Model Gateway** exposes an OpenAI-compatible chat endpoint that can route requests to models hosted by multiple providers (for example OpenAI, Anthropic, or third-party providers you register) behind a single watsonx.ai entry point. LangChain4j integrates with it through `WatsonxGatewayChatModel` and `WatsonxGatewayStreamingChatModel`.
+
+> **Note:** the gateway must be configured by an administrator before use — each `modelName` you pass must be an id already registered in the gateway.
+
+### WatsonxGatewayChatModel
+
+To create an instance, specify:
+
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
+- `apiKey(...)` – IBM Cloud IAM API key (or a full `Authenticator` via `.authenticator(...)`);
+- `modelName(...)` – OpenAI-style model id registered in the gateway;
+
+```java
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayChatModel;
+import com.ibm.watsonx.ai.CloudRegion;
+
+ChatModel chatModel = WatsonxGatewayChatModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("gpt-4o")
+    .temperature(0.7)
+    .build();
+
+String answer = chatModel.chat("Hello from the watsonx.ai Model Gateway");
+System.out.println(answer);
+```
+
+### WatsonxGatewayStreamingChatModel
+
+`WatsonxGatewayStreamingChatModel` provides streaming support for the gateway. It uses the same configuration
+as `WatsonxGatewayChatModel`; responses are delivered incrementally through a handler.
+
+```java
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.ChatResponse;
+import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
+import com.ibm.watsonx.ai.CloudRegion;
+
+StreamingChatModel model = WatsonxGatewayStreamingChatModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("gpt-4o")
+    .build();
+
+model.chat("What is the capital of Italy?", new StreamingChatResponseHandler() {
+
+    @Override
+    public void onPartialResponse(String partialResponse) {
+        System.out.println("Partial: " + partialResponse);
+    }
+
+    @Override
+    public void onCompleteResponse(ChatResponse completeResponse) {
+        System.out.println("Complete: " + completeResponse);
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        error.printStackTrace();
+    }
+});
+```
+
+### Gateway-only parameters
+
+Each watsonx.ai chat service has its own `ChatRequestParameters` implementation, exposing the parameters that
+service accepts and nothing else:
+
+| Class | Used by |
+|---|---|
+| `WatsonxChatRequestParameters` | `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel`, `WatsonxDeploymentStreamingChatModel` |
+| `WatsonxGatewayChatRequestParameters` | `WatsonxGatewayChatModel`, `WatsonxGatewayStreamingChatModel` |
+
+The two classes are independent implementations of `ChatRequestParameters`: each one declares exactly what its service
+supports, so neither knows anything about the other's parameters. Passing the parameters of one service to the other —
+either through `defaultRequestParameters(...)` on the builder or through the parameters of a single `ChatRequest` —
+therefore contributes only what `DefaultChatRequestParameters` covers (`modelName`, `temperature`, `topP`,
+`maxOutputTokens`, …), and every watsonx.ai-specific parameter they carry is ignored. Use the class that matches the
+model you are calling.
+
+In addition to the common chat parameters, `WatsonxGatewayChatRequestParameters` exposes gateway-specific parameters:
+
+| Parameter | Description |
+|---|---|
+| `serviceTier(...)` | Service tier: `AUTO`, `DEFAULT`, `FLEX`, or `PRIORITY`. |
+| `reasoningEffort(...)` | Reasoning effort for reasoning models: `LOW`, `MEDIUM`, or `HIGH`. |
+| `router(...)` / `cache(...)` | Router configuration, including a prompt `Cache`. |
+| `modalities(...)` | Output modalities (e.g. `["text"]`). |
+| `store(...)` | Whether the provider should persist the request/response. |
+| `parallelToolCalls(...)` | Enable/disable parallel tool calls. |
+| `user(...)` | End-user identifier forwarded to the provider. |
+| `metadata(...)` | Free-form metadata map forwarded to the provider. |
+| `logitBias(...)`, `logprobs(...)`, `topLogprobs(...)`, `seed(...)` | OpenAI-compatible sampling controls. |
+
+```java
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
+import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ServiceTier;
+
+ChatRequest request = ChatRequest.builder()
+    .messages(dev.langchain4j.data.message.UserMessage.from("Solve this step by step."))
+    .parameters(
+        WatsonxGatewayChatRequestParameters.builder()
+            .serviceTier(ServiceTier.FLEX)
+            .reasoningEffort(ReasoningEffort.HIGH)
+            .build()
+    ).build();
+
+String answer = chatModel.chat(request).aiMessage().text();
+```
+
+### Response metadata
+
+Every watsonx.ai chat response carries a `WatsonxChatResponseMetadata`. Three of its fields are only populated by the
+Model Gateway and stay `null` for the other services:
+
+```java
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
+
+ChatResponse response = chatModel.chat(request);
+var metadata = (WatsonxChatResponseMetadata) response.metadata();
+
+metadata.getServiceTier();       // service tier that served the request (gateway only)
+metadata.getSystemFingerprint(); // provider system fingerprint (gateway only)
+metadata.getCached();            // whether the response was served from cache (gateway only)
+```
 
 ## Tool Integration
 
-Both `WatsonxChatModel` and `WatsonxStreamingChatModel` support **LangChain4j Tools**, allowing the model to call Java methods annotated with `@Tool`.
+All the watsonx.ai chat models — `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel`, `WatsonxDeploymentStreamingChatModel`, `WatsonxGatewayChatModel` and `WatsonxGatewayStreamingChatModel` — support **LangChain4j Tools**, allowing the model to call Java methods annotated with `@Tool`.
 
-Here’s an example using the synchronous model (`WatsonxChatModel`), but the same approach applies to the streaming variant.
+Here’s an example using the synchronous model (`WatsonxChatModel`), but the same approach applies to the streaming and to the deployment/gateway variants.
 
 ```java
 static class Tools {
@@ -306,7 +446,7 @@ ChatModel chatModel = WatsonxChatModel.builder()
     .build();
 
 AiService aiService = AiServices.builder(AiService.class)
-        .chatModel(model)
+        .chatModel(chatModel)
         .tools(new Tools())
         .build();
 
@@ -329,6 +469,8 @@ There are two main configuration modes:
 
 - **`ExtractionTags`** → for models that return reasoning and response in the same text block (e.g **ibm/granite-3-3-8b-instruct**).  
 - **`ThinkingEffort`** → for models that already separate reasoning and response automatically (e.g **openai/gpt-oss-120b**).  
+
+> The `thinking(...)` builder method is available on `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel` and `WatsonxDeploymentStreamingChatModel`. The Model Gateway does not accept it: use [`reasoningEffort(...)`](#gateway-only-parameters) on the gateway models instead.
 
 ### Models that return reasoning and response together
 
@@ -454,6 +596,36 @@ ModelCatalog modelCatalog = WatsonxModelCatalog.builder()
 var models = modelCatalog.listModels();
 ```
 
+> 🔗 [SDK foundation model service](https://ibm.github.io/watsonx-ai-java-sdk/services/foundation-model-service)
+
+## WatsonxTokenCountEstimator
+
+The `WatsonxTokenCountEstimator` implements the LangChain4j `TokenCountEstimator` interface by calling the watsonx.ai
+tokenization endpoint, so the count comes from the tokenizer of the model itself rather than from a local approximation.
+Because of that, `modelName(...)` is mandatory.
+
+### Example
+
+```java
+import dev.langchain4j.model.TokenCountEstimator;
+import dev.langchain4j.model.watsonx.WatsonxTokenCountEstimator;
+import com.ibm.watsonx.ai.CloudRegion;
+
+TokenCountEstimator tokenCountEstimator = WatsonxTokenCountEstimator.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .projectId("your-project-id")
+    .modelName("ibm/granite-4-h-small")
+    .build();
+
+int tokenCount = tokenCountEstimator.estimateTokenCountInText("Hello from watsonx.ai");
+```
+
+> **Note:** every estimate is a remote call. `estimateTokenCountInMessage(...)` also counts the thinking text and the
+> tool execution requests of an `AiMessage`; image, audio, PDF and video contents are not supported.
+
+> 🔗 [SDK tokenization service](https://ibm.github.io/watsonx-ai-java-sdk/services/tokenization-service)
+
 ## WatsonxModerationModel
 
 The `WatsonxModerationModel` provides a LangChain4j implementation of the `ModerationModel` interface using IBM watsonx.ai.  
@@ -497,10 +669,14 @@ Map<String, Object> metadata = response.metadata();
 System.out.println("Detection type: " + metadata.get("detection_type"));
 System.out.println("Score: " + metadata.get("score"));
 ```
+
+> 🔗 [SDK detection service](https://ibm.github.io/watsonx-ai-java-sdk/services/detection-service), for the full list of
+> detectors and their options.
+
 ## Configuration via Environment Variables
 
-The LangChain4j watsonx integration allows customization of internal HTTP behavior through environment variables.  
-These settings are optional and sensible defaults are used when variables are not explicitly defined.
+The internal HTTP behavior of the underlying SDK can be customized through environment variables, without any code
+change. These settings are optional and sensible defaults are used when variables are not explicitly defined.
 
 ### Retry Configuration
 
@@ -517,13 +693,44 @@ Retry behavior can be customized using the following environment variables:
 ### HTTP IO Executor Configuration
 
 Streaming responses and HTTP response processing are handled by an internal IO executor.  
-By default, a single-threaded executor is used to ensure sequential processing of streaming events.
+By default, virtual threads are used on Java 21+ and a cached thread pool on Java 17–20.
 
 This behavior can be customized using the following environment variable:
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| `WATSONX_IO_EXECUTOR_THREADS` | Number of threads used for HTTP IO and SSE stream parsing | `1` |
+| `WATSONX_IO_EXECUTOR_THREADS` | Caps the IO executor to a fixed-size pool of this many threads | _unset_ |
+
+> 🔗 [Full reference of the SDK environment variables](https://ibm.github.io/watsonx-ai-java-sdk/advanced/environment-variables)
+
+## Error Handling
+
+The watsonx.ai errors raised by the SDK are translated into the standard LangChain4j exceptions, so you can handle them
+the same way as with any other provider. The mapping is driven by the error code returned by watsonx.ai:
+
+| watsonx.ai error code | LangChain4j exception |
+|---|---|
+| `authentication_token_expired`, `authorization_rejected` | `AuthenticationException` |
+| `invalid_input_argument`, `invalid_request_entity`, `json_type_error`, `json_validation_error` | `InvalidRequestException` |
+| `model_not_supported` | `ModelNotFoundException` |
+| `token_quota_reached` | `RateLimitException` |
+| any other error code | `LangChain4jException` |
+
+When the response carries no error body, the exception is chosen from the HTTP status code instead. A request that
+exceeds its `timeout(...)` is reported as a `TimeoutException`.
+
+```java
+try {
+    String answer = chatModel.chat("Hello from watsonx.ai");
+} catch (RateLimitException e) {
+    // token quota reached
+} catch (InvalidRequestException e) {
+    // a request parameter was rejected by watsonx.ai
+}
+```
+
+> 🔗 [SDK exception hierarchy](https://ibm.github.io/watsonx-ai-java-sdk/advanced/error-handling), for the underlying
+> `WatsonxException` and its `statusCode()`, `errorCode()` and `traceId()`, available through `getCause()`.
 
 ## Quarkus
 
@@ -534,7 +741,7 @@ See more details [here](https://docs.quarkiverse.io/quarkus-langchain4j/dev/wats
 - [WatsonxChatModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxChatModelTest.java)
 - [WatsonxChatModelReasoningTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxChatModelReasoningTest.java)
 - [WatsonxStreamingChatModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxStreamingChatModelTest.java)
-- [WatsonxStreamingChatModelReasoningTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxStreamingChatModelTest.java)
+- [WatsonxStreamingChatModelReasoningTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxStreamingChatModelReasoningTest.java)
 - [WatsonxToolsTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxToolsTest.java)
 - [WatsonxTokenCounterEstimatorTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxTokenCounterEstimatorTest.java)
 - [WatsonxModerationModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxModerationModelTest.java)

--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -8,7 +8,7 @@ sidebar_position: 22
 - [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
 - [watsonx.ai Java SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/)
 
-This integration is built on top of the **IBM watsonx.ai Java SDK**: every model described below wraps one of its services. When you need details on a behavior that is not specific to LangChain4j — token caching, retries, HTTP client tuning — the [SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/) is the reference.
+This integration is built on top of the **IBM watsonx.ai Java SDK**. Every model described below wraps one of its services. When you need details on a behavior that is not specific to LangChain4j - token caching, retries, HTTP client tuning - the [SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/) is the reference.
 
 ## Maven Dependency
 
@@ -32,7 +32,7 @@ This allows you to use different authentication mechanisms depending on your dep
 
 The `WatsonxChatModel`, `WatsonxStreamingChatModel`, and other service builders accept either a shortcut via `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
 
-Token caching and renewal are handled transparently: a token is fetched on the first request, cached, and refreshed before it expires — you never manage its lifecycle. Passing the same `Authenticator` instance to several models lets them share a single cached token. See the [SDK authentication guide](https://ibm.github.io/watsonx-ai-java-sdk/authentication) for the full list of authenticators and their parameters.
+Token caching and renewal are handled transparently. A token is fetched on the first request, cached, and refreshed before it expires, so you never manage its lifecycle. Passing the same `Authenticator` instance to several models lets them share a single cached token. See the [SDK authentication guide](https://ibm.github.io/watsonx-ai-java-sdk/authentication) for the full list of authenticators and their parameters.
 
 ### Example
 ```java
@@ -133,10 +133,10 @@ You can create an API key at [https://cloud.ibm.com/iam/apikeys](https://cloud.i
 The `WatsonxChatModel` class allows you to create an instance of the `ChatModel` interface fully encapsulated within LangChain4j.
 To create an instance, you must specify the mandatory parameters:
 
-- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
-- `apiKey(...)` – IBM Cloud IAM API key;
-- `projectId(...)` – IBM Cloud Project ID (or use `spaceId(...)`);
-- `modelName(...)` – Foundation model ID for inference;
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`)
+- `apiKey(...)` – IBM Cloud IAM API key
+- `projectId(...)` – IBM Cloud Project ID (or use `spaceId(...)`)
+- `modelName(...)` – Foundation model ID for inference
 
 > You can authenticate using either `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
 
@@ -212,17 +212,17 @@ model.chat("What is the capital of Italy?", new StreamingChatResponseHandler() {
 
 ## Deployed models (on-demand deployment)
 
-IBM watsonx.ai allows you to deploy foundation models on-demand on dedicated hardware for exclusive use by your organization. These deployed models are addressed by their `deploymentId` and are served by a different watsonx.ai endpoint than the foundation-model catalog, so LangChain4j exposes them through their own pair of classes: `WatsonxDeploymentChatModel` and `WatsonxDeploymentStreamingChatModel`.
+IBM watsonx.ai allows you to deploy foundation models on-demand on dedicated hardware for exclusive use by your organization. These deployed models are addressed by their `deploymentId` and are served by a different watsonx.ai endpoint than the foundation-model catalog, so LangChain4j exposes them through their own pair of classes, `WatsonxDeploymentChatModel` and `WatsonxDeploymentStreamingChatModel`.
 
 To create an instance, you must specify:
 
-- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
-- `apiKey(...)` – IBM Cloud IAM API key;
-- `deploymentId(...)` – Deployment ID of the on-demand deployed model;
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`)
+- `apiKey(...)` – IBM Cloud IAM API key
+- `deploymentId(...)` – Deployment ID of the on-demand deployed model
 
 A deployment already targets a specific model within a project or space, so these builders expose neither `modelName(...)` nor `projectId(...)`/`spaceId(...)`. Every other generation parameter (`temperature`, `maxOutputTokens`, `thinking`, tools, `responseFormat`, …) works exactly as it does on `WatsonxChatModel`.
 
-> **Note:** `deploymentId` is a connection-level setting fixed when the model is built — it selects the deployment endpoint, so it cannot be overridden per request through `WatsonxChatRequestParameters`.
+> **Note:** `deploymentId` is a connection-level setting fixed when the model is built - it selects the deployment endpoint, so it cannot be overridden per request through `WatsonxChatRequestParameters`.
 
 ### WatsonxDeploymentChatModel
 
@@ -284,15 +284,15 @@ model.chat("What is the capital of Italy?", new StreamingChatResponseHandler() {
 
 The IBM watsonx.ai **Model Gateway** exposes an OpenAI-compatible chat endpoint that can route requests to models hosted by multiple providers (for example OpenAI, Anthropic, or third-party providers you register) behind a single watsonx.ai entry point. LangChain4j integrates with it through `WatsonxGatewayChatModel` and `WatsonxGatewayStreamingChatModel`.
 
-> **Note:** the gateway must be configured by an administrator before use — each `modelName` you pass must be an id already registered in the gateway.
+> **Note:** the gateway must be configured by an administrator before use - each `modelName` you pass must be an id already registered in the gateway.
 
 ### WatsonxGatewayChatModel
 
 To create an instance, specify:
 
-- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
-- `apiKey(...)` – IBM Cloud IAM API key (or a full `Authenticator` via `.authenticator(...)`);
-- `modelName(...)` – OpenAI-style model id registered in the gateway;
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`)
+- `apiKey(...)` – IBM Cloud IAM API key (or a full `Authenticator` via `.authenticator(...)`)
+- `modelName(...)` – OpenAI-style model id registered in the gateway
 
 ```java
 import dev.langchain4j.model.chat.ChatModel;
@@ -313,7 +313,7 @@ System.out.println(answer);
 ### WatsonxGatewayStreamingChatModel
 
 `WatsonxGatewayStreamingChatModel` provides streaming support for the gateway. It uses the same configuration
-as `WatsonxGatewayChatModel`; responses are delivered incrementally through a handler.
+as `WatsonxGatewayChatModel`. Responses are delivered incrementally through a handler.
 
 ```java
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -357,9 +357,9 @@ service accepts and nothing else:
 | `WatsonxChatRequestParameters` | `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel`, `WatsonxDeploymentStreamingChatModel` |
 | `WatsonxGatewayChatRequestParameters` | `WatsonxGatewayChatModel`, `WatsonxGatewayStreamingChatModel` |
 
-The two classes are independent implementations of `ChatRequestParameters`: each one declares exactly what its service
-supports, so neither knows anything about the other's parameters. Passing the parameters of one service to the other —
-either through `defaultRequestParameters(...)` on the builder or through the parameters of a single `ChatRequest` —
+The two classes are independent implementations of `ChatRequestParameters`. Each one declares exactly what its service
+supports, so neither knows anything about the other's parameters. Passing the parameters of one service to the other -
+either through `defaultRequestParameters(...)` on the builder or through the parameters of a single `ChatRequest` -
 therefore contributes only what `DefaultChatRequestParameters` covers (`modelName`, `temperature`, `topP`,
 `maxOutputTokens`, …), and every watsonx.ai-specific parameter they carry is ignored. Use the class that matches the
 model you are calling.
@@ -368,8 +368,8 @@ In addition to the common chat parameters, `WatsonxGatewayChatRequestParameters`
 
 | Parameter | Description |
 |---|---|
-| `serviceTier(...)` | Service tier: `AUTO`, `DEFAULT`, `FLEX`, or `PRIORITY`. |
-| `reasoningEffort(...)` | Reasoning effort for reasoning models: `LOW`, `MEDIUM`, or `HIGH`. |
+| `serviceTier(...)` | Service tier, one of `AUTO`, `DEFAULT`, `FLEX`, or `PRIORITY`. |
+| `reasoningEffort(...)` | Reasoning effort for reasoning models, one of `LOW`, `MEDIUM`, or `HIGH`. |
 | `router(...)` / `cache(...)` | Router configuration, including a prompt `Cache`. |
 | `modalities(...)` | Output modalities (e.g. `["text"]`). |
 | `store(...)` | Whether the provider should persist the request/response. |
@@ -379,13 +379,14 @@ In addition to the common chat parameters, `WatsonxGatewayChatRequestParameters`
 | `logitBias(...)`, `logprobs(...)`, `topLogprobs(...)`, `seed(...)` | OpenAI-compatible sampling controls. |
 
 ```java
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
 import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ReasoningEffort;
 import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ServiceTier;
 
 ChatRequest request = ChatRequest.builder()
-    .messages(dev.langchain4j.data.message.UserMessage.from("Solve this step by step."))
+    .messages(UserMessage.from("Solve this step by step."))
     .parameters(
         WatsonxGatewayChatRequestParameters.builder()
             .serviceTier(ServiceTier.FLEX)
@@ -415,7 +416,7 @@ metadata.getCached();            // whether the response was served from cache (
 
 ## Tool Integration
 
-All the watsonx.ai chat models — `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel`, `WatsonxDeploymentStreamingChatModel`, `WatsonxGatewayChatModel` and `WatsonxGatewayStreamingChatModel` — support **LangChain4j Tools**, allowing the model to call Java methods annotated with `@Tool`.
+All the watsonx.ai chat models - `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel`, `WatsonxDeploymentStreamingChatModel`, `WatsonxGatewayChatModel` and `WatsonxGatewayStreamingChatModel` - support **LangChain4j Tools**, allowing the model to call Java methods annotated with `@Tool`.
 
 Here’s an example using the synchronous model (`WatsonxChatModel`), but the same approach applies to the streaming and to the deployment/gateway variants.
 
@@ -470,7 +471,7 @@ There are two main configuration modes:
 - **`ExtractionTags`** → for models that return reasoning and response in the same text block (e.g **ibm/granite-3-3-8b-instruct**).  
 - **`ThinkingEffort`** → for models that already separate reasoning and response automatically (e.g **openai/gpt-oss-120b**).  
 
-> The `thinking(...)` builder method is available on `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel` and `WatsonxDeploymentStreamingChatModel`. The Model Gateway does not accept it: use [`reasoningEffort(...)`](#gateway-only-parameters) on the gateway models instead.
+> The `thinking(...)` builder method is available on `WatsonxChatModel`, `WatsonxStreamingChatModel`, `WatsonxDeploymentChatModel` and `WatsonxDeploymentStreamingChatModel`. The Model Gateway does not accept it, so use [`reasoningEffort(...)`](#gateway-only-parameters) on the gateway models instead.
 
 ### Models that return reasoning and response together
 
@@ -479,8 +480,8 @@ The tags define XML-like markers used to separate the reasoning from the final r
 
 **Example tags:**
 
-- **Reasoning tag:** `<think>` — contains the model's internal reasoning.  
-- **Response tag:** `<response>` — contains the user-facing answer.  
+- **Reasoning tag:** `<think>` - contains the model's internal reasoning.  
+- **Response tag:** `<response>` - contains the user-facing answer.  
 
 #### Behavior
 
@@ -598,6 +599,45 @@ var models = modelCatalog.listModels();
 
 > 🔗 [SDK foundation model service](https://ibm.github.io/watsonx-ai-java-sdk/services/foundation-model-service)
 
+## WatsonxGatewayModelCatalog
+
+The `WatsonxGatewayModelCatalog` is the [Model Gateway](#model-gateway) counterpart of `WatsonxModelCatalog`. Instead of listing the foundation models hosted by watsonx.ai, it lists the models configured in the gateway, aggregated across all the providers registered in it. It also implements the LangChain4j `ModelCatalog` interface.
+
+The `name()` of every returned `ModelDescription` is the identifier to pass to `WatsonxGatewayChatModel.modelName(...)` and `WatsonxGatewayStreamingChatModel.modelName(...)`. It is the model **alias** when the gateway administrator defined one, otherwise the provider-side model id.
+
+### Example
+
+```java
+import dev.langchain4j.model.catalog.ModelCatalog;
+import dev.langchain4j.model.catalog.ModelDescription;
+import dev.langchain4j.model.watsonx.WatsonxGatewayModelCatalog;
+import com.ibm.watsonx.ai.CloudRegion;
+
+ModelCatalog modelCatalog = WatsonxGatewayModelCatalog.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .build();
+
+for (ModelDescription model : modelCatalog.listModels()) {
+    System.out.println(model.name() + " (" + model.owner() + ")");
+}
+// → gpt-4o (openai)
+// → claude-3-5-sonnet (anthropic)
+```
+
+### How the gateway models are mapped
+
+| `ModelDescription` | Gateway field | Notes |
+|---|---|---|
+| `name()` | `alias`, or `id` when there is no alias | the id to use with the gateway chat models |
+| `displayName()` | same as `name()` | the gateway has no separate label |
+| `description()` | `description` | user-defined, `null` unless the administrator set it |
+| `owner()` | `owned_by` | provider, e.g. `openai` |
+| `createdAt()` | `created` | Unix timestamp of the *gateway configuration*, not of the model release |
+| `type()` | - | always `ModelType.CHAT` because the gateway does not expose model capabilities |
+| `maxInputTokens()` | `metadata.context_window` | `null` when the administrator did not configure the metadata |
+| `maxOutputTokens()` | - | always `null`, the gateway does not return it |
+
 ## WatsonxTokenCountEstimator
 
 The `WatsonxTokenCountEstimator` implements the LangChain4j `TokenCountEstimator` interface by calling the watsonx.ai
@@ -622,7 +662,7 @@ int tokenCount = tokenCountEstimator.estimateTokenCountInText("Hello from watson
 ```
 
 > **Note:** every estimate is a remote call. `estimateTokenCountInMessage(...)` also counts the thinking text and the
-> tool execution requests of an `AiMessage`; image, audio, PDF and video contents are not supported.
+> tool execution requests of an `AiMessage`. Image, audio, PDF and video contents are not supported.
 
 > 🔗 [SDK tokenization service](https://ibm.github.io/watsonx-ai-java-sdk/services/tokenization-service)
 

--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -458,6 +458,34 @@ System.out.println(answer);
 > **NOTE:** Ensure your selected model supports tool use.
 ---
 
+## Structured Outputs
+
+All the watsonx.ai chat models can constrain the response to a JSON Schema. The generic LangChain4j documentation is available [here](/tutorials/structured-outputs), while this section describes the watsonx.ai specific behavior.
+
+The `strictJsonSchema(...)` builder method controls how the schema is sent to the service and defaults to `true`. In strict mode the model is required to adhere to the schema, every property is marked as `required`, `additionalProperties` is set to `false` and the properties left out of the required list are made nullable.
+
+```java
+import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.watsonx.WatsonxChatModel;
+import com.ibm.watsonx.ai.CloudRegion;
+
+ChatModel chatModel = WatsonxChatModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .projectId("your-project-id")
+    .modelName("ibm/granite-4-h-small")
+    .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)
+    .strictJsonSchema(true) // default value
+    .build();
+```
+
+> Use `strictJsonSchema(false)` to send the schema as a hint instead of a constraint. The model still tries to produce a response that adheres to the schema, but the request does not fail when the response diverges from it, the required list is sent as declared and `additionalProperties` is left out. This is the mode to use when optional fields must stay optional.
+
+> `supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)` is needed only when the model is used through AI Services, where the JSON Schema is generated from the return type of the AI Service method.
+
+The root element of the JSON Schema must be a `JsonObjectSchema` or a `JsonRawSchema`. Any other root element makes the request fail with an `IllegalArgumentException`.
+
 ## Enabling Thinking / Reasoning Output
 
 Some foundation models can include internal *reasoning* (also referred to as *thinking*) steps as part of their responses.  

--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -382,8 +382,8 @@ In addition to the common chat parameters, `WatsonxGatewayChatRequestParameters`
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
 
 ChatRequest request = ChatRequest.builder()
     .messages(UserMessage.from("Solve this step by step."))

--- a/docs/docs/integrations/scoring-reranking-models/watsonx.md
+++ b/docs/docs/integrations/scoring-reranking-models/watsonx.md
@@ -6,6 +6,7 @@ sidebar_position: 7
 
 - [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#text-rerank)
 - [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
+- [watsonx.ai Java SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/services/rerank-service)
 
 ## Maven Dependency
 

--- a/langchain4j-watsonx/pom.xml
+++ b/langchain4j-watsonx/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.watsonx</groupId>
             <artifactId>watsonx-ai</artifactId>
-            <version>0.22.0</version>
+            <version>999-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-watsonx/pom.xml
+++ b/langchain4j-watsonx/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.watsonx</groupId>
             <artifactId>watsonx-ai</artifactId>
-            <version>0.30.0</version>
+            <version>0.30.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-watsonx/pom.xml
+++ b/langchain4j-watsonx/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.watsonx</groupId>
             <artifactId>watsonx-ai</artifactId>
-            <version>999-SNAPSHOT</version>
+            <version>0.30.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-watsonx/revapi.json
+++ b/langchain4j-watsonx/revapi.json
@@ -5,19 +5,69 @@
       "ignore": true,
       "differences": [
         {
-          "code": "java.field.removed",
-          "old": "field dev.langchain4j.model.watsonx.WatsonxChat.chatService @ dev.langchain4j.model.watsonx.WatsonxChatModel",
-          "justification": "Internal field renamed from chatService to chatProvider to support deployment models; WatsonxChat is @Internal"
+          "regex": true,
+          "code": "java\\.class\\.externalClassExposedInAPI",
+          "new": "missing-class com\\.ibm\\.watsonx\\..*",
+          "justification": "watsonx.ai SDK types are intentionally exposed on the public API of this module."
         },
         {
-          "code": "java.field.removed",
-          "old": "field dev.langchain4j.model.watsonx.WatsonxChat.chatService @ dev.langchain4j.model.watsonx.WatsonxStreamingChatModel",
-          "justification": "Internal field renamed from chatService to chatProvider to support deployment models; WatsonxChat is @Internal"
+          "regex": true,
+          "code": "java\\.class\\.externalClassExposedInAPI",
+          "new": "missing-class dev\\.langchain4j\\..*",
+          "justification": "LangChain4j core types are intentionally exposed on the public API of this module."
         },
         {
-          "code": "java.class.externalClassExposedInAPI",
-          "new": "missing-class com.ibm.watsonx.ai.chat.ChatProvider",
-          "justification": "ChatProvider is an interface from watsonx-ai SDK used internally; WatsonxChat is @Internal and the field is protected"
+          "regex": true,
+          "code": "java\\.method\\.removed",
+          "old": ".*::deploymentId\\(java\\.lang\\.String\\).*",
+          "justification": "Deployments are now served by their own models (WatsonxDeploymentChatModel / WatsonxDeploymentStreamingChatModel), so deploymentId no longer belongs to the foundation-model builders or to WatsonxChatRequestParameters. The module is still in beta."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method java.lang.String dev.langchain4j.model.watsonx.WatsonxChatRequestParameters::deploymentId()",
+          "justification": "Deployments now have their own parameters type, because the deployment service does not accept the same parameters as the text-chat service. The module is still in beta."
+        },
+        {
+          "regex": true,
+          "code": "java\\.(method|field)\\.removed",
+          "old": ".*[.:](projectId|spaceId).*@ dev\\.langchain4j\\.model\\.watsonx\\.WatsonxModelCatalog\\.Builder",
+          "justification": "The foundation-model specs endpoint is global: projectId and spaceId were accepted and then silently ignored. WatsonxModelCatalog.Builder now extends the connection-only builder base, so they can no longer be set. The module is still in beta."
+        },
+        {
+          "regex": true,
+          "code": "java\\.field\\.removed",
+          "old": "field dev\\.langchain4j\\.model\\.watsonx\\.WatsonxChat\\.chatProvider @ .*",
+          "justification": "The protected chatProvider field was replaced by an abstract chatProvider() accessor, so each chat backend can hold its own service type. WatsonxChat is @Internal."
+        },
+        {
+          "regex": true,
+          "code": "java\\.method\\.returnTypeErasureChanged",
+          "old": "method T dev\\.langchain4j\\.model\\.watsonx\\.Watsonx(Builder|ConnectionBuilder|Chat\\.Builder|ChatBase\\.Builder)<.*",
+          "justification": "The chat support was refactored into three backends (foundation models, deployments and Model Gateway), each exposing only the parameters its watsonx.ai service actually accepts. The @Internal builder base classes were reorganised accordingly, so the self-typed setters are declared on different @Internal classes than in 1.18.1-beta28 and their erased return type changed. Source-compatible: callers only need to recompile. The module is still in beta."
+        },
+        {
+          "regex": true,
+          "code": "java\\.method\\.returnTypeErasureChanged",
+          "new": "method T dev\\.langchain4j\\.model\\.watsonx\\.Watsonx(Builder|ConnectionBuilder|Chat\\.Builder|ChatBase\\.Builder)<.*",
+          "justification": "Same refactor, for setters that used to be overridden in the public builder and are now only inherited from an @Internal base class. See the previous justification."
+        },
+        {
+          "regex": true,
+          "code": "java\\.class\\.(nonFinalClassInheritsFromNewClass|noLongerInheritsFromClass|nonPublicPartOfAPI)",
+          "old": "class dev\\.langchain4j\\.model\\.watsonx\\..*",
+          "justification": "Same refactor: the @Internal base classes sitting between the public models/builders and their common code were reorganised. See the java.method.returnTypeErasureChanged justification."
+        },
+        {
+          "regex": true,
+          "code": "java\\.class\\.(nonFinalClassInheritsFromNewClass|noLongerInheritsFromClass|nonPublicPartOfAPI)",
+          "new": "class dev\\.langchain4j\\.model\\.watsonx\\..*",
+          "justification": "Same refactor: the @Internal base classes sitting between the public models/builders and their common code were reorganised. See the java.method.returnTypeErasureChanged justification."
+        },
+        {
+          "regex": true,
+          "code": "java\\.method\\.finalMethodAddedToNonFinalClass",
+          "new": "method .* dev\\.langchain4j\\.model\\.watsonx\\.WatsonxChatBase<R extends com\\.ibm\\.watsonx\\.ai\\.chat\\.BaseChatRequest>::.*",
+          "justification": "executeChat, executeChatStreaming and applyCommonParameters are inherited from the @Internal WatsonxChatBase and are not part of the public API."
         }
       ]
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -3,7 +3,7 @@ package dev.langchain4j.model.watsonx;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
-import java.util.List;
+
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
@@ -39,6 +39,7 @@ import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
 
 @Internal
 class Converter {
@@ -125,7 +126,9 @@ class Converter {
                 .tokenUsage(tokenUsage);
 
         if (textChatResponse instanceof ModelGatewayChatResponse gatewayResponse) {
-            metadata.serviceTier(gatewayResponse.serviceTier())
+
+            metadata.modelName(gatewayResponse.model())
+                    .serviceTier(gatewayResponse.serviceTier())
                     .systemFingerprint(gatewayResponse.systemFingerprint())
                     .cached(gatewayResponse.cached());
         }
@@ -191,9 +194,16 @@ class Converter {
         builder.frequencyPenalty(parameters.frequencyPenalty());
         builder.maxCompletionTokens(parameters.maxOutputTokens());
         builder.presencePenalty(parameters.presencePenalty());
-        builder.stop(parameters.stopSequences());
         builder.temperature(parameters.temperature());
         builder.topP(parameters.topP());
+
+        // DefaultChatRequestParameters returns an empty list when no stop sequence is set, and the Model Gateway
+        // rejects an empty "stop" array, so the field is sent only when there is at least one sequence.
+        List<String> stopSequences = parameters.stopSequences();
+
+        if (nonNull(stopSequences) && !stopSequences.isEmpty()) {
+            builder.stop(stopSequences);
+        }
 
         ResponseFormat responseFormat = parameters.responseFormat();
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -3,10 +3,14 @@ package dev.langchain4j.model.watsonx;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
-
+import java.util.List;
+import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
+import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
+import com.ibm.watsonx.ai.chat.model.BaseChatParameters;
+import com.ibm.watsonx.ai.chat.model.BaseChatParameters.ToolChoiceOption;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
-import com.ibm.watsonx.ai.chat.model.ChatParameters.ToolChoiceOption;
+import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.Image.Detail;
 import com.ibm.watsonx.ai.chat.model.ImageContent;
 import com.ibm.watsonx.ai.chat.model.TextContent;
@@ -14,6 +18,8 @@ import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.ToolMessage;
 import com.ibm.watsonx.ai.chat.model.UserContent;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -28,15 +34,16 @@ import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.output.FinishReason;
-import java.util.List;
+import dev.langchain4j.model.output.TokenUsage;
 
 @Internal
 class Converter {
 
-    public static com.ibm.watsonx.ai.chat.model.ChatMessage toChatMessage(ChatMessage chatMessage) {
+    static com.ibm.watsonx.ai.chat.model.ChatMessage toChatMessage(ChatMessage chatMessage) {
         return switch (chatMessage.type()) {
             case SYSTEM -> toSystemMessage(SystemMessage.class.cast(chatMessage));
             case AI -> toAssistantMessage(AiMessage.class.cast(chatMessage));
@@ -46,14 +53,14 @@ class Converter {
         };
     }
 
-    public static Tool toTool(ToolSpecification toolSpecification) {
+    static Tool toTool(ToolSpecification toolSpecification) {
         var parameters = nonNull(toolSpecification.parameters())
                 ? JsonSchemaElementUtils.toMap(toolSpecification.parameters())
                 : null;
         return Tool.of(toolSpecification.name(), toolSpecification.description(), parameters);
     }
 
-    public static ToolExecutionRequest toToolExecutionRequest(ToolCall toolCall) {
+    static ToolExecutionRequest toToolExecutionRequest(ToolCall toolCall) {
         return ToolExecutionRequest.builder()
                 .arguments(toolCall.function().arguments())
                 .id(toolCall.id())
@@ -61,7 +68,7 @@ class Converter {
                 .build();
     }
 
-    public static FinishReason toFinishReason(String finishReason) {
+    static FinishReason toFinishReason(String finishReason) {
         if (finishReason == null) return FinishReason.OTHER;
 
         return switch (finishReason) {
@@ -73,11 +80,11 @@ class Converter {
         };
     }
 
-    public static CompleteToolCall toCompleteToolCall(ToolCall toolCall) {
+    static CompleteToolCall toCompleteToolCall(ToolCall toolCall) {
         return new CompleteToolCall(toolCall.index(), toToolExecutionRequest(toolCall));
     }
 
-    public static PartialToolCall toPartialToolCall(com.ibm.watsonx.ai.chat.model.PartialToolCall partialToolCall) {
+    static PartialToolCall toPartialToolCall(com.ibm.watsonx.ai.chat.model.PartialToolCall partialToolCall) {
         return PartialToolCall.builder()
                 .id(partialToolCall.id())
                 .index(partialToolCall.toolIndex())
@@ -86,16 +93,107 @@ class Converter {
                 .build();
     }
 
-    public static ChatParameters toChatParameters(ChatRequestParameters parameters) {
+    static ChatResponse toChatResponse(TextChatResponse textChatResponse) {
 
-        ChatParameters.Builder builder = ChatParameters.builder()
-                .modelId(parameters.modelName())
-                .frequencyPenalty(parameters.frequencyPenalty())
-                .maxCompletionTokens(parameters.maxOutputTokens())
-                .presencePenalty(parameters.presencePenalty())
-                .stop(parameters.stopSequences())
-                .temperature(parameters.temperature())
-                .topP(parameters.topP());
+        AssistantMessage assistantMessage = textChatResponse.toAssistantMessage();
+        ResultChoice choice = textChatResponse.choices().get(0);
+        ChatUsage usage = textChatResponse.usage();
+
+        AiMessage.Builder aiMessage = AiMessage.builder();
+
+        if (nonNull(assistantMessage.toolCalls())
+                && !assistantMessage.toolCalls().isEmpty()) {
+            var toolExecutionRequests = assistantMessage.toolCalls().stream()
+                    .map(Converter::toToolExecutionRequest)
+                    .toList();
+            aiMessage.toolExecutionRequests(toolExecutionRequests);
+        }
+
+        aiMessage.thinking(assistantMessage.thinking());
+        aiMessage.text(assistantMessage.content());
+
+        TokenUsage tokenUsage = nonNull(usage)
+                ? new TokenUsage(usage.promptTokens(), usage.completionTokens(), usage.totalTokens())
+                : null;
+
+        var metadata = WatsonxChatResponseMetadata.builder()
+                .created(textChatResponse.created())
+                .modelVersion(textChatResponse.modelVersion())
+                .finishReason(toFinishReason(choice.finishReason()))
+                .id(textChatResponse.id())
+                .modelName(textChatResponse.modelId())
+                .tokenUsage(tokenUsage);
+
+        if (textChatResponse instanceof ModelGatewayChatResponse gatewayResponse) {
+            metadata.serviceTier(gatewayResponse.serviceTier())
+                    .systemFingerprint(gatewayResponse.systemFingerprint())
+                    .cached(gatewayResponse.cached());
+        }
+
+        return ChatResponse.builder()
+                .aiMessage(aiMessage.build())
+                .metadata(metadata.build())
+                .build();
+    }
+
+    static ChatParameters toChatParameters(ChatRequestParameters parameters) {
+
+        ChatParameters.Builder builder = ChatParameters.builder();
+        applyBaseParameters(builder, parameters);
+
+        if (parameters instanceof WatsonxChatRequestParameters watsonxParameters) {
+            builder.logitBias(watsonxParameters.logitBias());
+            builder.logprobs(watsonxParameters.logprobs());
+            builder.topLogprobs(watsonxParameters.topLogprobs());
+            builder.seed(watsonxParameters.seed());
+            builder.timeLimit(watsonxParameters.timeout());
+            applyToolChoice(builder, parameters, watsonxParameters.toolChoiceName());
+            builder.projectId(watsonxParameters.projectId());
+            builder.spaceId(watsonxParameters.spaceId());
+            builder.guidedChoice(watsonxParameters.guidedChoice());
+            builder.guidedGrammar(watsonxParameters.guidedGrammar());
+            builder.guidedRegex(watsonxParameters.guidedRegex());
+            builder.repetitionPenalty(watsonxParameters.repetitionPenalty());
+            builder.lengthPenalty(watsonxParameters.lengthPenalty());
+        }
+
+        return builder.build();
+    }
+
+    static ModelGatewayParameters toModelGatewayParameters(ChatRequestParameters parameters) {
+
+        ModelGatewayParameters.Builder builder = ModelGatewayParameters.builder();
+        applyBaseParameters(builder, parameters);
+
+        if (parameters instanceof WatsonxGatewayChatRequestParameters gatewayParameters) {
+            builder.logitBias(gatewayParameters.logitBias());
+            builder.logprobs(gatewayParameters.logprobs());
+            builder.topLogprobs(gatewayParameters.topLogprobs());
+            builder.seed(gatewayParameters.seed());
+            builder.timeLimit(gatewayParameters.timeout());
+            applyToolChoice(builder, parameters, gatewayParameters.toolChoiceName());
+            builder.serviceTier(gatewayParameters.serviceTier());
+            builder.reasoningEffort(gatewayParameters.reasoningEffort());
+            builder.router(gatewayParameters.router());
+            builder.modalities(gatewayParameters.modalities());
+            builder.store(gatewayParameters.store());
+            builder.parallelToolCalls(gatewayParameters.parallelToolCalls());
+            builder.user(gatewayParameters.user());
+            builder.metadata(gatewayParameters.metadata());
+        }
+
+        return builder.build();
+    }
+
+    private static void applyBaseParameters(BaseChatParameters.Builder<?> builder, ChatRequestParameters parameters) {
+
+        builder.modelId(parameters.modelName());
+        builder.frequencyPenalty(parameters.frequencyPenalty());
+        builder.maxCompletionTokens(parameters.maxOutputTokens());
+        builder.presencePenalty(parameters.presencePenalty());
+        builder.stop(parameters.stopSequences());
+        builder.temperature(parameters.temperature());
+        builder.topP(parameters.topP());
 
         ResponseFormat responseFormat = parameters.responseFormat();
 
@@ -116,57 +214,41 @@ class Converter {
                 }
             }
         }
+    }
 
-        if (parameters instanceof WatsonxChatRequestParameters watsonxParameters) {
-            builder.projectId(watsonxParameters.projectId());
-            builder.spaceId(watsonxParameters.spaceId());
-            builder.logitBias(watsonxParameters.logitBias());
-            builder.logprobs(watsonxParameters.logprobs());
-            builder.seed(watsonxParameters.seed());
-            builder.timeLimit(watsonxParameters.timeout());
-            builder.topLogprobs(watsonxParameters.topLogprobs());
-            builder.guidedChoice(watsonxParameters.guidedChoice());
-            builder.guidedGrammar(watsonxParameters.guidedGrammar());
-            builder.guidedRegex(watsonxParameters.guidedRegex());
-            builder.repetitionPenalty(watsonxParameters.repetitionPenalty());
-            builder.lengthPenalty(watsonxParameters.lengthPenalty());
+    private static void applyToolChoice(
+            BaseChatParameters.Builder<?> builder, ChatRequestParameters parameters, String toolChoiceName) {
 
-            List<ToolSpecification> toolSpecifications = parameters.toolSpecifications();
-            ToolChoice toolChoice = parameters.toolChoice();
+        List<ToolSpecification> toolSpecifications = parameters.toolSpecifications();
+        ToolChoice toolChoice = parameters.toolChoice();
 
-            if ((isNull(toolChoice) || toolChoice.equals(ToolChoice.REQUIRED))
-                    && nonNull(watsonxParameters.toolChoiceName())) {
+        if ((isNull(toolChoice) || toolChoice.equals(ToolChoice.REQUIRED)) && nonNull(toolChoiceName)) {
 
-                if (toolSpecifications.isEmpty())
-                    throw new IllegalArgumentException(
-                            "If tool-choice-name is set, at least one tool must be specified.");
+            if (toolSpecifications.isEmpty())
+                throw new IllegalArgumentException("If tool-choice-name is set, at least one tool must be specified.");
 
-                builder.toolChoiceOption(null);
-                builder.toolChoice(toolSpecifications.stream()
-                        .filter(toolSpecification ->
-                                toolSpecification.name().equalsIgnoreCase(watsonxParameters.toolChoiceName()))
-                        .findFirst()
-                        .map(ToolSpecification::name)
-                        .orElseThrow(() -> new IllegalArgumentException(
-                                "The tool with name '%s' is not available in the list of tools sent to the model."
-                                        .formatted(watsonxParameters.toolChoiceName()))));
+            builder.toolChoiceOption(null);
+            builder.toolChoice(toolSpecifications.stream()
+                    .filter(toolSpecification -> toolSpecification.name().equalsIgnoreCase(toolChoiceName))
+                    .findFirst()
+                    .map(ToolSpecification::name)
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "The tool with name '%s' is not available in the list of tools sent to the model."
+                                    .formatted(toolChoiceName))));
 
-            } else if (nonNull(toolChoice)) {
-                switch (toolChoice) {
-                    case AUTO -> builder.toolChoiceOption(ToolChoiceOption.AUTO);
-                    case REQUIRED -> {
-                        if (toolSpecifications.isEmpty())
-                            throw new IllegalArgumentException(
-                                    "If tool-choice is 'REQUIRED', at least one tool must be specified.");
+        } else if (nonNull(toolChoice)) {
+            switch (toolChoice) {
+                case AUTO -> builder.toolChoiceOption(ToolChoiceOption.AUTO);
+                case REQUIRED -> {
+                    if (toolSpecifications.isEmpty())
+                        throw new IllegalArgumentException(
+                                "If tool-choice is 'REQUIRED', at least one tool must be specified.");
 
-                        builder.toolChoiceOption(ToolChoiceOption.REQUIRED);
-                    }
-                    case NONE -> builder.toolChoiceOption(ToolChoiceOption.NONE);
+                    builder.toolChoiceOption(ToolChoiceOption.REQUIRED);
                 }
+                case NONE -> builder.toolChoiceOption(ToolChoiceOption.NONE);
             }
         }
-
-        return builder.build();
     }
 
     private static ToolCall toToolCall(ToolExecutionRequest toolExecutionRequest) {
@@ -209,7 +291,9 @@ class Converter {
                             case AUTO -> Detail.AUTO;
                             case HIGH -> Detail.HIGH;
                             case LOW -> Detail.LOW;
-                            default -> throw new UnsupportedFeatureException("Unsupported detail level: " + imageContent.detailLevel());
+                            default ->
+                                throw new UnsupportedFeatureException(
+                                        "Unsupported detail level: " + imageContent.detailLevel());
                         };
                 yield ImageContent.of(mimeType, base64Data, detailLevel);
             }
@@ -223,8 +307,7 @@ class Converter {
     private static ToolMessage toToolMessage(ToolExecutionResultMessage toolExecutionResultMessage) {
         if (!toolExecutionResultMessage.hasSingleText()) {
             throw new UnsupportedFeatureException(
-                    "watsonx does not support non-text content in tool results. "
-                            + "Only text content is supported.");
+                    "watsonx does not support non-text content in tool results. Only text content is supported.");
         }
         return ToolMessage.of(toolExecutionResultMessage.text(), toolExecutionResultMessage.id());
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -34,6 +34,8 @@ import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
@@ -139,10 +141,10 @@ class Converter {
                 .build();
     }
 
-    static ChatParameters toChatParameters(ChatRequestParameters parameters) {
+    static ChatParameters toChatParameters(ChatRequestParameters parameters, boolean strictJsonSchema) {
 
         ChatParameters.Builder builder = ChatParameters.builder();
-        applyBaseParameters(builder, parameters);
+        applyBaseParameters(builder, parameters, strictJsonSchema);
 
         if (parameters instanceof WatsonxChatRequestParameters watsonxParameters) {
             builder.logitBias(watsonxParameters.logitBias());
@@ -163,10 +165,10 @@ class Converter {
         return builder.build();
     }
 
-    static ModelGatewayParameters toModelGatewayParameters(ChatRequestParameters parameters) {
+    static ModelGatewayParameters toModelGatewayParameters(ChatRequestParameters parameters, boolean strictJsonSchema) {
 
         ModelGatewayParameters.Builder builder = ModelGatewayParameters.builder();
-        applyBaseParameters(builder, parameters);
+        applyBaseParameters(builder, parameters, strictJsonSchema);
 
         if (parameters instanceof WatsonxGatewayChatRequestParameters gatewayParameters) {
             builder.logitBias(gatewayParameters.logitBias());
@@ -188,7 +190,8 @@ class Converter {
         return builder.build();
     }
 
-    private static void applyBaseParameters(BaseChatParameters.Builder<?> builder, ChatRequestParameters parameters) {
+    private static void applyBaseParameters(
+            BaseChatParameters.Builder<?> builder, ChatRequestParameters parameters, boolean strictJsonSchema) {
 
         builder.modelId(parameters.modelName());
         builder.frequencyPenalty(parameters.frequencyPenalty());
@@ -211,10 +214,17 @@ class Converter {
             switch (responseFormat.type()) {
                 case JSON -> {
                     if (nonNull(responseFormat.jsonSchema())) {
+
                         var name = responseFormat.jsonSchema().name();
-                        var jsonSchema = JsonSchemaElementUtils.toMap(
-                                responseFormat.jsonSchema().rootElement());
-                        builder.responseAsJsonSchema(name, jsonSchema, true);
+                        var rootElement = responseFormat.jsonSchema().rootElement();
+
+                        if (!(rootElement instanceof JsonObjectSchema || rootElement instanceof JsonRawSchema))
+                            throw new IllegalArgumentException(
+                                    "The root element of the JSON Schema must be either a JsonObjectSchema or a JsonRawSchema, but it was: "
+                                            + rootElement.getClass());
+
+                        var jsonSchema = JsonSchemaElementUtils.toMap(rootElement, strictJsonSchema);
+                        builder.responseAsJsonSchema(name, jsonSchema, strictJsonSchema);
                     } else {
                         builder.responseAsJson();
                     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxBuilder.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxBuilder.java
@@ -1,67 +1,18 @@
 package dev.langchain4j.model.watsonx;
 
-import com.ibm.watsonx.ai.CloudRegion;
-import com.ibm.watsonx.ai.core.auth.Authenticator;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.time.Duration;
+import dev.langchain4j.Internal;
 
+/**
+ * Abstract builder for the watsonx.ai services that operate inside a project or a deployment space.
+ *
+ * @param <T> the concrete builder subclass
+ */
+@Internal
 @SuppressWarnings("unchecked")
-abstract class WatsonxBuilder<T extends WatsonxBuilder<T>> {
+abstract class WatsonxBuilder<T extends WatsonxBuilder<T>> extends WatsonxConnectionBuilder<T> {
 
-    protected URI baseUrl;
-    protected String version;
-    protected String apiKey;
     protected String projectId;
     protected String spaceId;
-    protected Boolean logRequests;
-    protected Boolean logResponses;
-    protected Duration timeout;
-    protected Authenticator authenticator;
-    protected HttpClient httpClient;
-    protected boolean verifySsl = true;
-
-    /**
-     * Sets the IBM watsonx.ai endpoint from a predefined {@link CloudRegion}.
-     *
-     * @param baseUrl the IBM Cloud region whose ML endpoint will be used
-     * @return {@code this}
-     */
-    public T baseUrl(CloudRegion baseUrl) {
-        return baseUrl(baseUrl.mlEndpoint());
-    }
-
-    /**
-     * Sets the base URL of the IBM watsonx.ai API.
-     *
-     * @param url the base URL string, e.g. {@code "https://us-south.ml.cloud.ibm.com"}
-     * @return {@code this}
-     */
-    public T baseUrl(String url) {
-        return baseUrl(URI.create(url));
-    }
-
-    /**
-     * Sets the base URL of the IBM watsonx.ai API as a {@link URI}.
-     *
-     * @param url the base URL URI
-     * @return {@code this}
-     */
-    public T baseUrl(URI url) {
-        this.baseUrl = url;
-        return (T) this;
-    }
-
-    /**
-     * Sets the watsonx.ai API version date, e.g. {@code "2024-05-31"}.
-     *
-     * @param version the API version date string
-     * @return {@code this}
-     */
-    public T version(String version) {
-        this.version = version;
-        return (T) this;
-    }
 
     /**
      * Sets the IBM Cloud project ID that owns the watsonx.ai resources.
@@ -84,85 +35,6 @@ abstract class WatsonxBuilder<T extends WatsonxBuilder<T>> {
      */
     public T spaceId(String spaceId) {
         this.spaceId = spaceId;
-        return (T) this;
-    }
-
-    /**
-     * Sets the IBM Cloud API key used to generate IAM access tokens for authentication.
-     *
-     * @param apiKey the IBM Cloud API key
-     * @return {@code this}
-     */
-    public T apiKey(String apiKey) {
-        this.apiKey = apiKey;
-        return (T) this;
-    }
-
-    /**
-     * Enables debug logging of request bodies sent to the watsonx.ai API.
-     *
-     * @param logRequests {@code true} to enable request logging
-     * @return {@code this}
-     */
-    public T logRequests(Boolean logRequests) {
-        this.logRequests = logRequests;
-        return (T) this;
-    }
-
-    /**
-     * Enables debug logging of response bodies received from the watsonx.ai API.
-     *
-     * @param logResponses {@code true} to enable response logging
-     * @return {@code this}
-     */
-    public T logResponses(Boolean logResponses) {
-        this.logResponses = logResponses;
-        return (T) this;
-    }
-
-    /**
-     * Sets the HTTP request timeout. Defaults to 60 seconds.
-     *
-     * @param timeout the request timeout
-     * @return {@code this}
-     */
-    public T timeout(Duration timeout) {
-        this.timeout = timeout;
-        return (T) this;
-    }
-
-    /**
-     * Sets a custom {@link Authenticator} for generating bearer tokens.
-     * Use this instead of {@link #apiKey} when you need a non-standard authentication flow.
-     *
-     * @param authenticator the authenticator
-     * @return {@code this}
-     */
-    public T authenticator(Authenticator authenticator) {
-        this.authenticator = authenticator;
-        return (T) this;
-    }
-
-    /**
-     * Sets a custom {@link HttpClient} to use for all API calls.
-     *
-     * @param httpClient the HTTP client
-     * @return {@code this}
-     */
-    public T httpClient(HttpClient httpClient) {
-        this.httpClient = httpClient;
-        return (T) this;
-    }
-
-    /**
-     * Controls whether SSL certificate verification is performed. Defaults to {@code true}.
-     * Set to {@code false} only in non-production environments.
-     *
-     * @param verifySsl {@code false} to disable SSL verification
-     * @return {@code this}
-     */
-    public T verifySsl(boolean verifySsl) {
-        this.verifySsl = verifySsl;
         return (T) this;
     }
 }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -52,7 +52,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         var requestBuilder = ChatRequest.builder()
                 .messages(messages)
                 .tools(tools)
-                .parameters(Converter.toChatParameters(parameters));
+                .parameters(Converter.toChatParameters(parameters, strictJsonSchema));
 
         if (parameters instanceof WatsonxChatRequestParameters watsonxParameters
                 && nonNull(watsonxParameters.thinking())) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -8,17 +8,13 @@ import com.ibm.watsonx.ai.chat.ChatRequest;
 import com.ibm.watsonx.ai.chat.ChatService;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
-import com.ibm.watsonx.ai.chat.model.ExtractionTags;
-import com.ibm.watsonx.ai.chat.model.Thinking;
-import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import com.ibm.watsonx.ai.chat.model.Tool;
 import dev.langchain4j.Internal;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import java.util.List;
-import java.util.Set;
 
 @Internal
-abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
+abstract class WatsonxChat extends WatsonxTextChatBase<ChatRequest> {
 
     protected final ChatService chatService;
 
@@ -49,17 +45,8 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
     protected ChatRequest buildChatRequest(
             List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
 
-        var requestBuilder = ChatRequest.builder()
-                .messages(messages)
-                .tools(tools)
-                .parameters(Converter.toChatParameters(parameters, strictJsonSchema));
-
-        if (parameters instanceof WatsonxChatRequestParameters watsonxParameters
-                && nonNull(watsonxParameters.thinking())) {
-            requestBuilder.thinking(watsonxParameters.thinking());
-        }
-
-        return requestBuilder.build();
+        return applyChatRequest(ChatRequest.builder(), messages, tools, parameters)
+                .build();
     }
 
     @Override
@@ -74,35 +61,17 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
                 : WatsonxChatRequestParameters.EMPTY;
 
         var target = WatsonxChatRequestParameters.builder();
-        applyCommonParameters(target, builder);
+        applyTextChatParameters(target, builder);
 
         return target.projectId(getOrDefault(builder.projectId, watsonxParameters.projectId()))
                 .spaceId(getOrDefault(builder.spaceId, watsonxParameters.spaceId()))
-                .logitBias(getOrDefault(builder.logitBias, watsonxParameters.logitBias()))
-                .logprobs(getOrDefault(builder.logprobs, watsonxParameters.logprobs()))
-                .topLogprobs(getOrDefault(builder.topLogprobs, watsonxParameters.topLogprobs()))
-                .seed(getOrDefault(builder.seed, watsonxParameters.seed()))
-                .toolChoiceName(getOrDefault(builder.toolChoiceName, watsonxParameters.toolChoiceName()))
-                .timeout(getOrDefault(builder.timeout, watsonxParameters.timeout()))
-                .thinking(getOrDefault(builder.thinking, watsonxParameters.thinking()))
-                .guidedChoice(getOrDefault(builder.guidedChoice, watsonxParameters.guidedChoice()))
-                .guidedGrammar(getOrDefault(builder.guidedGrammar, watsonxParameters.guidedGrammar()))
-                .guidedRegex(getOrDefault(builder.guidedRegex, watsonxParameters.guidedRegex()))
-                .lengthPenalty(getOrDefault(builder.lengthPenalty, watsonxParameters.lengthPenalty()))
-                .repetitionPenalty(getOrDefault(builder.repetitionPenalty, watsonxParameters.repetitionPenalty()))
                 .build();
     }
 
     @SuppressWarnings("unchecked")
-    abstract static class Builder<T extends Builder<T>> extends WatsonxChatBase.Builder<T> {
+    abstract static class Builder<T extends Builder<T>> extends WatsonxTextChatBase.Builder<T> {
         protected String projectId;
         protected String spaceId;
-        protected Thinking thinking;
-        protected Set<String> guidedChoice;
-        protected String guidedRegex;
-        protected String guidedGrammar;
-        protected Double repetitionPenalty;
-        protected Double lengthPenalty;
 
         /**
          * Sets the foundation model id, e.g. {@code "ibm/granite-4-h-small"}.
@@ -134,118 +103,6 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
          */
         public T spaceId(String spaceId) {
             this.spaceId = spaceId;
-            return (T) this;
-        }
-
-        /**
-         * Enables or disables extended thinking (chain-of-thought reasoning before the response).
-         *
-         * @param enabled {@code true} to enable extended thinking
-         * @return {@code this}
-         */
-        public T thinking(boolean enabled) {
-            return thinking(Thinking.builder().enabled(enabled).build());
-        }
-
-        /**
-         * Configures extended thinking with custom extraction tags for parsing the thinking block. Passing {@code null} disables thinking.
-         *
-         * @param tags the extraction tags, or {@code null} to disable thinking
-         * @return {@code this}
-         */
-        public T thinking(ExtractionTags tags) {
-            if (nonNull(tags)) return thinking(Thinking.of(tags));
-
-            this.thinking = null;
-            return (T) this;
-        }
-
-        /**
-         * Configures extended thinking with a specific effort level.
-         *
-         * @param thinkingEffort the thinking effort level
-         * @return {@code this}
-         */
-        public T thinking(ThinkingEffort thinkingEffort) {
-            if (nonNull(thinkingEffort)) return thinking(Thinking.of(thinkingEffort));
-
-            this.thinking = null;
-            return (T) this;
-        }
-
-        /**
-         * Sets a fully configured {@link Thinking} object for extended thinking.
-         *
-         * @param thinking the thinking configuration
-         * @return {@code this}
-         */
-        public T thinking(Thinking thinking) {
-            this.thinking = thinking;
-            return (T) this;
-        }
-
-        /**
-         * Constrains the model output to one of the given string choices (guided decoding).
-         *
-         * @param guidedChoice the allowed output values
-         * @return {@code this}
-         */
-        public T guidedChoice(String... guidedChoice) {
-            return guidedChoice(Set.of(guidedChoice));
-        }
-
-        /**
-         * Constrains the model output to one of the given string choices (guided decoding).
-         *
-         * @param guidedChoices the set of allowed output values
-         * @return {@code this}
-         */
-        public T guidedChoice(Set<String> guidedChoices) {
-            this.guidedChoice = guidedChoices;
-            return (T) this;
-        }
-
-        /**
-         * Constrains the model output to match the given regular expression (guided decoding).
-         *
-         * @param guidedRegex the regular expression pattern
-         * @return {@code this}
-         */
-        public T guidedRegex(String guidedRegex) {
-            this.guidedRegex = guidedRegex;
-            return (T) this;
-        }
-
-        /**
-         * Constrains the model output to conform to the given EBNF grammar (guided decoding).
-         *
-         * @param guidedGrammar the EBNF grammar string
-         * @return {@code this}
-         */
-        public T guidedGrammar(String guidedGrammar) {
-            this.guidedGrammar = guidedGrammar;
-            return (T) this;
-        }
-
-        /**
-         * Sets the repetition penalty. Values greater than {@code 1.0} discourage repetition; values less than {@code 1.0} encourage it.
-         *
-         * @param repetitionPenalty the repetition penalty
-         * @return {@code this}
-         */
-        public T repetitionPenalty(Double repetitionPenalty) {
-            this.repetitionPenalty = repetitionPenalty;
-            return (T) this;
-        }
-
-        /**
-         * Sets the length penalty applied to the sequence score during beam search. Values greater than {@code 1.0} favor longer sequences.
-         *
-         * @param lengthPenalty the length penalty
-         * @return {@code this}
-         */
-        public T lengthPenalty(Double lengthPenalty) {
-            this.lengthPenalty = lengthPenalty;
             return (T) this;
         }
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -1,0 +1,425 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+import static dev.langchain4j.model.ModelProvider.WATSONX;
+import static java.util.Arrays.asList;
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toCollection;
+
+import com.ibm.watsonx.ai.chat.BaseChatRequest;
+import com.ibm.watsonx.ai.chat.ChatHandler;
+import com.ibm.watsonx.ai.chat.ChatProvider;
+import com.ibm.watsonx.ai.chat.TextChatResponse;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
+import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
+import com.ibm.watsonx.ai.chat.model.PartialToolCall;
+import com.ibm.watsonx.ai.chat.model.Tool;
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Internal
+abstract class WatsonxChatBase<R extends BaseChatRequest> {
+
+    protected final List<ChatModelListener> listeners;
+    protected final ChatRequestParameters defaultRequestParameters;
+    protected final Set<Capability> supportedCapabilities;
+
+    protected WatsonxChatBase(Builder<?> builder, ChatRequestParameters defaultRequestParameters) {
+        this.listeners = copy(builder.listeners);
+        this.supportedCapabilities = copy(builder.supportedCapabilities);
+        this.defaultRequestParameters = defaultRequestParameters;
+    }
+
+    protected abstract ChatProvider<R, ? extends TextChatResponse> chatProvider();
+
+    protected abstract R buildChatRequest(
+            List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters);
+
+    public List<ChatModelListener> listeners() {
+        return listeners;
+    }
+
+    public ChatRequestParameters defaultRequestParameters() {
+        return defaultRequestParameters;
+    }
+
+    public Set<Capability> supportedCapabilities() {
+        return supportedCapabilities;
+    }
+
+    public ModelProvider provider() {
+        return WATSONX;
+    }
+
+    protected final ChatResponse executeChat(ChatRequest chatRequest) {
+
+        var watsonxChatRequest = toWatsonxChatRequest(chatRequest);
+        TextChatResponse chatResponse = WatsonxExceptionMapper.INSTANCE.withExceptionMapper(
+                () -> chatProvider().chat(watsonxChatRequest));
+
+        String refusal = chatResponse.toAssistantMessage().refusal();
+
+        if (isNotNullOrBlank(refusal)) throw new ContentFilteredException(refusal);
+
+        return Converter.toChatResponse(chatResponse);
+    }
+
+    protected final void executeChatStreaming(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+
+        var watsonxChatRequest = toWatsonxChatRequest(chatRequest);
+
+        chatProvider().chatStreaming(watsonxChatRequest, new ChatHandler() {
+            @Override
+            public void onCompleteResponse(com.ibm.watsonx.ai.chat.ChatResponse completeResponse) {
+
+                TextChatResponse textChatResponse = (TextChatResponse) completeResponse;
+                ChatResponse chatResponse;
+
+                try {
+                    String refusal = textChatResponse.toAssistantMessage().refusal();
+
+                    if (isNotNullOrBlank(refusal)) {
+                        handler.onError(new ContentFilteredException(refusal));
+                        return;
+                    }
+
+                    chatResponse = Converter.toChatResponse(textChatResponse);
+                } catch (RuntimeException e) {
+                    handler.onError(WatsonxExceptionMapper.INSTANCE.mapException(e));
+                    return;
+                }
+
+                handler.onCompleteResponse(chatResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                handler.onError(WatsonxExceptionMapper.INSTANCE.mapException(error));
+            }
+
+            @Override
+            public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {
+                handler.onPartialResponse(partialResponse);
+            }
+
+            @Override
+            public void onCompleteToolCall(CompletedToolCall completedToolCall) {
+                handler.onCompleteToolCall(Converter.toCompleteToolCall(completedToolCall.toolCall()));
+            }
+
+            @Override
+            public void onPartialThinking(String partialThinking, PartialChatResponse partialChatResponse) {
+                handler.onPartialThinking(new PartialThinking(partialThinking));
+            }
+
+            @Override
+            public void onPartialToolCall(PartialToolCall partialToolCall) {
+                handler.onPartialToolCall(Converter.toPartialToolCall(partialToolCall));
+            }
+        });
+    }
+
+    protected static final void applyCommonParameters(
+            DefaultChatRequestParameters.Builder<?> target, Builder<?> builder) {
+        ChatRequestParameters common = DefaultChatRequestParameters.EMPTY;
+        if (nonNull(builder.defaultRequestParameters)) {
+            validate(builder.defaultRequestParameters);
+            common = builder.defaultRequestParameters;
+        }
+
+        target.modelName(getOrDefault(builder.modelName, common.modelName()));
+        target.temperature(getOrDefault(builder.temperature, common.temperature()));
+        target.topP(getOrDefault(builder.topP, common.topP()));
+        target.frequencyPenalty(getOrDefault(builder.frequencyPenalty, common.frequencyPenalty()));
+        target.presencePenalty(getOrDefault(builder.presencePenalty, common.presencePenalty()));
+        target.maxOutputTokens(getOrDefault(builder.maxOutputTokens, common.maxOutputTokens()));
+        target.stopSequences(getOrDefault(builder.stopSequences, common.stopSequences()));
+        target.toolSpecifications(getOrDefault(builder.toolSpecifications, common.toolSpecifications()));
+        target.toolChoice(getOrDefault(builder.toolChoice, common.toolChoice()));
+        target.responseFormat(getOrDefault(builder.responseFormat, common.responseFormat()));
+    }
+
+    private R toWatsonxChatRequest(ChatRequest chatRequest) {
+
+        validate(chatRequest.parameters());
+
+        List<ToolSpecification> toolSpecifications = getOrDefault(
+                chatRequest.parameters().toolSpecifications(), defaultRequestParameters.toolSpecifications());
+
+        List<ChatMessage> messages =
+                chatRequest.messages().stream().map(Converter::toChatMessage).collect(toCollection(ArrayList::new));
+
+        List<Tool> tools = nonNull(toolSpecifications) && !toolSpecifications.isEmpty()
+                ? toolSpecifications.stream().map(Converter::toTool).toList()
+                : null;
+
+        return buildChatRequest(messages, tools, chatRequest.parameters());
+    }
+
+    private static void validate(ChatRequestParameters parameters) {
+        if (nonNull(parameters.topK()))
+            throw new UnsupportedFeatureException("'topK' parameter is not supported by watsonx.ai");
+    }
+
+    @SuppressWarnings("unchecked")
+    abstract static class Builder<T extends Builder<T>> extends WatsonxConnectionBuilder<T> {
+        protected String modelName;
+        protected Double temperature;
+        protected Double topP;
+        protected Double frequencyPenalty;
+        protected Double presencePenalty;
+        protected Integer maxOutputTokens;
+        protected List<String> stopSequences;
+        protected ToolChoice toolChoice;
+        protected ResponseFormat responseFormat;
+        protected List<ToolSpecification> toolSpecifications;
+        protected List<ChatModelListener> listeners;
+        protected ChatRequestParameters defaultRequestParameters;
+        protected Set<Capability> supportedCapabilities;
+        protected Map<String, Integer> logitBias;
+        protected Boolean logprobs;
+        protected Integer topLogprobs;
+        protected Integer seed;
+        protected String toolChoiceName;
+
+        /**
+         * Sets the sampling temperature in the range {@code [0.0, 2.0]}.
+         *
+         * @param temperature the sampling temperature
+         * @return {@code this}
+         */
+        public T temperature(Double temperature) {
+            this.temperature = temperature;
+            return (T) this;
+        }
+
+        /**
+         * Sets the nucleus sampling probability in the range {@code (0.0, 1.0]}
+         *
+         * @param topP the nucleus sampling threshold
+         * @return {@code this}
+         */
+        public T topP(Double topP) {
+            this.topP = topP;
+            return (T) this;
+        }
+
+        /**
+         * Sets the frequency penalty in the range {@code [-2.0, 2.0]}.
+         *
+         * @param frequencyPenalty the frequency penalty
+         * @return {@code this}
+         */
+        public T frequencyPenalty(Double frequencyPenalty) {
+            this.frequencyPenalty = frequencyPenalty;
+            return (T) this;
+        }
+
+        /**
+         * Sets the presence penalty in the range {@code [-2.0, 2.0]}.
+         *
+         * @param presencePenalty the presence penalty
+         * @return {@code this}
+         */
+        public T presencePenalty(Double presencePenalty) {
+            this.presencePenalty = presencePenalty;
+            return (T) this;
+        }
+
+        /**
+         * Sets the maximum number of tokens to generate in the response.
+         *
+         * @param maxOutputTokens the maximum number of output tokens
+         * @return {@code this}
+         */
+        public T maxOutputTokens(Integer maxOutputTokens) {
+            this.maxOutputTokens = maxOutputTokens;
+            return (T) this;
+        }
+
+        /**
+         * Sets the sequences that will stop generation when encountered.
+         *
+         * @param stopSequences the stop sequences
+         * @return {@code this}
+         */
+        public T stopSequences(List<String> stopSequences) {
+            this.stopSequences = stopSequences;
+            return (T) this;
+        }
+
+        /**
+         * Sets the sequences that will stop generation when encountered.
+         *
+         * @param stopSequences the stop sequences
+         * @return {@code this}
+         */
+        public T stopSequences(String... stopSequences) {
+            return stopSequences(asList(stopSequences));
+        }
+
+        /**
+         * Sets how the model selects tools. Controls whether tool use is automatic, forced, or disabled.
+         *
+         * @param toolChoice the tool choice mode
+         * @return {@code this}
+         */
+        public T toolChoice(ToolChoice toolChoice) {
+            this.toolChoice = toolChoice;
+            return (T) this;
+        }
+
+        /**
+         * Sets the response format to control structured output, e.g. JSON mode.
+         *
+         * @param responseFormat the response format
+         * @return {@code this}
+         */
+        public T responseFormat(ResponseFormat responseFormat) {
+            this.responseFormat = responseFormat;
+            return (T) this;
+        }
+
+        /**
+         * Sets the tool definitions available to the model for function calling.
+         *
+         * @param toolSpecifications the list of tool specifications
+         * @return {@code this}
+         */
+        public T toolSpecifications(List<ToolSpecification> toolSpecifications) {
+            this.toolSpecifications = toolSpecifications;
+            return (T) this;
+        }
+
+        /**
+         * Sets the tool definitions available to the model for function calling.
+         *
+         * @param toolSpecifications the tool specifications
+         * @return {@code this}
+         */
+        public T toolSpecifications(ToolSpecification... toolSpecifications) {
+            return toolSpecifications(asList(toolSpecifications));
+        }
+
+        /**
+         * Sets the list of {@link ChatModelListener} instances for observing chat model interactions.
+         *
+         * @param listeners the listeners to register
+         * @return {@code this}
+         */
+        public T listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return (T) this;
+        }
+
+        /**
+         * Sets default request parameters that are merged into every chat request.
+         *
+         * @param defaultRequestParameters the default request parameters
+         * @return {@code this}
+         */
+        public T defaultRequestParameters(ChatRequestParameters defaultRequestParameters) {
+            this.defaultRequestParameters = defaultRequestParameters;
+            return (T) this;
+        }
+
+        /**
+         * Declares the capabilities supported by this model instance.
+         *
+         * @param supportedCapabilities the set of supported capabilities
+         * @return {@code this}
+         */
+        public T supportedCapabilities(Set<Capability> supportedCapabilities) {
+            this.supportedCapabilities = supportedCapabilities;
+            return (T) this;
+        }
+
+        /**
+         * Declares the capabilities supported by this model instance.
+         *
+         * @param supportedCapabilities the supported capabilities
+         * @return {@code this}
+         */
+        public T supportedCapabilities(Capability... supportedCapabilities) {
+            return supportedCapabilities(new HashSet<>(asList(supportedCapabilities)));
+        }
+
+        /**
+         * Sets per-token logit biases to increase or decrease the likelihood of specific tokens. Keys are token IDs; values are bias offsets in the
+         * range {@code [-100, 100]}.
+         *
+         * @param logitBias the logit bias map
+         * @return {@code this}
+         */
+        public T logitBias(Map<String, Integer> logitBias) {
+            this.logitBias = logitBias;
+            return (T) this;
+        }
+
+        /**
+         * Enables returning log probabilities of the output tokens.
+         *
+         * @param logprobs {@code true} to include log probabilities in the response
+         * @return {@code this}
+         */
+        public T logprobs(Boolean logprobs) {
+            this.logprobs = logprobs;
+            return (T) this;
+        }
+
+        /**
+         * Sets the number of most likely tokens to return log probabilities for at each position. Requires {@link #logprobs} to be {@code true}.
+         * Value must be between 0 and 20.
+         *
+         * @param topLogprobs the number of top log probabilities to return
+         * @return {@code this}
+         */
+        public T topLogprobs(Integer topLogprobs) {
+            this.topLogprobs = topLogprobs;
+            return (T) this;
+        }
+
+        /**
+         * Sets the random seed for deterministic sampling. Using the same seed and parameters should produce the same output across calls.
+         *
+         * @param seed the random seed
+         * @return {@code this}
+         */
+        public T seed(Integer seed) {
+            this.seed = seed;
+            return (T) this;
+        }
+
+        /**
+         * Sets the name of the specific tool to force when {@link #toolChoice} is set to force a particular tool.
+         *
+         * @param toolChoiceName the tool name to force
+         * @return {@code this}
+         */
+        public T toolChoiceName(String toolChoiceName) {
+            this.toolChoiceName = toolChoiceName;
+            return (T) this;
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -31,7 +31,9 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -40,6 +42,8 @@ import java.util.Set;
 
 @Internal
 abstract class WatsonxChatBase<R extends BaseChatRequest> {
+
+    private static final StreamingHandle CANCELLATION_UNSUPPORTED = new CancellationUnsupportedStreamingHandle();
 
     protected final List<ChatModelListener> listeners;
     protected final ChatRequestParameters defaultRequestParameters;
@@ -137,7 +141,9 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
 
             @Override
             public void onPartialToolCall(PartialToolCall partialToolCall) {
-                handler.onPartialToolCall(Converter.toPartialToolCall(partialToolCall));
+                handler.onPartialToolCall(
+                        Converter.toPartialToolCall(partialToolCall),
+                        new PartialToolCallContext(CANCELLATION_UNSUPPORTED));
             }
         });
     }
@@ -182,6 +188,19 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
     private static void validate(ChatRequestParameters parameters) {
         if (nonNull(parameters.topK()))
             throw new UnsupportedFeatureException("'topK' parameter is not supported by watsonx.ai");
+    }
+
+    private static final class CancellationUnsupportedStreamingHandle implements StreamingHandle {
+
+        @Override
+        public void cancel() {
+            throw new UnsupportedFeatureException("Streaming cancellation is not supported by watsonx.ai");
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -50,7 +50,7 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
         this.defaultRequestParameters = defaultRequestParameters;
-        this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
+        this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, true);
     }
 
     protected abstract ChatProvider<R, ? extends TextChatResponse> chatProvider();
@@ -305,7 +305,11 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
         }
 
         /**
-         * Enables the strict mode for the JSON Schema used by structured outputs. Defaults to {@code false}.
+         * Enables the strict mode for the JSON Schema used by structured outputs. Defaults to {@code true}.
+         *
+         * <p>In strict mode the model is required to adhere to the schema, every property is marked as
+         * {@code required} and {@code additionalProperties} is set to {@code false}. Set it to {@code false} to let
+         * the model treat the schema as a hint instead of a constraint.
          *
          * @param strictJsonSchema {@code true} to enable the strict mode
          * @return {@code this}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -21,6 +21,7 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -30,8 +31,6 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.PartialThinking;
-import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
 import java.util.ArrayList;
@@ -126,7 +125,8 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
 
             @Override
             public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {
-                handler.onPartialResponse(partialResponse);
+                InternalStreamingChatResponseHandlerUtils.onPartialResponse(
+                        handler, partialResponse, CANCELLATION_UNSUPPORTED);
             }
 
             @Override
@@ -136,14 +136,14 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
 
             @Override
             public void onPartialThinking(String partialThinking, PartialChatResponse partialChatResponse) {
-                handler.onPartialThinking(new PartialThinking(partialThinking));
+                InternalStreamingChatResponseHandlerUtils.onPartialThinking(
+                        handler, partialThinking, CANCELLATION_UNSUPPORTED);
             }
 
             @Override
             public void onPartialToolCall(PartialToolCall partialToolCall) {
-                handler.onPartialToolCall(
-                        Converter.toPartialToolCall(partialToolCall),
-                        new PartialToolCallContext(CANCELLATION_UNSUPPORTED));
+                InternalStreamingChatResponseHandlerUtils.onPartialToolCall(
+                        handler, Converter.toPartialToolCall(partialToolCall), CANCELLATION_UNSUPPORTED);
             }
         });
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -44,11 +44,13 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
     protected final List<ChatModelListener> listeners;
     protected final ChatRequestParameters defaultRequestParameters;
     protected final Set<Capability> supportedCapabilities;
+    protected final boolean strictJsonSchema;
 
     protected WatsonxChatBase(Builder<?> builder, ChatRequestParameters defaultRequestParameters) {
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
         this.defaultRequestParameters = defaultRequestParameters;
+        this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
     }
 
     protected abstract ChatProvider<R, ? extends TextChatResponse> chatProvider();
@@ -193,6 +195,7 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
         protected List<String> stopSequences;
         protected ToolChoice toolChoice;
         protected ResponseFormat responseFormat;
+        protected Boolean strictJsonSchema;
         protected List<ToolSpecification> toolSpecifications;
         protected List<ChatModelListener> listeners;
         protected ChatRequestParameters defaultRequestParameters;
@@ -298,6 +301,17 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
          */
         public T responseFormat(ResponseFormat responseFormat) {
             this.responseFormat = responseFormat;
+            return (T) this;
+        }
+
+        /**
+         * Enables the strict mode for the JSON Schema used by structured outputs. Defaults to {@code false}.
+         *
+         * @param strictJsonSchema {@code true} to enable the strict mode
+         * @return {@code this}
+         */
+        public T strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
             return (T) this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
@@ -18,47 +18,37 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
     public static final WatsonxChatRequestParameters EMPTY =
             WatsonxChatRequestParameters.builder().build();
 
-    private final String projectId;
-    private final String spaceId;
-    private final Thinking thinking;
     private final Map<String, Integer> logitBias;
     private final Boolean logprobs;
     private final Integer topLogprobs;
     private final Integer seed;
     private final String toolChoiceName;
+    private final Duration timeout;
+    private final String projectId;
+    private final String spaceId;
+    private final Thinking thinking;
     private final Set<String> guidedChoice;
     private final String guidedRegex;
     private final String guidedGrammar;
     private final Double repetitionPenalty;
     private final Double lengthPenalty;
-    private final String deploymentId;
-    private final Duration timeout;
 
     private WatsonxChatRequestParameters(Builder builder) {
         super(builder);
-        projectId = builder.projectId;
-        spaceId = builder.spaceId;
         logitBias = builder.logitBias;
         logprobs = builder.logprobs;
         topLogprobs = builder.topLogprobs;
         seed = builder.seed;
         toolChoiceName = builder.toolChoiceName;
         timeout = builder.timeout;
+        projectId = builder.projectId;
+        spaceId = builder.spaceId;
         thinking = builder.thinking;
         guidedChoice = builder.guidedChoice;
         guidedRegex = builder.guidedRegex;
         guidedGrammar = builder.guidedGrammar;
         repetitionPenalty = builder.repetitionPenalty;
         lengthPenalty = builder.lengthPenalty;
-        deploymentId = builder.deploymentId;
-    }
-
-    public String projectId() {
-        return projectId;
-    }
-
-    public String spaceId() {
-        return spaceId;
     }
 
     public Map<String, Integer> logitBias() {
@@ -85,6 +75,14 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
         return timeout;
     }
 
+    public String projectId() {
+        return projectId;
+    }
+
+    public String spaceId() {
+        return spaceId;
+    }
+
     public Thinking thinking() {
         return thinking;
     }
@@ -109,10 +107,6 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
         return lengthPenalty;
     }
 
-    public String deploymentId() {
-        return deploymentId;
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -135,45 +129,42 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         WatsonxChatRequestParameters that = (WatsonxChatRequestParameters) o;
-        return Objects.equals(projectId, that.projectId)
-                && Objects.equals(spaceId, that.spaceId)
-                && Objects.equals(thinking, that.thinking)
-                && Objects.equals(logitBias, that.logitBias)
+        return Objects.equals(logitBias, that.logitBias)
                 && Objects.equals(logprobs, that.logprobs)
                 && Objects.equals(topLogprobs, that.topLogprobs)
                 && Objects.equals(seed, that.seed)
                 && Objects.equals(toolChoiceName, that.toolChoiceName)
+                && Objects.equals(timeout, that.timeout)
+                && Objects.equals(projectId, that.projectId)
+                && Objects.equals(spaceId, that.spaceId)
+                && Objects.equals(thinking, that.thinking)
                 && Objects.equals(guidedChoice, that.guidedChoice)
                 && Objects.equals(guidedRegex, that.guidedRegex)
                 && Objects.equals(guidedGrammar, that.guidedGrammar)
                 && Objects.equals(repetitionPenalty, that.repetitionPenalty)
-                && Objects.equals(lengthPenalty, that.lengthPenalty)
-                && Objects.equals(deploymentId, that.deploymentId)
-                && Objects.equals(timeout, that.timeout);
+                && Objects.equals(lengthPenalty, that.lengthPenalty);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
                 super.hashCode(),
-                projectId,
-                spaceId,
-                thinking,
                 logitBias,
                 logprobs,
                 topLogprobs,
                 seed,
                 toolChoiceName,
+                timeout,
+                projectId,
+                spaceId,
+                thinking,
                 guidedChoice,
                 guidedRegex,
                 guidedGrammar,
                 repetitionPenalty,
-                lengthPenalty,
-                deploymentId,
-                timeout);
+                lengthPenalty);
     }
 
     @Override
@@ -202,58 +193,46 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
                 + guidedRegex + ", guidedGrammar="
                 + guidedGrammar + ", repetitionPenalty="
                 + repetitionPenalty + ", lengthPenalty="
-                + lengthPenalty + ", deploymentId="
-                + deploymentId + ", timeout="
+                + lengthPenalty + ", timeout="
                 + timeout + '}';
     }
 
     public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {
-        private String projectId;
-        private String spaceId;
+
         private Map<String, Integer> logitBias;
         private Boolean logprobs;
         private Integer topLogprobs;
         private Integer seed;
         private String toolChoiceName;
         private Duration timeout;
+        private String projectId;
+        private String spaceId;
+        private Thinking thinking;
         private Set<String> guidedChoice;
         private String guidedRegex;
         private String guidedGrammar;
         private Double repetitionPenalty;
         private Double lengthPenalty;
-        private String deploymentId;
-        private Thinking thinking;
 
         @Override
         public Builder overrideWith(ChatRequestParameters parameters) {
             super.overrideWith(parameters);
             if (parameters instanceof WatsonxChatRequestParameters watsonxParameters) {
-                projectId(getOrDefault(watsonxParameters.projectId(), projectId));
-                spaceId(getOrDefault(watsonxParameters.spaceId(), spaceId));
                 logitBias(getOrDefault(watsonxParameters.logitBias(), logitBias));
                 logprobs(getOrDefault(watsonxParameters.logprobs(), logprobs));
                 topLogprobs(getOrDefault(watsonxParameters.topLogprobs(), topLogprobs));
                 seed(getOrDefault(watsonxParameters.seed(), seed));
                 toolChoiceName(getOrDefault(watsonxParameters.toolChoiceName(), toolChoiceName));
                 timeout(getOrDefault(watsonxParameters.timeout(), timeout));
+                projectId(getOrDefault(watsonxParameters.projectId(), projectId));
+                spaceId(getOrDefault(watsonxParameters.spaceId(), spaceId));
                 thinking(getOrDefault(watsonxParameters.thinking(), thinking));
                 guidedChoice(getOrDefault(watsonxParameters.guidedChoice(), guidedChoice));
                 guidedRegex(getOrDefault(watsonxParameters.guidedRegex(), guidedRegex));
                 guidedGrammar(getOrDefault(watsonxParameters.guidedGrammar(), guidedGrammar));
                 repetitionPenalty(getOrDefault(watsonxParameters.repetitionPenalty(), repetitionPenalty));
                 lengthPenalty(getOrDefault(watsonxParameters.lengthPenalty(), lengthPenalty));
-                deploymentId(getOrDefault(watsonxParameters.deploymentId(), deploymentId));
             }
-            return this;
-        }
-
-        public Builder projectId(String projectId) {
-            this.projectId = projectId;
-            return this;
-        }
-
-        public Builder spaceId(String spaceId) {
-            this.spaceId = spaceId;
             return this;
         }
 
@@ -287,8 +266,13 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
             return this;
         }
 
-        public Builder deploymentId(String deploymentId) {
-            this.deploymentId = deploymentId;
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            return this;
+        }
+
+        public Builder spaceId(String spaceId) {
+            this.spaceId = spaceId;
             return this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadata.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadata.java
@@ -6,11 +6,17 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
 
     private final Long created;
     private final String modelVersion;
+    private final String serviceTier;
+    private final String systemFingerprint;
+    private final Boolean cached;
 
     private WatsonxChatResponseMetadata(Builder builder) {
         super(builder);
         created = builder.created;
         modelVersion = builder.modelVersion;
+        serviceTier = builder.serviceTier;
+        systemFingerprint = builder.systemFingerprint;
+        cached = builder.cached;
     }
 
     public Long getCreated() {
@@ -21,6 +27,18 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
         return modelVersion;
     }
 
+    public String getServiceTier() {
+        return serviceTier;
+    }
+
+    public String getSystemFingerprint() {
+        return systemFingerprint;
+    }
+
+    public Boolean getCached() {
+        return cached;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -28,6 +46,9 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
     public static class Builder extends ChatResponseMetadata.Builder<Builder> {
         private Long created;
         private String modelVersion;
+        private String serviceTier;
+        private String systemFingerprint;
+        private Boolean cached;
 
         public Builder created(Long created) {
             this.created = created;
@@ -36,6 +57,21 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
 
         public Builder modelVersion(String modelVersion) {
             this.modelVersion = modelVersion;
+            return this;
+        }
+
+        public Builder serviceTier(String serviceTier) {
+            this.serviceTier = serviceTier;
+            return this;
+        }
+
+        public Builder systemFingerprint(String systemFingerprint) {
+            this.systemFingerprint = systemFingerprint;
+            return this;
+        }
+
+        public Builder cached(Boolean cached) {
+            this.cached = cached;
             return this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxConnectionBuilder.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxConnectionBuilder.java
@@ -1,0 +1,141 @@
+package dev.langchain4j.model.watsonx;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.core.auth.Authenticator;
+import dev.langchain4j.Internal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+@Internal
+@SuppressWarnings("unchecked")
+abstract class WatsonxConnectionBuilder<T extends WatsonxConnectionBuilder<T>> {
+    protected URI baseUrl;
+    protected String version;
+    protected String apiKey;
+    protected Boolean logRequests;
+    protected Boolean logResponses;
+    protected Duration timeout;
+    protected Authenticator authenticator;
+    protected HttpClient httpClient;
+    protected boolean verifySsl = true;
+
+    /**
+     * Sets the IBM watsonx.ai endpoint from a predefined {@link CloudRegion}.
+     *
+     * @param baseUrl the IBM Cloud region whose ML endpoint will be used
+     * @return {@code this}
+     */
+    public T baseUrl(CloudRegion baseUrl) {
+        return baseUrl(baseUrl.mlEndpoint());
+    }
+
+    /**
+     * Sets the base URL of the IBM watsonx.ai API.
+     *
+     * @param url the base URL string, e.g. {@code "https://us-south.ml.cloud.ibm.com"}
+     * @return {@code this}
+     */
+    public T baseUrl(String url) {
+        return baseUrl(URI.create(url));
+    }
+
+    /**
+     * Sets the base URL of the IBM watsonx.ai API as a {@link URI}.
+     *
+     * @param url the base URL URI
+     * @return {@code this}
+     */
+    public T baseUrl(URI url) {
+        this.baseUrl = url;
+        return (T) this;
+    }
+
+    /**
+     * Sets the watsonx.ai API version date, e.g. {@code "2024-05-31"}.
+     *
+     * @param version the API version date string
+     * @return {@code this}
+     */
+    public T version(String version) {
+        this.version = version;
+        return (T) this;
+    }
+
+    /**
+     * Sets the IBM Cloud API key used to generate IAM access tokens for authentication.
+     *
+     * @param apiKey the IBM Cloud API key
+     * @return {@code this}
+     */
+    public T apiKey(String apiKey) {
+        this.apiKey = apiKey;
+        return (T) this;
+    }
+
+    /**
+     * Enables debug logging of request bodies sent to the watsonx.ai API.
+     *
+     * @param logRequests {@code true} to enable request logging
+     * @return {@code this}
+     */
+    public T logRequests(Boolean logRequests) {
+        this.logRequests = logRequests;
+        return (T) this;
+    }
+
+    /**
+     * Enables debug logging of response bodies received from the watsonx.ai API.
+     *
+     * @param logResponses {@code true} to enable response logging
+     * @return {@code this}
+     */
+    public T logResponses(Boolean logResponses) {
+        this.logResponses = logResponses;
+        return (T) this;
+    }
+
+    /**
+     * Sets the HTTP request timeout. Defaults to 60 seconds.
+     *
+     * @param timeout the request timeout
+     * @return {@code this}
+     */
+    public T timeout(Duration timeout) {
+        this.timeout = timeout;
+        return (T) this;
+    }
+
+    /**
+     * Sets a custom {@link Authenticator} for generating bearer tokens.
+     *
+     * @param authenticator the authenticator
+     * @return {@code this}
+     */
+    public T authenticator(Authenticator authenticator) {
+        this.authenticator = authenticator;
+        return (T) this;
+    }
+
+    /**
+     * Sets a custom {@link HttpClient} to use for all API calls.
+     *
+     * @param httpClient the HTTP client
+     * @return {@code this}
+     */
+    public T httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return (T) this;
+    }
+
+    /**
+     * Controls whether SSL certificate verification is performed. Defaults to {@code true}.
+     *
+     * @param verifySsl {@code false} to disable SSL verification
+     * @return {@code this}
+     */
+    public T verifySsl(boolean verifySsl) {
+        this.verifySsl = verifySsl;
+        return (T) this;
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
@@ -13,6 +13,7 @@ import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.deployment.DeploymentChatRequest;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.Internal;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import java.util.List;
 import java.util.Set;
@@ -49,6 +50,8 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
     protected DeploymentChatRequest buildChatRequest(
             List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
 
+        validateModelName(parameters);
+
         var requestBuilder = DeploymentChatRequest.builder()
                 .deploymentId(deploymentId)
                 .messages(messages)
@@ -70,6 +73,8 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
 
     private static WatsonxChatRequestParameters mergeParameters(Builder<?> builder) {
 
+        validateModelName(builder.defaultRequestParameters);
+
         var watsonxParameters = builder.defaultRequestParameters instanceof WatsonxChatRequestParameters parameters
                 ? parameters
                 : WatsonxChatRequestParameters.EMPTY;
@@ -90,6 +95,12 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
                 .lengthPenalty(getOrDefault(builder.lengthPenalty, watsonxParameters.lengthPenalty()))
                 .repetitionPenalty(getOrDefault(builder.repetitionPenalty, watsonxParameters.repetitionPenalty()))
                 .build();
+    }
+
+    private static void validateModelName(ChatRequestParameters parameters) {
+        if (nonNull(parameters) && nonNull(parameters.modelName()))
+            throw new UnsupportedFeatureException(
+                    "The 'modelName' parameter is not supported, the deployment id defines the model to call");
     }
 
     @SuppressWarnings("unchecked")

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
@@ -1,14 +1,10 @@
 package dev.langchain4j.model.watsonx;
 
-import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.util.Objects.nonNull;
 
 import com.ibm.watsonx.ai.chat.ChatProvider;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
-import com.ibm.watsonx.ai.chat.model.ExtractionTags;
-import com.ibm.watsonx.ai.chat.model.Thinking;
-import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.deployment.DeploymentChatRequest;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
@@ -16,10 +12,9 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import java.util.List;
-import java.util.Set;
 
 @Internal
-abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatRequest> {
+abstract class WatsonxDeploymentChat extends WatsonxTextChatBase<DeploymentChatRequest> {
 
     protected final DeploymentService deploymentService;
     protected final String deploymentId;
@@ -52,18 +47,8 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
 
         validateModelName(parameters);
 
-        var requestBuilder = DeploymentChatRequest.builder()
-                .deploymentId(deploymentId)
-                .messages(messages)
-                .tools(tools)
-                .parameters(Converter.toChatParameters(parameters, strictJsonSchema));
-
-        if (parameters instanceof WatsonxChatRequestParameters watsonxParameters
-                && nonNull(watsonxParameters.thinking())) {
-            requestBuilder.thinking(watsonxParameters.thinking());
-        }
-
-        return requestBuilder.build();
+        return applyChatRequest(DeploymentChatRequest.builder().deploymentId(deploymentId), messages, tools, parameters)
+                .build();
     }
 
     @Override
@@ -75,26 +60,10 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
 
         validateModelName(builder.defaultRequestParameters);
 
-        var watsonxParameters = builder.defaultRequestParameters instanceof WatsonxChatRequestParameters parameters
-                ? parameters
-                : WatsonxChatRequestParameters.EMPTY;
-
         var target = WatsonxChatRequestParameters.builder();
-        applyCommonParameters(target, builder);
+        applyTextChatParameters(target, builder);
 
-        return target.logitBias(getOrDefault(builder.logitBias, watsonxParameters.logitBias()))
-                .logprobs(getOrDefault(builder.logprobs, watsonxParameters.logprobs()))
-                .topLogprobs(getOrDefault(builder.topLogprobs, watsonxParameters.topLogprobs()))
-                .seed(getOrDefault(builder.seed, watsonxParameters.seed()))
-                .toolChoiceName(getOrDefault(builder.toolChoiceName, watsonxParameters.toolChoiceName()))
-                .timeout(getOrDefault(builder.timeout, watsonxParameters.timeout()))
-                .thinking(getOrDefault(builder.thinking, watsonxParameters.thinking()))
-                .guidedChoice(getOrDefault(builder.guidedChoice, watsonxParameters.guidedChoice()))
-                .guidedGrammar(getOrDefault(builder.guidedGrammar, watsonxParameters.guidedGrammar()))
-                .guidedRegex(getOrDefault(builder.guidedRegex, watsonxParameters.guidedRegex()))
-                .lengthPenalty(getOrDefault(builder.lengthPenalty, watsonxParameters.lengthPenalty()))
-                .repetitionPenalty(getOrDefault(builder.repetitionPenalty, watsonxParameters.repetitionPenalty()))
-                .build();
+        return target.build();
     }
 
     private static void validateModelName(ChatRequestParameters parameters) {
@@ -104,14 +73,8 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
     }
 
     @SuppressWarnings("unchecked")
-    abstract static class Builder<T extends Builder<T>> extends WatsonxChatBase.Builder<T> {
+    abstract static class Builder<T extends Builder<T>> extends WatsonxTextChatBase.Builder<T> {
         protected String deploymentId;
-        protected Thinking thinking;
-        protected Set<String> guidedChoice;
-        protected String guidedRegex;
-        protected String guidedGrammar;
-        protected Double repetitionPenalty;
-        protected Double lengthPenalty;
 
         /**
          * Sets the id of the on-demand model to call.
@@ -121,118 +84,6 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
          */
         public T deploymentId(String deploymentId) {
             this.deploymentId = deploymentId;
-            return (T) this;
-        }
-
-        /**
-         * Enables or disables thinking.
-         *
-         * @param enabled {@code true} to enable extended thinking
-         * @return {@code this}
-         */
-        public T thinking(boolean enabled) {
-            return thinking(Thinking.builder().enabled(enabled).build());
-        }
-
-        /**
-         * Configures extended thinking with custom extraction tags for parsing the thinking block.
-         *
-         * @param tags the extraction tags
-         * @return {@code this}
-         */
-        public T thinking(ExtractionTags tags) {
-            if (nonNull(tags)) return thinking(Thinking.of(tags));
-
-            this.thinking = null;
-            return (T) this;
-        }
-
-        /**
-         * Configures extended thinking with a specific effort level.
-         *
-         * @param thinkingEffort the thinking effort level
-         * @return {@code this}
-         */
-        public T thinking(ThinkingEffort thinkingEffort) {
-            if (nonNull(thinkingEffort)) return thinking(Thinking.of(thinkingEffort));
-
-            this.thinking = null;
-            return (T) this;
-        }
-
-        /**
-         * Sets a fully configured {@link Thinking} object for extended thinking.
-         *
-         * @param thinking the thinking configuration
-         * @return {@code this}
-         */
-        public T thinking(Thinking thinking) {
-            this.thinking = thinking;
-            return (T) this;
-        }
-
-        /**
-         * Constrains the model output to one of the given string choices.
-         *
-         * @param guidedChoice the allowed output values
-         * @return {@code this}
-         */
-        public T guidedChoice(String... guidedChoice) {
-            return guidedChoice(Set.of(guidedChoice));
-        }
-
-        /**
-         * Constrains the model output to one of the given string choices.
-         *
-         * @param guidedChoices the set of allowed output values
-         * @return {@code this}
-         */
-        public T guidedChoice(Set<String> guidedChoices) {
-            this.guidedChoice = guidedChoices;
-            return (T) this;
-        }
-
-        /**
-         * Constrains the model output to match the given regular expression.
-         *
-         * @param guidedRegex the regular expression pattern
-         * @return {@code this}
-         */
-        public T guidedRegex(String guidedRegex) {
-            this.guidedRegex = guidedRegex;
-            return (T) this;
-        }
-
-        /**
-         * Constrains the model output to conform to the given EBNF grammar.
-         *
-         * @param guidedGrammar the EBNF grammar string
-         * @return {@code this}
-         */
-        public T guidedGrammar(String guidedGrammar) {
-            this.guidedGrammar = guidedGrammar;
-            return (T) this;
-        }
-
-        /**
-         * Sets the repetition penalty.
-         *
-         * @param repetitionPenalty the repetition penalty
-         * @return {@code this}
-         */
-        public T repetitionPenalty(Double repetitionPenalty) {
-            this.repetitionPenalty = repetitionPenalty;
-            return (T) this;
-        }
-
-        /**
-         * Sets the length penalty applied to the sequence score during beam search.
-         *
-         * @param lengthPenalty the length penalty
-         * @return {@code this}
-         */
-        public T lengthPenalty(Double lengthPenalty) {
-            this.lengthPenalty = lengthPenalty;
             return (T) this;
         }
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
@@ -4,39 +4,39 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.util.Objects.nonNull;
 
 import com.ibm.watsonx.ai.chat.ChatProvider;
-import com.ibm.watsonx.ai.chat.ChatRequest;
-import com.ibm.watsonx.ai.chat.ChatService;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.Thinking;
 import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import com.ibm.watsonx.ai.chat.model.Tool;
+import com.ibm.watsonx.ai.deployment.DeploymentChatRequest;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.Internal;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import java.util.List;
 import java.util.Set;
 
 @Internal
-abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
+abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatRequest> {
 
-    protected final ChatService chatService;
+    protected final DeploymentService deploymentService;
+    protected final String deploymentId;
 
-    protected WatsonxChat(Builder<?> builder) {
+    protected WatsonxDeploymentChat(Builder<?> builder) {
         super(builder, mergeParameters(builder));
+
+        this.deploymentId = builder.deploymentId;
 
         var parameters = (WatsonxChatRequestParameters) defaultRequestParameters;
 
         var serviceBuilder = nonNull(builder.authenticator)
-                ? ChatService.builder().authenticator(builder.authenticator)
-                : ChatService.builder().apiKey(builder.apiKey);
+                ? DeploymentService.builder().authenticator(builder.authenticator)
+                : DeploymentService.builder().apiKey(builder.apiKey);
 
-        chatService = serviceBuilder
+        deploymentService = serviceBuilder
                 .baseUrl(builder.baseUrl)
-                .modelId(parameters.modelName())
                 .version(builder.version)
-                .projectId(parameters.projectId())
-                .spaceId(parameters.spaceId())
                 .timeout(parameters.timeout())
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
@@ -46,10 +46,11 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
     }
 
     @Override
-    protected ChatRequest buildChatRequest(
+    protected DeploymentChatRequest buildChatRequest(
             List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
 
-        var requestBuilder = ChatRequest.builder()
+        var requestBuilder = DeploymentChatRequest.builder()
+                .deploymentId(deploymentId)
                 .messages(messages)
                 .tools(tools)
                 .parameters(Converter.toChatParameters(parameters));
@@ -63,8 +64,8 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
     }
 
     @Override
-    protected ChatProvider<ChatRequest, TextChatResponse> chatProvider() {
-        return chatService;
+    protected ChatProvider<DeploymentChatRequest, TextChatResponse> chatProvider() {
+        return deploymentService;
     }
 
     private static WatsonxChatRequestParameters mergeParameters(Builder<?> builder) {
@@ -76,9 +77,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         var target = WatsonxChatRequestParameters.builder();
         applyCommonParameters(target, builder);
 
-        return target.projectId(getOrDefault(builder.projectId, watsonxParameters.projectId()))
-                .spaceId(getOrDefault(builder.spaceId, watsonxParameters.spaceId()))
-                .logitBias(getOrDefault(builder.logitBias, watsonxParameters.logitBias()))
+        return target.logitBias(getOrDefault(builder.logitBias, watsonxParameters.logitBias()))
                 .logprobs(getOrDefault(builder.logprobs, watsonxParameters.logprobs()))
                 .topLogprobs(getOrDefault(builder.topLogprobs, watsonxParameters.topLogprobs()))
                 .seed(getOrDefault(builder.seed, watsonxParameters.seed()))
@@ -95,8 +94,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
 
     @SuppressWarnings("unchecked")
     abstract static class Builder<T extends Builder<T>> extends WatsonxChatBase.Builder<T> {
-        protected String projectId;
-        protected String spaceId;
+        protected String deploymentId;
         protected Thinking thinking;
         protected Set<String> guidedChoice;
         protected String guidedRegex;
@@ -105,40 +103,18 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         protected Double lengthPenalty;
 
         /**
-         * Sets the foundation model id, e.g. {@code "ibm/granite-4-h-small"}.
+         * Sets the id of the on-demand model to call.
          *
-         * @param modelName the model id
+         * @param deploymentId the deployment id
          * @return {@code this}
          */
-        public T modelName(String modelName) {
-            this.modelName = modelName;
+        public T deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
             return (T) this;
         }
 
         /**
-         * Sets the IBM Cloud project ID that owns the watsonx.ai resources. Exactly one of {@code projectId} or {@code spaceId} must be set.
-         *
-         * @param projectId the IBM Cloud project ID
-         * @return {@code this}
-         */
-        public T projectId(String projectId) {
-            this.projectId = projectId;
-            return (T) this;
-        }
-
-        /**
-         * Sets the IBM Cloud deployment space ID. Exactly one of {@code projectId} or {@code spaceId} must be set.
-         *
-         * @param spaceId the IBM Cloud deployment space ID
-         * @return {@code this}
-         */
-        public T spaceId(String spaceId) {
-            this.spaceId = spaceId;
-            return (T) this;
-        }
-
-        /**
-         * Enables or disables extended thinking (chain-of-thought reasoning before the response).
+         * Enables or disables thinking.
          *
          * @param enabled {@code true} to enable extended thinking
          * @return {@code this}
@@ -148,9 +124,9 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         }
 
         /**
-         * Configures extended thinking with custom extraction tags for parsing the thinking block. Passing {@code null} disables thinking.
+         * Configures extended thinking with custom extraction tags for parsing the thinking block.
          *
-         * @param tags the extraction tags, or {@code null} to disable thinking
+         * @param tags the extraction tags
          * @return {@code this}
          */
         public T thinking(ExtractionTags tags) {
@@ -185,7 +161,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         }
 
         /**
-         * Constrains the model output to one of the given string choices (guided decoding).
+         * Constrains the model output to one of the given string choices.
          *
          * @param guidedChoice the allowed output values
          * @return {@code this}
@@ -195,7 +171,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         }
 
         /**
-         * Constrains the model output to one of the given string choices (guided decoding).
+         * Constrains the model output to one of the given string choices.
          *
          * @param guidedChoices the set of allowed output values
          * @return {@code this}
@@ -206,7 +182,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         }
 
         /**
-         * Constrains the model output to match the given regular expression (guided decoding).
+         * Constrains the model output to match the given regular expression.
          *
          * @param guidedRegex the regular expression pattern
          * @return {@code this}
@@ -217,7 +193,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         }
 
         /**
-         * Constrains the model output to conform to the given EBNF grammar (guided decoding).
+         * Constrains the model output to conform to the given EBNF grammar.
          *
          * @param guidedGrammar the EBNF grammar string
          * @return {@code this}
@@ -228,7 +204,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         }
 
         /**
-         * Sets the repetition penalty. Values greater than {@code 1.0} discourage repetition; values less than {@code 1.0} encourage it.
+         * Sets the repetition penalty.
          *
          * @param repetitionPenalty the repetition penalty
          * @return {@code this}
@@ -239,7 +215,7 @@ abstract class WatsonxChat extends WatsonxChatBase<ChatRequest> {
         }
 
         /**
-         * Sets the length penalty applied to the sequence score during beam search. Values greater than {@code 1.0} favor longer sequences.
+         * Sets the length penalty applied to the sequence score during beam search.
          *
          * @param lengthPenalty the length penalty
          * @return {@code this}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
@@ -53,7 +53,7 @@ abstract class WatsonxDeploymentChat extends WatsonxChatBase<DeploymentChatReque
                 .deploymentId(deploymentId)
                 .messages(messages)
                 .tools(tools)
-                .parameters(Converter.toChatParameters(parameters));
+                .parameters(Converter.toChatParameters(parameters, strictJsonSchema));
 
         if (parameters instanceof WatsonxChatRequestParameters watsonxParameters
                 && nonNull(watsonxParameters.thinking())) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModel.java
@@ -5,25 +5,24 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 
 /**
- * A {@link ChatModel} implementation that integrates IBM watsonx.ai foundation models with LangChain4j.
+ * A {@link ChatModel} implementation that integrates the IBM watsonx.ai Deployment with LangChain4j.
  * <p>
  * <b>Example usage:</b>
  *
  * <pre>{@code
- * ChatModel chatModel = WatsonxChatModel.builder()
+ * ChatModel chatModel = WatsonxDeploymentChatModel.builder()
  *     .baseUrl("https://...") // or use CloudRegion
  *     .apiKey("...")
- *     .projectId("...")
- *     .modelName("ibm/granite-4-h-small")
+ *     .deploymentId("...")
  *     .maxOutputTokens(0)
  *     .temperature(0.7)
  *     .build();
  * }</pre>
  *
  */
-public class WatsonxChatModel extends WatsonxChat implements ChatModel {
+public class WatsonxDeploymentChatModel extends WatsonxDeploymentChat implements ChatModel {
 
-    private WatsonxChatModel(Builder builder) {
+    private WatsonxDeploymentChatModel(Builder builder) {
         super(builder);
     }
 
@@ -38,11 +37,10 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
      * <b>Example usage:</b>
      *
      * <pre>{@code
-     * ChatModel chatModel = WatsonxChatModel.builder()
+     * ChatModel chatModel = WatsonxDeploymentChatModel.builder()
      *     .baseUrl("https://...") // or use CloudRegion
      *     .apiKey("...")
-     *     .projectId("...")
-     *     .modelName("ibm/granite-4-h-small")
+     *     .deploymentId("...")
      *     .maxOutputTokens(0)
      *     .temperature(0.7)
      *     .build();
@@ -55,14 +53,14 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
     }
 
     /**
-     * Builder class for constructing {@link WatsonxChatModel} instances with configurable parameters.
+     * Builder class for constructing {@link WatsonxDeploymentChatModel} instances with configurable parameters.
      */
-    public static class Builder extends WatsonxChat.Builder<Builder> {
+    public static class Builder extends WatsonxDeploymentChat.Builder<Builder> {
 
         private Builder() {}
 
-        public WatsonxChatModel build() {
-            return new WatsonxChatModel(this);
+        public WatsonxDeploymentChatModel build() {
+            return new WatsonxDeploymentChatModel(this);
         }
     }
 }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentStreamingChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentStreamingChatModel.java
@@ -5,26 +5,24 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 
 /**
- * A {@link StreamingChatModel} implementation that integrates IBM watsonx.ai foundation models with LangChain4j.
+ * A {@link StreamingChatModel} implementation that integrates the IBM watsonx.ai Deployment with LangChain4j.
  * <p>
  * <b>Example usage:</b>
  *
  * <pre>{@code
- *
- * StreamingChatModel chatModel = WatsonxStreamingChatModel.builder()
+ * StreamingChatModel chatModel = WatsonxDeploymentStreamingChatModel.builder()
  *     .baseUrl("https://...") // or use CloudRegion
  *     .apiKey("...")
- *     .projectId("...")
- *     .modelName("ibm/granite-4-h-small")
+ *     .deploymentId("...")
  *     .maxOutputTokens(0)
  *     .temperature(0.7)
  *     .build();
  * }</pre>
  *
  */
-public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingChatModel {
+public class WatsonxDeploymentStreamingChatModel extends WatsonxDeploymentChat implements StreamingChatModel {
 
-    private WatsonxStreamingChatModel(Builder builder) {
+    private WatsonxDeploymentStreamingChatModel(Builder builder) {
         super(builder);
     }
 
@@ -39,32 +37,30 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
      * <b>Example usage:</b>
      *
      * <pre>{@code
-     * StreamingChatModel chatModel = WatsonxStreamingChatModel.builder()
+     * StreamingChatModel chatModel = WatsonxDeploymentStreamingChatModel.builder()
      *     .baseUrl("https://...") // or use CloudRegion
      *     .apiKey("...")
-     *     .projectId("...")
-     *     .modelName("ibm/granite-4-h-small")
+     *     .deploymentId("...")
      *     .maxOutputTokens(0)
      *     .temperature(0.7)
      *     .build();
      * }</pre>
      *
      * @return {@link Builder} instance.
-     *
      */
     public static Builder builder() {
         return new Builder();
     }
 
     /**
-     * Builder class for constructing {@link WatsonxStreamingChatModel} instances with configurable parameters.
+     * Builder class for constructing {@link WatsonxDeploymentStreamingChatModel} instances with configurable parameters.
      */
-    public static class Builder extends WatsonxChat.Builder<Builder> {
+    public static class Builder extends WatsonxDeploymentChat.Builder<Builder> {
 
         private Builder() {}
 
-        public WatsonxStreamingChatModel build() {
-            return new WatsonxStreamingChatModel(this);
+        public WatsonxDeploymentStreamingChatModel build() {
+            return new WatsonxDeploymentStreamingChatModel(this);
         }
     }
 }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
@@ -4,6 +4,7 @@ import com.ibm.watsonx.ai.core.exception.WatsonxException;
 import com.ibm.watsonx.ai.core.exception.model.WatsonxError;
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.exception.InternalServerException;
 import dev.langchain4j.exception.InvalidRequestException;
 import dev.langchain4j.exception.LangChain4jException;
 import dev.langchain4j.exception.ModelNotFoundException;
@@ -40,7 +41,7 @@ class WatsonxExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
                     default -> new LangChain4jException(error.message(), watsonxException);
                 };
             } catch (IllegalArgumentException e) {
-                return new LangChain4jException(error.message(), watsonxException);
+                return mapUnknownErrorCode(error.message(), watsonxException);
             }
 
         } else if (t instanceof HttpTimeoutException || t instanceof java.util.concurrent.TimeoutException) {
@@ -48,5 +49,18 @@ class WatsonxExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
         }
 
         return t instanceof RuntimeException re ? re : new LangChain4jException(t);
+    }
+
+    private RuntimeException mapUnknownErrorCode(String message, WatsonxException exception) {
+        int statusCode = exception.statusCode();
+
+        if (statusCode == 401 || statusCode == 403) return new AuthenticationException(message, exception);
+        if (statusCode == 408) return new TimeoutException(message, exception);
+        if (statusCode == 429) return new RateLimitException(message, exception);
+        if (statusCode >= 500 && statusCode < 600) return new InternalServerException(message, exception);
+        if (statusCode >= 400 && statusCode < 500 && statusCode != 404)
+            return new InvalidRequestException(message, exception);
+
+        return new LangChain4jException(message, exception);
     }
 }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
@@ -51,15 +51,20 @@ class WatsonxExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
         return t instanceof RuntimeException re ? re : new LangChain4jException(t);
     }
 
+    /**
+     * Maps the errors whose code is not part of {@link WatsonxError.Code} on the HTTP status code, following the same
+     * table as {@link ExceptionMapper.DefaultExceptionMapper#mapHttpStatusCode(Throwable, int)} but keeping the
+     * message returned by the service.
+     */
     private RuntimeException mapUnknownErrorCode(String message, WatsonxException exception) {
         int statusCode = exception.statusCode();
 
+        if (statusCode >= 500 && statusCode < 600) return new InternalServerException(message, exception);
         if (statusCode == 401 || statusCode == 403) return new AuthenticationException(message, exception);
+        if (statusCode == 404) return new ModelNotFoundException(message, exception);
         if (statusCode == 408) return new TimeoutException(message, exception);
         if (statusCode == 429) return new RateLimitException(message, exception);
-        if (statusCode >= 500 && statusCode < 600) return new InternalServerException(message, exception);
-        if (statusCode >= 400 && statusCode < 500 && statusCode != 404)
-            return new InvalidRequestException(message, exception);
+        if (statusCode >= 400 && statusCode < 500) return new InvalidRequestException(message, exception);
 
         return new LangChain4jException(message, exception);
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
@@ -2,8 +2,7 @@ package dev.langchain4j.model.watsonx;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.util.Objects.nonNull;
-import java.util.List;
-import java.util.Map;
+
 import com.ibm.watsonx.ai.chat.ChatProvider;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
@@ -16,6 +15,8 @@ import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
 import dev.langchain4j.Internal;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import java.util.List;
+import java.util.Map;
 
 @Internal
 abstract class WatsonxGatewayChat extends WatsonxChatBase<ModelGatewayChatRequest> {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
@@ -1,0 +1,209 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static java.util.Objects.nonNull;
+import java.util.List;
+import java.util.Map;
+import com.ibm.watsonx.ai.chat.ChatProvider;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.Tool;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
+import dev.langchain4j.Internal;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+
+@Internal
+abstract class WatsonxGatewayChat extends WatsonxChatBase<ModelGatewayChatRequest> {
+
+    protected final ModelGatewayService modelGatewayService;
+
+    protected WatsonxGatewayChat(Builder<?> builder) {
+        super(builder, mergeParameters(builder));
+
+        var parameters = (WatsonxGatewayChatRequestParameters) defaultRequestParameters;
+
+        var serviceBuilder = nonNull(builder.authenticator)
+                ? ModelGatewayService.builder().authenticator(builder.authenticator)
+                : ModelGatewayService.builder().apiKey(builder.apiKey);
+
+        modelGatewayService = serviceBuilder
+                .baseUrl(builder.baseUrl)
+                .version(builder.version)
+                .modelId(parameters.modelName())
+                .timeout(parameters.timeout())
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
+                .build();
+    }
+
+    @Override
+    protected ChatProvider<ModelGatewayChatRequest, ModelGatewayChatResponse> chatProvider() {
+        return modelGatewayService;
+    }
+
+    @Override
+    protected ModelGatewayChatRequest buildChatRequest(
+            List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
+
+        return ModelGatewayChatRequest.builder()
+                .messages(messages)
+                .tools(tools)
+                .parameters(Converter.toModelGatewayParameters(parameters))
+                .build();
+    }
+
+    private static WatsonxGatewayChatRequestParameters mergeParameters(Builder<?> builder) {
+
+        var gatewayParameters = builder.defaultRequestParameters instanceof WatsonxGatewayChatRequestParameters p
+                ? p
+                : WatsonxGatewayChatRequestParameters.EMPTY;
+
+        var target = WatsonxGatewayChatRequestParameters.builder();
+        applyCommonParameters(target, builder);
+
+        return target.serviceTier(getOrDefault(builder.serviceTier, gatewayParameters.serviceTier()))
+                .reasoningEffort(getOrDefault(builder.reasoningEffort, gatewayParameters.reasoningEffort()))
+                .router(getOrDefault(builder.router, gatewayParameters.router()))
+                .modalities(getOrDefault(builder.modalities, gatewayParameters.modalities()))
+                .store(getOrDefault(builder.store, gatewayParameters.store()))
+                .parallelToolCalls(getOrDefault(builder.parallelToolCalls, gatewayParameters.parallelToolCalls()))
+                .user(getOrDefault(builder.user, gatewayParameters.user()))
+                .metadata(getOrDefault(builder.metadata, gatewayParameters.metadata()))
+                .logitBias(getOrDefault(builder.logitBias, gatewayParameters.logitBias()))
+                .logprobs(getOrDefault(builder.logprobs, gatewayParameters.logprobs()))
+                .topLogprobs(getOrDefault(builder.topLogprobs, gatewayParameters.topLogprobs()))
+                .seed(getOrDefault(builder.seed, gatewayParameters.seed()))
+                .toolChoiceName(getOrDefault(builder.toolChoiceName, gatewayParameters.toolChoiceName()))
+                .timeout(getOrDefault(builder.timeout, gatewayParameters.timeout()))
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    abstract static class Builder<T extends Builder<T>> extends WatsonxChatBase.Builder<T> {
+        protected ServiceTier serviceTier;
+        protected ReasoningEffort reasoningEffort;
+        protected Router router;
+        protected List<String> modalities;
+        protected Boolean store;
+        protected Boolean parallelToolCalls;
+        protected String user;
+        protected Map<String, String> metadata;
+
+        /**
+         * Sets the gateway model id, e.g. {@code "gpt-4o"}.
+         *
+         * @param modelName the model id
+         * @return {@code this}
+         */
+        public T modelName(String modelName) {
+            this.modelName = modelName;
+            return (T) this;
+        }
+
+        /**
+         * Sets the service tier used to process the request.
+         *
+         * @param serviceTier the {@link ServiceTier}
+         * @return {@code this}
+         */
+        public T serviceTier(ServiceTier serviceTier) {
+            this.serviceTier = serviceTier;
+            return (T) this;
+        }
+
+        /**
+         * Sets the reasoning effort constraint for reasoning models.
+         *
+         * @param reasoningEffort the {@link ReasoningEffort}
+         * @return {@code this}
+         */
+        public T reasoningEffort(ReasoningEffort reasoningEffort) {
+            this.reasoningEffort = reasoningEffort;
+            return (T) this;
+        }
+
+        /**
+         * Sets the model routing configuration for the request.
+         *
+         * @param router the {@link Router}
+         * @return {@code this}
+         */
+        public T router(Router router) {
+            this.router = router;
+            return (T) this;
+        }
+
+        /**
+         * Convenience for {@code router(new Router(cache))}. Caching is only honored on non-streaming requests.
+         *
+         * @param cache the {@link Cache} configuration
+         * @return {@code this}
+         */
+        public T cache(Cache cache) {
+            this.router = cache == null ? null : new Router(cache);
+            return (T) this;
+        }
+
+        /**
+         * Sets the requested output modalities (e.g. {@code ["text"]}).
+         *
+         * @param modalities the modalities
+         * @return {@code this}
+         */
+        public T modalities(List<String> modalities) {
+            this.modalities = modalities;
+            return (T) this;
+        }
+
+        /**
+         * Sets whether the output should be stored for model distillation or evals.
+         *
+         * @param store {@code true} to store the output
+         * @return {@code this}
+         */
+        public T store(Boolean store) {
+            this.store = store;
+            return (T) this;
+        }
+
+        /**
+         * Enables or disables parallel function calling during tool use.
+         *
+         * @param parallelToolCalls {@code true} to enable, {@code false} to disable
+         * @return {@code this}
+         */
+        public T parallelToolCalls(Boolean parallelToolCalls) {
+            this.parallelToolCalls = parallelToolCalls;
+            return (T) this;
+        }
+
+        /**
+         * Sets the end-user identifier for abuse monitoring.
+         *
+         * @param user the user identifier
+         * @return {@code this}
+         */
+        public T user(String user) {
+            this.user = user;
+            return (T) this;
+        }
+
+        /**
+         * Sets developer-defined tags and values used for filtering completions.
+         *
+         * @param metadata the metadata map
+         * @return {@code this}
+         */
+        public T metadata(Map<String, String> metadata) {
+            this.metadata = metadata;
+            return (T) this;
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
@@ -56,7 +56,7 @@ abstract class WatsonxGatewayChat extends WatsonxChatBase<ModelGatewayChatReques
         return ModelGatewayChatRequest.builder()
                 .messages(messages)
                 .tools(tools)
-                .parameters(Converter.toModelGatewayParameters(parameters))
+                .parameters(Converter.toModelGatewayParameters(parameters, strictJsonSchema))
                 .build();
     }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModel.java
@@ -5,25 +5,24 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 
 /**
- * A {@link ChatModel} implementation that integrates IBM watsonx.ai foundation models with LangChain4j.
+ * A {@link ChatModel} implementation that integrates the IBM watsonx.ai Model Gateway with LangChain4j.
  * <p>
  * <b>Example usage:</b>
  *
  * <pre>{@code
- * ChatModel chatModel = WatsonxChatModel.builder()
+ * ChatModel chatModel = WatsonxGatewayChatModel.builder()
  *     .baseUrl("https://...") // or use CloudRegion
  *     .apiKey("...")
- *     .projectId("...")
- *     .modelName("ibm/granite-4-h-small")
+ *     .modelName("gpt-4o")
  *     .maxOutputTokens(0)
  *     .temperature(0.7)
  *     .build();
  * }</pre>
  *
  */
-public class WatsonxChatModel extends WatsonxChat implements ChatModel {
+public class WatsonxGatewayChatModel extends WatsonxGatewayChat implements ChatModel {
 
-    private WatsonxChatModel(Builder builder) {
+    private WatsonxGatewayChatModel(Builder builder) {
         super(builder);
     }
 
@@ -38,11 +37,10 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
      * <b>Example usage:</b>
      *
      * <pre>{@code
-     * ChatModel chatModel = WatsonxChatModel.builder()
+     * ChatModel chatModel = WatsonxGatewayChatModel.builder()
      *     .baseUrl("https://...") // or use CloudRegion
      *     .apiKey("...")
-     *     .projectId("...")
-     *     .modelName("ibm/granite-4-h-small")
+     *     .modelName("gpt-4o")
      *     .maxOutputTokens(0)
      *     .temperature(0.7)
      *     .build();
@@ -55,14 +53,14 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
     }
 
     /**
-     * Builder class for constructing {@link WatsonxChatModel} instances with configurable parameters.
+     * Builder class for constructing {@link WatsonxGatewayChatModel} instances with configurable parameters.
      */
-    public static class Builder extends WatsonxChat.Builder<Builder> {
+    public static class Builder extends WatsonxGatewayChat.Builder<Builder> {
 
         private Builder() {}
 
-        public WatsonxChatModel build() {
-            return new WatsonxChatModel(this);
+        public WatsonxGatewayChatModel build() {
+            return new WatsonxGatewayChatModel(this);
         }
     }
 }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParameters.java
@@ -1,0 +1,318 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+
+public class WatsonxGatewayChatRequestParameters extends DefaultChatRequestParameters {
+
+    public static final WatsonxGatewayChatRequestParameters EMPTY =
+            WatsonxGatewayChatRequestParameters.builder().build();
+
+    private final Map<String, Integer> logitBias;
+    private final Boolean logprobs;
+    private final Integer topLogprobs;
+    private final Integer seed;
+    private final String toolChoiceName;
+    private final Duration timeout;
+    private final ServiceTier serviceTier;
+    private final ReasoningEffort reasoningEffort;
+    private final Router router;
+    private final List<String> modalities;
+    private final Boolean store;
+    private final Boolean parallelToolCalls;
+    private final String user;
+    private final Map<String, String> metadata;
+
+    private WatsonxGatewayChatRequestParameters(Builder builder) {
+        super(builder);
+        logitBias = builder.logitBias;
+        logprobs = builder.logprobs;
+        topLogprobs = builder.topLogprobs;
+        seed = builder.seed;
+        toolChoiceName = builder.toolChoiceName;
+        timeout = builder.timeout;
+        serviceTier = builder.serviceTier;
+        reasoningEffort = builder.reasoningEffort;
+        router = builder.router;
+        modalities = builder.modalities;
+        store = builder.store;
+        parallelToolCalls = builder.parallelToolCalls;
+        user = builder.user;
+        metadata = builder.metadata;
+    }
+
+    public Map<String, Integer> logitBias() {
+        return logitBias;
+    }
+
+    public Boolean logprobs() {
+        return logprobs;
+    }
+
+    public Integer topLogprobs() {
+        return topLogprobs;
+    }
+
+    public Integer seed() {
+        return seed;
+    }
+
+    public String toolChoiceName() {
+        return toolChoiceName;
+    }
+
+    public Duration timeout() {
+        return timeout;
+    }
+
+    public ServiceTier serviceTier() {
+        return serviceTier;
+    }
+
+    public ReasoningEffort reasoningEffort() {
+        return reasoningEffort;
+    }
+
+    public Router router() {
+        return router;
+    }
+
+    public List<String> modalities() {
+        return modalities;
+    }
+
+    public Boolean store() {
+        return store;
+    }
+
+    public Boolean parallelToolCalls() {
+        return parallelToolCalls;
+    }
+
+    public String user() {
+        return user;
+    }
+
+    public Map<String, String> metadata() {
+        return metadata;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public ChatRequestParameters overrideWith(ChatRequestParameters that) {
+        return WatsonxGatewayChatRequestParameters.builder()
+                .overrideWith(this)
+                .overrideWith(that)
+                .build();
+    }
+
+    @Override
+    public WatsonxGatewayChatRequestParameters defaultedBy(ChatRequestParameters that) {
+        return WatsonxGatewayChatRequestParameters.builder()
+                .overrideWith(that)
+                .overrideWith(this)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false;
+        WatsonxGatewayChatRequestParameters that = (WatsonxGatewayChatRequestParameters) o;
+        return Objects.equals(logitBias, that.logitBias)
+                && Objects.equals(logprobs, that.logprobs)
+                && Objects.equals(topLogprobs, that.topLogprobs)
+                && Objects.equals(seed, that.seed)
+                && Objects.equals(toolChoiceName, that.toolChoiceName)
+                && Objects.equals(timeout, that.timeout)
+                && Objects.equals(serviceTier, that.serviceTier)
+                && Objects.equals(reasoningEffort, that.reasoningEffort)
+                && Objects.equals(router, that.router)
+                && Objects.equals(modalities, that.modalities)
+                && Objects.equals(store, that.store)
+                && Objects.equals(parallelToolCalls, that.parallelToolCalls)
+                && Objects.equals(user, that.user)
+                && Objects.equals(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                super.hashCode(),
+                logitBias,
+                logprobs,
+                topLogprobs,
+                seed,
+                toolChoiceName,
+                timeout,
+                serviceTier,
+                reasoningEffort,
+                router,
+                modalities,
+                store,
+                parallelToolCalls,
+                user,
+                metadata);
+    }
+
+    @Override
+    public String toString() {
+        return "WatsonxGatewayChatRequestParameters{" + "modelName="
+                + modelName() + ", temperature="
+                + temperature() + ", topP="
+                + topP() + ", topK="
+                + topK() + ", frequencyPenalty="
+                + frequencyPenalty() + ", presencePenalty="
+                + presencePenalty() + ", maxOutputTokens="
+                + maxOutputTokens() + ", stopSequences="
+                + stopSequences() + ", toolSpecifications="
+                + toolSpecifications() + ", toolChoice="
+                + toolChoice() + ", responseFormat="
+                + responseFormat() + ", serviceTier="
+                + serviceTier + ", reasoningEffort="
+                + reasoningEffort + ", router="
+                + router + ", modalities="
+                + modalities + ", store="
+                + store + ", parallelToolCalls="
+                + parallelToolCalls + ", user="
+                + user + ", metadata="
+                + metadata + ", logitBias="
+                + logitBias + ", logprobs="
+                + logprobs + ", topLogprobs="
+                + topLogprobs + ", seed="
+                + seed + ", toolChoiceName="
+                + toolChoiceName + ", timeout="
+                + timeout + '}';
+    }
+
+    public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {
+
+        private Map<String, Integer> logitBias;
+        private Boolean logprobs;
+        private Integer topLogprobs;
+        private Integer seed;
+        private String toolChoiceName;
+        private Duration timeout;
+        private ServiceTier serviceTier;
+        private ReasoningEffort reasoningEffort;
+        private Router router;
+        private List<String> modalities;
+        private Boolean store;
+        private Boolean parallelToolCalls;
+        private String user;
+        private Map<String, String> metadata;
+
+        @Override
+        public Builder overrideWith(ChatRequestParameters parameters) {
+            super.overrideWith(parameters);
+            if (parameters instanceof WatsonxGatewayChatRequestParameters gatewayParameters) {
+                logitBias(getOrDefault(gatewayParameters.logitBias(), logitBias));
+                logprobs(getOrDefault(gatewayParameters.logprobs(), logprobs));
+                topLogprobs(getOrDefault(gatewayParameters.topLogprobs(), topLogprobs));
+                seed(getOrDefault(gatewayParameters.seed(), seed));
+                toolChoiceName(getOrDefault(gatewayParameters.toolChoiceName(), toolChoiceName));
+                timeout(getOrDefault(gatewayParameters.timeout(), timeout));
+                serviceTier(getOrDefault(gatewayParameters.serviceTier(), serviceTier));
+                reasoningEffort(getOrDefault(gatewayParameters.reasoningEffort(), reasoningEffort));
+                router(getOrDefault(gatewayParameters.router(), router));
+                modalities(getOrDefault(gatewayParameters.modalities(), modalities));
+                store(getOrDefault(gatewayParameters.store(), store));
+                parallelToolCalls(getOrDefault(gatewayParameters.parallelToolCalls(), parallelToolCalls));
+                user(getOrDefault(gatewayParameters.user(), user));
+                metadata(getOrDefault(gatewayParameters.metadata(), metadata));
+            }
+            return this;
+        }
+
+        public Builder logitBias(Map<String, Integer> logitBias) {
+            this.logitBias = logitBias;
+            return this;
+        }
+
+        public Builder logprobs(Boolean logprobs) {
+            this.logprobs = logprobs;
+            return this;
+        }
+
+        public Builder topLogprobs(Integer topLogprobs) {
+            this.topLogprobs = topLogprobs;
+            return this;
+        }
+
+        public Builder seed(Integer seed) {
+            this.seed = seed;
+            return this;
+        }
+
+        public Builder toolChoiceName(String toolChoiceName) {
+            this.toolChoiceName = toolChoiceName;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder serviceTier(ServiceTier serviceTier) {
+            this.serviceTier = serviceTier;
+            return this;
+        }
+
+        public Builder reasoningEffort(ReasoningEffort reasoningEffort) {
+            this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        public Builder router(Router router) {
+            this.router = router;
+            return this;
+        }
+
+        public Builder cache(Cache cache) {
+            this.router = cache == null ? null : new Router(cache);
+            return this;
+        }
+
+        public Builder modalities(List<String> modalities) {
+            this.modalities = modalities;
+            return this;
+        }
+
+        public Builder store(Boolean store) {
+            this.store = store;
+            return this;
+        }
+
+        public Builder parallelToolCalls(Boolean parallelToolCalls) {
+            this.parallelToolCalls = parallelToolCalls;
+            return this;
+        }
+
+        public Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public Builder metadata(Map<String, String> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        @Override
+        public WatsonxGatewayChatRequestParameters build() {
+            return new WatsonxGatewayChatRequestParameters(this);
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParameters.java
@@ -1,16 +1,17 @@
 package dev.langchain4j.model.watsonx;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class WatsonxGatewayChatRequestParameters extends DefaultChatRequestParameters {
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayModelCatalog.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayModelCatalog.java
@@ -1,0 +1,112 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.model.ModelProvider.WATSONX;
+import static java.util.Objects.nonNull;
+
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogService;
+import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayModel;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.catalog.ModelCatalog;
+import dev.langchain4j.model.catalog.ModelDescription;
+import dev.langchain4j.model.catalog.ModelType;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * A {@link ModelCatalog} implementation that lists the models configured in the IBM watsonx.ai Model Gateway.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ModelCatalog modelCatalog = WatsonxGatewayModelCatalog.builder()
+ *     .baseUrl("https://...") // or use CloudRegion
+ *     .apiKey("...")
+ *     .build();
+ * }</pre>
+ *
+ */
+public class WatsonxGatewayModelCatalog implements ModelCatalog {
+
+    private final ModelGatewayCatalogService modelGatewayCatalogService;
+
+    public WatsonxGatewayModelCatalog(Builder builder) {
+
+        var serviceBuilder = nonNull(builder.authenticator)
+                ? ModelGatewayCatalogService.builder().authenticator(builder.authenticator)
+                : ModelGatewayCatalogService.builder().apiKey(builder.apiKey);
+
+        modelGatewayCatalogService = serviceBuilder
+                .baseUrl(builder.baseUrl)
+                .version(builder.version)
+                .timeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
+                .build();
+    }
+
+    @Override
+    public List<ModelDescription> listModels() {
+        return modelGatewayCatalogService.listModels().stream()
+                .map(WatsonxGatewayModelCatalog::toModelDescription)
+                .toList();
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return WATSONX;
+    }
+
+    private static ModelDescription toModelDescription(ModelGatewayModel model) {
+
+        var id = nonNull(model.alias()) ? model.alias() : model.id();
+        var builder = ModelDescription.builder()
+                .name(id)
+                .displayName(id)
+                .description(model.description())
+                .owner(model.ownedBy())
+                .provider(WATSONX)
+                .type(ModelType.CHAT);
+
+        if (nonNull(model.created())) {
+            builder.createdAt(Instant.ofEpochSecond(model.created()));
+        }
+
+        if (nonNull(model.metadata())) {
+            builder.maxInputTokens(model.metadata().contextWindow());
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ModelCatalog modelCatalog = WatsonxGatewayModelCatalog.builder()
+     *     .baseUrl("https://...") // or use CloudRegion
+     *     .apiKey("...")
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link WatsonxGatewayModelCatalog} instances with configurable parameters.
+     */
+    public static class Builder extends WatsonxConnectionBuilder<Builder> {
+
+        private Builder() {}
+
+        public WatsonxGatewayModelCatalog build() {
+            return new WatsonxGatewayModelCatalog(this);
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModel.java
@@ -5,26 +5,25 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 
 /**
- * A {@link StreamingChatModel} implementation that integrates IBM watsonx.ai foundation models with LangChain4j.
+ * A {@link StreamingChatModel} implementation that integrates the IBM watsonx.ai Model Gateway with LangChain4j.
  * <p>
  * <b>Example usage:</b>
  *
  * <pre>{@code
  *
- * StreamingChatModel chatModel = WatsonxStreamingChatModel.builder()
+ * StreamingChatModel chatModel = WatsonxGatewayStreamingChatModel.builder()
  *     .baseUrl("https://...") // or use CloudRegion
  *     .apiKey("...")
- *     .projectId("...")
- *     .modelName("ibm/granite-4-h-small")
+ *     .modelName("gpt-4o")
  *     .maxOutputTokens(0)
  *     .temperature(0.7)
  *     .build();
  * }</pre>
  *
  */
-public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingChatModel {
+public class WatsonxGatewayStreamingChatModel extends WatsonxGatewayChat implements StreamingChatModel {
 
-    private WatsonxStreamingChatModel(Builder builder) {
+    private WatsonxGatewayStreamingChatModel(Builder builder) {
         super(builder);
     }
 
@@ -39,11 +38,10 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
      * <b>Example usage:</b>
      *
      * <pre>{@code
-     * StreamingChatModel chatModel = WatsonxStreamingChatModel.builder()
+     * StreamingChatModel chatModel = WatsonxGatewayStreamingChatModel.builder()
      *     .baseUrl("https://...") // or use CloudRegion
      *     .apiKey("...")
-     *     .projectId("...")
-     *     .modelName("ibm/granite-4-h-small")
+     *     .modelName("gpt-4o")
      *     .maxOutputTokens(0)
      *     .temperature(0.7)
      *     .build();
@@ -57,14 +55,14 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
     }
 
     /**
-     * Builder class for constructing {@link WatsonxStreamingChatModel} instances with configurable parameters.
+     * Builder class for constructing {@link WatsonxGatewayStreamingChatModel} instances with configurable parameters.
      */
-    public static class Builder extends WatsonxChat.Builder<Builder> {
+    public static class Builder extends WatsonxGatewayChat.Builder<Builder> {
 
         private Builder() {}
 
-        public WatsonxStreamingChatModel build() {
-            return new WatsonxStreamingChatModel(this);
+        public WatsonxGatewayStreamingChatModel build() {
+            return new WatsonxGatewayStreamingChatModel(this);
         }
     }
 }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
@@ -120,7 +120,7 @@ public class WatsonxModelCatalog implements ModelCatalog {
     /**
      * Builder class for constructing {@link WatsonxModelCatalog} instances with configurable parameters.
      */
-    public static class Builder extends WatsonxBuilder<Builder> {
+    public static class Builder extends WatsonxConnectionBuilder<Builder> {
 
         private Builder() {}
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTextChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTextChatBase.java
@@ -35,7 +35,7 @@ abstract class WatsonxTextChatBase<R extends BaseChatRequest> extends WatsonxCha
      * @param parameters the parameters of the current request
      * @return {@code requestBuilder}
      */
-    protected final <B extends NativeChatRequest.Builder<B>> B applyChatRequest(
+    final <B extends NativeChatRequest.Builder<B>> B applyChatRequest(
             B requestBuilder, List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
 
         requestBuilder

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTextChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTextChatBase.java
@@ -1,0 +1,203 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static java.util.Objects.nonNull;
+
+import com.ibm.watsonx.ai.chat.BaseChatRequest;
+import com.ibm.watsonx.ai.chat.NativeChatRequest;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.Thinking;
+import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
+import com.ibm.watsonx.ai.chat.model.Tool;
+import dev.langchain4j.Internal;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Base class for the services that call the watsonx.ai text chat API, either on a foundation model
+ * ({@link WatsonxChat}) or on an on-demand deployment ({@link WatsonxDeploymentChat}).
+ */
+@Internal
+abstract class WatsonxTextChatBase<R extends BaseChatRequest> extends WatsonxChatBase<R> {
+
+    protected WatsonxTextChatBase(Builder<?> builder, WatsonxChatRequestParameters defaultRequestParameters) {
+        super(builder, defaultRequestParameters);
+    }
+
+    /**
+     * Fills the parts of the request that are the same for both services.
+     *
+     * @param requestBuilder the request builder to fill
+     * @param messages the messages to send
+     * @param tools the tools available to the model, or {@code null}
+     * @param parameters the parameters of the current request
+     * @return {@code requestBuilder}
+     */
+    protected final <B extends NativeChatRequest.Builder<B>> B applyChatRequest(
+            B requestBuilder, List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
+
+        requestBuilder
+                .messages(messages)
+                .tools(tools)
+                .parameters(Converter.toChatParameters(parameters, strictJsonSchema));
+
+        if (parameters instanceof WatsonxChatRequestParameters watsonxParameters
+                && nonNull(watsonxParameters.thinking())) {
+            requestBuilder.thinking(watsonxParameters.thinking());
+        }
+
+        return requestBuilder;
+    }
+
+    /**
+     * Merges into {@code target} the builder values and the default request parameters that both services accept.
+     *
+     * @param target the parameters builder to fill
+     * @param builder the model builder holding the values set by the caller
+     */
+    protected static void applyTextChatParameters(WatsonxChatRequestParameters.Builder target, Builder<?> builder) {
+
+        var watsonxParameters = builder.defaultRequestParameters instanceof WatsonxChatRequestParameters parameters
+                ? parameters
+                : WatsonxChatRequestParameters.EMPTY;
+
+        applyCommonParameters(target, builder);
+
+        target.logitBias(getOrDefault(builder.logitBias, watsonxParameters.logitBias()))
+                .logprobs(getOrDefault(builder.logprobs, watsonxParameters.logprobs()))
+                .topLogprobs(getOrDefault(builder.topLogprobs, watsonxParameters.topLogprobs()))
+                .seed(getOrDefault(builder.seed, watsonxParameters.seed()))
+                .toolChoiceName(getOrDefault(builder.toolChoiceName, watsonxParameters.toolChoiceName()))
+                .timeout(getOrDefault(builder.timeout, watsonxParameters.timeout()))
+                .thinking(getOrDefault(builder.thinking, watsonxParameters.thinking()))
+                .guidedChoice(getOrDefault(builder.guidedChoice, watsonxParameters.guidedChoice()))
+                .guidedGrammar(getOrDefault(builder.guidedGrammar, watsonxParameters.guidedGrammar()))
+                .guidedRegex(getOrDefault(builder.guidedRegex, watsonxParameters.guidedRegex()))
+                .lengthPenalty(getOrDefault(builder.lengthPenalty, watsonxParameters.lengthPenalty()))
+                .repetitionPenalty(getOrDefault(builder.repetitionPenalty, watsonxParameters.repetitionPenalty()));
+    }
+
+    @SuppressWarnings("unchecked")
+    abstract static class Builder<T extends Builder<T>> extends WatsonxChatBase.Builder<T> {
+        protected Thinking thinking;
+        protected Set<String> guidedChoice;
+        protected String guidedRegex;
+        protected String guidedGrammar;
+        protected Double repetitionPenalty;
+        protected Double lengthPenalty;
+
+        /**
+         * Enables or disables thinking.
+         *
+         * @param enabled {@code true} to enable thinking
+         * @return {@code this}
+         */
+        public T thinking(boolean enabled) {
+            return thinking(Thinking.builder().enabled(enabled).build());
+        }
+
+        /**
+         * Configures thinking with custom extraction tags for parsing the thinking block.
+         *
+         * @param tags the extraction tags
+         * @return {@code this}
+         */
+        public T thinking(ExtractionTags tags) {
+            if (nonNull(tags)) return thinking(Thinking.of(tags));
+
+            this.thinking = null;
+            return (T) this;
+        }
+
+        /**
+         * Configures thinking with a specific effort level.
+         *
+         * @param thinkingEffort the thinking effort level
+         * @return {@code this}
+         */
+        public T thinking(ThinkingEffort thinkingEffort) {
+            if (nonNull(thinkingEffort)) return thinking(Thinking.of(thinkingEffort));
+
+            this.thinking = null;
+            return (T) this;
+        }
+
+        /**
+         * Sets a fully configured {@link Thinking} object for thinking.
+         *
+         * @param thinking the thinking configuration
+         * @return {@code this}
+         */
+        public T thinking(Thinking thinking) {
+            this.thinking = thinking;
+            return (T) this;
+        }
+
+        /**
+         * Constrains the model output to one of the given string choices (guided decoding).
+         *
+         * @param guidedChoice the allowed output values
+         * @return {@code this}
+         */
+        public T guidedChoice(String... guidedChoice) {
+            return guidedChoice(Set.of(guidedChoice));
+        }
+
+        /**
+         * Constrains the model output to one of the given string choices (guided decoding).
+         *
+         * @param guidedChoices the set of allowed output values
+         * @return {@code this}
+         */
+        public T guidedChoice(Set<String> guidedChoices) {
+            this.guidedChoice = guidedChoices;
+            return (T) this;
+        }
+
+        /**
+         * Constrains the model output to match the given regular expression (guided decoding).
+         *
+         * @param guidedRegex the regular expression pattern
+         * @return {@code this}
+         */
+        public T guidedRegex(String guidedRegex) {
+            this.guidedRegex = guidedRegex;
+            return (T) this;
+        }
+
+        /**
+         * Constrains the model output to conform to the given EBNF grammar (guided decoding).
+         *
+         * @param guidedGrammar the EBNF grammar string
+         * @return {@code this}
+         */
+        public T guidedGrammar(String guidedGrammar) {
+            this.guidedGrammar = guidedGrammar;
+            return (T) this;
+        }
+
+        /**
+         * Sets the repetition penalty. Values greater than {@code 1.0} discourage repetition; values less than {@code 1.0} encourage it.
+         *
+         * @param repetitionPenalty the repetition penalty
+         * @return {@code this}
+         */
+        public T repetitionPenalty(Double repetitionPenalty) {
+            this.repetitionPenalty = repetitionPenalty;
+            return (T) this;
+        }
+
+        /**
+         * Sets the length penalty applied to the sequence score during beam search. Values greater than {@code 1.0} favor longer sequences.
+         *
+         * @param lengthPenalty the length penalty
+         * @return {@code this}
+         */
+        public T lengthPenalty(Double lengthPenalty) {
+            this.lengthPenalty = lengthPenalty;
+            return (T) this;
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimator.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimator.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
  *     .baseUrl("https://...") // or use CloudRegion
  *     .apiKey("...")
  *     .projectId("...")
+ *     .modelName("ibm/granite-4-h-small")
  *     .build();
  * }</pre>
  *
@@ -164,9 +165,11 @@ public class WatsonxTokenCountEstimator implements TokenCountEstimator {
      *     .baseUrl("https://...") // or use CloudRegion
      *     .apiKey("...")
      *     .projectId("...")
+     *     .modelName("ibm/granite-4-h-small")
      *     .build();
      * }</pre>
      *
+     * @return {@link Builder} instance.
      */
     public static Builder builder() {
         return new Builder();
@@ -181,37 +184,13 @@ public class WatsonxTokenCountEstimator implements TokenCountEstimator {
         private Builder() {}
 
         /**
-         * Sets the watsonx.ai model ID used for token counting, e.g. {@code "ibm/granite-3-8b-instruct"}.
+         * Sets the watsonx.ai model ID used for token counting, e.g. {@code "ibm/granite-4-h-small"}.
          *
          * @param modelName the model ID
          * @return {@code this}
          */
         public Builder modelName(String modelName) {
             this.modelName = modelName;
-            return this;
-        }
-
-        /**
-         * Sets the IBM Cloud project ID that owns the watsonx.ai resources.
-         * Exactly one of {@code projectId} or {@code spaceId} must be set.
-         *
-         * @param projectId the IBM Cloud project ID
-         * @return {@code this}
-         */
-        public Builder projectId(String projectId) {
-            this.projectId = projectId;
-            return this;
-        }
-
-        /**
-         * Sets the IBM Cloud deployment space ID.
-         * Exactly one of {@code projectId} or {@code spaceId} must be set.
-         *
-         * @param spaceId the IBM Cloud deployment space ID
-         * @return {@code this}
-         */
-        public Builder spaceId(String spaceId) {
-            this.spaceId = spaceId;
             return this;
         }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
@@ -5,13 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import java.net.URI;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
+
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
@@ -46,6 +40,13 @@ import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.output.FinishReason;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class ConverterTest {
 
@@ -373,6 +374,17 @@ public class ConverterTest {
     }
 
     @Test
+    void testToChatParameters_withoutStopSequences() {
+        assertNull(Converter.toChatParameters(
+                        WatsonxChatRequestParameters.builder().build())
+                .stop());
+        assertNull(Converter.toChatParameters(WatsonxChatRequestParameters.builder()
+                        .stopSequences(List.of())
+                        .build())
+                .stop());
+    }
+
+    @Test
     void testToChatParameters_withInvalidToolChoice() {
         assertThrows(
                 IllegalArgumentException.class,
@@ -526,6 +538,19 @@ public class ConverterTest {
 
         var p = Converter.toModelGatewayParameters(parameters);
         assertEquals("none", p.toolChoiceOption());
+    }
+
+    @Test
+    void testToModelGatewayParameters_withoutStopSequences() {
+        // The Model Gateway rejects an empty "stop" array with "Field validation for 'Sequences' failed on the
+        // 'min' tag", so it must not be sent.
+        assertNull(Converter.toModelGatewayParameters(
+                        WatsonxGatewayChatRequestParameters.builder().build())
+                .stop());
+        assertNull(Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
+                        .stopSequences(List.of())
+                        .build())
+                .stop());
     }
 
     @Test

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
@@ -36,7 +36,9 @@ import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.output.FinishReason;
@@ -314,7 +316,7 @@ public class ConverterTest {
                 .repetitionPenalty(1.2)
                 .build();
 
-        var p = Converter.toChatParameters(parameters);
+        var p = Converter.toChatParameters(parameters, false);
         assertEquals(0.1, p.frequencyPenalty());
         assertEquals(0, p.maxCompletionTokens());
         assertEquals("modelName", p.modelId());
@@ -347,7 +349,7 @@ public class ConverterTest {
                         ToolSpecification.builder().name("toolChoiceName").build())
                 .build();
 
-        var p = Converter.toChatParameters(parameters);
+        var p = Converter.toChatParameters(parameters, false);
         assertEquals("required", p.toolChoiceOption());
 
         parameters = WatsonxChatRequestParameters.builder()
@@ -357,7 +359,7 @@ public class ConverterTest {
                         ToolSpecification.builder().name("toolChoiceName").build())
                 .build();
 
-        p = Converter.toChatParameters(parameters);
+        p = Converter.toChatParameters(parameters, false);
         assertNull(p.toolChoiceOption());
         assertEquals("function", p.toolChoice().get("type"));
         assertEquals("toolChoiceName", ((Map) p.toolChoice().get("function")).get("name"));
@@ -369,18 +371,20 @@ public class ConverterTest {
                 .toolChoice(ToolChoice.NONE)
                 .build();
 
-        var p = Converter.toChatParameters(parameters);
+        var p = Converter.toChatParameters(parameters, false);
         assertEquals("none", p.toolChoiceOption());
     }
 
     @Test
     void testToChatParameters_withoutStopSequences() {
         assertNull(Converter.toChatParameters(
-                        WatsonxChatRequestParameters.builder().build())
+                        WatsonxChatRequestParameters.builder().build(), false)
                 .stop());
-        assertNull(Converter.toChatParameters(WatsonxChatRequestParameters.builder()
-                        .stopSequences(List.of())
-                        .build())
+        assertNull(Converter.toChatParameters(
+                        WatsonxChatRequestParameters.builder()
+                                .stopSequences(List.of())
+                                .build(),
+                        false)
                 .stop());
     }
 
@@ -388,33 +392,42 @@ public class ConverterTest {
     void testToChatParameters_withInvalidToolChoice() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toChatParameters(WatsonxChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .build()));
+                () -> Converter.toChatParameters(
+                        WatsonxChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .build(),
+                        false));
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toChatParameters(WatsonxChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .toolChoiceName("toolChoiceName")
-                        .build()));
+                () -> Converter.toChatParameters(
+                        WatsonxChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .toolChoiceName("toolChoiceName")
+                                .build(),
+                        false));
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toChatParameters(WatsonxChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .toolChoiceName("toolChoiceName")
-                        .toolSpecifications(List.of())
-                        .build()));
+                () -> Converter.toChatParameters(
+                        WatsonxChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .toolChoiceName("toolChoiceName")
+                                .toolSpecifications(List.of())
+                                .build(),
+                        false));
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toChatParameters(WatsonxChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .toolChoiceName("toolChoiceName")
-                        .toolSpecifications(
-                                ToolSpecification.builder().name("notMatch").build())
-                        .build()));
+                () -> Converter.toChatParameters(
+                        WatsonxChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .toolChoiceName("toolChoiceName")
+                                .toolSpecifications(ToolSpecification.builder()
+                                        .name("notMatch")
+                                        .build())
+                                .build(),
+                        false));
     }
 
     @Test
@@ -423,7 +436,7 @@ public class ConverterTest {
                 .responseFormat(ResponseFormat.JSON)
                 .build();
 
-        var p = Converter.toChatParameters(parameters);
+        var p = Converter.toChatParameters(parameters, false);
         assertEquals("json_object", p.responseFormat());
 
         parameters = WatsonxChatRequestParameters.builder()
@@ -435,10 +448,10 @@ public class ConverterTest {
                         .build())
                 .build();
 
-        p = Converter.toChatParameters(parameters);
+        p = Converter.toChatParameters(parameters, false);
         assertEquals("json_schema", p.responseFormat());
         assertEquals("test", p.jsonSchema().name());
-        assertEquals(true, p.jsonSchema().strict());
+        assertEquals(false, p.jsonSchema().strict());
         JSONAssert.assertEquals("""
                                 {
                                     "type" : "object",
@@ -449,6 +462,86 @@ public class ConverterTest {
                                     },
                                     required : [ ]
                                 }""", Json.toJson(p.jsonSchema().schema()), true);
+    }
+
+    @Test
+    void testToChatParameters_withStrictJsonSchema() throws Exception {
+        var parameters = WatsonxChatRequestParameters.builder()
+                .responseFormat(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addStringProperty("content")
+                                .addBooleanProperty("flag")
+                                .required("content")
+                                .build())
+                        .build())
+                .build();
+
+        var p = Converter.toChatParameters(parameters, true);
+        assertEquals("json_schema", p.responseFormat());
+        assertEquals("test", p.jsonSchema().name());
+        assertEquals(true, p.jsonSchema().strict());
+        JSONAssert.assertEquals("""
+                {
+                    "type" : "object",
+                    "properties" : {
+                        "content" : {
+                            "type" : "string"
+                        },
+                        "flag" : {
+                            "type" : [ "boolean", "null" ]
+                        }
+                    },
+                    "required" : [ "content", "flag" ],
+                    "additionalProperties" : false
+                }""", Json.toJson(p.jsonSchema().schema()), true);
+    }
+
+    @Test
+    void testToChatParameters_withRawJsonSchema() throws Exception {
+        var rawSchema = """
+                {
+                    "type" : "object",
+                    "properties" : {
+                        "content" : {
+                            "type" : "string"
+                        }
+                    },
+                    "required" : [ "content" ],
+                    "additionalProperties" : true
+                }""";
+
+        var parameters = WatsonxChatRequestParameters.builder()
+                .responseFormat(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonRawSchema.from(rawSchema))
+                        .build())
+                .build();
+
+        for (boolean strict : List.of(true, false)) {
+            var p = Converter.toChatParameters(parameters, strict);
+            assertEquals("json_schema", p.responseFormat());
+            assertEquals(strict, p.jsonSchema().strict());
+            JSONAssert.assertEquals(rawSchema, Json.toJson(p.jsonSchema().schema()), true);
+        }
+    }
+
+    @Test
+    void testToChatParameters_withInvalidJsonSchemaRootElement() {
+        var parameters = WatsonxChatRequestParameters.builder()
+                .responseFormat(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonStringSchema.builder().build())
+                        .build())
+                .build();
+
+        var exception =
+                assertThrows(IllegalArgumentException.class, () -> Converter.toChatParameters(parameters, false));
+
+        assertEquals(
+                "The root element of the JSON Schema must be either a JsonObjectSchema or a JsonRawSchema, but it was: "
+                        + JsonStringSchema.class,
+                exception.getMessage());
     }
 
     @Test
@@ -480,7 +573,7 @@ public class ConverterTest {
                 .metadata(Map.of("k", "v"))
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters);
+        var p = Converter.toModelGatewayParameters(parameters, false);
         assertEquals(0.1, p.frequencyPenalty());
         assertEquals(0, p.maxCompletionTokens());
         assertEquals("modelName", p.modelId());
@@ -514,7 +607,7 @@ public class ConverterTest {
                         ToolSpecification.builder().name("toolChoiceName").build())
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters);
+        var p = Converter.toModelGatewayParameters(parameters, false);
         assertEquals("required", p.toolChoiceOption());
 
         parameters = WatsonxGatewayChatRequestParameters.builder()
@@ -524,7 +617,7 @@ public class ConverterTest {
                         ToolSpecification.builder().name("toolChoiceName").build())
                 .build();
 
-        p = Converter.toModelGatewayParameters(parameters);
+        p = Converter.toModelGatewayParameters(parameters, false);
         assertNull(p.toolChoiceOption());
         assertEquals("function", p.toolChoice().get("type"));
         assertEquals("toolChoiceName", ((Map) p.toolChoice().get("function")).get("name"));
@@ -536,7 +629,7 @@ public class ConverterTest {
                 .toolChoice(ToolChoice.NONE)
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters);
+        var p = Converter.toModelGatewayParameters(parameters, false);
         assertEquals("none", p.toolChoiceOption());
     }
 
@@ -545,11 +638,13 @@ public class ConverterTest {
         // The Model Gateway rejects an empty "stop" array with "Field validation for 'Sequences' failed on the
         // 'min' tag", so it must not be sent.
         assertNull(Converter.toModelGatewayParameters(
-                        WatsonxGatewayChatRequestParameters.builder().build())
+                        WatsonxGatewayChatRequestParameters.builder().build(), false)
                 .stop());
-        assertNull(Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
-                        .stopSequences(List.of())
-                        .build())
+        assertNull(Converter.toModelGatewayParameters(
+                        WatsonxGatewayChatRequestParameters.builder()
+                                .stopSequences(List.of())
+                                .build(),
+                        false)
                 .stop());
     }
 
@@ -557,33 +652,42 @@ public class ConverterTest {
     void testToModelGatewayParameters_withInvalidToolChoice() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .build()));
+                () -> Converter.toModelGatewayParameters(
+                        WatsonxGatewayChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .build(),
+                        false));
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .toolChoiceName("toolChoiceName")
-                        .build()));
+                () -> Converter.toModelGatewayParameters(
+                        WatsonxGatewayChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .toolChoiceName("toolChoiceName")
+                                .build(),
+                        false));
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .toolChoiceName("toolChoiceName")
-                        .toolSpecifications(List.of())
-                        .build()));
+                () -> Converter.toModelGatewayParameters(
+                        WatsonxGatewayChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .toolChoiceName("toolChoiceName")
+                                .toolSpecifications(List.of())
+                                .build(),
+                        false));
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
-                        .toolChoice(ToolChoice.REQUIRED)
-                        .toolChoiceName("toolChoiceName")
-                        .toolSpecifications(
-                                ToolSpecification.builder().name("notMatch").build())
-                        .build()));
+                () -> Converter.toModelGatewayParameters(
+                        WatsonxGatewayChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .toolChoiceName("toolChoiceName")
+                                .toolSpecifications(ToolSpecification.builder()
+                                        .name("notMatch")
+                                        .build())
+                                .build(),
+                        false));
     }
 
     @Test
@@ -592,7 +696,7 @@ public class ConverterTest {
                 .responseFormat(ResponseFormat.JSON)
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters);
+        var p = Converter.toModelGatewayParameters(parameters, false);
         assertEquals("json_object", p.responseFormat());
 
         parameters = WatsonxGatewayChatRequestParameters.builder()
@@ -604,10 +708,10 @@ public class ConverterTest {
                         .build())
                 .build();
 
-        p = Converter.toModelGatewayParameters(parameters);
+        p = Converter.toModelGatewayParameters(parameters, false);
         assertEquals("json_schema", p.responseFormat());
         assertEquals("test", p.jsonSchema().name());
-        assertEquals(true, p.jsonSchema().strict());
+        assertEquals(false, p.jsonSchema().strict());
         JSONAssert.assertEquals("""
                                 {
                                     "type" : "object",
@@ -618,6 +722,57 @@ public class ConverterTest {
                                     },
                                     required : [ ]
                                 }""", Json.toJson(p.jsonSchema().schema()), true);
+    }
+
+    @Test
+    void testToModelGatewayParameters_withStrictJsonSchema() throws Exception {
+        var parameters = WatsonxGatewayChatRequestParameters.builder()
+                .responseFormat(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addStringProperty("content")
+                                .addBooleanProperty("flag")
+                                .required("content")
+                                .build())
+                        .build())
+                .build();
+
+        var p = Converter.toModelGatewayParameters(parameters, true);
+        assertEquals("json_schema", p.responseFormat());
+        assertEquals("test", p.jsonSchema().name());
+        assertEquals(true, p.jsonSchema().strict());
+        JSONAssert.assertEquals("""
+                {
+                    "type" : "object",
+                    "properties" : {
+                        "content" : {
+                            "type" : "string"
+                        },
+                        "flag" : {
+                            "type" : [ "boolean", "null" ]
+                        }
+                    },
+                    "required" : [ "content", "flag" ],
+                    "additionalProperties" : false
+                }""", Json.toJson(p.jsonSchema().schema()), true);
+    }
+
+    @Test
+    void testToModelGatewayParameters_withInvalidJsonSchemaRootElement() {
+        var parameters = WatsonxGatewayChatRequestParameters.builder()
+                .responseFormat(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonStringSchema.builder().build())
+                        .build())
+                .build();
+
+        var exception = assertThrows(
+                IllegalArgumentException.class, () -> Converter.toModelGatewayParameters(parameters, false));
+
+        assertEquals(
+                "The root element of the JSON Schema must be either a JsonObjectSchema or a JsonRawSchema, but it was: "
+                        + JsonStringSchema.class,
+                exception.getMessage());
     }
 
     @Test

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
@@ -1,13 +1,28 @@
 package dev.langchain4j.model.watsonx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
+import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
+import com.ibm.watsonx.ai.chat.model.ChatUsage;
+import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.ToolMessage;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -31,13 +46,6 @@ import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.output.FinishReason;
-import java.net.URI;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class ConverterTest {
 
@@ -119,6 +127,18 @@ public class ConverterTest {
         assertEquals(ToolMessage.ROLE, toolMessage.role());
         assertEquals("id", toolMessage.toolCallId());
         assertEquals("result", toolMessage.content());
+    }
+
+    @Test
+    void testToToolMessageWithNonTextContent() {
+
+        var nonTextResult = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("toolName")
+                .contents(ImageContent.from("data", "image/png"))
+                .build();
+
+        assertThrows(UnsupportedFeatureException.class, () -> Converter.toChatMessage(nonTextResult));
     }
 
     @Test
@@ -407,8 +427,7 @@ public class ConverterTest {
         assertEquals("json_schema", p.responseFormat());
         assertEquals("test", p.jsonSchema().name());
         assertEquals(true, p.jsonSchema().strict());
-        JSONAssert.assertEquals(
-                """
+        JSONAssert.assertEquals("""
                                 {
                                     "type" : "object",
                                     "properties" : {
@@ -417,8 +436,200 @@ public class ConverterTest {
                                         }
                                     },
                                     required : [ ]
-                                }""",
-                Json.toJson(p.jsonSchema().schema()),
-                true);
+                                }""", Json.toJson(p.jsonSchema().schema()), true);
+    }
+
+    @Test
+    void testToModelGatewayParameters_withAllFieldsSet() {
+        var parameters = WatsonxGatewayChatRequestParameters.builder()
+                .frequencyPenalty(0.1)
+                .maxOutputTokens(0)
+                .modelName("modelName")
+                .presencePenalty(0.2)
+                .stopSequences("[")
+                .temperature(0.3)
+                .toolChoice(ToolChoice.AUTO)
+                .responseFormat(ResponseFormat.TEXT)
+                .timeout(Duration.ofMillis(30))
+                .topP(0.4)
+                .logitBias(Map.of("test", 10))
+                .logprobs(true)
+                .seed(5)
+                .toolChoiceName("toolChoiceName")
+                .toolSpecifications(ToolSpecification.builder().name("test").build())
+                .topLogprobs(10)
+                .serviceTier(ServiceTier.AUTO)
+                .reasoningEffort(ReasoningEffort.LOW)
+                .router(new Router(new Cache(true, null, null)))
+                .modalities(List.of("text"))
+                .store(true)
+                .parallelToolCalls(true)
+                .user("user")
+                .metadata(Map.of("k", "v"))
+                .build();
+
+        var p = Converter.toModelGatewayParameters(parameters);
+        assertEquals(0.1, p.frequencyPenalty());
+        assertEquals(0, p.maxCompletionTokens());
+        assertEquals("modelName", p.modelId());
+        assertEquals(0.2, p.presencePenalty());
+        assertEquals(List.of("["), p.stop());
+        assertEquals(0.3, p.temperature());
+        assertEquals("auto", p.toolChoiceOption());
+        assertEquals(0.4, p.topP());
+        assertEquals(30, p.timeLimit());
+        assertEquals(Map.of("test", 10), p.logitBias());
+        assertEquals(true, p.logprobs());
+        assertEquals(5, p.seed());
+        assertEquals(10, p.topLogprobs());
+        assertEquals("auto", p.serviceTier());
+        assertEquals("low", p.reasoningEffort());
+        assertEquals(new Router(new Cache(true, null, null)), p.router());
+        assertEquals(List.of("text"), p.modalities());
+        assertEquals(true, p.store());
+        assertEquals(true, p.parallelToolCalls());
+        assertEquals("user", p.user());
+        assertEquals(Map.of("k", "v"), p.metadata());
+        assertNull(p.responseFormat());
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void testToModelGatewayParameters_withToolChoiceRequiredAndMatchingTool() {
+        var parameters = WatsonxGatewayChatRequestParameters.builder()
+                .toolChoice(ToolChoice.REQUIRED)
+                .toolSpecifications(
+                        ToolSpecification.builder().name("toolChoiceName").build())
+                .build();
+
+        var p = Converter.toModelGatewayParameters(parameters);
+        assertEquals("required", p.toolChoiceOption());
+
+        parameters = WatsonxGatewayChatRequestParameters.builder()
+                .toolChoice(ToolChoice.REQUIRED)
+                .toolChoiceName("toolChoiceName")
+                .toolSpecifications(
+                        ToolSpecification.builder().name("toolChoiceName").build())
+                .build();
+
+        p = Converter.toModelGatewayParameters(parameters);
+        assertNull(p.toolChoiceOption());
+        assertEquals("function", p.toolChoice().get("type"));
+        assertEquals("toolChoiceName", ((Map) p.toolChoice().get("function")).get("name"));
+    }
+
+    @Test
+    void testToModelGatewayParameters_withToolChoiceNone() {
+        var parameters = WatsonxGatewayChatRequestParameters.builder()
+                .toolChoice(ToolChoice.NONE)
+                .build();
+
+        var p = Converter.toModelGatewayParameters(parameters);
+        assertEquals("none", p.toolChoiceOption());
+    }
+
+    @Test
+    void testToModelGatewayParameters_withInvalidToolChoice() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
+                        .toolChoice(ToolChoice.REQUIRED)
+                        .build()));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
+                        .toolChoice(ToolChoice.REQUIRED)
+                        .toolChoiceName("toolChoiceName")
+                        .build()));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
+                        .toolChoice(ToolChoice.REQUIRED)
+                        .toolChoiceName("toolChoiceName")
+                        .toolSpecifications(List.of())
+                        .build()));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Converter.toModelGatewayParameters(WatsonxGatewayChatRequestParameters.builder()
+                        .toolChoice(ToolChoice.REQUIRED)
+                        .toolChoiceName("toolChoiceName")
+                        .toolSpecifications(
+                                ToolSpecification.builder().name("notMatch").build())
+                        .build()));
+    }
+
+    @Test
+    void testToModelGatewayParameters_withResponseFormat() throws Exception {
+        var parameters = WatsonxGatewayChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.JSON)
+                .build();
+
+        var p = Converter.toModelGatewayParameters(parameters);
+        assertEquals("json_object", p.responseFormat());
+
+        parameters = WatsonxGatewayChatRequestParameters.builder()
+                .responseFormat(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addBooleanProperty("test")
+                                .build())
+                        .build())
+                .build();
+
+        p = Converter.toModelGatewayParameters(parameters);
+        assertEquals("json_schema", p.responseFormat());
+        assertEquals("test", p.jsonSchema().name());
+        assertEquals(true, p.jsonSchema().strict());
+        JSONAssert.assertEquals("""
+                                {
+                                    "type" : "object",
+                                    "properties" : {
+                                        "test" : {
+                                          "type" : boolean
+                                        }
+                                    },
+                                    required : [ ]
+                                }""", Json.toJson(p.jsonSchema().schema()), true);
+    }
+
+    @Test
+    void testToChatResponseWithoutUsage() {
+
+        var withoutUsage = TextChatResponse.builder()
+                .id("id")
+                .modelId("modelId")
+                .createdAt("createdAt")
+                .created(1L)
+                .choices(List.of(new ResultChoice(
+                        0, new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null), "stop")))
+                .build();
+
+        assertNull(Converter.toChatResponse(withoutUsage).tokenUsage());
+    }
+
+    @Test
+    void testToChatResponseWithoutGatewayMetadata() {
+
+        var plainResponse = TextChatResponse.builder()
+                .id("id")
+                .modelId("modelId")
+                .modelVersion("modelVersion")
+                .createdAt("createdAt")
+                .created(1L)
+                .usage(new ChatUsage(10, 10, 20))
+                .choices(List.of(new ResultChoice(
+                        0, new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null), "stop")))
+                .build();
+
+        var metadata = assertInstanceOf(
+                WatsonxChatResponseMetadata.class,
+                Converter.toChatResponse(plainResponse).metadata());
+
+        assertNull(metadata.getServiceTier());
+        assertNull(metadata.getSystemFingerprint());
+        assertNull(metadata.getCached());
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -10,13 +10,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.ChatService;
+import com.ibm.watsonx.ai.chat.EmptyChatResponseException;
+import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
@@ -28,7 +33,7 @@ import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
-import com.ibm.watsonx.ai.deployment.DeploymentService;
+import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
@@ -65,18 +70,12 @@ public class WatsonxChatModelTest {
     ChatService mockChatService;
 
     @Mock
-    DeploymentService deploymentService;
-
-    @Mock
     ChatService.Builder mockChatServiceBuilder;
-
-    @Mock
-    DeploymentService.Builder mockDeploymentServiceBuilder;
 
     @Captor
     ArgumentCaptor<com.ibm.watsonx.ai.chat.ChatRequest> chatRequestCaptor;
 
-    static ChatResponse.Builder chatResponse;
+    static TextChatResponse.Builder<?> chatResponse;
 
     @BeforeEach
     void setUp() {
@@ -95,19 +94,8 @@ public class WatsonxChatModelTest {
         when(mockChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.build()).thenReturn(mockChatService);
 
-        when(mockDeploymentServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.timeout(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.version(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.logRequests(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.logResponses(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.authenticator(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.apiKey(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.httpClient(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.build()).thenReturn(deploymentService);
-
         var chatUsage = new ChatUsage(10, 10, 20);
-        chatResponse = ChatResponse.build()
+        chatResponse = TextChatResponse.builder()
                 .id("id")
                 .modelId("modelId")
                 .model("model")
@@ -135,11 +123,11 @@ public class WatsonxChatModelTest {
         var defaultRequestParameters =
                 assertInstanceOf(WatsonxChatRequestParameters.class, chatModel.defaultRequestParameters());
 
-        var chatProviderField =
-                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
-        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(chatModel));
+        var chatServiceField =
+                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("chatService"));
+        var chatService = assertDoesNotThrow(() -> chatServiceField.get(chatModel));
 
-        assertInstanceOf(ChatService.class, chatProvider);
+        assertInstanceOf(ChatService.class, chatService);
         assertNull(defaultRequestParameters.frequencyPenalty());
         assertNull(defaultRequestParameters.logitBias());
         assertNull(defaultRequestParameters.logprobs());
@@ -167,53 +155,6 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void should_create_create_a_watsonx_chat_model_from_a_deployment_service() {
-
-        var chatModel = assertDoesNotThrow(() -> WatsonxChatModel.builder()
-                .baseUrl(CloudRegion.FRANKFURT)
-                .apiKey("api-key-test")
-                .version("my-version")
-                .logRequests(true)
-                .logResponses(true)
-                .deploymentId("deployment-id")
-                .build());
-
-        var defaultRequestParameters =
-                assertInstanceOf(WatsonxChatRequestParameters.class, chatModel.defaultRequestParameters());
-
-        var chatProviderField =
-                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
-        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(chatModel));
-
-        assertInstanceOf(DeploymentService.class, chatProvider);
-        assertNull(defaultRequestParameters.frequencyPenalty());
-        assertNull(defaultRequestParameters.logitBias());
-        assertNull(defaultRequestParameters.logprobs());
-        assertNull(defaultRequestParameters.maxOutputTokens());
-        assertNull(defaultRequestParameters.modelName());
-        assertNull(defaultRequestParameters.presencePenalty());
-        assertNull(defaultRequestParameters.projectId());
-        assertNull(defaultRequestParameters.responseFormat());
-        assertNull(defaultRequestParameters.seed());
-        assertNull(defaultRequestParameters.spaceId());
-        assertEquals(List.of(), defaultRequestParameters.stopSequences());
-        assertNull(defaultRequestParameters.temperature());
-        assertNull(defaultRequestParameters.timeout());
-        assertNull(defaultRequestParameters.toolChoice());
-        assertNull(defaultRequestParameters.toolChoiceName());
-        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
-        assertNull(defaultRequestParameters.topK());
-        assertNull(defaultRequestParameters.topLogprobs());
-        assertNull(defaultRequestParameters.topP());
-        assertNull(defaultRequestParameters.guidedChoice());
-        assertNull(defaultRequestParameters.guidedGrammar());
-        assertNull(defaultRequestParameters.guidedRegex());
-        assertNull(defaultRequestParameters.repetitionPenalty());
-        assertNull(defaultRequestParameters.lengthPenalty());
-        assertEquals("deployment-id", defaultRequestParameters.deploymentId());
-    }
-
-    @Test
     void should_do_chat() {
 
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
@@ -234,45 +175,6 @@ public class WatsonxChatModelTest {
             assertEquals(
                     List.of(UserMessage.text("hello")),
                     chatRequestCaptor.getValue().messages());
-            assertNull(chatRequestCaptor.getValue().deploymentId());
-        });
-    }
-
-    @Test
-    void should_do_chat_with_deployment_service() {
-
-        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
-        var resultChoice = new ResultChoice(0, resultMessage, "stop");
-        chatResponse.choices(List.of(resultChoice));
-
-        when(deploymentService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
-
-        withDeploymentServiceMock(() -> {
-            var chatModel = WatsonxChatModel.builder()
-                    .baseUrl("https://test.com")
-                    .deploymentId("deployment-id")
-                    .apiKey("api-key")
-                    .build();
-
-            assertEquals("Hello", chatModel.chat("hello"));
-            assertEquals(
-                    List.of(UserMessage.text("hello")),
-                    chatRequestCaptor.getValue().messages());
-
-            var chatRequest = ChatRequest.builder()
-                    .messages(List.of(dev.langchain4j.data.message.UserMessage.from("hello")))
-                    .parameters(WatsonxChatRequestParameters.builder()
-                            .deploymentId("deployment-id-override")
-                            .build())
-                    .build();
-
-            assertNotNull(chatModel.chat(chatRequest));
-            assertEquals(2, chatRequestCaptor.getAllValues().size());
-            assertEquals(
-                    "deployment-id", chatRequestCaptor.getAllValues().get(0).deploymentId());
-            assertEquals(
-                    "deployment-id-override",
-                    chatRequestCaptor.getAllValues().get(1).deploymentId());
         });
     }
 
@@ -294,6 +196,46 @@ public class WatsonxChatModelTest {
                     .build();
 
             assertThrows(ContentFilteredException.class, () -> chatModel.chat("hello"), "refusal");
+        });
+    }
+
+    @Test
+    void should_propagate_empty_response_with_no_choices() {
+
+        chatResponse.choices(List.of());
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .build();
+
+            assertThrows(EmptyChatResponseException.class, () -> chatModel.chat("hello"));
+        });
+    }
+
+    @Test
+    void should_propagate_empty_response_truncated_by_length() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, null, null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "length");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .build();
+
+            assertThrows(EmptyChatResponseException.class, () -> chatModel.chat("hello"));
         });
     }
 
@@ -986,16 +928,66 @@ public class WatsonxChatModelTest {
         assertTrue(chatModel.supportedCapabilities().contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
     }
 
+    @Test
+    void should_authenticate_with_an_authenticator_instead_of_an_api_key() {
+
+        var authenticator = mock(IBMCloudAuthenticator.class);
+
+        withChatServiceMock(() -> {
+            assertDoesNotThrow(() -> WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .authenticator(authenticator)
+                    .build());
+
+            verify(mockChatServiceBuilder).authenticator(authenticator);
+            verify(mockChatServiceBuilder, never()).apiKey(any());
+        });
+    }
+
+    @Test
+    void should_disable_thinking_when_the_builder_receives_null() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    // enabled first, so the null below has something to switch off
+                    .thinking(ExtractionTags.of(new Think("<think>", "</think>")))
+                    .thinking((ExtractionTags) null)
+                    .build();
+
+            chatModel.chat("hello");
+            assertNull(chatRequestCaptor.getValue().thinking());
+        });
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .thinking(ThinkingEffort.LOW)
+                    .thinking((ThinkingEffort) null)
+                    .build();
+
+            chatModel.chat("hello");
+            assertNull(chatRequestCaptor.getValue().thinking());
+        });
+    }
+
     private void withChatServiceMock(Runnable action) {
         try (MockedStatic<ChatService> mockedStatic = mockStatic(ChatService.class)) {
             mockedStatic.when(ChatService::builder).thenReturn(mockChatServiceBuilder);
-            action.run();
-        }
-    }
-
-    private void withDeploymentServiceMock(Runnable action) {
-        try (MockedStatic<DeploymentService> mockedStatic = mockStatic(DeploymentService.class)) {
-            mockedStatic.when(DeploymentService::builder).thenReturn(mockDeploymentServiceBuilder);
             action.run();
         }
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -1020,9 +1020,9 @@ public class WatsonxChatModelTest {
             var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
             var schema = assertInstanceOf(Map.class, jsonSchema.schema());
 
-            assertFalse(jsonSchema.strict());
-            assertEquals(List.of("content"), schema.get("required"));
-            assertFalse(schema.containsKey("additionalProperties"));
+            assertTrue(jsonSchema.strict());
+            assertEquals(List.of("content", "flag"), schema.get("required"));
+            assertEquals(false, schema.get("additionalProperties"));
         });
 
         withChatServiceMock(() -> {
@@ -1032,16 +1032,16 @@ public class WatsonxChatModelTest {
                     .projectId("project-id")
                     .apiKey("api-key")
                     .responseFormat(responseFormat)
-                    .strictJsonSchema(true)
+                    .strictJsonSchema(false)
                     .build();
 
             chatModel.chat("hello");
             var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
             var schema = assertInstanceOf(Map.class, jsonSchema.schema());
 
-            assertTrue(jsonSchema.strict());
-            assertEquals(List.of("content", "flag"), schema.get("required"));
-            assertEquals(false, schema.get("additionalProperties"));
+            assertFalse(jsonSchema.strict());
+            assertEquals(List.of("content"), schema.get("required"));
+            assertFalse(schema.containsKey("additionalProperties"));
         });
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -42,6 +42,7 @@ import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
@@ -982,6 +983,65 @@ public class WatsonxChatModelTest {
 
             chatModel.chat("hello");
             assertNull(chatRequestCaptor.getValue().thinking());
+        });
+    }
+
+    @Test
+    void should_do_chat_with_strict_json_schema() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        var responseFormat = ResponseFormat.builder()
+                .type(ResponseFormatType.JSON)
+                .jsonSchema(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addStringProperty("content")
+                                .addBooleanProperty("flag")
+                                .required("content")
+                                .build())
+                        .build())
+                .build();
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .responseFormat(responseFormat)
+                    .build();
+
+            chatModel.chat("hello");
+            var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
+            var schema = assertInstanceOf(Map.class, jsonSchema.schema());
+
+            assertFalse(jsonSchema.strict());
+            assertEquals(List.of("content"), schema.get("required"));
+            assertFalse(schema.containsKey("additionalProperties"));
+        });
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .responseFormat(responseFormat)
+                    .strictJsonSchema(true)
+                    .build();
+
+            chatModel.chat("hello");
+            var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
+            var schema = assertInstanceOf(Map.class, jsonSchema.schema());
+
+            assertTrue(jsonSchema.strict());
+            assertEquals(List.of("content", "flag"), schema.get("required"));
+            assertEquals(false, schema.get("additionalProperties"));
         });
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParametersTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParametersTest.java
@@ -2,6 +2,10 @@ package dev.langchain4j.model.watsonx;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
+import com.ibm.watsonx.ai.chat.model.Thinking;
+import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
@@ -18,6 +22,7 @@ class WatsonxChatRequestParametersTest {
                 // watsonx-specific fields
                 .projectId("project-id")
                 .spaceId("space-id")
+                .thinking(Thinking.of(ThinkingEffort.LOW))
                 .logitBias(Map.of("token", 1))
                 .logprobs(true)
                 .topLogprobs(5)
@@ -28,8 +33,7 @@ class WatsonxChatRequestParametersTest {
                 .guidedRegex("[0-9]+")
                 .guidedGrammar("grammar")
                 .repetitionPenalty(1.1)
-                .lengthPenalty(1.2)
-                .deploymentId("deployment-id");
+                .lengthPenalty(1.2);
     }
 
     @Test
@@ -48,6 +52,10 @@ class WatsonxChatRequestParametersTest {
         assertThat(base).isNotEqualTo(fullyPopulated().projectId("other").build());
         assertThat(base).isNotEqualTo(fullyPopulated().spaceId("other").build());
         assertThat(base)
+                .isNotEqualTo(fullyPopulated()
+                        .thinking(Thinking.of(ThinkingEffort.HIGH))
+                        .build());
+        assertThat(base)
                 .isNotEqualTo(fullyPopulated().logitBias(Map.of("token", 2)).build());
         assertThat(base).isNotEqualTo(fullyPopulated().logprobs(false).build());
         assertThat(base).isNotEqualTo(fullyPopulated().topLogprobs(9).build());
@@ -60,7 +68,6 @@ class WatsonxChatRequestParametersTest {
         assertThat(base).isNotEqualTo(fullyPopulated().guidedGrammar("other").build());
         assertThat(base).isNotEqualTo(fullyPopulated().repetitionPenalty(2.0).build());
         assertThat(base).isNotEqualTo(fullyPopulated().lengthPenalty(2.0).build());
-        assertThat(base).isNotEqualTo(fullyPopulated().deploymentId("other").build());
     }
 
     @Test
@@ -72,13 +79,52 @@ class WatsonxChatRequestParametersTest {
     }
 
     @Test
+    void equals_should_reject_null_and_other_types() {
+        WatsonxChatRequestParameters base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(null);
+        assertThat(base).isNotEqualTo("not a parameters object");
+    }
+
+    @Test
+    void overrideWith_and_defaultedBy_should_be_mirror_images() {
+        WatsonxChatRequestParameters base = fullyPopulated().build();
+        WatsonxChatRequestParameters other =
+                WatsonxChatRequestParameters.builder().projectId("other").build();
+
+        // overrideWith lets the argument win (it is declared on the interface, so it returns the interface type)
+        var overridden = (WatsonxChatRequestParameters) base.overrideWith(other);
+        assertThat(overridden.projectId()).isEqualTo("other");
+        // defaultedBy lets the receiver win, and fills the gaps from the argument
+        assertThat(other.defaultedBy(base).projectId()).isEqualTo("other");
+        assertThat(other.defaultedBy(base).spaceId()).isEqualTo("space-id");
+        assertThat(other.defaultedBy(base).seed()).isEqualTo(42);
+    }
+
+    @Test
+    void thinking_should_be_disabled_by_a_null_argument() {
+        assertThat(WatsonxChatRequestParameters.builder()
+                        .thinking(ExtractionTags.of(new Think("<think>", "</think>")))
+                        .thinking((ExtractionTags) null)
+                        .build()
+                        .thinking())
+                .isNull();
+
+        assertThat(WatsonxChatRequestParameters.builder()
+                        .thinking(ThinkingEffort.LOW)
+                        .thinking((ThinkingEffort) null)
+                        .build()
+                        .thinking())
+                .isNull();
+    }
+
+    @Test
     void toString_should_include_watsonx_fields() {
         String text = fullyPopulated().build().toString();
 
         assertThat(text)
                 .contains("projectId=project-id")
                 .contains("spaceId=space-id")
-                .contains("seed=42")
-                .contains("deploymentId=deployment-id");
+                .contains("seed=42");
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCrossServiceParametersTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCrossServiceParametersTest.java
@@ -1,0 +1,164 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class WatsonxCrossServiceParametersTest {
+
+    private static final WatsonxChatRequestParameters NATIVE_PARAMETERS = WatsonxChatRequestParameters.builder()
+            .temperature(0.7)
+            .seed(42)
+            .projectId("project-id")
+            .build();
+
+    private static final WatsonxGatewayChatRequestParameters GATEWAY_PARAMETERS =
+            WatsonxGatewayChatRequestParameters.builder()
+                    .temperature(0.3)
+                    .seed(7)
+                    .user("user")
+                    .build();
+
+    @Test
+    void overrideWith_should_ignore_the_parameters_of_the_other_service() {
+
+        var merged = (WatsonxChatRequestParameters) NATIVE_PARAMETERS.overrideWith(GATEWAY_PARAMETERS);
+
+        assertThat(merged.temperature()).isEqualTo(0.3);
+        assertThat(merged.seed()).isEqualTo(42);
+        assertThat(merged.projectId()).isEqualTo("project-id");
+    }
+
+    @Test
+    void overrideWith_should_ignore_the_parameters_of_the_other_service_in_both_directions() {
+
+        var merged = (WatsonxGatewayChatRequestParameters) GATEWAY_PARAMETERS.overrideWith(NATIVE_PARAMETERS);
+
+        assertThat(merged.temperature()).isEqualTo(0.7);
+        assertThat(merged.seed()).isEqualTo(7);
+        assertThat(merged.user()).isEqualTo("user");
+    }
+
+    @Test
+    void defaultedBy_should_ignore_the_parameters_of_the_other_service() {
+
+        var merged = NATIVE_PARAMETERS.defaultedBy(GATEWAY_PARAMETERS);
+        assertThat(merged.temperature()).isEqualTo(0.7);
+        assertThat(merged.seed()).isEqualTo(42);
+        assertThat(merged.projectId()).isEqualTo("project-id");
+    }
+
+    @Test
+    void overrideWith_should_accept_plain_parameters() {
+
+        var plain = DefaultChatRequestParameters.builder().temperature(0.5).build();
+        assertThat(NATIVE_PARAMETERS.overrideWith(plain).temperature()).isEqualTo(0.5);
+        assertThat(GATEWAY_PARAMETERS.overrideWith(plain).temperature()).isEqualTo(0.5);
+    }
+
+    @Test
+    void builder_should_ignore_the_default_parameters_of_the_other_service() {
+
+        var defaults = (WatsonxChatRequestParameters)
+                nativeChatModel(GATEWAY_PARAMETERS).defaultRequestParameters();
+
+        assertThat(defaults.temperature()).isEqualTo(0.3);
+        assertThat(defaults.seed()).isNull();
+
+        var gatewayDefaults = (WatsonxGatewayChatRequestParameters)
+                gatewayChatModel(NATIVE_PARAMETERS).defaultRequestParameters();
+
+        assertThat(gatewayDefaults.temperature()).isEqualTo(0.7);
+        assertThat(gatewayDefaults.seed()).isNull();
+    }
+
+    @Test
+    void builder_should_accept_the_default_parameters_of_the_other_service() {
+
+        assertThatCode(() -> Stream.<Runnable>of(
+                                () -> nativeChatModel(GATEWAY_PARAMETERS),
+                                () -> nativeStreamingChatModel(GATEWAY_PARAMETERS),
+                                () -> deploymentChatModel(GATEWAY_PARAMETERS),
+                                () -> deploymentStreamingChatModel(GATEWAY_PARAMETERS),
+                                () -> gatewayChatModel(NATIVE_PARAMETERS),
+                                () -> gatewayStreamingChatModel(NATIVE_PARAMETERS))
+                        .forEach(Runnable::run))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void builder_should_accept_plain_default_parameters() {
+
+        var plain = DefaultChatRequestParameters.builder().temperature(0.5).build();
+
+        assertThatCode(() -> {
+                    nativeChatModel(plain);
+                    nativeStreamingChatModel(plain);
+                    deploymentChatModel(plain);
+                    deploymentStreamingChatModel(plain);
+                    gatewayChatModel(plain);
+                    gatewayStreamingChatModel(plain);
+                })
+                .doesNotThrowAnyException();
+    }
+
+    private static WatsonxChatModel nativeChatModel(ChatRequestParameters defaults) {
+        return WatsonxChatModel.builder()
+                .baseUrl("https://test.com")
+                .apiKey("api-key")
+                .modelName("modelId")
+                .projectId("project-id")
+                .defaultRequestParameters(defaults)
+                .build();
+    }
+
+    private static WatsonxStreamingChatModel nativeStreamingChatModel(ChatRequestParameters defaults) {
+        return WatsonxStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .apiKey("api-key")
+                .modelName("modelId")
+                .projectId("project-id")
+                .defaultRequestParameters(defaults)
+                .build();
+    }
+
+    private static WatsonxDeploymentChatModel deploymentChatModel(ChatRequestParameters defaults) {
+        return WatsonxDeploymentChatModel.builder()
+                .baseUrl("https://test.com")
+                .apiKey("api-key")
+                .deploymentId("deployment-id")
+                .defaultRequestParameters(defaults)
+                .build();
+    }
+
+    private static WatsonxDeploymentStreamingChatModel deploymentStreamingChatModel(ChatRequestParameters defaults) {
+        return WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .apiKey("api-key")
+                .deploymentId("deployment-id")
+                .defaultRequestParameters(defaults)
+                .build();
+    }
+
+    private static WatsonxGatewayChatModel gatewayChatModel(ChatRequestParameters defaults) {
+        return WatsonxGatewayChatModel.builder()
+                .baseUrl("https://test.com")
+                .apiKey("api-key")
+                .modelName("gpt-4o")
+                .defaultRequestParameters(defaults)
+                .build();
+    }
+
+    private static WatsonxGatewayStreamingChatModel gatewayStreamingChatModel(ChatRequestParameters defaults) {
+        return WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .apiKey("api-key")
+                .modelName("gpt-4o")
+                .defaultRequestParameters(defaults)
+                .build();
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -31,8 +31,8 @@ public class WatsonxCustomHttpClientTest {
                 .httpClient(customClient)
                 .build();
 
-        Object chatProvider = getFieldValue(chatModel, "chatProvider");
-        Object restclient = getFieldValue(chatProvider, "client");
+        Object chatService = getFieldValue(chatModel, "chatService");
+        Object restclient = getFieldValue(chatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
@@ -63,8 +63,8 @@ public class WatsonxCustomHttpClientTest {
                         .verifySsl(verifySsl)
                         .build();
 
-                Object chatProvider = getFieldValue(chatModel, "chatProvider");
-                Object restclient = getFieldValue(chatProvider, "client");
+                Object chatService = getFieldValue(chatModel, "chatService");
+                Object restclient = getFieldValue(chatService, "client");
                 assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
                 assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 
@@ -94,8 +94,8 @@ public class WatsonxCustomHttpClientTest {
                 .httpClient(customClient)
                 .build();
 
-        Object chatProvider = getFieldValue(streamingChatModel, "chatProvider");
-        Object restclient = getFieldValue(chatProvider, "client");
+        Object chatService = getFieldValue(streamingChatModel, "chatService");
+        Object restclient = getFieldValue(chatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
@@ -126,8 +126,8 @@ public class WatsonxCustomHttpClientTest {
                         .verifySsl(verifySsl)
                         .build();
 
-                Object chatProvider = getFieldValue(streamingChatModel, "chatProvider");
-                Object restclient = getFieldValue(chatProvider, "client");
+                Object chatService = getFieldValue(streamingChatModel, "chatService");
+                Object restclient = getFieldValue(chatService, "client");
                 assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
                 assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 
@@ -143,6 +143,266 @@ public class WatsonxCustomHttpClientTest {
                 fail(e);
             }
         });
+    }
+
+    @Test
+    void should_use_custom_http_client_for_gateway_chat_model() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        ChatModel chatModel = WatsonxGatewayChatModel.builder()
+                .baseUrl("https://localhost")
+                .modelName("gpt-4o")
+                .apiKey("apiKey")
+                .httpClient(customClient)
+                .build();
+
+        Object modelGatewayService = getFieldValue(chatModel, "modelGatewayService");
+        Object restclient = getFieldValue(modelGatewayService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
+
+        Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+        assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(asyncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_gateway_chat_model() {
+
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
+
+                HttpClient customClient = HttpClient.newHttpClient();
+                ChatModel chatModel = WatsonxGatewayChatModel.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("gpt-4o")
+                        .apiKey("apiKey")
+                        .verifySsl(verifySsl)
+                        .build();
+
+                Object modelGatewayService = getFieldValue(chatModel, "modelGatewayService");
+                Object restclient = getFieldValue(modelGatewayService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+                Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+                assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(asyncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_use_custom_http_client_for_gateway_streaming_chat_model() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        StreamingChatModel streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl("https://localhost")
+                .modelName("gpt-4o")
+                .apiKey("apiKey")
+                .httpClient(customClient)
+                .build();
+
+        Object modelGatewayService = getFieldValue(streamingChatModel, "modelGatewayService");
+        Object restclient = getFieldValue(modelGatewayService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
+
+        Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+        assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(asyncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_gateway_streaming_chat_model() {
+
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
+
+                HttpClient customClient = HttpClient.newHttpClient();
+                StreamingChatModel streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("gpt-4o")
+                        .apiKey("apiKey")
+                        .verifySsl(verifySsl)
+                        .build();
+
+                Object modelGatewayService = getFieldValue(streamingChatModel, "modelGatewayService");
+                Object restclient = getFieldValue(modelGatewayService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+                Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+                assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(asyncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_use_custom_http_client_for_deployment_chat_model() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        ChatModel chatModel = WatsonxDeploymentChatModel.builder()
+                .baseUrl("https://localhost")
+                .deploymentId("deploymentId")
+                .apiKey("apiKey")
+                .httpClient(customClient)
+                .build();
+
+        Object deploymentService = getFieldValue(chatModel, "deploymentService");
+        Object restclient = getFieldValue(deploymentService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
+
+        Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+        assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(asyncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_deployment_chat_model() {
+
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
+
+                HttpClient customClient = HttpClient.newHttpClient();
+                ChatModel chatModel = WatsonxDeploymentChatModel.builder()
+                        .baseUrl("https://localhost")
+                        .deploymentId("deploymentId")
+                        .apiKey("apiKey")
+                        .verifySsl(verifySsl)
+                        .build();
+
+                Object deploymentService = getFieldValue(chatModel, "deploymentService");
+                Object restclient = getFieldValue(deploymentService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+                Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+                assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(asyncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_use_custom_http_client_for_deployment_streaming_chat_model() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        StreamingChatModel streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl("https://localhost")
+                .deploymentId("deploymentId")
+                .apiKey("apiKey")
+                .httpClient(customClient)
+                .build();
+
+        Object deploymentService = getFieldValue(streamingChatModel, "deploymentService");
+        Object restclient = getFieldValue(deploymentService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
+
+        Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+        assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(asyncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_deployment_streaming_chat_model() {
+
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
+
+                HttpClient customClient = HttpClient.newHttpClient();
+                StreamingChatModel streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
+                        .baseUrl("https://localhost")
+                        .deploymentId("deploymentId")
+                        .apiKey("apiKey")
+                        .verifySsl(verifySsl)
+                        .build();
+
+                Object deploymentService = getFieldValue(streamingChatModel, "deploymentService");
+                Object restclient = getFieldValue(deploymentService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+                Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+                assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(asyncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_use_default_http_client_when_verify_ssl_is_not_set() throws Exception {
+
+        ChatModel chatModel = WatsonxChatModel.builder()
+                .baseUrl("https://localhost")
+                .modelName("modelName")
+                .apiKey("apiKey")
+                .projectId("projectId")
+                .build();
+
+        Object chatService = getFieldValue(chatModel, "chatService");
+        Object restclient = getFieldValue(chatService, "client");
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
     }
 
     @Test

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -678,6 +678,56 @@ public class WatsonxCustomHttpClientTest {
         });
     }
 
+    @Test
+    void should_use_custom_http_client_for_gateway_model_catalog() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        ModelCatalog modelCatalog = WatsonxGatewayModelCatalog.builder()
+                .baseUrl("https://localhost")
+                .apiKey("apiKey")
+                .httpClient(customClient)
+                .build();
+
+        Object modelGatewayCatalogService = getFieldValue(modelCatalog, "modelGatewayCatalogService");
+        Object restclient = getFieldValue(modelGatewayCatalogService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_gateway_model_catalog() throws Exception {
+
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
+
+                HttpClient customClient = HttpClient.newHttpClient();
+                ModelCatalog modelCatalog = WatsonxGatewayModelCatalog.builder()
+                        .baseUrl("https://localhost")
+                        .apiKey("apiKey")
+                        .verifySsl(verifySsl)
+                        .build();
+
+                Object modelGatewayCatalogService = getFieldValue(modelCatalog, "modelGatewayCatalogService");
+                Object restclient = getFieldValue(modelGatewayCatalogService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
     @SuppressWarnings("null")
     public static Object getFieldValue(Object obj, String fieldName) throws Exception {
         Class<?> clazz = obj.getClass();

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModelTest.java
@@ -216,6 +216,34 @@ public class WatsonxDeploymentChatModelTest {
     }
 
     @Test
+    void should_throw_exception_for_chat_request_with_model_name() {
+
+        var chatModel = WatsonxDeploymentChatModel.builder()
+                .baseUrl("https://test.com")
+                .deploymentId("deployment-id")
+                .apiKey("api-key")
+                .build();
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> chatModel.chat(ChatRequest.builder()
+                        .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                        .modelName("my-model")
+                        .build()));
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxDeploymentChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .deploymentId("deployment-id")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(ChatRequestParameters.builder()
+                                .modelName("my-model")
+                                .build())
+                        .build());
+    }
+
+    @Test
     void should_support_capabilities() {
 
         var chatModel = WatsonxDeploymentChatModel.builder()

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModelTest.java
@@ -1,0 +1,289 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
+import com.ibm.watsonx.ai.chat.TextChatResponse;
+import com.ibm.watsonx.ai.chat.model.AssistantMessage;
+import com.ibm.watsonx.ai.chat.model.ChatUsage;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
+import com.ibm.watsonx.ai.chat.model.ResultMessage;
+import com.ibm.watsonx.ai.chat.model.UserMessage;
+import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
+import com.ibm.watsonx.ai.deployment.DeploymentChatRequest;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WatsonxDeploymentChatModelTest {
+
+    @Mock
+    DeploymentService mockDeploymentService;
+
+    @Mock
+    DeploymentService.Builder mockDeploymentServiceBuilder;
+
+    @Captor
+    ArgumentCaptor<DeploymentChatRequest> chatRequestCaptor;
+
+    static TextChatResponse.Builder<?> chatResponse;
+
+    @BeforeEach
+    void setUp() {
+
+        when(mockDeploymentServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.timeout(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.version(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logRequests(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logResponses(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.authenticator(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.apiKey(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.httpClient(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.build()).thenReturn(mockDeploymentService);
+
+        var chatUsage = new ChatUsage(10, 10, 20);
+        chatResponse = TextChatResponse.builder()
+                .id("id")
+                .modelId("modelId")
+                .model("model")
+                .modelVersion("modelVersion")
+                .object("object")
+                .usage(chatUsage)
+                .createdAt("createdAt")
+                .created(1L);
+    }
+
+    @Test
+    void should_create_a_watsonx_chat_model_from_a_deployment_service() {
+
+        var chatModel = assertDoesNotThrow(() -> WatsonxDeploymentChatModel.builder()
+                .baseUrl(CloudRegion.FRANKFURT)
+                .apiKey("api-key-test")
+                .version("my-version")
+                .logRequests(true)
+                .logResponses(true)
+                .deploymentId("deployment-id")
+                .build());
+
+        var defaultRequestParameters =
+                assertInstanceOf(WatsonxChatRequestParameters.class, chatModel.defaultRequestParameters());
+
+        var deploymentServiceField =
+                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("deploymentService"));
+        var deploymentService = assertDoesNotThrow(() -> deploymentServiceField.get(chatModel));
+
+        assertInstanceOf(DeploymentService.class, deploymentService);
+        assertNull(defaultRequestParameters.frequencyPenalty());
+        assertNull(defaultRequestParameters.logitBias());
+        assertNull(defaultRequestParameters.logprobs());
+        assertNull(defaultRequestParameters.maxOutputTokens());
+        assertNull(defaultRequestParameters.modelName());
+        assertNull(defaultRequestParameters.presencePenalty());
+        assertNull(defaultRequestParameters.projectId());
+        assertNull(defaultRequestParameters.responseFormat());
+        assertNull(defaultRequestParameters.seed());
+        assertNull(defaultRequestParameters.spaceId());
+        assertEquals(List.of(), defaultRequestParameters.stopSequences());
+        assertNull(defaultRequestParameters.temperature());
+        assertNull(defaultRequestParameters.timeout());
+        assertNull(defaultRequestParameters.toolChoice());
+        assertNull(defaultRequestParameters.toolChoiceName());
+        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
+        assertNull(defaultRequestParameters.topK());
+        assertNull(defaultRequestParameters.topLogprobs());
+        assertNull(defaultRequestParameters.topP());
+        assertNull(defaultRequestParameters.guidedChoice());
+        assertNull(defaultRequestParameters.guidedGrammar());
+        assertNull(defaultRequestParameters.guidedRegex());
+        assertNull(defaultRequestParameters.repetitionPenalty());
+        assertNull(defaultRequestParameters.lengthPenalty());
+    }
+
+    @Test
+    void should_do_chat() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockDeploymentService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withDeploymentServiceMock(() -> {
+            var chatModel = WatsonxDeploymentChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .build();
+
+            assertEquals("Hello", chatModel.chat("hello"));
+            assertEquals(
+                    List.of(UserMessage.text("hello")),
+                    chatRequestCaptor.getValue().messages());
+            // deploymentId is a connection-level selector fixed at build time, carried on every request
+            assertEquals("deployment-id", chatRequestCaptor.getValue().deploymentId());
+        });
+    }
+
+    @Test
+    void should_do_chat_with_refusal() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, "refusal", null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockDeploymentService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withDeploymentServiceMock(() -> {
+            var chatModel = WatsonxDeploymentChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .build();
+
+            assertThrows(ContentFilteredException.class, () -> chatModel.chat("hello"), "refusal");
+        });
+    }
+
+    @Test
+    void should_not_expose_foundation_model_selectors() throws Exception {
+
+        // deploymentId already identifies both the model and its project or space
+        var builderClass = WatsonxDeploymentChatModel.Builder.class;
+        assertThrows(NoSuchMethodException.class, () -> builderClass.getMethod("modelName", String.class));
+        assertThrows(NoSuchMethodException.class, () -> builderClass.getMethod("projectId", String.class));
+        assertThrows(NoSuchMethodException.class, () -> builderClass.getMethod("spaceId", String.class));
+        assertNotNull(builderClass.getMethod("deploymentId", String.class));
+    }
+
+    @Test
+    void should_throw_exception_for_chat_request_with_top_k() {
+
+        var chatModel = WatsonxDeploymentChatModel.builder()
+                .baseUrl("https://test.com")
+                .deploymentId("deployment-id")
+                .apiKey("api-key")
+                .build();
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> chatModel.chat(ChatRequest.builder()
+                        .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                        .topK(10)
+                        .build()));
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxDeploymentChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .deploymentId("deployment-id")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(
+                                ChatRequestParameters.builder().topK(10).build())
+                        .build());
+    }
+
+    @Test
+    void should_support_capabilities() {
+
+        var chatModel = WatsonxDeploymentChatModel.builder()
+                .baseUrl("https://test.com")
+                .deploymentId("deployment-id")
+                .apiKey("api-key")
+                .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                .build();
+
+        assertEquals(1, chatModel.supportedCapabilities().size());
+        assertTrue(chatModel.supportedCapabilities().contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
+    }
+
+    @Test
+    void should_authenticate_with_an_authenticator_instead_of_an_api_key() {
+
+        var authenticator = mock(IBMCloudAuthenticator.class);
+
+        withDeploymentServiceMock(() -> {
+            assertDoesNotThrow(() -> WatsonxDeploymentChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .authenticator(authenticator)
+                    .build());
+
+            verify(mockDeploymentServiceBuilder).authenticator(authenticator);
+            verify(mockDeploymentServiceBuilder, never()).apiKey(any());
+        });
+    }
+
+    @Test
+    void should_send_thinking_on_the_deployment_request() {
+
+        var resultMessage = new ResultMessage(
+                AssistantMessage.ROLE, "<think>I'm thinking</think><response>Hello</response>", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockDeploymentService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withDeploymentServiceMock(() -> {
+            var chatModel = WatsonxDeploymentChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .thinking(ExtractionTags.of(new Think("<think>", "</think>")))
+                    .build();
+
+            chatModel.chat("hello");
+            assertNotNull(chatRequestCaptor.getValue().thinking());
+        });
+
+        withDeploymentServiceMock(() -> {
+            var chatModel = WatsonxDeploymentChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .build();
+
+            chatModel.chat("hello");
+            assertNull(chatRequestCaptor.getValue().thinking());
+        });
+    }
+
+    private void withDeploymentServiceMock(Runnable action) {
+        try (MockedStatic<DeploymentService> mockedStatic = mockStatic(DeploymentService.class)) {
+            mockedStatic.when(DeploymentService::builder).thenReturn(mockDeploymentServiceBuilder);
+            action.run();
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentStreamingChatModelTest.java
@@ -315,6 +315,53 @@ public class WatsonxDeploymentStreamingChatModelTest {
     }
 
     @Test
+    void should_throw_exception_for_chat_request_with_model_name() {
+
+        var streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .deploymentId("deployment-id")
+                .apiKey("api-key")
+                .build();
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> streamingChatModel.chat(
+                        ChatRequest.builder()
+                                .messages(UserMessage.from("Hello"))
+                                .modelName("my-model")
+                                .build(),
+                        new StreamingChatResponseHandler() {
+
+                            @Override
+                            public void onPartialResponse(String partialResponse) {
+                                throw new UnsupportedOperationException("Unimplemented method 'onPartialResponse'");
+                            }
+
+                            @Override
+                            public void onCompleteResponse(
+                                    dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                                throw new UnsupportedOperationException("Unimplemented method 'onCompleteResponse'");
+                            }
+
+                            @Override
+                            public void onError(Throwable error) {
+                                throw new UnsupportedOperationException("Unimplemented method 'onError'");
+                            }
+                        }));
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxDeploymentStreamingChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .deploymentId("deployment-id")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(ChatRequestParameters.builder()
+                                .modelName("my-model")
+                                .build())
+                        .build());
+    }
+
+    @Test
     void should_support_capabilities() {
 
         var streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentStreamingChatModelTest.java
@@ -1,0 +1,337 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.chat.ChatHandler;
+import com.ibm.watsonx.ai.chat.ChatResponse;
+import com.ibm.watsonx.ai.chat.TextChatResponse;
+import com.ibm.watsonx.ai.chat.model.AssistantMessage;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.ChatUsage;
+import com.ibm.watsonx.ai.chat.model.ResultMessage;
+import com.ibm.watsonx.ai.deployment.DeploymentChatRequest;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WatsonxDeploymentStreamingChatModelTest {
+
+    @Mock
+    DeploymentService mockDeploymentService;
+
+    @Mock
+    DeploymentService.Builder mockDeploymentServiceBuilder;
+
+    @Captor
+    ArgumentCaptor<DeploymentChatRequest> chatRequestCaptor;
+
+    static TextChatResponse.Builder<?> chatResponse;
+
+    @BeforeEach
+    void setUp() {
+
+        when(mockDeploymentServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.timeout(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.version(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logRequests(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logResponses(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.authenticator(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.apiKey(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.httpClient(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.build()).thenReturn(mockDeploymentService);
+
+        var chatUsage = new ChatUsage(10, 10, 20);
+        chatResponse = TextChatResponse.builder()
+                .id("id")
+                .modelId("modelId")
+                .model("model")
+                .modelVersion("modelVersion")
+                .object("object")
+                .usage(chatUsage)
+                .createdAt("createdAt")
+                .created(1L);
+    }
+
+    @Test
+    void should_create_a_watsonx_chat_model_from_a_deployment_service() {
+
+        var streamingChatModel = assertDoesNotThrow(() -> WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl(CloudRegion.FRANKFURT)
+                .apiKey("api-key-test")
+                .version("my-version")
+                .logRequests(true)
+                .logResponses(true)
+                .deploymentId("deployment-id")
+                .build());
+
+        var defaultRequestParameters =
+                assertInstanceOf(WatsonxChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
+
+        var deploymentServiceField = assertDoesNotThrow(
+                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("deploymentService"));
+        var deploymentService = assertDoesNotThrow(() -> deploymentServiceField.get(streamingChatModel));
+
+        assertInstanceOf(DeploymentService.class, deploymentService);
+        assertNull(defaultRequestParameters.frequencyPenalty());
+        assertNull(defaultRequestParameters.logitBias());
+        assertNull(defaultRequestParameters.logprobs());
+        assertNull(defaultRequestParameters.maxOutputTokens());
+        assertNull(defaultRequestParameters.modelName());
+        assertNull(defaultRequestParameters.presencePenalty());
+        assertNull(defaultRequestParameters.projectId());
+        assertNull(defaultRequestParameters.responseFormat());
+        assertNull(defaultRequestParameters.seed());
+        assertNull(defaultRequestParameters.spaceId());
+        assertEquals(List.of(), defaultRequestParameters.stopSequences());
+        assertNull(defaultRequestParameters.temperature());
+        assertNull(defaultRequestParameters.timeout());
+        assertNull(defaultRequestParameters.toolChoice());
+        assertNull(defaultRequestParameters.toolChoiceName());
+        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
+        assertNull(defaultRequestParameters.topK());
+        assertNull(defaultRequestParameters.topLogprobs());
+        assertNull(defaultRequestParameters.topP());
+        assertNull(defaultRequestParameters.guidedChoice());
+        assertNull(defaultRequestParameters.guidedGrammar());
+        assertNull(defaultRequestParameters.guidedRegex());
+        assertNull(defaultRequestParameters.repetitionPenalty());
+        assertNull(defaultRequestParameters.lengthPenalty());
+    }
+
+    @Test
+    void should_do_chat() {
+
+        var messages = List.<ChatMessage>of(com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"));
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+
+                    for (String response : List.of("Hello", "World")) handler.onPartialResponse(response, null);
+
+                    var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello World", null, null, null);
+                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+                    chatResponse.choices(List.of(resultChoice));
+                    handler.onCompleteResponse(chatResponse.build());
+
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockDeploymentService)
+                .chatStreaming(chatRequestCaptor.capture(), any(ChatHandler.class));
+
+        withDeploymentServiceMock(() -> {
+            var streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .build();
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            var receivedResponses = new ArrayList<>();
+            var latch = new CountDownLatch(1);
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {
+                    receivedResponses.add(partialResponse);
+                }
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    assertEquals("Hello World", completeResponse.aiMessage().text());
+                    latch.countDown();
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+            assertEquals(messages, chatRequestCaptor.getValue().messages());
+            // deploymentId is a connection-level selector fixed at build time, carried on every request
+            assertEquals("deployment-id", chatRequestCaptor.getValue().deploymentId());
+
+            try {
+                boolean completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+                assertEquals(List.of("Hello", "World"), receivedResponses);
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_do_chat_with_refusal() {
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+
+                    for (String response : List.of("Hello", "World")) handler.onPartialResponse(response, null);
+
+                    var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello World", null, "refusal", null);
+                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+                    chatResponse.choices(List.of(resultChoice));
+                    handler.onCompleteResponse(chatResponse.build());
+
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockDeploymentService)
+                .chatStreaming(chatRequestCaptor.capture(), any(ChatHandler.class));
+
+        withDeploymentServiceMock(() -> {
+            var streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .build();
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            var latch = new CountDownLatch(1);
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    fail("onCompleteResponse must not be called after a refusal");
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    assertInstanceOf(ContentFilteredException.class, error);
+                    assertEquals("refusal", error.getMessage());
+                    latch.countDown();
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+
+            try {
+                assertTrue(latch.await(2, TimeUnit.SECONDS), "Handler did not complete in time");
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_not_expose_foundation_model_selectors() throws Exception {
+
+        // deploymentId already identifies both the model and its project or space
+        var builderClass = WatsonxDeploymentStreamingChatModel.Builder.class;
+        assertThrows(NoSuchMethodException.class, () -> builderClass.getMethod("modelName", String.class));
+        assertThrows(NoSuchMethodException.class, () -> builderClass.getMethod("projectId", String.class));
+        assertThrows(NoSuchMethodException.class, () -> builderClass.getMethod("spaceId", String.class));
+        assertNotNull(builderClass.getMethod("deploymentId", String.class));
+    }
+
+    @Test
+    void should_throw_exception_for_chat_request_with_top_k() {
+
+        var streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .deploymentId("deployment-id")
+                .apiKey("api-key")
+                .build();
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> streamingChatModel.chat(
+                        ChatRequest.builder()
+                                .messages(UserMessage.from("Hello"))
+                                .topK(10)
+                                .build(),
+                        new StreamingChatResponseHandler() {
+
+                            @Override
+                            public void onPartialResponse(String partialResponse) {
+                                throw new UnsupportedOperationException("Unimplemented method 'onPartialResponse'");
+                            }
+
+                            @Override
+                            public void onCompleteResponse(
+                                    dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                                throw new UnsupportedOperationException("Unimplemented method 'onCompleteResponse'");
+                            }
+
+                            @Override
+                            public void onError(Throwable error) {
+                                throw new UnsupportedOperationException("Unimplemented method 'onError'");
+                            }
+                        }));
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxDeploymentStreamingChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .deploymentId("deployment-id")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(
+                                ChatRequestParameters.builder().topK(10).build())
+                        .build());
+    }
+
+    @Test
+    void should_support_capabilities() {
+
+        var streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .deploymentId("deployment-id")
+                .apiKey("api-key")
+                .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                .build();
+
+        assertEquals(1, streamingChatModel.supportedCapabilities().size());
+        assertTrue(streamingChatModel.supportedCapabilities().contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
+    }
+
+    private void withDeploymentServiceMock(Runnable action) {
+        try (MockedStatic<DeploymentService> mockedStatic = mockStatic(DeploymentService.class)) {
+            mockedStatic.when(DeploymentService::builder).thenReturn(mockDeploymentServiceBuilder);
+            action.run();
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapperTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapperTest.java
@@ -80,6 +80,28 @@ public class WatsonxExceptionMapperTest {
         assertInstanceOf(InternalServerException.class, ex);
     }
 
+    @Test
+    void testUnknownErrorCode() {
+        assertUnknownErrorCode(400, InvalidRequestException.class, "model invalid-model not found");
+        assertUnknownErrorCode(401, AuthenticationException.class, "unauthorized");
+        assertUnknownErrorCode(403, AuthenticationException.class, "forbidden");
+        assertUnknownErrorCode(408, TimeoutException.class, "request timeout");
+        assertUnknownErrorCode(429, RateLimitException.class, "too many requests");
+        assertUnknownErrorCode(503, InternalServerException.class, "service unavailable");
+        assertUnknownErrorCode(404, LangChain4jException.class, "not found");
+    }
+
+    private void assertUnknownErrorCode(int statusCode, Class<? extends Exception> expectedClass, String message) {
+        var details = new WatsonxError(
+                statusCode,
+                "301a82ca2fdf101f930be912ebcad3c5",
+                List.of(new WatsonxError.Error("Bad Request", message, null)));
+        var ex = mapper.mapException(new WatsonxException("Bad Request", statusCode, details));
+        assertEquals(expectedClass, ex.getClass());
+        assertEquals(message, ex.getMessage());
+        assertInstanceOf(WatsonxException.class, ex.getCause());
+    }
+
     private WatsonxError createWatsonxError(WatsonxError.Code code, int statusCode, String message) {
         return new WatsonxError(
                 statusCode,

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapperTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapperTest.java
@@ -82,13 +82,14 @@ public class WatsonxExceptionMapperTest {
 
     @Test
     void testUnknownErrorCode() {
+        assertUnknownErrorCode(302, LangChain4jException.class, "found");
         assertUnknownErrorCode(400, InvalidRequestException.class, "model invalid-model not found");
         assertUnknownErrorCode(401, AuthenticationException.class, "unauthorized");
         assertUnknownErrorCode(403, AuthenticationException.class, "forbidden");
+        assertUnknownErrorCode(404, ModelNotFoundException.class, "deployment not found");
         assertUnknownErrorCode(408, TimeoutException.class, "request timeout");
         assertUnknownErrorCode(429, RateLimitException.class, "too many requests");
         assertUnknownErrorCode(503, InternalServerException.class, "service unavailable");
-        assertUnknownErrorCode(404, LangChain4jException.class, "not found");
     }
 
     private void assertUnknownErrorCode(int statusCode, Class<? extends Exception> expectedClass, String message) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.watsonx;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -40,6 +41,7 @@ import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
@@ -588,6 +590,63 @@ public class WatsonxGatewayChatModelTest {
 
             verify(mockModelGatewayServiceBuilder).authenticator(authenticator);
             verify(mockModelGatewayServiceBuilder, never()).apiKey(any());
+        });
+    }
+
+    @Test
+    void should_do_chat_with_strict_json_schema() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        var responseFormat = ResponseFormat.builder()
+                .type(ResponseFormatType.JSON)
+                .jsonSchema(JsonSchema.builder()
+                        .name("test")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addStringProperty("content")
+                                .addBooleanProperty("flag")
+                                .required("content")
+                                .build())
+                        .build())
+                .build();
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .responseFormat(responseFormat)
+                    .build();
+
+            chatModel.chat("hello");
+            var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
+            var schema = assertInstanceOf(Map.class, jsonSchema.schema());
+
+            assertFalse(jsonSchema.strict());
+            assertEquals(List.of("content"), schema.get("required"));
+            assertFalse(schema.containsKey("additionalProperties"));
+        });
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .responseFormat(responseFormat)
+                    .strictJsonSchema(true)
+                    .build();
+
+            chatModel.chat("hello");
+            var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
+            var schema = assertInstanceOf(Map.class, jsonSchema.schema());
+
+            assertTrue(jsonSchema.strict());
+            assertEquals(List.of("content", "flag"), schema.get("required"));
+            assertEquals(false, schema.get("additionalProperties"));
         });
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
@@ -626,9 +626,9 @@ public class WatsonxGatewayChatModelTest {
             var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
             var schema = assertInstanceOf(Map.class, jsonSchema.schema());
 
-            assertFalse(jsonSchema.strict());
-            assertEquals(List.of("content"), schema.get("required"));
-            assertFalse(schema.containsKey("additionalProperties"));
+            assertTrue(jsonSchema.strict());
+            assertEquals(List.of("content", "flag"), schema.get("required"));
+            assertEquals(false, schema.get("additionalProperties"));
         });
 
         withModelGatewayServiceMock(() -> {
@@ -637,16 +637,16 @@ public class WatsonxGatewayChatModelTest {
                     .modelName("gpt-4o")
                     .apiKey("api-key")
                     .responseFormat(responseFormat)
-                    .strictJsonSchema(true)
+                    .strictJsonSchema(false)
                     .build();
 
             chatModel.chat("hello");
             var jsonSchema = chatRequestCaptor.getValue().parameters().jsonSchema();
             var schema = assertInstanceOf(Map.class, jsonSchema.schema());
 
-            assertTrue(jsonSchema.strict());
-            assertEquals(List.of("content", "flag"), schema.get("required"));
-            assertEquals(false, schema.get("additionalProperties"));
+            assertFalse(jsonSchema.strict());
+            assertEquals(List.of("content"), schema.get("required"));
+            assertFalse(schema.containsKey("additionalProperties"));
         });
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
@@ -1,0 +1,599 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
+import com.ibm.watsonx.ai.chat.model.AssistantMessage;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.ChatUsage;
+import com.ibm.watsonx.ai.chat.model.FunctionCall;
+import com.ibm.watsonx.ai.chat.model.ResultMessage;
+import com.ibm.watsonx.ai.chat.model.ToolCall;
+import com.ibm.watsonx.ai.chat.model.UserMessage;
+import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.output.FinishReason;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WatsonxGatewayChatModelTest {
+
+    @Mock
+    ModelGatewayService mockModelGatewayService;
+
+    @Mock
+    ModelGatewayService.Builder mockModelGatewayServiceBuilder;
+
+    @Captor
+    ArgumentCaptor<ModelGatewayChatRequest> chatRequestCaptor;
+
+    static ModelGatewayChatResponse.Builder<?> chatResponse;
+
+    @BeforeEach
+    void setUp() {
+
+        when(mockModelGatewayServiceBuilder.modelId(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.timeout(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.version(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.logRequests(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.logResponses(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.authenticator(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.httpClient(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.build()).thenReturn(mockModelGatewayService);
+
+        var chatUsage = new ChatUsage(10, 10, 20);
+        chatResponse = ModelGatewayChatResponse.builder()
+                .id("id")
+                .modelId("modelId")
+                .model("model")
+                .modelVersion("modelVersion")
+                .object("object")
+                .usage(chatUsage)
+                .createdAt("createdAt")
+                .created(1L)
+                .serviceTier("auto")
+                .systemFingerprint("fp")
+                .cached(true);
+    }
+
+    @Test
+    void should_create_a_watsonx_gateway_chat_model() {
+
+        var chatModel = assertDoesNotThrow(() -> WatsonxGatewayChatModel.builder()
+                .baseUrl(CloudRegion.FRANKFURT)
+                .modelName("gpt-4o")
+                .apiKey("api-key-test")
+                .version("my-version")
+                .logRequests(true)
+                .logResponses(true)
+                .build());
+
+        var defaultRequestParameters =
+                assertInstanceOf(WatsonxGatewayChatRequestParameters.class, chatModel.defaultRequestParameters());
+
+        var modelGatewayServiceField =
+                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("modelGatewayService"));
+        var modelGatewayService = assertDoesNotThrow(() -> modelGatewayServiceField.get(chatModel));
+
+        assertInstanceOf(ModelGatewayService.class, modelGatewayService);
+        assertEquals(ModelProvider.WATSONX, chatModel.provider());
+        assertNull(defaultRequestParameters.frequencyPenalty());
+        assertNull(defaultRequestParameters.logitBias());
+        assertNull(defaultRequestParameters.logprobs());
+        assertNull(defaultRequestParameters.maxOutputTokens());
+        assertEquals("gpt-4o", defaultRequestParameters.modelName());
+        assertNull(defaultRequestParameters.presencePenalty());
+        assertNull(defaultRequestParameters.responseFormat());
+        assertNull(defaultRequestParameters.seed());
+        assertEquals(List.of(), defaultRequestParameters.stopSequences());
+        assertNull(defaultRequestParameters.temperature());
+        assertNull(defaultRequestParameters.timeout());
+        assertNull(defaultRequestParameters.toolChoice());
+        assertNull(defaultRequestParameters.toolChoiceName());
+        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
+        assertNull(defaultRequestParameters.topK());
+        assertNull(defaultRequestParameters.topLogprobs());
+        assertNull(defaultRequestParameters.topP());
+        assertNull(defaultRequestParameters.serviceTier());
+        assertNull(defaultRequestParameters.reasoningEffort());
+        assertNull(defaultRequestParameters.router());
+        assertNull(defaultRequestParameters.modalities());
+        assertNull(defaultRequestParameters.store());
+        assertNull(defaultRequestParameters.parallelToolCalls());
+        assertNull(defaultRequestParameters.user());
+        assertNull(defaultRequestParameters.metadata());
+    }
+
+    @Test
+    void should_do_chat() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .build();
+
+            assertEquals("Hello", chatModel.chat("hello"));
+            assertEquals(
+                    List.of(UserMessage.text("hello")),
+                    chatRequestCaptor.getValue().messages());
+        });
+    }
+
+    @Test
+    void should_do_chat_with_refusal() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, "refusal", null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .build();
+
+            assertThrows(ContentFilteredException.class, () -> chatModel.chat("hello"), "refusal");
+        });
+    }
+
+    @Test
+    void should_do_chat_with_tool() {
+
+        var toolCall = new ToolCall(0, "id", "function", new FunctionCall("name", "{}"));
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, null, null, null, List.of(toolCall));
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .build();
+
+            var chatRequest = ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("hello"))
+                    .toolSpecifications(ToolSpecification.builder()
+                            .name("name")
+                            .description("description")
+                            .parameters(JsonObjectSchema.builder()
+                                    .addStringProperty("string")
+                                    .required("string")
+                                    .build())
+                            .build())
+                    .build();
+
+            var response = chatModel.chat(chatRequest);
+            var metadata = (WatsonxChatResponseMetadata) response.metadata();
+            assertEquals("id", response.id());
+            assertEquals("modelId", response.modelName());
+            assertEquals("modelVersion", metadata.getModelVersion());
+            assertEquals(1L, metadata.getCreated());
+            assertEquals("auto", metadata.getServiceTier());
+            assertEquals("fp", metadata.getSystemFingerprint());
+            assertEquals(true, metadata.getCached());
+            assertEquals(FinishReason.STOP, response.finishReason());
+            assertEquals(10, response.tokenUsage().inputTokenCount());
+            assertEquals(10, response.tokenUsage().outputTokenCount());
+            assertEquals(20, response.tokenUsage().totalTokenCount());
+            assertTrue(response.aiMessage().hasToolExecutionRequests());
+            assertEquals(1, response.aiMessage().toolExecutionRequests().size());
+            assertEquals(
+                    "name", response.aiMessage().toolExecutionRequests().get(0).name());
+            assertEquals(
+                    "id", response.aiMessage().toolExecutionRequests().get(0).id());
+            assertEquals(
+                    "{}", response.aiMessage().toolExecutionRequests().get(0).arguments());
+        });
+    }
+
+    @Test
+    void should_handle_chat_request() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .listeners(List.of(new ChatModelListener() {}))
+                    .build();
+
+            var chatRequest = ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                    .parameters(WatsonxGatewayChatRequestParameters.builder()
+                            .modelName("claude-3-5-sonnet")
+                            .frequencyPenalty(0.10)
+                            .maxOutputTokens(10)
+                            .presencePenalty(0.10)
+                            .responseFormat(ResponseFormat.JSON)
+                            .stopSequences(List.of("stop"))
+                            .temperature(0.10)
+                            .toolChoice(ToolChoice.REQUIRED)
+                            .toolSpecifications(
+                                    ToolSpecification.builder().name("name").build())
+                            .topP(0.10)
+                            .serviceTier(ServiceTier.FLEX)
+                            .reasoningEffort(ReasoningEffort.HIGH)
+                            .modalities(List.of("text"))
+                            .store(true)
+                            .parallelToolCalls(true)
+                            .user("user")
+                            .metadata(Map.of("k", "v"))
+                            .logitBias(Map.of("token", 1))
+                            .logprobs(true)
+                            .topLogprobs(5)
+                            .seed(42)
+                            .build())
+                    .build();
+
+            chatModel.chat(chatRequest);
+            assertEquals(
+                    List.<ChatMessage>of(UserMessage.text("Hello")),
+                    chatRequestCaptor.getValue().messages());
+
+            var parameters = chatRequestCaptor.getValue().parameters();
+            assertEquals(1, chatModel.listeners().size());
+            assertEquals("claude-3-5-sonnet", parameters.modelId());
+            assertEquals(0.10, parameters.frequencyPenalty());
+            assertEquals(10, parameters.maxCompletionTokens());
+            assertEquals(0.10, parameters.presencePenalty());
+            assertEquals("json_object", parameters.responseFormat());
+            assertEquals(List.of("stop"), parameters.stop());
+            assertEquals(0.10, parameters.temperature());
+            assertEquals("required", parameters.toolChoiceOption());
+            assertEquals(0.10, parameters.topP());
+            assertEquals("flex", parameters.serviceTier());
+            assertEquals("high", parameters.reasoningEffort());
+            assertEquals(List.of("text"), parameters.modalities());
+            assertEquals(true, parameters.store());
+            assertEquals(true, parameters.parallelToolCalls());
+            assertEquals("user", parameters.user());
+            assertEquals(Map.of("k", "v"), parameters.metadata());
+            assertEquals(Map.of("token", 1), parameters.logitBias());
+            assertTrue(parameters.logprobs());
+            assertEquals(5, parameters.topLogprobs());
+            assertEquals(42, parameters.seed());
+        });
+    }
+
+    @Test
+    void should_handle_chat_request_parameters_from_builder() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .frequencyPenalty(0.1)
+                    .maxOutputTokens(0)
+                    .presencePenalty(0.2)
+                    .stopSequences("[")
+                    .temperature(0.3)
+                    .toolChoice(ToolChoice.REQUIRED)
+                    .responseFormat(ResponseFormat.TEXT)
+                    .timeout(Duration.ofMillis(30))
+                    .topP(0.4)
+                    .serviceTier(ServiceTier.AUTO)
+                    .reasoningEffort(ReasoningEffort.LOW)
+                    .logitBias(Map.of("test", 10))
+                    .logprobs(true)
+                    .seed(5)
+                    .toolChoiceName("toolChoiceName")
+                    .topLogprobs(10)
+                    .toolSpecifications(
+                            ToolSpecification.builder().name("toolChoiceName").build())
+                    .build();
+
+            var chatRequest = ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                    .build();
+
+            chatModel.chat(chatRequest);
+            var parameters = chatRequestCaptor.getValue().parameters();
+
+            assertEquals(0.1, parameters.frequencyPenalty());
+            assertEquals(0, parameters.maxCompletionTokens());
+            assertEquals("gpt-4o", parameters.modelId());
+            assertEquals(0.2, parameters.presencePenalty());
+            assertEquals(List.of("["), parameters.stop());
+            assertEquals(0.3, parameters.temperature());
+            assertNull(parameters.toolChoiceOption());
+            assertNull(parameters.responseFormat());
+            assertEquals(30, parameters.timeLimit());
+            assertEquals(0.4, parameters.topP());
+            assertEquals("auto", parameters.serviceTier());
+            assertEquals("low", parameters.reasoningEffort());
+            assertEquals(Map.of("test", 10), parameters.logitBias());
+            assertTrue(parameters.logprobs());
+            assertEquals(5, parameters.seed());
+            assertEquals(
+                    Map.of("type", "function", "function", Map.of("name", "toolChoiceName")), parameters.toolChoice());
+            assertEquals(10, parameters.topLogprobs());
+        });
+    }
+
+    @Test
+    void should_override_default_parameters_with_request_parameters() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .apiKey("api-key")
+                    .defaultRequestParameters(WatsonxGatewayChatRequestParameters.builder()
+                            .modelName("default-model-name")
+                            .frequencyPenalty(0.1)
+                            .maxOutputTokens(0)
+                            .presencePenalty(0.2)
+                            .stopSequences("[")
+                            .temperature(0.3)
+                            .topP(0.4)
+                            .serviceTier(ServiceTier.AUTO)
+                            .build())
+                    .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                    .build();
+
+            var chatRequest = ChatRequest.builder()
+                    .modelName("customModelName")
+                    .frequencyPenalty(0.10)
+                    .maxOutputTokens(10)
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                    .presencePenalty(0.10)
+                    .responseFormat(ResponseFormat.JSON)
+                    .stopSequences(List.of("stop"))
+                    .temperature(0.10)
+                    .topP(0.10)
+                    .build();
+
+            chatModel.chat(chatRequest);
+            var parameters = chatRequestCaptor.getValue().parameters();
+
+            assertEquals("customModelName", parameters.modelId());
+            assertEquals(0.10, parameters.frequencyPenalty());
+            assertEquals(10, parameters.maxCompletionTokens());
+            assertEquals(0.10, parameters.presencePenalty());
+            assertEquals("json_object", parameters.responseFormat());
+            assertEquals(List.of("stop"), parameters.stop());
+            assertEquals(0.10, parameters.temperature());
+            assertEquals(0.10, parameters.topP());
+            // the default service tier survives because the request did not override it
+            assertEquals("auto", parameters.serviceTier());
+        });
+    }
+
+    @Test
+    void should_use_json_schema_response_format() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withModelGatewayServiceMock(() -> {
+            var chatModel = WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                    .build();
+
+            var chatRequest = ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                    .parameters(WatsonxGatewayChatRequestParameters.builder()
+                            .responseFormat(JsonSchema.builder()
+                                    .name("test")
+                                    .rootElement(JsonObjectSchema.builder()
+                                            .addStringProperty("city")
+                                            .build())
+                                    .build())
+                            .build())
+                    .build();
+
+            chatModel.chat(chatRequest);
+            var parameters = chatRequestCaptor.getValue().parameters();
+
+            assertEquals("json_schema", parameters.responseFormat());
+            assertEquals("test", parameters.jsonSchema().name());
+        });
+    }
+
+    @Test
+    void should_throw_exception_for_chat_request_with_top_k() {
+
+        var chatModel = WatsonxGatewayChatModel.builder()
+                .baseUrl("https://test.com")
+                .modelName("gpt-4o")
+                .apiKey("api-key")
+                .build();
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> chatModel.chat(ChatRequest.builder()
+                        .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                        .topK(10)
+                        .build()));
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxGatewayChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .modelName("gpt-4o")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(
+                                ChatRequestParameters.builder().topK(10).build())
+                        .build());
+    }
+
+    @Test
+    void should_support_capabilities() {
+
+        var chatModel = WatsonxGatewayChatModel.builder()
+                .baseUrl("https://test.com")
+                .modelName("gpt-4o")
+                .apiKey("api-key")
+                .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                .build();
+
+        assertEquals(1, chatModel.supportedCapabilities().size());
+        assertTrue(chatModel.supportedCapabilities().contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
+    }
+
+    @Test
+    void should_merge_every_gateway_builder_setter_into_the_default_parameters() {
+
+        var router = new Router(new Cache(true, null, null));
+
+        var chatModel = WatsonxGatewayChatModel.builder()
+                .baseUrl("https://test.com")
+                .modelName("gpt-4o")
+                .apiKey("api-key")
+                .serviceTier(ServiceTier.AUTO)
+                .reasoningEffort(ReasoningEffort.LOW)
+                .router(router)
+                .modalities(List.of("text"))
+                .store(true)
+                .parallelToolCalls(true)
+                .user("user")
+                .metadata(Map.of("key", "value"))
+                .build();
+
+        var parameters =
+                assertInstanceOf(WatsonxGatewayChatRequestParameters.class, chatModel.defaultRequestParameters());
+
+        assertEquals(ServiceTier.AUTO, parameters.serviceTier());
+        assertEquals(ReasoningEffort.LOW, parameters.reasoningEffort());
+        assertEquals(router, parameters.router());
+        assertEquals(List.of("text"), parameters.modalities());
+        assertTrue(parameters.store());
+        assertTrue(parameters.parallelToolCalls());
+        assertEquals("user", parameters.user());
+        assertEquals(Map.of("key", "value"), parameters.metadata());
+    }
+
+    @Test
+    void cache_should_be_a_shortcut_for_router() {
+
+        var cache = new Cache(true, null, null);
+
+        var withCache = WatsonxGatewayChatModel.builder()
+                .baseUrl("https://test.com")
+                .modelName("gpt-4o")
+                .apiKey("api-key")
+                .cache(cache)
+                .build();
+
+        assertEquals(
+                new Router(cache),
+                ((WatsonxGatewayChatRequestParameters) withCache.defaultRequestParameters()).router());
+
+        var withoutCache = WatsonxGatewayChatModel.builder()
+                .baseUrl("https://test.com")
+                .modelName("gpt-4o")
+                .apiKey("api-key")
+                .cache(null)
+                .build();
+
+        assertNull(((WatsonxGatewayChatRequestParameters) withoutCache.defaultRequestParameters()).router());
+    }
+
+    @Test
+    void should_authenticate_with_an_authenticator_instead_of_an_api_key() {
+
+        var authenticator = mock(IBMCloudAuthenticator.class);
+
+        withModelGatewayServiceMock(() -> {
+            assertDoesNotThrow(() -> WatsonxGatewayChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .authenticator(authenticator)
+                    .build());
+
+            verify(mockModelGatewayServiceBuilder).authenticator(authenticator);
+            verify(mockModelGatewayServiceBuilder, never()).apiKey(any());
+        });
+    }
+
+    private void withModelGatewayServiceMock(Runnable action) {
+        try (MockedStatic<ModelGatewayService> mockedStatic = mockStatic(ModelGatewayService.class)) {
+            mockedStatic.when(ModelGatewayService::builder).thenReturn(mockModelGatewayServiceBuilder);
+            action.run();
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
@@ -13,20 +13,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import java.net.URI;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
+
 import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
@@ -57,6 +44,20 @@ import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.output.FinishReason;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -225,7 +226,7 @@ public class WatsonxGatewayChatModelTest {
             var response = chatModel.chat(chatRequest);
             var metadata = (WatsonxChatResponseMetadata) response.metadata();
             assertEquals("id", response.id());
-            assertEquals("modelId", response.modelName());
+            assertEquals("model", response.modelName());
             assertEquals("modelVersion", metadata.getModelVersion());
             assertEquals(1L, metadata.getCreated());
             assertEquals("auto", metadata.getServiceTier());

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParametersTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParametersTest.java
@@ -1,14 +1,15 @@
 package dev.langchain4j.model.watsonx;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.Test;
+
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
 
 class WatsonxGatewayChatRequestParametersTest {
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParametersTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParametersTest.java
@@ -1,0 +1,133 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+
+class WatsonxGatewayChatRequestParametersTest {
+
+    private static WatsonxGatewayChatRequestParameters.Builder fullyPopulated() {
+        return WatsonxGatewayChatRequestParameters.builder()
+                // common (parent) fields
+                .modelName("gpt-4o")
+                .temperature(0.7)
+                .maxOutputTokens(100)
+                // gateway-specific fields
+                .serviceTier(ServiceTier.AUTO)
+                .reasoningEffort(ReasoningEffort.LOW)
+                .router(new Router(new Cache(true, null, null)))
+                .modalities(List.of("text"))
+                .store(true)
+                .parallelToolCalls(true)
+                .user("user")
+                .metadata(Map.of("key", "value"))
+                .logitBias(Map.of("token", 1))
+                .logprobs(true)
+                .topLogprobs(5)
+                .seed(42)
+                .toolChoiceName("tool")
+                .timeout(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void equals_and_hashCode_should_include_gateway_fields() {
+        WatsonxGatewayChatRequestParameters params1 = fullyPopulated().build();
+        WatsonxGatewayChatRequestParameters params2 = fullyPopulated().build();
+
+        assertThat(params1).isEqualTo(params2);
+        assertThat(params1.hashCode()).isEqualTo(params2.hashCode());
+    }
+
+    @Test
+    void equals_should_distinguish_each_gateway_field() {
+        WatsonxGatewayChatRequestParameters base = fullyPopulated().build();
+
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().serviceTier(ServiceTier.FLEX).build());
+        assertThat(base)
+                .isNotEqualTo(
+                        fullyPopulated().reasoningEffort(ReasoningEffort.HIGH).build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated()
+                        .router(new Router(new Cache(false, null, null)))
+                        .build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().modalities(List.of("audio")).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().store(false).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().parallelToolCalls(false).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().user("other").build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().metadata(Map.of("k", "v")).build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().logitBias(Map.of("token", 2)).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().logprobs(false).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().topLogprobs(9).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().seed(7).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().toolChoiceName("other").build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().timeout(Duration.ofSeconds(20)).build());
+    }
+
+    @Test
+    void equals_should_still_honor_inherited_fields() {
+        WatsonxGatewayChatRequestParameters base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(fullyPopulated().modelName("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().temperature(0.1).build());
+    }
+
+    @Test
+    void cache_convenience_should_be_equivalent_to_router() {
+        var cache = new Cache(true, null, null);
+
+        WatsonxGatewayChatRequestParameters viaCache =
+                fullyPopulated().cache(cache).build();
+        WatsonxGatewayChatRequestParameters viaRouter =
+                fullyPopulated().router(new Router(cache)).build();
+
+        assertThat(viaCache).isEqualTo(viaRouter);
+        assertThat(viaCache.router()).isEqualTo(new Router(cache));
+        assertThat(fullyPopulated().cache(null).build().router()).isNull();
+    }
+
+    @Test
+    void equals_should_reject_null_and_other_types() {
+        WatsonxGatewayChatRequestParameters base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(null);
+        assertThat(base).isNotEqualTo("not a parameters object");
+    }
+
+    @Test
+    void overrideWith_and_defaultedBy_should_be_mirror_images() {
+        WatsonxGatewayChatRequestParameters base = fullyPopulated().build();
+        WatsonxGatewayChatRequestParameters other =
+                WatsonxGatewayChatRequestParameters.builder().user("other").build();
+
+        // overrideWith lets the argument win (it is declared on the interface, so it returns the interface type)
+        var overridden = (WatsonxGatewayChatRequestParameters) base.overrideWith(other);
+        assertThat(overridden.user()).isEqualTo("other");
+        // defaultedBy lets the receiver win, and fills the gaps from the argument
+        assertThat(other.defaultedBy(base).user()).isEqualTo("other");
+        assertThat(other.defaultedBy(base).serviceTier()).isEqualTo(ServiceTier.AUTO);
+        assertThat(other.defaultedBy(base).seed()).isEqualTo(42);
+    }
+
+    @Test
+    void toString_should_include_gateway_fields() {
+        String text = fullyPopulated().build().toString();
+
+        assertThat(text)
+                .contains("serviceTier=AUTO")
+                .contains("reasoningEffort=LOW")
+                .contains("user=user")
+                .contains("seed=42")
+                .contains("toolChoiceName=tool");
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayModelCatalogTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayModelCatalogTest.java
@@ -1,0 +1,139 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.model.ModelProvider.WATSONX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
+import com.ibm.watsonx.ai.core.provider.HttpClientProvider;
+import dev.langchain4j.model.catalog.ModelType;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("unchecked")
+public class WatsonxGatewayModelCatalogTest {
+
+    @Test
+    void should_list_models() throws Exception {
+
+        var mockHttpClient = mock(HttpClient.class);
+        var mockHttpResponse = mock(HttpResponse.class);
+        var mockAuthenticator = mock(IBMCloudAuthenticator.class);
+        var mockHttpRequest = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(mockAuthenticator.token()).thenReturn("my-super-token");
+        when(mockHttpResponse.statusCode()).thenReturn(200);
+        when(mockHttpResponse.body()).thenReturn("""
+                    {
+                        "object": "list",
+                        "data": [
+                            {
+                                "uuid": "123e4567-e89b-12d3-a456-426614174000",
+                                "object": "model",
+                                "created": 1677649963,
+                                "owned_by": "openai",
+                                "id": "gpt-4o",
+                                "alias": "gpt-4o-alias",
+                                "description": "A flagship model",
+                                "metadata": {
+                                    "cost": 0.02,
+                                    "model_family": "gpt-4",
+                                    "recommender_label": "gpt-4o",
+                                    "region": "us-east-1",
+                                    "batch": false,
+                                    "context_window": 128000
+                                }
+                            },
+                            {
+                                "uuid": "223e4567-e89b-12d3-a456-426614174000",
+                                "object": "model",
+                                "id": "claude-sonnet-4-5",
+                                "owned_by": "anthropic"
+                            }
+                        ]
+                    }""");
+
+        when(mockHttpClient.send(mockHttpRequest.capture(), any(BodyHandler.class)))
+                .thenReturn(mockHttpResponse);
+
+        try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mockHttpClient);
+
+            var modelCatalog = WatsonxGatewayModelCatalog.builder()
+                    .baseUrl(CloudRegion.FRANKFURT)
+                    .authenticator(mockAuthenticator)
+                    .build();
+
+            var models = modelCatalog.listModels();
+
+            assertTrue(mockHttpRequest.getValue().uri().getPath().endsWith("/ml/gateway/v1/models"));
+            assertEquals(2, models.size());
+
+            // The alias takes precedence over the provider model id.
+            var model = models.get(0);
+            assertEquals("gpt-4o-alias", model.name());
+            assertEquals("gpt-4o-alias", model.displayName());
+            assertEquals("A flagship model", model.description());
+            assertEquals("openai", model.owner());
+            assertEquals(WATSONX, model.provider());
+            assertEquals(ModelType.CHAT, model.type());
+            assertEquals("2023-03-01T05:52:43Z", model.createdAt().toString());
+            assertEquals(128000, model.maxInputTokens());
+            assertNull(model.maxOutputTokens());
+
+            // No alias and only the mandatory fields are returned by the gateway.
+            var minimalModel = models.get(1);
+            assertEquals("claude-sonnet-4-5", minimalModel.name());
+            assertEquals("claude-sonnet-4-5", minimalModel.displayName());
+            assertEquals("anthropic", minimalModel.owner());
+            assertEquals(ModelType.CHAT, minimalModel.type());
+            assertNull(minimalModel.description());
+            assertNull(minimalModel.createdAt());
+            assertNull(minimalModel.maxInputTokens());
+        }
+    }
+
+    @Test
+    void should_throw_exception_when_no_credentials_are_provided() {
+        assertThrows(
+                NullPointerException.class,
+                () -> WatsonxGatewayModelCatalog.builder()
+                        .baseUrl(CloudRegion.FRANKFURT)
+                        .build());
+    }
+
+    @Test
+    void should_return_watsonx_provider() {
+
+        var mockAuthenticator = mock(IBMCloudAuthenticator.class);
+
+        try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mock(HttpClient.class));
+
+            var modelCatalog = WatsonxGatewayModelCatalog.builder()
+                    .baseUrl(CloudRegion.FRANKFURT)
+                    .authenticator(mockAuthenticator)
+                    .build();
+
+            assertEquals(WATSONX, modelCatalog.provider());
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
@@ -13,23 +13,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
+
 import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatResponse;
@@ -60,6 +44,23 @@ import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -315,7 +316,7 @@ public class WatsonxGatewayStreamingChatModelTest {
                     var metadata = (WatsonxChatResponseMetadata) completeResponse.metadata();
                     assertTrue(completeResponse.aiMessage().hasToolExecutionRequests());
                     assertEquals("id", completeResponse.id());
-                    assertEquals("modelId", completeResponse.modelName());
+                    assertEquals("model", completeResponse.modelName());
                     assertEquals("modelVersion", metadata.getModelVersion());
                     assertEquals(1L, metadata.getCreated());
                     assertEquals("auto", metadata.getServiceTier());

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
@@ -1,0 +1,537 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.chat.ChatHandler;
+import com.ibm.watsonx.ai.chat.ChatResponse;
+import com.ibm.watsonx.ai.chat.model.AssistantMessage;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.ChatUsage;
+import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
+import com.ibm.watsonx.ai.chat.model.FunctionCall;
+import com.ibm.watsonx.ai.chat.model.ResultMessage;
+import com.ibm.watsonx.ai.chat.model.ToolCall;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WatsonxGatewayStreamingChatModelTest {
+
+    @Mock
+    ModelGatewayService mockModelGatewayService;
+
+    @Mock
+    ModelGatewayService.Builder mockModelGatewayServiceBuilder;
+
+    @Captor
+    ArgumentCaptor<ModelGatewayChatRequest> chatRequestCaptor;
+
+    static ModelGatewayChatResponse.Builder<?> chatResponse;
+
+    @BeforeEach
+    void setUp() {
+
+        when(mockModelGatewayServiceBuilder.modelId(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.timeout(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.version(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.logRequests(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.logResponses(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.authenticator(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.httpClient(any())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockModelGatewayServiceBuilder);
+        when(mockModelGatewayServiceBuilder.build()).thenReturn(mockModelGatewayService);
+
+        var chatUsage = new ChatUsage(10, 10, 20);
+        chatResponse = ModelGatewayChatResponse.builder()
+                .id("id")
+                .modelId("modelId")
+                .model("model")
+                .modelVersion("modelVersion")
+                .object("object")
+                .usage(chatUsage)
+                .createdAt("createdAt")
+                .created(1L)
+                .serviceTier("auto")
+                .systemFingerprint("fp")
+                .cached(true);
+    }
+
+    @Test
+    void should_create_a_watsonx_gateway_streaming_chat_model() {
+
+        var streamingChatModel = assertDoesNotThrow(() -> WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl(CloudRegion.FRANKFURT)
+                .modelName("gpt-4o")
+                .apiKey("api-key-test")
+                .version("my-version")
+                .logRequests(true)
+                .logResponses(true)
+                .build());
+
+        var defaultRequestParameters = assertInstanceOf(
+                WatsonxGatewayChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
+
+        var modelGatewayServiceField = assertDoesNotThrow(
+                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("modelGatewayService"));
+        var modelGatewayService = assertDoesNotThrow(() -> modelGatewayServiceField.get(streamingChatModel));
+
+        assertInstanceOf(ModelGatewayService.class, modelGatewayService);
+        assertEquals(ModelProvider.WATSONX, streamingChatModel.provider());
+        assertEquals("gpt-4o", defaultRequestParameters.modelName());
+        assertNull(defaultRequestParameters.serviceTier());
+        assertNull(defaultRequestParameters.reasoningEffort());
+        assertNull(defaultRequestParameters.topK());
+    }
+
+    @Test
+    public void should_do_chat() throws Exception {
+
+        var messages = List.<ChatMessage>of(com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"));
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+
+                    for (String response : List.of("Hello", "World")) handler.onPartialResponse(response, null);
+
+                    var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello World", null, null, null);
+                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+                    chatResponse.choices(List.of(resultChoice));
+                    handler.onCompleteResponse(chatResponse.build());
+
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockModelGatewayService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withModelGatewayServiceMock(() -> {
+            var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .build();
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            var receivedResponses = new ArrayList<>();
+            var latch = new CountDownLatch(1);
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {
+                    receivedResponses.add(partialResponse);
+                }
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    var metadata = (WatsonxChatResponseMetadata) completeResponse.metadata();
+                    assertEquals("Hello World", completeResponse.aiMessage().text());
+                    assertEquals("auto", metadata.getServiceTier());
+                    assertEquals("fp", metadata.getSystemFingerprint());
+                    assertEquals(true, metadata.getCached());
+                    assertEquals("modelVersion", metadata.getModelVersion());
+                    assertEquals(1L, metadata.getCreated());
+                    latch.countDown();
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+            assertEquals(messages, chatRequestCaptor.getValue().messages());
+            var parameters = chatRequestCaptor.getValue().parameters();
+
+            try {
+                boolean completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+                assertEquals(List.of("Hello", "World"), receivedResponses);
+                assertEquals("gpt-4o", parameters.modelId());
+                assertNull(parameters.frequencyPenalty());
+                assertNull(parameters.serviceTier());
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_do_chat_with_refusal() {
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+
+                    for (String response : List.of("Hello", "World")) handler.onPartialResponse(response, null);
+
+                    var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello World", null, "refusal", null);
+                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+                    chatResponse.choices(List.of(resultChoice));
+                    handler.onCompleteResponse(chatResponse.build());
+
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockModelGatewayService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withModelGatewayServiceMock(() -> {
+            var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .build();
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            var latch = new CountDownLatch(1);
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    fail("onCompleteResponse must not be called after a refusal");
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    assertInstanceOf(ContentFilteredException.class, error);
+                    assertEquals("refusal", error.getMessage());
+                    latch.countDown();
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+
+            try {
+                boolean completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    public void should_do_chat_with_tool() throws Exception {
+
+        var toolCall = new ToolCall(0, "id", "function", new FunctionCall("name", "{}"));
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, null, null, null, List.of(toolCall));
+        var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "tool_calls");
+        chatResponse.choices(List.of(resultChoice));
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+                    handler.onPartialToolCall(new com.ibm.watsonx.ai.chat.model.PartialToolCall(
+                            "completion-id", 0, 0, null, "name", "{"));
+                    handler.onPartialToolCall(new com.ibm.watsonx.ai.chat.model.PartialToolCall(
+                            "completion-id", 0, 0, "id", "name", "}"));
+                    handler.onCompleteToolCall(new CompletedToolCall("completion-id", 0, toolCall));
+                    handler.onCompleteResponse(chatResponse.build());
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockModelGatewayService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withModelGatewayServiceMock(() -> {
+            StreamingChatModel streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .build();
+
+            ChatRequest chatRequest = ChatRequest.builder()
+                    .messages(UserMessage.from("Hello"))
+                    .toolSpecifications(ToolSpecification.builder()
+                            .name("name")
+                            .description("description")
+                            .parameters(JsonObjectSchema.builder()
+                                    .addStringProperty("string")
+                                    .required("string")
+                                    .build())
+                            .build())
+                    .build();
+
+            CountDownLatch latch = new CountDownLatch(1);
+            StreamingChatResponseHandler streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {
+                    fail();
+                }
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    var metadata = (WatsonxChatResponseMetadata) completeResponse.metadata();
+                    assertTrue(completeResponse.aiMessage().hasToolExecutionRequests());
+                    assertEquals("id", completeResponse.id());
+                    assertEquals("modelId", completeResponse.modelName());
+                    assertEquals("modelVersion", metadata.getModelVersion());
+                    assertEquals(1L, metadata.getCreated());
+                    assertEquals("auto", metadata.getServiceTier());
+                    assertEquals("fp", metadata.getSystemFingerprint());
+                    assertEquals(true, metadata.getCached());
+                    assertEquals(FinishReason.TOOL_EXECUTION, completeResponse.finishReason());
+                    assertEquals(
+                            1,
+                            completeResponse.aiMessage().toolExecutionRequests().size());
+                    assertEquals(
+                            "name",
+                            completeResponse
+                                    .aiMessage()
+                                    .toolExecutionRequests()
+                                    .get(0)
+                                    .name());
+                    latch.countDown();
+                }
+
+                @Override
+                public void onCompleteToolCall(CompleteToolCall completeToolCall) {
+                    assertEquals(0, completeToolCall.index());
+                    assertEquals("id", completeToolCall.toolExecutionRequest().id());
+                    assertEquals("name", completeToolCall.toolExecutionRequest().name());
+                    assertEquals("{}", completeToolCall.toolExecutionRequest().arguments());
+                }
+
+                @Override
+                public void onPartialToolCall(PartialToolCall partialToolCall) {
+                    assertEquals(0, partialToolCall.index());
+                    assertTrue(Objects.isNull(partialToolCall.id())
+                            || partialToolCall.id().equals("id"));
+                    assertEquals("name", partialToolCall.name());
+                    assertTrue(partialToolCall.partialArguments().equals("{")
+                            || partialToolCall.partialArguments().equals("}"));
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+
+            try {
+                boolean completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_handle_chat_request_parameters() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+                    handler.onCompleteResponse(chatResponse.build());
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockModelGatewayService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withModelGatewayServiceMock(() -> {
+            var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .defaultRequestParameters(WatsonxGatewayChatRequestParameters.builder()
+                            .serviceTier(ServiceTier.FLEX)
+                            .reasoningEffort(ReasoningEffort.HIGH)
+                            .toolChoice(ToolChoice.REQUIRED)
+                            .toolSpecifications(
+                                    ToolSpecification.builder().name("test").build())
+                            .build())
+                    .build();
+
+            var latch = new CountDownLatch(1);
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            streamingChatModel.chat("Hello", streamingHandler);
+            var parameters = chatRequestCaptor.getValue().parameters();
+
+            try {
+                var completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+                assertEquals("flex", parameters.serviceTier());
+                assertEquals("high", parameters.reasoningEffort());
+                assertEquals("required", parameters.toolChoiceOption());
+                assertNotNull(parameters.modelId());
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_propagate_error_through_exception_mapper() {
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+                    handler.onError(new Exception("test"));
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockModelGatewayService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withModelGatewayServiceMock(() -> {
+            var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-4o")
+                    .apiKey("api-key")
+                    .build();
+
+            var latch = new CountDownLatch(1);
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {}
+
+                @Override
+                public void onError(Throwable error) {
+                    assertEquals("test", error.getMessage());
+                    latch.countDown();
+                }
+            };
+
+            streamingChatModel.chat("Hello", streamingHandler);
+
+            try {
+                var completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_throw_exception_for_chat_request_with_top_k() {
+
+        var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .modelName("gpt-4o")
+                .apiKey("api-key")
+                .build();
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> streamingChatModel.chat(
+                        ChatRequest.builder()
+                                .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                                .topK(10)
+                                .build(),
+                        new StreamingChatResponseHandler() {
+                            @Override
+                            public void onPartialResponse(String partialResponse) {}
+
+                            @Override
+                            public void onCompleteResponse(
+                                    dev.langchain4j.model.chat.response.ChatResponse completeResponse) {}
+
+                            @Override
+                            public void onError(Throwable error) {}
+                        }));
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxGatewayStreamingChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .modelName("gpt-4o")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(
+                                ChatRequestParameters.builder().topK(10).build())
+                        .build());
+    }
+
+    @Test
+    void should_support_capabilities() {
+
+        var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl("https://test.com")
+                .modelName("gpt-4o")
+                .apiKey("api-key")
+                .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                .build();
+
+        assertEquals(1, streamingChatModel.supportedCapabilities().size());
+        assertTrue(streamingChatModel.supportedCapabilities().contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
+    }
+
+    private void withModelGatewayServiceMock(Runnable action) {
+        try (MockedStatic<ModelGatewayService> mockedStatic = mockStatic(ModelGatewayService.class)) {
+            mockedStatic.when(ModelGatewayService::builder).thenReturn(mockModelGatewayServiceBuilder);
+            action.run();
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -228,7 +228,7 @@ public class WatsonxStreamingChatModelTest {
                 assertNull(parameters.responseFormat());
                 assertNull(parameters.seed());
                 assertEquals("spaceId", parameters.spaceId());
-                assertEquals(List.of(), parameters.stop());
+                assertNull(parameters.stop());
                 assertNull(parameters.temperature());
                 assertNull(parameters.timeLimit());
                 assertNull(parameters.toolChoice());
@@ -565,7 +565,7 @@ public class WatsonxStreamingChatModelTest {
                 assertNull(parameters.responseFormat());
                 assertNull(parameters.seed());
                 assertEquals("spaceId", parameters.spaceId());
-                assertEquals(List.of(), parameters.stop());
+                assertNull(parameters.stop());
                 assertNull(parameters.temperature());
                 assertNull(parameters.timeLimit());
                 assertNull(parameters.toolChoice());

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -18,6 +18,8 @@ import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.ChatService;
+import com.ibm.watsonx.ai.chat.EmptyChatResponseException;
+import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
@@ -28,7 +30,6 @@ import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import com.ibm.watsonx.ai.chat.model.FunctionCall;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
-import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.ContentFilteredException;
@@ -71,18 +72,12 @@ public class WatsonxStreamingChatModelTest {
     ChatService mockChatService;
 
     @Mock
-    DeploymentService deploymentService;
-
-    @Mock
     ChatService.Builder mockChatServiceBuilder;
-
-    @Mock
-    DeploymentService.Builder mockDeploymentServiceBuilder;
 
     @Captor
     ArgumentCaptor<com.ibm.watsonx.ai.chat.ChatRequest> chatRequestCaptor;
 
-    static ChatResponse.Builder chatResponse;
+    static TextChatResponse.Builder<?> chatResponse;
 
     @BeforeEach
     void setUp() {
@@ -101,19 +96,8 @@ public class WatsonxStreamingChatModelTest {
         when(mockChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.build()).thenReturn(mockChatService);
 
-        when(mockDeploymentServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.timeout(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.version(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.logRequests(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.logResponses(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.authenticator(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.apiKey(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.httpClient(any())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockDeploymentServiceBuilder);
-        when(mockDeploymentServiceBuilder.build()).thenReturn(deploymentService);
-
         var chatUsage = new ChatUsage(10, 10, 20);
-        chatResponse = ChatResponse.build()
+        chatResponse = TextChatResponse.builder()
                 .id("id")
                 .modelId("modelId")
                 .model("model")
@@ -141,11 +125,11 @@ public class WatsonxStreamingChatModelTest {
         var defaultRequestParameters =
                 assertInstanceOf(WatsonxChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
 
-        var chatProviderField = assertDoesNotThrow(
-                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
-        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(streamingChatModel));
+        var chatServiceField = assertDoesNotThrow(
+                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("chatService"));
+        var chatService = assertDoesNotThrow(() -> chatServiceField.get(streamingChatModel));
 
-        assertInstanceOf(ChatService.class, chatProvider);
+        assertInstanceOf(ChatService.class, chatService);
         assertNull(defaultRequestParameters.frequencyPenalty());
         assertNull(defaultRequestParameters.logitBias());
         assertNull(defaultRequestParameters.logprobs());
@@ -170,50 +154,6 @@ public class WatsonxStreamingChatModelTest {
         assertNull(defaultRequestParameters.guidedRegex());
         assertNull(defaultRequestParameters.repetitionPenalty());
         assertNull(defaultRequestParameters.lengthPenalty());
-    }
-
-    @Test
-    void should_create_create_a_watsonx_chat_model_from_a_deployment_service() {
-
-        var streamingChatModel = assertDoesNotThrow(() -> WatsonxStreamingChatModel.builder()
-                .baseUrl(CloudRegion.FRANKFURT)
-                .apiKey("api-key-test")
-                .version("my-version")
-                .logRequests(true)
-                .logResponses(true)
-                .deploymentId("deployment-id")
-                .build());
-
-        var defaultRequestParameters =
-                assertInstanceOf(WatsonxChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
-
-        var chatProviderField = assertDoesNotThrow(
-                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
-        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(streamingChatModel));
-
-        assertInstanceOf(DeploymentService.class, chatProvider);
-        assertNull(defaultRequestParameters.frequencyPenalty());
-        assertNull(defaultRequestParameters.logitBias());
-        assertNull(defaultRequestParameters.logprobs());
-        assertNull(defaultRequestParameters.maxOutputTokens());
-        assertNull(defaultRequestParameters.modelName());
-        assertNull(defaultRequestParameters.presencePenalty());
-        assertNull(defaultRequestParameters.projectId());
-        assertNull(defaultRequestParameters.responseFormat());
-        assertNull(defaultRequestParameters.seed());
-        assertNull(defaultRequestParameters.spaceId());
-        assertEquals(List.of(), defaultRequestParameters.stopSequences());
-        assertNull(defaultRequestParameters.temperature());
-        assertNull(defaultRequestParameters.timeout());
-        assertNull(defaultRequestParameters.toolChoice());
-        assertNull(defaultRequestParameters.toolChoiceName());
-        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
-        assertNull(defaultRequestParameters.topK());
-        assertNull(defaultRequestParameters.topLogprobs());
-        assertNull(defaultRequestParameters.topP());
-        assertNull(defaultRequestParameters.guidedChoice());
-        assertNull(defaultRequestParameters.guidedGrammar());
-        assertNull(defaultRequestParameters.guidedRegex());
     }
 
     @Test
@@ -300,89 +240,10 @@ public class WatsonxStreamingChatModelTest {
                 assertNull(parameters.guidedRegex());
                 assertNull(parameters.repetitionPenalty());
                 assertNull(parameters.lengthPenalty());
-                assertNull(chatRequestCaptor.getValue().deploymentId());
 
             } catch (Exception e) {
                 fail(e);
             }
-        });
-    }
-
-    @Test
-    public void should_do_chat_with_deployment_service() throws Exception {
-
-        var messages = List.<ChatMessage>of(com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"));
-        doAnswer(invocation -> {
-                    ChatHandler handler = invocation.getArgument(1);
-
-                    for (String response : List.of("Hello", "World")) handler.onPartialResponse(response, null);
-
-                    var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello World", null, null, null);
-                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
-                    chatResponse.choices(List.of(resultChoice));
-                    handler.onCompleteResponse(chatResponse.build());
-
-                    return CompletableFuture.completedFuture(null);
-                })
-                .when(deploymentService)
-                .chatStreaming(chatRequestCaptor.capture(), any(ChatHandler.class));
-
-        withDeploymentServiceMock(() -> {
-            var streamingChatModel = WatsonxStreamingChatModel.builder()
-                    .baseUrl("https://test.com")
-                    .deploymentId("deployment-id")
-                    .apiKey("api-key")
-                    .build();
-
-            var chatRequest =
-                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
-
-            var receivedResponses = new ArrayList<>();
-            var latch = new CountDownLatch(1);
-
-            var streamingHandler = new StreamingChatResponseHandler() {
-                @Override
-                public void onPartialResponse(String partialResponse) {
-                    receivedResponses.add(partialResponse);
-                }
-
-                @Override
-                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
-                    assertEquals("Hello World", completeResponse.aiMessage().text());
-                    latch.countDown();
-                }
-
-                @Override
-                public void onError(Throwable error) {
-                    fail("Unexpected error: " + error);
-                }
-            };
-
-            streamingChatModel.chat(chatRequest, streamingHandler);
-            assertEquals(messages, chatRequestCaptor.getValue().messages());
-
-            try {
-                boolean completed = latch.await(2, TimeUnit.SECONDS);
-                assertTrue(completed, "Handler did not complete in time");
-                assertEquals(List.of("Hello", "World"), receivedResponses);
-            } catch (Exception e) {
-                fail(e);
-            }
-
-            chatRequest = ChatRequest.builder()
-                    .messages(List.of(dev.langchain4j.data.message.UserMessage.from("hello")))
-                    .parameters(WatsonxChatRequestParameters.builder()
-                            .deploymentId("deployment-id-override")
-                            .build())
-                    .build();
-
-            streamingChatModel.chat(chatRequest, streamingHandler);
-            assertEquals(2, chatRequestCaptor.getAllValues().size());
-            assertEquals(
-                    "deployment-id", chatRequestCaptor.getAllValues().get(0).deploymentId());
-            assertEquals(
-                    "deployment-id-override",
-                    chatRequestCaptor.getAllValues().get(1).deploymentId());
         });
     }
 
@@ -663,7 +524,7 @@ public class WatsonxStreamingChatModelTest {
                     ChatRequest.builder().messages(UserMessage.from("Hello")).build();
 
             var receivedResponses = new ArrayList<>();
-            var latch = new CountDownLatch(2);
+            var latch = new CountDownLatch(1);
 
             var streamingHandler = new StreamingChatResponseHandler() {
                 @Override
@@ -673,8 +534,7 @@ public class WatsonxStreamingChatModelTest {
 
                 @Override
                 public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
-                    assertEquals("Hello World", completeResponse.aiMessage().text());
-                    latch.countDown();
+                    fail("onCompleteResponse must not be called after a refusal");
                 }
 
                 @Override
@@ -712,6 +572,61 @@ public class WatsonxStreamingChatModelTest {
                 assertNull(parameters.toolChoiceOption());
                 assertNull(parameters.topLogprobs());
                 assertNull(parameters.topP());
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_report_empty_response_to_onError() {
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+
+                    var resultMessage = new ResultMessage(AssistantMessage.ROLE, null, null, null, null);
+                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "length");
+                    chatResponse.choices(List.of(resultChoice));
+                    handler.onCompleteResponse(chatResponse.build());
+
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockChatService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withChatServiceMock(() -> {
+            var streamingChatModel = WatsonxStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("projectId")
+                    .apiKey("api-key")
+                    .build();
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            var latch = new CountDownLatch(1);
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    fail("onCompleteResponse must not be called for an empty response");
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    assertInstanceOf(EmptyChatResponseException.class, error);
+                    latch.countDown();
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+
+            try {
+                assertTrue(latch.await(2, TimeUnit.SECONDS), "Handler did not complete in time");
             } catch (Exception e) {
                 fail(e);
             }
@@ -984,13 +899,6 @@ public class WatsonxStreamingChatModelTest {
     private void withChatServiceMock(Runnable action) {
         try (MockedStatic<ChatService> mockedStatic = mockStatic(ChatService.class)) {
             mockedStatic.when(ChatService::builder).thenReturn(mockChatServiceBuilder);
-            action.run();
-        }
-    }
-
-    private void withDeploymentServiceMock(Runnable action) {
-        try (MockedStatic<DeploymentService> mockedStatic = mockStatic(DeploymentService.class)) {
-            mockedStatic.when(DeploymentService::builder).thenReturn(mockDeploymentServiceBuilder);
             action.run();
         }
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelIT.java
@@ -1,7 +1,5 @@
 package dev.langchain4j.model.watsonx.it;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.common.AbstractChatModelIT;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -9,7 +7,6 @@ import dev.langchain4j.model.watsonx.WatsonxChatModel;
 import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
 import java.time.Duration;
 import java.util.List;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
@@ -20,7 +17,6 @@ public class WatsonxChatModelIT extends AbstractChatModelIT {
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
-    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
 
     @Override
     protected List<ChatModel> models() {
@@ -104,20 +100,6 @@ public class WatsonxChatModelIT extends AbstractChatModelIT {
     protected void should_respect_JSON_response_format_with_schema(ChatModel model) {
         super.should_respect_JSON_response_format_with_schema(
                 createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Test
-    @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
-    void should_use_deployed_model_with_deployment_id() {
-        var chatModel = WatsonxChatModel.builder()
-                .baseUrl(URL)
-                .apiKey(API_KEY)
-                .deploymentId(DEPLOYMENT_ID)
-                .timeout(Duration.ofSeconds(30))
-                .build();
-
-        var response = chatModel.chat("Hello");
-        assertNotNull(response);
     }
 
     private WatsonxChatModel.Builder createChatModel(String model) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelIT.java
@@ -3,11 +3,15 @@ package dev.langchain4j.model.watsonx.it;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.common.AbstractChatModelIT;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.watsonx.WatsonxChatModel;
 import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
@@ -20,7 +24,19 @@ public class WatsonxChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected List<ChatModel> models() {
-        return List.of(createChatModel("mistralai/mistral-medium-2505").build());
+        return List.of(
+                createChatModel("mistralai/mistral-small-3-1-24b-instruct-2503").build());
+    }
+
+    @Override
+    protected List<ChatModel> modelsSupportingTools() {
+        return List.of(createChatModel("meta-llama/llama-4-maverick-17b-128e-instruct-fp8")
+                .build());
+    }
+
+    @Override
+    protected List<ChatModel> modelsSupportingStructuredOutputs() {
+        return List.of(createChatModel("ibm/granite-4-h-small").build());
     }
 
     @Override
@@ -43,62 +59,28 @@ public class WatsonxChatModelIT extends AbstractChatModelIT {
     }
 
     @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(ChatModel model) {
+        return WatsonxChatResponseMetadata.class;
+    }
+
+    @Override
     public boolean supportsSingleImageInputAsPublicURL() {
         // Watsonx does not support images as URLs, only as Base64-encoded strings
         return false;
     }
 
     @Override
-    protected void should_execute_a_tool_then_answer(ChatModel model) {
-        super.should_execute_a_tool_then_answer(
-                createChatModel("ibm/granite-4-h-small").build());
+    protected boolean supportsToolsAndJsonResponseFormatWithSchema() {
+        // None of the models available in the project can combine the two features. They either answer with the
+        // requested JSON instead of calling the tool, or return a "tool_calls" finish reason without any tool call
+        return false;
     }
 
     @Override
-    protected void should_execute_a_tool_without_arguments_then_answer(ChatModel model) {
-        super.should_execute_a_tool_without_arguments_then_answer(
-                createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_execute_multiple_tools_in_parallel_then_answer(ChatModel model) {
-        super.should_execute_multiple_tools_in_parallel_then_answer(
-                createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_force_LLM_to_execute_any_tool(ChatModel model) {
-        super.should_force_LLM_to_execute_any_tool(
-                createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_force_LLM_to_execute_specific_tool(ChatModel model) {
-        super.should_force_LLM_to_execute_specific_tool(
-                createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(ChatModel model) {
-        super.should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(
-                createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
+    @ParameterizedTest
+    @MethodSource("models")
     protected void should_respect_user_message(ChatModel model) {
         super.should_respect_user_message(
-                createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_respect_JSON_response_format(ChatModel model) {
-        super.should_respect_JSON_response_format(
-                createChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_respect_JSON_response_format_with_schema(ChatModel model) {
-        super.should_respect_JSON_response_format_with_schema(
                 createChatModel("ibm/granite-4-h-small").build());
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelThinkingIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelThinkingIT.java
@@ -9,6 +9,7 @@ import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.watsonx.WatsonxChatModel;
+import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -27,7 +28,7 @@ public class WatsonxChatModelThinkingIT {
     @Test
     public void should_return_and_send_thinking() {
 
-        ChatModel chatModel = WatsonxChatModel.builder()
+        ChatModel chatModel = WatsonxDeploymentChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
                 .deploymentId(DEPLOYMENT_ID)
@@ -48,7 +49,7 @@ public class WatsonxChatModelThinkingIT {
     @Test
     void should_return_and_NOT_send_thinking() {
 
-        ChatModel chatModel = WatsonxChatModel.builder()
+        ChatModel chatModel = WatsonxDeploymentChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
                 .deploymentId(DEPLOYMENT_ID)

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelIT.java
@@ -1,0 +1,31 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+public class WatsonxDeploymentChatModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
+
+    @Test
+    void should_use_deployed_model_with_deployment_id() {
+        var chatModel = WatsonxDeploymentChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .deploymentId(DEPLOYMENT_ID)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        var response = chatModel.chat("Hello");
+        assertNotNull(response);
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelIT.java
@@ -1,31 +1,123 @@
 package dev.langchain4j.model.watsonx.it;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.common.AbstractChatModelIT;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
 import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
 import java.time.Duration;
-import org.junit.jupiter.api.Test;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
-public class WatsonxDeploymentChatModelIT {
+@EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GEMMA_DEPLOYMENT_ID", matches = ".+")
+public class WatsonxDeploymentChatModelIT extends AbstractChatModelIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String URL = System.getenv("WATSONX_URL");
     static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
+    static final String NO_REASONING_DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
+    static final String VISION_DEPLOYMENT_ID = System.getenv("WATSONX_GEMMA_DEPLOYMENT_ID");
 
-    @Test
-    void should_use_deployed_model_with_deployment_id() {
-        var chatModel = WatsonxDeploymentChatModel.builder()
+    @Override
+    protected List<ChatModel> models() {
+        return List.of(createChatModel(DEPLOYMENT_ID).build());
+    }
+
+    @Override
+    protected List<ChatModel> modelsSupportingTools() {
+        // The reasoning model rejects the tools created by the base test class, because it requires a description
+        // for every tool
+        return List.of(createChatModel(NO_REASONING_DEPLOYMENT_ID).build());
+    }
+
+    @Override
+    protected List<ChatModel> modelsSupportingImageInputs() {
+        return List.of(createChatModel(VISION_DEPLOYMENT_ID).build());
+    }
+
+    @Override
+    protected ChatModel createModelWith(ChatRequestParameters parameters) {
+        // Used by the "in_default_model_parameters" tests, which assert on maxOutputTokens and stopSequences
+        return createChatModel(NO_REASONING_DEPLOYMENT_ID)
+                .defaultRequestParameters(parameters)
+                .build();
+    }
+
+    @Override
+    protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
+        return WatsonxChatRequestParameters.builder()
+                .maxOutputTokens(maxOutputTokens)
+                .build();
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(ChatModel model) {
+        return WatsonxChatResponseMetadata.class;
+    }
+
+    @Override
+    protected boolean supportsModelNameParameter() {
+        // The deployment id already defines the model to call
+        return false;
+    }
+
+    @Override
+    public boolean supportsSingleImageInputAsPublicURL() {
+        // Watsonx does not support images as URLs, only as Base64-encoded strings
+        return false;
+    }
+
+    @Override
+    protected boolean supportsToolsAndJsonResponseFormatWithSchema() {
+        // None of the deployed models can combine the two features. The reasoning one rejects tools without a
+        // description, the others answer with the requested JSON instead of calling the tool
+        return false;
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsMaxOutputTokensParameter")
+    protected void should_respect_maxOutputTokens_in_chat_request(ChatModel model) {
+        super.should_respect_maxOutputTokens_in_chat_request(noReasoningChatModel());
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsMaxOutputTokensParameter")
+    protected void should_respect_common_parameters_wrapped_in_integration_specific_class_in_chat_request(
+            ChatModel model) {
+        super.should_respect_common_parameters_wrapped_in_integration_specific_class_in_chat_request(
+                noReasoningChatModel());
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsStopSequencesParameter")
+    protected void should_respect_stopSequences_in_chat_request(ChatModel model) {
+        super.should_respect_stopSequences_in_chat_request(noReasoningChatModel());
+    }
+
+    private ChatModel noReasoningChatModel() {
+        return createChatModel(NO_REASONING_DEPLOYMENT_ID).build();
+    }
+
+    private WatsonxDeploymentChatModel.Builder createChatModel(String deploymentId) {
+        return WatsonxDeploymentChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .deploymentId(DEPLOYMENT_ID)
-                .timeout(Duration.ofSeconds(30))
-                .build();
-
-        var response = chatModel.chat("Hello");
-        assertNotNull(response);
+                .deploymentId(deploymentId)
+                .timeout(Duration.ofSeconds(120));
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelListenerIT.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.model.watsonx.it;
+
+import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.common.AbstractChatModelListenerIT;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
+public class WatsonxDeploymentChatModelListenerIT extends AbstractChatModelListenerIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
+
+    @Override
+    protected ChatModel createModel(ChatModelListener listener) {
+        return createChatModel(DEPLOYMENT_ID)
+                .listeners(List.of(listener))
+                .defaultRequestParameters(ChatRequestParameters.builder()
+                        .temperature(temperature())
+                        .topP(topP())
+                        .maxOutputTokens(maxTokens())
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected Double temperature() {
+        return 0.0;
+    }
+
+    @Override
+    protected String modelName() {
+        // The deployment id already defines the model to call, so the request never carries a model name
+        return null;
+    }
+
+    @Override
+    protected ChatModel createFailingModel(ChatModelListener listener) {
+        return createChatModel("invalid-deployment-id")
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected Class<? extends Exception> expectedExceptionClass() {
+        return LangChain4jException.class;
+    }
+
+    private WatsonxDeploymentChatModel.Builder createChatModel(String deploymentId) {
+        return WatsonxDeploymentChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .deploymentId(deploymentId)
+                .timeout(Duration.ofSeconds(120));
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentChatModelListenerIT.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.watsonx.it;
 
-import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.exception.ModelNotFoundException;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.common.AbstractChatModelListenerIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -51,7 +51,8 @@ public class WatsonxDeploymentChatModelListenerIT extends AbstractChatModelListe
 
     @Override
     protected Class<? extends Exception> expectedExceptionClass() {
-        return LangChain4jException.class;
+        // An unknown deployment id makes the service answer with HTTP 404
+        return ModelNotFoundException.class;
     }
 
     private WatsonxDeploymentChatModel.Builder createChatModel(String deploymentId) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
@@ -90,6 +90,7 @@ public class WatsonxDeploymentStreamingChatModelIT extends AbstractStreamingChat
 
     @Override
     protected boolean supportsStreamingCancellation() {
+        // The watsonx models do not expose a StreamingHandle that can stop an ongoing stream
         return false;
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
@@ -153,6 +153,7 @@ public class WatsonxDeploymentStreamingChatModelIT extends AbstractStreamingChat
                 .baseUrl(URL)
                 .apiKey(API_KEY)
                 .deploymentId(deploymentId)
+                .temperature(0.0)
                 .timeout(Duration.ofSeconds(120));
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
@@ -1,53 +1,158 @@
 package dev.langchain4j.model.watsonx.it;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static dev.langchain4j.model.watsonx.it.WatsonxToolCallbacksVerifier.verifyToolCall;
 
-import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
 import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.Test;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InOrder;
 
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
-public class WatsonxDeploymentStreamingChatModelIT {
+@EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GEMMA_DEPLOYMENT_ID", matches = ".+")
+public class WatsonxDeploymentStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String URL = System.getenv("WATSONX_URL");
     static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
+    static final String NO_REASONING_DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
+    static final String VISION_DEPLOYMENT_ID = System.getenv("WATSONX_GEMMA_DEPLOYMENT_ID");
 
-    @Test
-    void should_use_deployed_model_with_deployment_id() {
-        var chatModel = WatsonxDeploymentStreamingChatModel.builder()
+    @Override
+    protected List<StreamingChatModel> models() {
+        return List.of(createStreamingChatModel(DEPLOYMENT_ID).build());
+    }
+
+    @Override
+    protected List<StreamingChatModel> modelsSupportingTools() {
+        // The reasoning model rejects the tools created by the base test class, because it requires a description
+        // for every tool
+        return List.of(createStreamingChatModel(NO_REASONING_DEPLOYMENT_ID).build());
+    }
+
+    @Override
+    protected List<StreamingChatModel> modelsSupportingImageInputs() {
+        return List.of(createStreamingChatModel(VISION_DEPLOYMENT_ID).build());
+    }
+
+    @Override
+    protected StreamingChatModel createModelWith(ChatRequestParameters parameters) {
+        // Used by the "in_default_model_parameters" tests, which assert on maxOutputTokens and stopSequences
+        return createStreamingChatModel(NO_REASONING_DEPLOYMENT_ID)
+                .defaultRequestParameters(parameters)
+                .build();
+    }
+
+    @Override
+    public StreamingChatModel createModelWith(ChatModelListener listener) {
+        return createStreamingChatModel(DEPLOYMENT_ID)
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
+        return WatsonxChatRequestParameters.builder()
+                .maxOutputTokens(maxOutputTokens)
+                .build();
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(StreamingChatModel model) {
+        return WatsonxChatResponseMetadata.class;
+    }
+
+    @Override
+    protected boolean supportsModelNameParameter() {
+        // The deployment id already defines the model to call
+        return false;
+    }
+
+    @Override
+    public boolean supportsSingleImageInputAsPublicURL() {
+        // Watsonx does not support images as URLs, only as Base64-encoded strings
+        return false;
+    }
+
+    @Override
+    protected boolean supportsStreamingCancellation() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsToolsAndJsonResponseFormatWithSchema() {
+        // None of the deployed models can combine the two features. The reasoning one rejects tools without a
+        // description, the others answer with the requested JSON instead of calling the tool
+        return false;
+    }
+
+    @Override
+    protected boolean assertThreads() {
+        // The watsonx.ai SDK dispatches every callback of a response through a virtual thread per task executor, so
+        // the callbacks stay sequential but do not share a single thread
+        return false;
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsMaxOutputTokensParameter")
+    protected void should_respect_maxOutputTokens_in_chat_request(StreamingChatModel model) {
+        super.should_respect_maxOutputTokens_in_chat_request(noReasoningStreamingChatModel());
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsMaxOutputTokensParameter")
+    protected void should_respect_common_parameters_wrapped_in_integration_specific_class_in_chat_request(
+            StreamingChatModel model) {
+        super.should_respect_common_parameters_wrapped_in_integration_specific_class_in_chat_request(
+                noReasoningStreamingChatModel());
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsStopSequencesParameter")
+    protected void should_respect_stopSequences_in_chat_request(StreamingChatModel model) {
+        super.should_respect_stopSequences_in_chat_request(noReasoningStreamingChatModel());
+    }
+
+    @Override
+    protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id) {
+        verifyToolCall(handler, io, 0, id, "getWeather", "{\"city\": \"Munich\"}");
+    }
+
+    @Override
+    protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2) {
+        verifyToolCallbacks(handler, io, id1);
+        verifyToolCall(handler, io, 1, id2, "getTime", "{\"country\": \"France\"}");
+    }
+
+    private StreamingChatModel noReasoningStreamingChatModel() {
+        return createStreamingChatModel(NO_REASONING_DEPLOYMENT_ID).build();
+    }
+
+    private WatsonxDeploymentStreamingChatModel.Builder createStreamingChatModel(String deploymentId) {
+        return WatsonxDeploymentStreamingChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .deploymentId(DEPLOYMENT_ID)
-                .timeout(Duration.ofSeconds(30))
-                .logRequests(true)
-                .build();
-
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<ChatResponse> chatResponse = new AtomicReference<ChatResponse>(null);
-
-        chatModel.chat("Hello", new StreamingChatResponseHandler() {
-
-            @Override
-            public void onCompleteResponse(ChatResponse completeResponse) {
-                latch.countDown();
-                chatResponse.set(completeResponse);
-            }
-
-            @Override
-            public void onError(Throwable error) {}
-        });
-
-        assertDoesNotThrow(() -> latch.await(5, TimeUnit.SECONDS));
-        assertNotNull(chatResponse.get().aiMessage().text());
+                .deploymentId(deploymentId)
+                .timeout(Duration.ofSeconds(120));
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+public class WatsonxDeploymentStreamingChatModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
+
+    @Test
+    void should_use_deployed_model_with_deployment_id() {
+        var chatModel = WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .deploymentId(DEPLOYMENT_ID)
+                .timeout(Duration.ofSeconds(30))
+                .logRequests(true)
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChatResponse> chatResponse = new AtomicReference<ChatResponse>(null);
+
+        chatModel.chat("Hello", new StreamingChatResponseHandler() {
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                latch.countDown();
+                chatResponse.set(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        assertDoesNotThrow(() -> latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(chatResponse.get().aiMessage().text());
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelListenerIT.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.model.watsonx.it;
+
+import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.common.AbstractStreamingChatModelListenerIT;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
+public class WatsonxDeploymentStreamingChatModelListenerIT extends AbstractStreamingChatModelListenerIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
+
+    @Override
+    protected StreamingChatModel createModel(ChatModelListener listener) {
+        return createStreamingChatModel(DEPLOYMENT_ID)
+                .listeners(List.of(listener))
+                .defaultRequestParameters(ChatRequestParameters.builder()
+                        .temperature(temperature())
+                        .topP(topP())
+                        .maxOutputTokens(maxTokens())
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected Double temperature() {
+        return 0.0;
+    }
+
+    @Override
+    protected String modelName() {
+        // The deployment id already defines the model to call, so the request never carries a model name
+        return null;
+    }
+
+    @Override
+    protected StreamingChatModel createFailingModel(ChatModelListener listener) {
+        return createStreamingChatModel("invalid-deployment-id")
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected Class<? extends Exception> expectedExceptionClass() {
+        return LangChain4jException.class;
+    }
+
+    private WatsonxDeploymentStreamingChatModel.Builder createStreamingChatModel(String deploymentId) {
+        return WatsonxDeploymentStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .deploymentId(deploymentId)
+                .timeout(Duration.ofSeconds(120));
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelListenerIT.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.watsonx.it;
 
-import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.exception.ModelNotFoundException;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.common.AbstractStreamingChatModelListenerIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -51,7 +51,8 @@ public class WatsonxDeploymentStreamingChatModelListenerIT extends AbstractStrea
 
     @Override
     protected Class<? extends Exception> expectedExceptionClass() {
-        return LangChain4jException.class;
+        // An unknown deployment id makes the service answer with HTTP 404
+        return ModelNotFoundException.class;
     }
 
     private WatsonxDeploymentStreamingChatModel.Builder createStreamingChatModel(String deploymentId) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelIT.java
@@ -1,59 +1,84 @@
 package dev.langchain4j.model.watsonx.it;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.common.AbstractChatModelIT;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatModel;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
 import java.time.Duration;
-import org.junit.jupiter.api.Test;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_MODEL", matches = ".+")
-public class WatsonxGatewayChatModelIT {
+public class WatsonxGatewayChatModelIT extends AbstractChatModelIT {
 
-    static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String URL = System.getenv("WATSONX_URL");
     static final String MODEL = System.getenv("WATSONX_GATEWAY_MODEL");
+    static final String CUSTOM_MODEL = getOrDefault(System.getenv("WATSONX_GATEWAY_CUSTOM_MODEL"), "claude-sonnet-5");
+    static final String STOP_SEQUENCES_MODEL =
+            getOrDefault(System.getenv("WATSONX_GATEWAY_STOP_SEQUENCES_MODEL"), "gemini-3.6-flash");
 
-    @Test
-    void should_do_sync_chat() {
-        var chatModel = WatsonxGatewayChatModel.builder()
-                .baseUrl(URL)
-                .apiKey(API_KEY)
-                .modelName(MODEL)
-                .timeout(Duration.ofSeconds(30))
-                .build();
-
-        var answer = chatModel.chat("What is the capital of Italy? Answer in one word.");
-        assertNotNull(answer);
-        assertTrue(answer.toLowerCase().contains("rome"));
+    @Override
+    protected List<ChatModel> models() {
+        return List.of(createChatModel(MODEL).build());
     }
 
-    @Test
-    void should_override_builder_defaults_with_per_request_parameters() {
-        var chatModel = WatsonxGatewayChatModel.builder()
+    @Override
+    protected String customModelName() {
+        return CUSTOM_MODEL;
+    }
+
+    @Override
+    protected ChatModel createModelWith(ChatRequestParameters parameters) {
+        String defaultModel = isNullOrEmpty(parameters.stopSequences()) ? MODEL : STOP_SEQUENCES_MODEL;
+        return createChatModel(getOrDefault(parameters.modelName(), defaultModel))
+                .defaultRequestParameters(parameters)
+                .build();
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsStopSequencesParameter")
+    protected void should_respect_stopSequences_in_chat_request(ChatModel model) {
+        super.should_respect_stopSequences_in_chat_request(
+                createChatModel(STOP_SEQUENCES_MODEL).build());
+    }
+
+    @Override
+    protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
+        return WatsonxGatewayChatRequestParameters.builder()
+                .maxOutputTokens(maxOutputTokens)
+                .build();
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(ChatModel model) {
+        return WatsonxChatResponseMetadata.class;
+    }
+
+    @Override
+    public boolean supportsSingleImageInputAsPublicURL() {
+        // Watsonx does not support images as URLs, only as Base64-encoded strings
+        return false;
+    }
+
+    private WatsonxGatewayChatModel.Builder createChatModel(String model) {
+        return WatsonxGatewayChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .modelName(MODEL)
-                .maxOutputTokens(200)
-                .timeout(Duration.ofSeconds(30))
-                .build();
-
-        var chatRequest = ChatRequest.builder()
-                .messages(UserMessage.from("Say hi."))
-                .parameters(WatsonxGatewayChatRequestParameters.builder()
-                        .maxOutputTokens(5)
-                        .build())
-                .build();
-
-        var response = chatModel.chat(chatRequest);
-        assertNotNull(response.aiMessage().text());
-        assertNotNull(response.modelName());
-        assertTrue(response.tokenUsage().outputTokenCount() <= 5);
+                .modelName(model)
+                .timeout(Duration.ofSeconds(120));
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelIT.java
@@ -1,0 +1,101 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.watsonx.WatsonxGatewayChatModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_MODEL", matches = ".+")
+public class WatsonxGatewayChatModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_GATEWAY_MODEL");
+
+    @Test
+    void should_do_sync_chat() {
+        var chatModel = WatsonxGatewayChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        var answer = chatModel.chat("What is the capital of Italy? Answer in one word.");
+        assertNotNull(answer);
+        assertTrue(answer.toLowerCase().contains("rome"));
+    }
+
+    @Test
+    void should_do_streaming_chat() throws Exception {
+        var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        var future = new CompletableFuture<ChatResponse>();
+        var partial = new StringBuilder();
+
+        streamingChatModel.chat(
+                "What is the capital of Italy? Answer in one word.", new StreamingChatResponseHandler() {
+                    @Override
+                    public void onPartialResponse(String partialResponse) {
+                        partial.append(partialResponse);
+                    }
+
+                    @Override
+                    public void onCompleteResponse(ChatResponse completeResponse) {
+                        future.complete(completeResponse);
+                    }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        future.completeExceptionally(error);
+                    }
+                });
+
+        var response = future.get(60, TimeUnit.SECONDS);
+        assertNotNull(response);
+        assertTrue(response.aiMessage().text().toLowerCase().contains("rome"));
+        assertTrue(partial.length() > 0);
+    }
+
+    @Test
+    void should_override_builder_defaults_with_per_request_parameters() {
+        var chatModel = WatsonxGatewayChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .modelName(MODEL)
+                .maxOutputTokens(200)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        var chatRequest = ChatRequest.builder()
+                .messages(dev.langchain4j.data.message.UserMessage.from("Say hi."))
+                .parameters(WatsonxGatewayChatRequestParameters.builder()
+                        .maxOutputTokens(5)
+                        .build())
+                .build();
+
+        var response = chatModel.chat(chatRequest);
+
+        assertNotNull(response.aiMessage().text());
+        assertNotNull(response.modelName());
+        // the per-request cap must have been honoured over the builder default of 200
+        assertTrue(response.tokenUsage().outputTokenCount() <= 5);
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelIT.java
@@ -3,24 +3,20 @@ package dev.langchain4j.model.watsonx.it;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatModel;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
-import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_MODEL", matches = ".+")
 public class WatsonxGatewayChatModelIT {
 
-    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
     static final String URL = System.getenv("WATSONX_URL");
     static final String MODEL = System.getenv("WATSONX_GATEWAY_MODEL");
 
@@ -39,42 +35,6 @@ public class WatsonxGatewayChatModelIT {
     }
 
     @Test
-    void should_do_streaming_chat() throws Exception {
-        var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
-                .baseUrl(URL)
-                .apiKey(API_KEY)
-                .modelName(MODEL)
-                .timeout(Duration.ofSeconds(30))
-                .build();
-
-        var future = new CompletableFuture<ChatResponse>();
-        var partial = new StringBuilder();
-
-        streamingChatModel.chat(
-                "What is the capital of Italy? Answer in one word.", new StreamingChatResponseHandler() {
-                    @Override
-                    public void onPartialResponse(String partialResponse) {
-                        partial.append(partialResponse);
-                    }
-
-                    @Override
-                    public void onCompleteResponse(ChatResponse completeResponse) {
-                        future.complete(completeResponse);
-                    }
-
-                    @Override
-                    public void onError(Throwable error) {
-                        future.completeExceptionally(error);
-                    }
-                });
-
-        var response = future.get(60, TimeUnit.SECONDS);
-        assertNotNull(response);
-        assertTrue(response.aiMessage().text().toLowerCase().contains("rome"));
-        assertTrue(partial.length() > 0);
-    }
-
-    @Test
     void should_override_builder_defaults_with_per_request_parameters() {
         var chatModel = WatsonxGatewayChatModel.builder()
                 .baseUrl(URL)
@@ -85,17 +45,15 @@ public class WatsonxGatewayChatModelIT {
                 .build();
 
         var chatRequest = ChatRequest.builder()
-                .messages(dev.langchain4j.data.message.UserMessage.from("Say hi."))
+                .messages(UserMessage.from("Say hi."))
                 .parameters(WatsonxGatewayChatRequestParameters.builder()
                         .maxOutputTokens(5)
                         .build())
                 .build();
 
         var response = chatModel.chat(chatRequest);
-
         assertNotNull(response.aiMessage().text());
         assertNotNull(response.modelName());
-        // the per-request cap must have been honoured over the builder default of 200
         assertTrue(response.tokenUsage().outputTokenCount() <= 5);
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayChatModelListenerIT.java
@@ -1,0 +1,63 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import dev.langchain4j.exception.InvalidRequestException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.common.AbstractChatModelListenerIT;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxGatewayChatModel;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_MODEL", matches = ".+")
+public class WatsonxGatewayChatModelListenerIT extends AbstractChatModelListenerIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_GATEWAY_MODEL");
+    static final String LISTENER_MODEL =
+            getOrDefault(System.getenv("WATSONX_GATEWAY_LISTENER_MODEL"), "gemini-3.6-flash");
+
+    @Override
+    protected ChatModel createModel(ChatModelListener listener) {
+        return createChatModel(LISTENER_MODEL)
+                .listeners(List.of(listener))
+                .defaultRequestParameters(ChatRequestParameters.builder()
+                        .modelName(modelName())
+                        .temperature(temperature())
+                        .topP(topP())
+                        .maxOutputTokens(maxTokens())
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected String modelName() {
+        return LISTENER_MODEL;
+    }
+
+    @Override
+    protected ChatModel createFailingModel(ChatModelListener listener) {
+        return createChatModel("invalid-model").listeners(List.of(listener)).build();
+    }
+
+    @Override
+    protected Class<? extends Exception> expectedExceptionClass() {
+        // For an unknown model the gateway answers with HTTP 400 and a generic "Bad Request" error code, so the
+        // exception mapper cannot narrow it down to ModelNotFoundException
+        return InvalidRequestException.class;
+    }
+
+    private WatsonxGatewayChatModel.Builder createChatModel(String model) {
+        return WatsonxGatewayChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .modelName(model)
+                .timeout(Duration.ofSeconds(120));
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayModelCatalogIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayModelCatalogIT.java
@@ -11,11 +11,11 @@ import dev.langchain4j.model.watsonx.WatsonxGatewayModelCatalog;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
 public class WatsonxGatewayModelCatalogIT {
 
-    static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String URL = System.getenv("WATSONX_URL");
 
     static final ModelCatalog modelCatalog = WatsonxGatewayModelCatalog.builder()

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayModelCatalogIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayModelCatalogIT.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.model.catalog.ModelCatalog;
+import dev.langchain4j.model.catalog.ModelType;
+import dev.langchain4j.model.watsonx.WatsonxGatewayModelCatalog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+public class WatsonxGatewayModelCatalogIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
+    static final String URL = System.getenv("WATSONX_URL");
+
+    static final ModelCatalog modelCatalog = WatsonxGatewayModelCatalog.builder()
+            .baseUrl(URL)
+            .apiKey(API_KEY)
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+    @Test
+    void should_list_models() {
+        var models = assertDoesNotThrow(() -> modelCatalog.listModels());
+        assertTrue(models.size() > 0);
+        var model = models.get(0);
+        assertNotNull(model.name());
+        assertNotNull(model.displayName());
+        assertNotNull(model.owner());
+        assertNotNull(model.provider());
+        assertNotNull(model.createdAt());
+        assertEquals(ModelType.CHAT, model.type());
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
@@ -85,6 +85,7 @@ public class WatsonxGatewayStreamingChatModelIT extends AbstractStreamingChatMod
 
     @Override
     protected boolean supportsStreamingCancellation() {
+        // The watsonx models do not expose a StreamingHandle that can stop an ongoing stream
         return false;
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
@@ -1,0 +1,174 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_MODEL", matches = ".+")
+public class WatsonxGatewayStreamingChatModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_GATEWAY_MODEL");
+
+    @Test
+    void should_do_streaming_chat() throws Exception {
+
+        var streamingChatModel = createStreamingChatModel().build();
+
+        var handler = new CollectingHandler();
+        streamingChatModel.chat("What is the capital of Italy? Answer in one word.", handler);
+
+        var response = handler.await();
+        var text = response.aiMessage().text();
+
+        assertNotNull(text);
+        assertTrue(text.toLowerCase().contains("rome"));
+        assertFalse(handler.partialResponses.isEmpty());
+        assertEquals(text, String.join("", handler.partialResponses));
+        assertEquals(FinishReason.STOP, response.finishReason());
+        assertNotNull(response.id());
+        assertNotNull(response.modelName());
+        assertTrue(response.tokenUsage().outputTokenCount() > 0);
+    }
+
+    @Test
+    void should_stream_a_tool_call() throws Exception {
+
+        var weatherTool = ToolSpecification.builder()
+                .name("getWeather")
+                .description("Returns the current weather of a city")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+
+        var streamingChatModel =
+                createStreamingChatModel().toolSpecifications(weatherTool).build();
+
+        var handler = new CollectingHandler();
+        streamingChatModel.chat("What is the weather in Rome?", handler);
+
+        var response = handler.await();
+        var toolExecutionRequests = response.aiMessage().toolExecutionRequests();
+
+        assertEquals(FinishReason.TOOL_EXECUTION, response.finishReason());
+        assertEquals(1, toolExecutionRequests.size());
+        assertEquals("getWeather", toolExecutionRequests.get(0).name());
+        assertTrue(toolExecutionRequests.get(0).arguments().toLowerCase().contains("rome"));
+        assertFalse(handler.completeToolCalls.isEmpty());
+        assertEquals(
+                "getWeather",
+                handler.completeToolCalls.get(0).toolExecutionRequest().name());
+    }
+
+    @Test
+    void should_respect_stop_sequences() throws Exception {
+
+        // A stop sequence is sent only when it is not empty, since the Model Gateway rejects an empty "stop" array.
+        var streamingChatModel =
+                createStreamingChatModel().stopSequences("Three").build();
+
+        var handler = new CollectingHandler();
+        streamingChatModel.chat(
+                "Count from one to five. Write one capitalized word per line, without punctuation.", handler);
+
+        var response = handler.await();
+        var text = response.aiMessage().text();
+
+        assertNotNull(text);
+        assertFalse(text.toLowerCase().contains("four"));
+        assertEquals(FinishReason.STOP, response.finishReason());
+    }
+
+    @Test
+    void should_override_builder_defaults_with_per_request_parameters() throws Exception {
+
+        var streamingChatModel = createStreamingChatModel().maxOutputTokens(200).build();
+
+        var chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Say hi."))
+                .parameters(WatsonxGatewayChatRequestParameters.builder()
+                        .maxOutputTokens(5)
+                        .build())
+                .build();
+
+        var handler = new CollectingHandler();
+        streamingChatModel.chat(chatRequest, handler);
+
+        var response = handler.await();
+
+        assertNotNull(response.aiMessage().text());
+        assertNotNull(response.modelName());
+        assertTrue(response.tokenUsage().outputTokenCount() <= 5);
+    }
+
+    // The temperature is left unset, since some models exposed by the gateway accept only their own default value.
+    private WatsonxGatewayStreamingChatModel.Builder createStreamingChatModel() {
+        return WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(120));
+    }
+
+    static class CollectingHandler implements StreamingChatResponseHandler {
+
+        final List<String> partialResponses = new ArrayList<>();
+        final List<PartialToolCall> partialToolCalls = new ArrayList<>();
+        final List<CompleteToolCall> completeToolCalls = new ArrayList<>();
+        final CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        @Override
+        public void onPartialResponse(String partialResponse) {
+            partialResponses.add(partialResponse);
+        }
+
+        @Override
+        public void onPartialToolCall(PartialToolCall partialToolCall) {
+            partialToolCalls.add(partialToolCall);
+        }
+
+        @Override
+        public void onCompleteToolCall(CompleteToolCall completeToolCall) {
+            completeToolCalls.add(completeToolCall);
+        }
+
+        @Override
+        public void onCompleteResponse(ChatResponse completeResponse) {
+            future.complete(completeResponse);
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            future.completeExceptionally(error);
+        }
+
+        ChatResponse await() throws Exception {
+            return future.get(150, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
@@ -1,174 +1,116 @@
 package dev.langchain4j.model.watsonx.it;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.model.watsonx.it.WatsonxToolCallbacksVerifier.verifyToolCall;
 
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.CompleteToolCall;
-import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatRequestParameters;
 import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InOrder;
 
-@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY_GATEWAY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_MODEL", matches = ".+")
-public class WatsonxGatewayStreamingChatModelIT {
+public class WatsonxGatewayStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
-    static final String API_KEY = System.getenv("WATSONX_API_KEY_GATEWAY");
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String URL = System.getenv("WATSONX_URL");
     static final String MODEL = System.getenv("WATSONX_GATEWAY_MODEL");
+    static final String CUSTOM_MODEL = getOrDefault(System.getenv("WATSONX_GATEWAY_CUSTOM_MODEL"), "claude-sonnet-5");
+    static final String STOP_SEQUENCES_MODEL =
+            getOrDefault(System.getenv("WATSONX_GATEWAY_STOP_SEQUENCES_MODEL"), "gemini-3.6-flash");
 
-    @Test
-    void should_do_streaming_chat() throws Exception {
-
-        var streamingChatModel = createStreamingChatModel().build();
-
-        var handler = new CollectingHandler();
-        streamingChatModel.chat("What is the capital of Italy? Answer in one word.", handler);
-
-        var response = handler.await();
-        var text = response.aiMessage().text();
-
-        assertNotNull(text);
-        assertTrue(text.toLowerCase().contains("rome"));
-        assertFalse(handler.partialResponses.isEmpty());
-        assertEquals(text, String.join("", handler.partialResponses));
-        assertEquals(FinishReason.STOP, response.finishReason());
-        assertNotNull(response.id());
-        assertNotNull(response.modelName());
-        assertTrue(response.tokenUsage().outputTokenCount() > 0);
+    @Override
+    protected List<StreamingChatModel> models() {
+        return List.of(createStreamingChatModel(MODEL).build());
     }
 
-    @Test
-    void should_stream_a_tool_call() throws Exception {
+    @Override
+    protected String customModelName() {
+        return CUSTOM_MODEL;
+    }
 
-        var weatherTool = ToolSpecification.builder()
-                .name("getWeather")
-                .description("Returns the current weather of a city")
-                .parameters(JsonObjectSchema.builder()
-                        .addStringProperty("city")
-                        .required("city")
-                        .build())
+    @Override
+    protected StreamingChatModel createModelWith(ChatRequestParameters parameters) {
+        String defaultModel = isNullOrEmpty(parameters.stopSequences()) ? MODEL : STOP_SEQUENCES_MODEL;
+        return createStreamingChatModel(getOrDefault(parameters.modelName(), defaultModel))
+                .defaultRequestParameters(parameters)
                 .build();
-
-        var streamingChatModel =
-                createStreamingChatModel().toolSpecifications(weatherTool).build();
-
-        var handler = new CollectingHandler();
-        streamingChatModel.chat("What is the weather in Rome?", handler);
-
-        var response = handler.await();
-        var toolExecutionRequests = response.aiMessage().toolExecutionRequests();
-
-        assertEquals(FinishReason.TOOL_EXECUTION, response.finishReason());
-        assertEquals(1, toolExecutionRequests.size());
-        assertEquals("getWeather", toolExecutionRequests.get(0).name());
-        assertTrue(toolExecutionRequests.get(0).arguments().toLowerCase().contains("rome"));
-        assertFalse(handler.completeToolCalls.isEmpty());
-        assertEquals(
-                "getWeather",
-                handler.completeToolCalls.get(0).toolExecutionRequest().name());
     }
 
-    @Test
-    void should_respect_stop_sequences() throws Exception {
-
-        // A stop sequence is sent only when it is not empty, since the Model Gateway rejects an empty "stop" array.
-        var streamingChatModel =
-                createStreamingChatModel().stopSequences("Three").build();
-
-        var handler = new CollectingHandler();
-        streamingChatModel.chat(
-                "Count from one to five. Write one capitalized word per line, without punctuation.", handler);
-
-        var response = handler.await();
-        var text = response.aiMessage().text();
-
-        assertNotNull(text);
-        assertFalse(text.toLowerCase().contains("four"));
-        assertEquals(FinishReason.STOP, response.finishReason());
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsStopSequencesParameter")
+    protected void should_respect_stopSequences_in_chat_request(StreamingChatModel model) {
+        super.should_respect_stopSequences_in_chat_request(
+                createStreamingChatModel(STOP_SEQUENCES_MODEL).build());
     }
 
-    @Test
-    void should_override_builder_defaults_with_per_request_parameters() throws Exception {
+    @Override
+    public StreamingChatModel createModelWith(ChatModelListener listener) {
+        return createStreamingChatModel(MODEL).listeners(List.of(listener)).build();
+    }
 
-        var streamingChatModel = createStreamingChatModel().maxOutputTokens(200).build();
-
-        var chatRequest = ChatRequest.builder()
-                .messages(UserMessage.from("Say hi."))
-                .parameters(WatsonxGatewayChatRequestParameters.builder()
-                        .maxOutputTokens(5)
-                        .build())
+    @Override
+    protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
+        return WatsonxGatewayChatRequestParameters.builder()
+                .maxOutputTokens(maxOutputTokens)
                 .build();
-
-        var handler = new CollectingHandler();
-        streamingChatModel.chat(chatRequest, handler);
-
-        var response = handler.await();
-
-        assertNotNull(response.aiMessage().text());
-        assertNotNull(response.modelName());
-        assertTrue(response.tokenUsage().outputTokenCount() <= 5);
     }
 
-    // The temperature is left unset, since some models exposed by the gateway accept only their own default value.
-    private WatsonxGatewayStreamingChatModel.Builder createStreamingChatModel() {
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(StreamingChatModel model) {
+        return WatsonxChatResponseMetadata.class;
+    }
+
+    @Override
+    public boolean supportsSingleImageInputAsPublicURL() {
+        // Watsonx does not support images as URLs, only as Base64-encoded strings
+        return false;
+    }
+
+    @Override
+    protected boolean supportsStreamingCancellation() {
+        return false;
+    }
+
+    @Override
+    protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id) {
+        verifyToolCall(handler, io, 0, id, "getWeather", "{\"city\": \"Munich\"}");
+    }
+
+    @Override
+    protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2) {
+        verifyToolCallbacks(handler, io, id1);
+        verifyToolCall(handler, io, 1, id2, "getTime", "{\"country\": \"France\"}");
+    }
+
+    @Override
+    protected boolean assertThreads() {
+        // The watsonx.ai SDK dispatches every callback of a response through a virtual thread per task executor, so
+        // the callbacks stay sequential but do not share a single thread
+        return false;
+    }
+
+    private WatsonxGatewayStreamingChatModel.Builder createStreamingChatModel(String model) {
         return WatsonxGatewayStreamingChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .modelName(MODEL)
+                .modelName(model)
                 .timeout(Duration.ofSeconds(120));
-    }
-
-    static class CollectingHandler implements StreamingChatResponseHandler {
-
-        final List<String> partialResponses = new ArrayList<>();
-        final List<PartialToolCall> partialToolCalls = new ArrayList<>();
-        final List<CompleteToolCall> completeToolCalls = new ArrayList<>();
-        final CompletableFuture<ChatResponse> future = new CompletableFuture<>();
-
-        @Override
-        public void onPartialResponse(String partialResponse) {
-            partialResponses.add(partialResponse);
-        }
-
-        @Override
-        public void onPartialToolCall(PartialToolCall partialToolCall) {
-            partialToolCalls.add(partialToolCall);
-        }
-
-        @Override
-        public void onCompleteToolCall(CompleteToolCall completeToolCall) {
-            completeToolCalls.add(completeToolCall);
-        }
-
-        @Override
-        public void onCompleteResponse(ChatResponse completeResponse) {
-            future.complete(completeResponse);
-        }
-
-        @Override
-        public void onError(Throwable error) {
-            future.completeExceptionally(error);
-        }
-
-        ChatResponse await() throws Exception {
-            return future.get(150, TimeUnit.SECONDS);
-        }
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelListenerIT.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import dev.langchain4j.exception.InvalidRequestException;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.common.AbstractStreamingChatModelListenerIT;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_MODEL", matches = ".+")
+public class WatsonxGatewayStreamingChatModelListenerIT extends AbstractStreamingChatModelListenerIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_GATEWAY_MODEL");
+    static final String LISTENER_MODEL =
+            getOrDefault(System.getenv("WATSONX_GATEWAY_LISTENER_MODEL"), "gemini-3.6-flash");
+
+    @Override
+    protected StreamingChatModel createModel(ChatModelListener listener) {
+        return createStreamingChatModel(LISTENER_MODEL)
+                .listeners(List.of(listener))
+                .defaultRequestParameters(ChatRequestParameters.builder()
+                        .modelName(modelName())
+                        .temperature(temperature())
+                        .topP(topP())
+                        .maxOutputTokens(maxTokens())
+                        .build())
+                .build();
+    }
+
+    @Override
+    protected String modelName() {
+        return LISTENER_MODEL;
+    }
+
+    @Override
+    protected StreamingChatModel createFailingModel(ChatModelListener listener) {
+        return createStreamingChatModel("invalid-model")
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected Class<? extends Exception> expectedExceptionClass() {
+        // For an unknown model the gateway answers with HTTP 400 and a generic "Bad Request" error code, so the
+        // exception mapper cannot narrow it down to ModelNotFoundException
+        return InvalidRequestException.class;
+    }
+
+    private WatsonxGatewayStreamingChatModel.Builder createStreamingChatModel(String model) {
+        return WatsonxGatewayStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .modelName(model)
+                .timeout(Duration.ofSeconds(120));
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxModerationModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxModerationModelListenerIT.java
@@ -1,7 +1,7 @@
 package dev.langchain4j.model.watsonx.it;
 
 import com.ibm.watsonx.ai.detection.detector.Hap;
-import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.exception.InvalidRequestException;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.moderation.common.AbstractModerationModelListenerIT;
 import dev.langchain4j.model.moderation.listener.ModerationModelListener;
@@ -42,6 +42,6 @@ public class WatsonxModerationModelListenerIT extends AbstractModerationModelLis
 
     @Override
     protected Class<? extends Exception> expectedExceptionClass() {
-        return LangChain4jException.class;
+        return InvalidRequestException.class;
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
@@ -1,15 +1,21 @@
 package dev.langchain4j.model.watsonx.it;
 
+import static dev.langchain4j.model.watsonx.it.WatsonxToolCallbacksVerifier.verifyToolCall;
+
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
 import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
 
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
@@ -23,7 +29,19 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected List<StreamingChatModel> models() {
-        return List.of(createStreamingChatModel("mistralai/mistral-medium-2505").build());
+        return List.of(createStreamingChatModel("mistralai/mistral-small-3-1-24b-instruct-2503")
+                .build());
+    }
+
+    @Override
+    protected List<StreamingChatModel> modelsSupportingTools() {
+        return List.of(createStreamingChatModel("meta-llama/llama-4-maverick-17b-128e-instruct-fp8")
+                .build());
+    }
+
+    @Override
+    protected List<StreamingChatModel> modelsSupportingStructuredOutputs() {
+        return List.of(createStreamingChatModel("ibm/granite-4-h-small").build());
     }
 
     @Override
@@ -53,33 +71,8 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
-    protected void should_execute_a_tool_then_answer(StreamingChatModel model) {
-        super.should_execute_a_tool_then_answer(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_execute_a_tool_without_arguments_then_answer(StreamingChatModel model) {
-        super.should_execute_a_tool_without_arguments_then_answer(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_execute_multiple_tools_in_parallel_then_answer(StreamingChatModel model) {
-        super.should_execute_multiple_tools_in_parallel_then_answer(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_force_LLM_to_execute_any_tool(StreamingChatModel model) {
-        super.should_force_LLM_to_execute_any_tool(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_force_LLM_to_execute_specific_tool(StreamingChatModel model) {
-        super.should_force_LLM_to_execute_specific_tool(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(StreamingChatModel model) {
+        return WatsonxChatResponseMetadata.class;
     }
 
     @Override
@@ -94,46 +87,36 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
+    protected boolean supportsToolsAndJsonResponseFormatWithSchema() {
+        // None of the models available in the project can combine the two features. They either answer with the
+        // requested JSON instead of calling the tool, or return a "tool_calls" finish reason without any tool call
+        return false;
+    }
+
+    @Override
+    @ParameterizedTest
+    @MethodSource("models")
     protected void should_respect_user_message(StreamingChatModel model) {
         super.should_respect_user_message(
                 createStreamingChatModel("ibm/granite-4-h-small").build());
     }
 
     @Override
-    protected void should_respect_JSON_response_format(StreamingChatModel model) {
-        super.should_respect_JSON_response_format(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(
-            StreamingChatModel model) {
-        super.should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
-    protected void should_respect_JSON_response_format_with_schema(StreamingChatModel model) {
-        super.should_respect_JSON_response_format_with_schema(
-                createStreamingChatModel("ibm/granite-4-h-small").build());
-    }
-
-    @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id) {
-        io.verify(handler).onPartialToolCall(partial(0, id, "getWeather", "{\"city\": \""));
-        io.verify(handler).onPartialToolCall(partial(0, id, "getWeather", "Mun"));
-        io.verify(handler).onPartialToolCall(partial(0, id, "getWeather", "ich"));
-        io.verify(handler).onPartialToolCall(partial(0, id, "getWeather", "\"}"));
-        io.verify(handler).onCompleteToolCall(complete(0, id, "getWeather", "{\"city\": \"Munich\"}"));
+        verifyToolCall(handler, io, 0, id, "getWeather", "{\"city\": \"Munich\"}");
     }
 
     @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2) {
         verifyToolCallbacks(handler, io, id1);
-        io.verify(handler).onPartialToolCall(partial(1, id2, "getTime", "{\"country\": \""));
-        io.verify(handler).onPartialToolCall(partial(1, id2, "getTime", "France"));
-        io.verify(handler).onPartialToolCall(partial(1, id2, "getTime", "\"}"));
-        io.verify(handler).onCompleteToolCall(complete(1, id2, "getTime", "{\"country\": \"France\"}"));
+        verifyToolCall(handler, io, 1, id2, "getTime", "{\"country\": \"France\"}");
+    }
+
+    @Override
+    protected boolean assertThreads() {
+        // The watsonx.ai SDK dispatches every callback of a response through a virtual thread per task executor, so
+        // the callbacks stay sequential but do not share a single thread
+        return false;
     }
 
     private WatsonxStreamingChatModel.Builder createStreamingChatModel(String model) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
@@ -1,22 +1,14 @@
 package dev.langchain4j.model.watsonx.it;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
 import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.InOrder;
 
@@ -28,7 +20,6 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
-    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
 
     @Override
     protected List<StreamingChatModel> models() {
@@ -143,36 +134,6 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
         io.verify(handler).onPartialToolCall(partial(1, id2, "getTime", "France"));
         io.verify(handler).onPartialToolCall(partial(1, id2, "getTime", "\"}"));
         io.verify(handler).onCompleteToolCall(complete(1, id2, "getTime", "{\"country\": \"France\"}"));
-    }
-
-    @Test
-    @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
-    void should_use_deployed_model_with_deployment_id() {
-        var chatModel = WatsonxStreamingChatModel.builder()
-                .baseUrl(URL)
-                .apiKey(API_KEY)
-                .deploymentId(DEPLOYMENT_ID)
-                .timeout(Duration.ofSeconds(30))
-                .logRequests(true)
-                .build();
-
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<ChatResponse> chatResponse = new AtomicReference<ChatResponse>(null);
-
-        chatModel.chat("Hello", new StreamingChatResponseHandler() {
-
-            @Override
-            public void onCompleteResponse(ChatResponse completeResponse) {
-                latch.countDown();
-                chatResponse.set(completeResponse);
-            }
-
-            @Override
-            public void onError(Throwable error) {}
-        });
-
-        assertDoesNotThrow(() -> latch.await(5, TimeUnit.SECONDS));
-        assertNotNull(chatResponse.get().aiMessage().text());
     }
 
     private WatsonxStreamingChatModel.Builder createStreamingChatModel(String model) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
@@ -83,6 +83,7 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected boolean supportsStreamingCancellation() {
+        // The watsonx models do not expose a StreamingHandle that can stop an ongoing stream
         return false;
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
@@ -142,8 +142,8 @@ public class WatsonxStreamingChatModelThinkingIT {
             }
         });
 
-        var chatResponse = assertDoesNotThrow(() -> futureChatResponse.get(10, TimeUnit.SECONDS));
-        assertDoesNotThrow(() -> futureThinking.get(10, TimeUnit.SECONDS));
+        var chatResponse = assertDoesNotThrow(() -> futureChatResponse.get(30, TimeUnit.SECONDS));
+        assertDoesNotThrow(() -> futureThinking.get(30, TimeUnit.SECONDS));
 
         var aiMessage = chatResponse.aiMessage();
         assertThat(aiMessage.thinking()).isNotBlank();

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
@@ -13,6 +13,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
 import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -74,7 +75,7 @@ public class WatsonxStreamingChatModelThinkingIT {
     @Test
     void should_return_and_NOT_send_thinking() {
 
-        StreamingChatModel streamingChatModel = WatsonxStreamingChatModel.builder()
+        StreamingChatModel streamingChatModel = WatsonxDeploymentStreamingChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
                 .deploymentId(DEPLOYMENT_ID)
@@ -149,8 +150,8 @@ public class WatsonxStreamingChatModelThinkingIT {
         assertThat(aiMessage.text()).isNotBlank();
     }
 
-    private WatsonxStreamingChatModel.Builder createStreamingChatModel() {
-        return WatsonxStreamingChatModel.builder()
+    private WatsonxDeploymentStreamingChatModel.Builder createStreamingChatModel() {
+        return WatsonxDeploymentStreamingChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
                 .deploymentId(DEPLOYMENT_ID)

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxToolCallbacksVerifier.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxToolCallbacksVerifier.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static dev.langchain4j.MockitoUtils.ignoreInteractions;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import org.mockito.InOrder;
+
+/**
+ * Verifies the callbacks of a single tool call without assuming how the model splits the tool arguments across the
+ * partial callbacks. Every model chunks them differently, and some send the whole JSON in a single callback.
+ */
+final class WatsonxToolCallbacksVerifier {
+
+    static void verifyToolCall(
+            StreamingChatResponseHandler handler, InOrder io, int index, String id, String name, String arguments) {
+
+        // Some models talk before calling a tool, so the partial responses are ignored.
+        ignoreInteractions(handler).onPartialResponse(any());
+        ignoreInteractions(handler).onPartialResponse(any(), any());
+
+        // At least one partial callback must carry the index, the id and the name of the tool, and it must arrive
+        // before the complete callback of the same tool.
+        io.verify(handler, atLeastOnce())
+                .onPartialToolCall(
+                        argThat(partial ->
+                                partial.index() == index && id.equals(partial.id()) && name.equals(partial.name())),
+                        any());
+
+        // The number of partial callbacks depends on how the model chunks the arguments, so the ones that the
+        // verification above did not consume are ignored to keep "verifyNoMoreInteractions" happy.
+        ignoreInteractions(handler).onPartialToolCall(any());
+        ignoreInteractions(handler).onPartialToolCall(any(), any());
+
+        io.verify(handler).onCompleteToolCall(argThat(complete -> {
+            ToolExecutionRequest request = complete.toolExecutionRequest();
+            return complete.index() == index
+                    && id.equals(request.id())
+                    && name.equals(request.name())
+                    && withoutWhitespace(arguments).equals(withoutWhitespace(request.arguments()));
+        }));
+    }
+
+    /**
+     * The models do not agree on how to indent the tool arguments, so they are compared without any whitespace.
+     */
+    private static String withoutWhitespace(String value) {
+        return value == null ? "" : value.replaceAll("\\s", "");
+    }
+
+    private WatsonxToolCallbacksVerifier() {}
+}


### PR DESCRIPTION
## Change

This PR updates the `langchain4j-watsonx` module to the watsonx.ai Java SDK `0.30.0` and adds support for two new watsonx.ai chat services.

| Class | Use it for |
|---|---|
| `WatsonxChatModel` / `WatsonxStreamingChatModel` | foundation models in a project or space (unchanged) |
| `WatsonxDeploymentChatModel` / `WatsonxDeploymentStreamingChatModel` | **new**, models deployed on-demand, selected with `deploymentId(...)` |
| `WatsonxGatewayChatModel` / `WatsonxGatewayStreamingChatModel` | **new**, models reached through the watsonx.ai Model Gateway |

**`WatsonxGatewayModelCatalog`**

The PR also adds a `ModelCatalog` implementation for the Model Gateway, backed by the `ModelGatewayCatalogService` of the SDK. It is the gateway counterpart of `WatsonxModelCatalog`, so instead of listing the foundation models hosted by watsonx.ai it lists the models configured in the gateway.

## Breaking Changes

This PR splits the watsonx.ai chat models by service, so three public APIs change.

### 1. Deployment support moved to dedicated models

`deploymentId(...)` is gone from `WatsonxChatModel.Builder` and `WatsonxStreamingChatModel.Builder`, and `WatsonxChatRequestParameters` no longer exposes `deploymentId()` nor `Builder.deploymentId(...)`. On-demand deployments are now served by `WatsonxDeploymentChatModel` and `WatsonxDeploymentStreamingChatModel`.

**Before**

```java
ChatModel model = WatsonxChatModel.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .projectId(System.getenv("WATSONX_PROJECT_ID"))
    .deploymentId("my-deployment-id")
    .build();
```

**After**

```java
ChatModel model = WatsonxDeploymentChatModel.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .deploymentId("my-deployment-id")
    .build();
```

Two things to keep in mind when migrating.

- `projectId` and `spaceId` are no longer accepted, because the deployment id already identifies the resource being called.
- Setting `modelName`, either on the builder or in the request parameters, now throws `UnsupportedFeatureException`, because the deployment defines which model is invoked.

### 2. `WatsonxModelCatalog.Builder` no longer accepts `projectId` and `spaceId`

Its builder now extends the connection-only builder. The two setters were accepted before but never read, the foundation model listing endpoint is not scoped to a project or a space.

**Before**

```java
ModelCatalog catalog = WatsonxModelCatalog.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .projectId(System.getenv("WATSONX_PROJECT_ID"))
    .build();
```

**After**

```java
ModelCatalog catalog = WatsonxModelCatalog.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .build();
```

### 3. Structured outputs now generate a strict JSON Schema

The previous code built the schema map in non-strict mode while still sending `strict: true` to the API, so the two disagreed. Both now derive from the new `strictJsonSchema` flag, which defaults to `true`.

With the default, a schema generated from a POJO marks every property as `required`, expresses optional fields as nullable and sets `additionalProperties` to `false`. Responses become more reliable, but a schema that the API accepted loosely before may now be rejected, and models that do not implement strict mode may fail.

To keep the previous, looser schema.

```java
ChatModel model = WatsonxChatModel.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .projectId(System.getenv("WATSONX_PROJECT_ID"))
    .modelName("ibm/granite-4-h-small")
    .strictJsonSchema(false)
    .build();
```

## General checklist
- [ ] There are no breaking changes (API, behaviour) <!-- see the "Note on breaking changes" section above, the module is in beta -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A, there is no watsonx Spring Boot starter -->
