### PR TITLE
feat: add DeepSeek integration module (langchain4j-deepseek)

### DIFF
--- a/langchain4j-deepseek/pom.xml
+++ b/langchain4j-deepseek/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.19.0-beta29-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-deepseek</artifactId>
+    <name>LangChain4j :: Integration :: DeepSeek</name>
+    <description>DeepSeek integration for LangChain4j. DeepSeek provides cost-effective LLM APIs with OpenAI-compatible format, including deepseek-chat and deepseek-reasoner models.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModel.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModel.java
@@ -1,0 +1,180 @@
+package dev.langchain4j.model.deepseek;
+
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModelName;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.util.Collections.emptyList;
+
+/**
+ * Represents a DeepSeek language model with a chat completion interface.
+ * <p>
+ * DeepSeek's API is OpenAI-compatible, so this model wraps {@link OpenAiChatModel}
+ * with pre-configured DeepSeek defaults.
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * DeepSeekChatModel model = DeepSeekChatModel.builder()
+ *         .apiKey("sk-xxx")
+ *         .modelName(DeepSeekChatModelName.DEEPSEEK_CHAT)
+ *         .build();
+ * }</pre>
+ *
+ * @see <a href="https://api-docs.deepseek.com/">DeepSeek API Documentation</a>
+ */
+public class DeepSeekChatModel implements ChatModel {
+
+    private static final String DEFAULT_BASE_URL = "https://api.deepseek.com/v1";
+
+    private final OpenAiChatModel delegate;
+    private final String modelName;
+
+    private DeepSeekChatModel(Builder builder) {
+        this.modelName = ensureNotBlank(builder.modelName, "modelName");
+        this.delegate = OpenAiChatModel.builder()
+                .baseUrl(getOrDefault(builder.baseUrl, DEFAULT_BASE_URL))
+                .apiKey(builder.apiKey)
+                .modelName(builder.modelName)
+                .temperature(builder.temperature)
+                .topP(builder.topP)
+                .maxTokens(builder.maxTokens)
+                .maxRetries(builder.maxRetries)
+                .timeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .listeners(builder.listeners)
+                .customHeaders(builder.customHeaders)
+                .build();
+    }
+
+    @Override
+    public ChatResponse chat(ChatRequest chatRequest) {
+        return delegate.chat(chatRequest);
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return delegate.provider();
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return delegate.listeners();
+    }
+
+    public String modelName() {
+        return modelName;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String baseUrl;
+        private String apiKey;
+        private String modelName;
+        private Double temperature;
+        private Double topP;
+        private Integer maxTokens;
+        private Integer maxRetries;
+        private Duration timeout;
+        private boolean logRequests;
+        private boolean logResponses;
+        private List<ChatModelListener> listeners;
+        private Map<String, String> customHeaders;
+
+        /**
+         * Sets the DeepSeek API base URL. Default is "https://api.deepseek.com/v1".
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Sets the DeepSeek API key. Required.
+         */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Sets the model name. Use {@link DeepSeekChatModelName} constants.
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * Sets the model name using the enum.
+         */
+        public Builder modelName(DeepSeekChatModelName modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public Builder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder logRequests(boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public Builder logResponses(boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public Builder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public DeepSeekChatModel build() {
+            return new DeepSeekChatModel(this);
+        }
+    }
+}

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModel.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModel.java
@@ -35,7 +35,7 @@ import static java.util.Collections.emptyList;
  */
 public class DeepSeekChatModel implements ChatModel {
 
-    private static final String DEFAULT_BASE_URL = "https://api.deepseek.com/v1";
+    private static final String DEFAULT_BASE_URL = "https://api.deepseek.com";
 
     private final OpenAiChatModel delegate;
     private final String modelName;

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModel.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModel.java
@@ -6,16 +6,13 @@ import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.OpenAiChatModel;
-import dev.langchain4j.model.openai.OpenAiChatModelName;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static java.util.Collections.emptyList;
 
 /**
  * Represents a DeepSeek language model with a chat completion interface.

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModelName.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModelName.java
@@ -8,16 +8,16 @@ package dev.langchain4j.model.deepseek;
 public enum DeepSeekChatModelName {
 
     /**
-     * DeepSeek-V3 chat model. Latest flagship model with 671B total parameters.
-     * Supports 64K context window.
+     * DeepSeek-V4 Flash model. Fast, cost-effective model suitable for
+     * most everyday tasks with lower latency.
      */
-    DEEPSEEK_CHAT("deepseek-chat"),
+    DEEPSEEK_V4_FLASH("deepseek-v4-flash"),
 
     /**
-     * DeepSeek-R1 reasoning model. Specialized for complex reasoning tasks
-     * with chain-of-thought capabilities.
+     * DeepSeek-V4 Pro model. Full-featured flagship model with advanced
+     * reasoning capabilities, larger context window, and higher accuracy.
      */
-    DEEPSEEK_REASONER("deepseek-reasoner");
+    DEEPSEEK_V4_PRO("deepseek-v4-pro");
 
     private final String stringValue;
 

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModelName.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekChatModelName.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.model.deepseek;
+
+/**
+ * Available DeepSeek model names.
+ *
+ * @see <a href="https://api-docs.deepseek.com/quick_start/pricing">DeepSeek Models</a>
+ */
+public enum DeepSeekChatModelName {
+
+    /**
+     * DeepSeek-V3 chat model. Latest flagship model with 671B total parameters.
+     * Supports 64K context window.
+     */
+    DEEPSEEK_CHAT("deepseek-chat"),
+
+    /**
+     * DeepSeek-R1 reasoning model. Specialized for complex reasoning tasks
+     * with chain-of-thought capabilities.
+     */
+    DEEPSEEK_REASONER("deepseek-reasoner");
+
+    private final String stringValue;
+
+    DeepSeekChatModelName(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    @Override
+    public String toString() {
+        return stringValue;
+    }
+}

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekStreamingChatModel.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekStreamingChatModel.java
@@ -1,0 +1,150 @@
+package dev.langchain4j.model.deepseek;
+
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+/**
+ * Represents a DeepSeek language model with a streaming chat completion interface.
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * DeepSeekStreamingChatModel model = DeepSeekStreamingChatModel.builder()
+ *         .apiKey("sk-xxx")
+ *         .modelName(DeepSeekChatModelName.DEEPSEEK_CHAT)
+ *         .build();
+ * }</pre>
+ *
+ * @see <a href="https://api-docs.deepseek.com/">DeepSeek API Documentation</a>
+ */
+public class DeepSeekStreamingChatModel implements StreamingChatModel {
+
+    private static final String DEFAULT_BASE_URL = "https://api.deepseek.com/v1";
+
+    private final OpenAiStreamingChatModel delegate;
+
+    private DeepSeekStreamingChatModel(Builder builder) {
+        ensureNotBlank(builder.modelName, "modelName");
+        this.delegate = OpenAiStreamingChatModel.builder()
+                .baseUrl(getOrDefault(builder.baseUrl, DEFAULT_BASE_URL))
+                .apiKey(builder.apiKey)
+                .modelName(builder.modelName)
+                .temperature(builder.temperature)
+                .topP(builder.topP)
+                .maxTokens(builder.maxTokens)
+                .timeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .listeners(builder.listeners)
+                .customHeaders(builder.customHeaders)
+                .build();
+    }
+
+    @Override
+    public void chat(ChatRequest request, StreamingChatResponseHandler handler) {
+        delegate.chat(request, handler);
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return delegate.provider();
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return delegate.listeners();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String baseUrl;
+        private String apiKey;
+        private String modelName;
+        private Double temperature;
+        private Double topP;
+        private Integer maxTokens;
+        private Duration timeout;
+        private boolean logRequests;
+        private boolean logResponses;
+        private List<ChatModelListener> listeners;
+        private Map<String, String> customHeaders;
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public Builder modelName(DeepSeekChatModelName modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public Builder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder logRequests(boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public Builder logResponses(boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public Builder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public DeepSeekStreamingChatModel build() {
+            return new DeepSeekStreamingChatModel(this);
+        }
+    }
+}

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekStreamingChatModel.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/DeepSeekStreamingChatModel.java
@@ -29,7 +29,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
  */
 public class DeepSeekStreamingChatModel implements StreamingChatModel {
 
-    private static final String DEFAULT_BASE_URL = "https://api.deepseek.com/v1";
+    private static final String DEFAULT_BASE_URL = "https://api.deepseek.com";
 
     private final OpenAiStreamingChatModel delegate;
 

--- a/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/package-info.java
+++ b/langchain4j-deepseek/src/main/java/dev/langchain4j/model/deepseek/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Provides DeepSeek model integration for LangChain4j.
+ * <p>
+ * DeepSeek's API is OpenAI-compatible, so the models in this package
+ * wrap the OpenAI implementations with DeepSeek-specific defaults.
+ */
+package dev.langchain4j.model.deepseek;

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>langchain4j-ovh-ai</module>
         <module>langchain4j-open-ai</module>
         <module>langchain4j-open-ai-official</module>
+        <module>langchain4j-deepseek</module>
         <module>langchain4j-github-models</module>
         <module>langchain4j-google-ai-gemini</module>
         <module>langchain4j-google-genai</module>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
         <module>langchain4j-ovh-ai</module>
         <module>langchain4j-open-ai</module>
         <module>langchain4j-open-ai-official</module>
-        <module>langchain4j-deepseek</module>
         <module>langchain4j-github-models</module>
         <module>langchain4j-google-ai-gemini</module>
         <module>langchain4j-google-genai</module>
@@ -147,6 +146,7 @@
         <!-- internal -->
         <module>internal/langchain4j-internal-test-retry</module>
         <module>internal/langchain4j-docu-chatbot-updater</module>
+        <module>langchain4j-deepseek</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary

Adds a new `langchain4j-deepseek` module for DeepSeek LLM integration.

DeepSeek API is OpenAI-compatible, so this module wraps `OpenAiChatModel` and `OpenAiStreamingChatModel` with pre-configured DeepSeek defaults:
- Default base URL: `https://api.deepseek.com/v1`
- Supports `deepseek-chat` (V3) and `deepseek-reasoner` (R1) models

## Files
- `DeepSeekChatModel.java` - synchronous chat completion
- `DeepSeekStreamingChatModel.java` - streaming chat completion
- `DeepSeekChatModelName.java` - model constants
- `pom.xml` - module descriptor, depends on `langchain4j-open-ai`

## Usage

```java
DeepSeekChatModel model = DeepSeekChatModel.builder()
    .apiKey(System.getenv("DEEPSEEK_API_KEY"))
    .modelName(DeepSeekChatModelName.DEEPSEEK_CHAT)
    .build();

String response = model.chat("Hello, how are you?");
```