### PR TITLE
fix: parse query router choices before explanations

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouter.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouter.java
@@ -122,7 +122,8 @@ public class LanguageModelQueryRouter implements QueryRouter {
     }
 
     protected Collection<ContentRetriever> parse(String choices) {
-        return stream(choices.split(","))
+        String firstLine = choices.stripLeading().lines().findFirst().orElse(choices);
+        return stream(firstLine.split(","))
                 .map(String::trim)
                 .map(Integer::parseInt)
                 .map(this::retrieverById)

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouterTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/query/router/LanguageModelQueryRouterTest.java
@@ -118,6 +118,55 @@ class LanguageModelQueryRouterTest {
     }
 
     @Test
+    void should_route_when_LLM_adds_explanation_after_choices() {
+
+        // given
+        Query query = Query.from("Do Labradors shed?");
+
+        Map<ContentRetriever, String> retrieverToDescription = new LinkedHashMap<>();
+        retrieverToDescription.put(catArticlesRetriever, "articles about cats");
+        retrieverToDescription.put(dogArticlesRetriever, "articles about dogs");
+
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds("""
+                2
+                Explanation: Retriever 2 is the best match for this query.
+                """);
+
+        QueryRouter router = LanguageModelQueryRouter.builder()
+                .chatModel(model)
+                .retrieverToDescription(retrieverToDescription)
+                .fallbackStrategy(FAIL)
+                .build();
+
+        // when
+        Collection<ContentRetriever> retrievers = router.route(query);
+
+        // then
+        assertThat(retrievers).containsExactly(dogArticlesRetriever);
+    }
+
+    @Test
+    void should_not_route_when_LLM_returns_prose_containing_a_number() {
+
+        // given
+        Query query = Query.from("Do Labradors shed?");
+
+        Map<ContentRetriever, String> retrieverToDescription = new LinkedHashMap<>();
+        retrieverToDescription.put(catArticlesRetriever, "articles about cats");
+        retrieverToDescription.put(dogArticlesRetriever, "articles about dogs");
+
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds("I cannot choose between the 2 sources");
+
+        QueryRouter router = new LanguageModelQueryRouter(model, retrieverToDescription);
+
+        // when
+        Collection<ContentRetriever> retrievers = router.route(query);
+
+        // then
+        assertThat(retrievers).isEmpty();
+    }
+
+    @Test
     void should_route_to_multiple_retrievers_with_custom_prompt_template() {
 
         // given


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #2447

## Change
<!-- Please describe the changes you made. -->

`LanguageModelQueryRouter.parse()` previously split the complete model response only on commas. A response such as `2\nExplanation: ...` therefore passed the entire multi-line token to `Integer.parseInt`, raised `NumberFormatException`, and applied the configured fallback even though the first line contained a valid retriever choice.

Parse the comma-separated choices from the first response line after leading whitespace. This preserves existing handling for multiple ids and invalid responses while allowing models to append an explanation on later lines.

The regression tests cover both boundaries:

- a valid first-line choice followed by an explanation selects the expected retriever;
- prose that merely contains a number remains invalid and does not cause an accidental route.

Regression evidence: `./mvnw -pl langchain4j-core -Dtest=LanguageModelQueryRouterTest test` fails on the unchanged base and passes with this fix.

Verification:

- `./mvnw clean test` (all 112 Reactor modules passed)
- `./mvnw -pl langchain4j-core -Pspotless com.diffplug.spotless:spotless-maven-plugin:2.44.4:check`

No documentation update is needed because this restores the router's documented choice behavior without changing its API or configuration.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
