### PR TITLE
Fix `AgentInvocationException` wrapping in the `DeferredResponse` timeout overload

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/DeferredResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/DeferredResponse.java
@@ -3,6 +3,7 @@ package dev.langchain4j.agentic.internal;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -66,10 +67,18 @@ public abstract class DeferredResponse<T> implements DelayedResponse<T> {
     public T blockingGet(long timeout, TimeUnit unit) throws TimeoutException {
         try {
             return futureResponse.get(timeout, unit);
-        } catch (TimeoutException e) {
-            throw e;
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new RuntimeException(cause);
         }
     }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/DelayedResponseTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/DelayedResponseTest.java
@@ -11,6 +11,8 @@ import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.service.TokenStream;
 import java.io.IOException;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
@@ -83,5 +85,42 @@ class DelayedResponseTest {
         response.complete("ok");
 
         assertThat(response.blockingGet()).isEqualTo("ok");
+    }
+
+    @Test
+    void timeout_overload_rethrows_original_runtime_exception_not_executionException() {
+        AgentInvocationException original = new AgentInvocationException("boom");
+        PendingResponse<String> response = new PendingResponse<>("id");
+        response.completeExceptionally(original);
+
+        assertThatThrownBy(() -> response.blockingGet(1, TimeUnit.SECONDS))
+                .isInstanceOf(AgentInvocationException.class)
+                .isSameAs(original);
+    }
+
+    @Test
+    void timeout_overload_leaves_checked_cause_wrapped() {
+        IOException checked = new IOException("io");
+        PendingResponse<String> response = new PendingResponse<>("id");
+        response.completeExceptionally(checked);
+
+        assertThatThrownBy(() -> response.blockingGet(1, TimeUnit.SECONDS))
+                .isInstanceOf(RuntimeException.class)
+                .hasCause(checked);
+    }
+
+    @Test
+    void timeout_overload_still_times_out_when_the_response_is_not_completed() {
+        PendingResponse<String> response = new PendingResponse<>("id");
+
+        assertThatThrownBy(() -> response.blockingGet(1, TimeUnit.MILLISECONDS)).isInstanceOf(TimeoutException.class);
+    }
+
+    @Test
+    void timeout_overload_returns_successful_response_unchanged() throws Exception {
+        PendingResponse<String> response = new PendingResponse<>("id");
+        response.complete("ok");
+
+        assertThat(response.blockingGet(1, TimeUnit.SECONDS)).isEqualTo("ok");
     }
 }


### PR DESCRIPTION
## Issue
Closes #5985

## Change
`DeferredResponse` has two ways to wait for a deferred response and they surfaced a failure
differently.

`blockingGet()` delegates to `DelayedResponse.join`, which rethrows an unchecked cause, so a
failed agent reaches the caller as the exception it threw. `blockingGet(long, TimeUnit)` caught
everything from `Future.get` and rewrapped it, so the same failure surfaced as
`RuntimeException(ExecutionException(...))`. The broad `catch (Exception e)` also swallowed
`InterruptedException` without restoring the interrupt flag.

The overload now rethrows an unchecked cause directly and restores the interrupt flag, using the
same handling already in `PlannerBasedInvocationHandler.parallelExecution`:

```java
} catch (InterruptedException e) {
    Thread.currentThread().interrupt();
    throw new RuntimeException(e);
} catch (ExecutionException e) {
    Throwable cause = e.getCause();
    if (cause instanceof RuntimeException runtimeException) {
        throw runtimeException;
    }
    if (cause instanceof Error error) {
        throw error;
    }
    throw new RuntimeException(cause);
}
```

`TimeoutException` now propagates on its own because the catch clauses are specific, so the
`catch (TimeoutException e) { throw e; }` rethrow is no longer needed.

Tests, offline and with no model, in `DelayedResponseTest`. The first two fail on the current
code and pass with the change:
- `timeout_overload_rethrows_original_runtime_exception_not_executionException`
- `timeout_overload_leaves_checked_cause_wrapped`
- `timeout_overload_still_times_out_when_the_response_is_not_completed`
- `timeout_overload_returns_successful_response_unchanged`

```
mvn -pl langchain4j-agentic test
Tests run: 114, Failures: 0, Errors: 0, Skipped: 0
```

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)