### PR TITLE
Fix interface-level `@SystemMessage` being ignored in AI Services

### DIFF
--- a/docs/docs/tutorials/ai-services.md
+++ b/docs/docs/tutorials/ai-services.md
@@ -128,6 +128,22 @@ This will be converted into a `SystemMessage` behind the scenes and sent to the 
 `@SystemMessage` can also load a prompt template from resources:
 `@SystemMessage(fromResource = "my-prompt-template.txt")`
 
+`@SystemMessage` can also be declared on the AI Service interface,
+in which case it applies to all methods exposed by that AI Service, including inherited ones:
+
+```java
+@SystemMessage("You are a good friend of mine. Answer using slang.")
+interface Friend {
+
+    String chat(String userMessage);
+
+    String chatAgain(String userMessage);
+}
+```
+
+A `@SystemMessage` declared on a method takes precedence over one declared on the interface.
+A `@SystemMessage` declared only on a parent interface is not inherited by a child AI Service interface.
+
 ### System Message Provider
 System messages can also be defined dynamically with the system message provider:
 ```java

--- a/integration-tests/integration-tests-guardrails/src/test/java/dev/langchain4j/service/guardrail/OutputGuardrailRepromptingTests.java
+++ b/integration-tests/integration-tests-guardrails/src/test/java/dev/langchain4j/service/guardrail/OutputGuardrailRepromptingTests.java
@@ -36,19 +36,25 @@ class OutputGuardrailRepromptingTests extends BaseGuardrailTests {
                 .extracting(ChatMemory::messages)
                 .satisfies(messages -> assertThat(messages)
                         .isNotNull()
-                        .hasSize(2)
+                        .hasSize(3)
                         .satisfies(
                                 message -> assertThat(message)
                                         .isNotNull()
                                         .extracting(ChatMessage::type)
-                                        .isEqualTo(ChatMessageType.USER),
+                                        .isEqualTo(ChatMessageType.SYSTEM),
                                 atIndex(0))
                         .satisfies(
                                 message -> assertThat(message)
                                         .isNotNull()
                                         .extracting(ChatMessage::type)
+                                        .isEqualTo(ChatMessageType.USER),
+                                atIndex(1))
+                        .satisfies(
+                                message -> assertThat(message)
+                                        .isNotNull()
+                                        .extracting(ChatMessage::type)
                                         .isEqualTo(ChatMessageType.AI),
-                                atIndex(1)));
+                                atIndex(2)));
     }
 
     @Test
@@ -61,19 +67,25 @@ class OutputGuardrailRepromptingTests extends BaseGuardrailTests {
                 .extracting(ChatMemory::messages)
                 .satisfies(messages -> assertThat(messages)
                         .isNotNull()
-                        .hasSize(2)
+                        .hasSize(3)
                         .satisfies(
                                 message -> assertThat(message)
                                         .isNotNull()
                                         .extracting(ChatMessage::type)
-                                        .isEqualTo(ChatMessageType.USER),
+                                        .isEqualTo(ChatMessageType.SYSTEM),
                                 atIndex(0))
                         .satisfies(
                                 message -> assertThat(message)
                                         .isNotNull()
                                         .extracting(ChatMessage::type)
+                                        .isEqualTo(ChatMessageType.USER),
+                                atIndex(1))
+                        .satisfies(
+                                message -> assertThat(message)
+                                        .isNotNull()
+                                        .extracting(ChatMessage::type)
                                         .isEqualTo(ChatMessageType.AI),
-                                atIndex(1)));
+                                atIndex(2)));
     }
 
     @Test
@@ -86,19 +98,25 @@ class OutputGuardrailRepromptingTests extends BaseGuardrailTests {
                 .extracting(ChatMemory::messages)
                 .satisfies(messages -> assertThat(messages)
                         .isNotNull()
-                        .hasSize(2)
+                        .hasSize(3)
                         .satisfies(
                                 message -> assertThat(message)
                                         .isNotNull()
                                         .extracting(ChatMessage::type)
-                                        .isEqualTo(ChatMessageType.USER),
+                                        .isEqualTo(ChatMessageType.SYSTEM),
                                 atIndex(0))
                         .satisfies(
                                 message -> assertThat(message)
                                         .isNotNull()
                                         .extracting(ChatMessage::type)
+                                        .isEqualTo(ChatMessageType.USER),
+                                atIndex(1))
+                        .satisfies(
+                                message -> assertThat(message)
+                                        .isNotNull()
+                                        .extracting(ChatMessage::type)
                                         .isEqualTo(ChatMessageType.AI),
-                                atIndex(1)));
+                                atIndex(2)));
     }
 
     @SystemMessage("Say Hi!")
@@ -157,8 +175,9 @@ class OutputGuardrailRepromptingTests extends BaseGuardrailTests {
 
             if (v == 1) {
                 ChatMessage last = messages.get(messages.size() - 1);
-                assertThat(last).isInstanceOfSatisfying(AiMessage.class, am -> assertThat(am.text())
-                        .isEqualTo("Nope"));
+                assertThat(last)
+                        .isInstanceOfSatisfying(
+                                AiMessage.class, am -> assertThat(am.text()).isEqualTo("Nope"));
                 assertThat(request.responseFromLLM().aiMessage().text()).isEqualTo("Nope");
                 return reprompt("Retry", "Retry");
             }
@@ -168,8 +187,9 @@ class OutputGuardrailRepromptingTests extends BaseGuardrailTests {
                 ChatMessage last = messages.get(messages.size() - 1);
                 ChatMessage beforeLast = messages.get(messages.size() - 2);
 
-                assertThat(last).isInstanceOfSatisfying(AiMessage.class, am -> assertThat(am.text())
-                        .isEqualTo("Nope"));
+                assertThat(last)
+                        .isInstanceOfSatisfying(
+                                AiMessage.class, am -> assertThat(am.text()).isEqualTo("Nope"));
                 assertThat(request.responseFromLLM().aiMessage().text()).isEqualTo("Hello");
                 assertThat(beforeLast)
                         .isInstanceOfSatisfying(
@@ -207,8 +227,9 @@ class OutputGuardrailRepromptingTests extends BaseGuardrailTests {
 
             if (v == 1) {
                 ChatMessage last = messages.get(messages.size() - 1);
-                assertThat(last).isInstanceOfSatisfying(AiMessage.class, am -> assertThat(am.text())
-                        .isEqualTo("Nope"));
+                assertThat(last)
+                        .isInstanceOfSatisfying(
+                                AiMessage.class, am -> assertThat(am.text()).isEqualTo("Nope"));
                 return reprompt("Retry", "Retry Once");
             }
 
@@ -217,8 +238,9 @@ class OutputGuardrailRepromptingTests extends BaseGuardrailTests {
                 ChatMessage last = messages.get(messages.size() - 1);
                 ChatMessage beforeLast = messages.get(messages.size() - 2);
 
-                assertThat(last).isInstanceOfSatisfying(AiMessage.class, am -> assertThat(am.text())
-                        .isEqualTo("Nope"));
+                assertThat(last)
+                        .isInstanceOfSatisfying(
+                                AiMessage.class, am -> assertThat(am.text()).isEqualTo("Nope"));
                 assertThat(beforeLast)
                         .isInstanceOfSatisfying(
                                 dev.langchain4j.data.message.UserMessage.class,

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -79,7 +79,8 @@ import java.util.function.UnaryOperator;
  * <p>
  * Currently, AI Services support:
  * <pre>
- * - Static system message templates, configured via @{@link SystemMessage} annotation on top of the method
+ * - Static system message templates, configured via @{@link SystemMessage} annotation
+ *   on top of the method or on the AI Service interface
  * - Dynamic system message templates, configured via {@link #systemMessageProvider(Function)}
  * - Static user message templates, configured via @{@link UserMessage} annotation on top of the method
  * - Dynamic user message templates, configured via method parameter annotated with @{@link UserMessage}

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -617,13 +617,34 @@ class DefaultAiServices<T> extends AiServices<T> {
                 method.getAnnotation(dev.langchain4j.service.SystemMessage.class);
         if (annotation != null) {
             return Optional.of(getTemplate(
-                    method, "System", annotation.fromResource(), annotation.value(), annotation.delimiter()));
+                    method.getDeclaringClass(),
+                    "System",
+                    annotation.fromResource(),
+                    annotation.value(),
+                    annotation.delimiter()));
         }
+
+        Optional<String> templateFromClassAnnotation =
+                findSystemMessageTemplateFromClassAnnotation(context.aiServiceClass);
+        if (templateFromClassAnnotation.isPresent()) {
+            return templateFromClassAnnotation;
+        }
+
         if (context.systemMessageProviderWithContext != null) {
             return Optional.of(context.systemMessageProviderWithContext.apply(invocationContext));
         } else {
             return context.systemMessageProvider.apply(invocationContext.chatMemoryId());
         }
+    }
+
+    private static Optional<String> findSystemMessageTemplateFromClassAnnotation(Class<?> annotatedClass) {
+        dev.langchain4j.service.SystemMessage annotation =
+                annotatedClass.getAnnotation(dev.langchain4j.service.SystemMessage.class);
+        if (annotation == null) {
+            return Optional.empty();
+        }
+        return Optional.of(getTemplate(
+                annotatedClass, "System", annotation.fromResource(), annotation.value(), annotation.delimiter()));
     }
 
     private static UserMessage prepareUserMessage(
@@ -712,7 +733,7 @@ class DefaultAiServices<T> extends AiServices<T> {
 
     private static Optional<String> findUserMessageTemplateFromMethodAnnotation(Method method) {
         return Optional.ofNullable(method.getAnnotation(dev.langchain4j.service.UserMessage.class))
-                .map(a -> getTemplate(method, "User", a.fromResource(), a.value(), a.delimiter()));
+                .map(a -> getTemplate(method.getDeclaringClass(), "User", a.fromResource(), a.value(), a.delimiter()));
     }
 
     private static Optional<String> findUserMessageTemplateFromAnnotatedParameter(
@@ -833,10 +854,11 @@ class DefaultAiServices<T> extends AiServices<T> {
         return o instanceof List<?> list && list.stream().allMatch(Content.class::isInstance);
     }
 
-    private static String getTemplate(Method method, String type, String resource, String[] value, String delimiter) {
+    private static String getTemplate(
+            Class<?> annotatedClass, String type, String resource, String[] value, String delimiter) {
         String messageTemplate;
         if (!resource.trim().isEmpty()) {
-            messageTemplate = getResourceText(method.getDeclaringClass(), resource);
+            messageTemplate = getResourceText(annotatedClass, resource);
             if (messageTemplate == null) {
                 throw illegalConfiguration("@%sMessage's resource '%s' not found", type, resource);
             }

--- a/langchain4j/src/main/java/dev/langchain4j/service/SystemMessage.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/SystemMessage.java
@@ -1,12 +1,12 @@
 package dev.langchain4j.service;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-import java.util.function.Function;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.function.Function;
 
 /**
  * Specifies either a complete system message (prompt) or a system message template to be used each time an AI service is invoked.
@@ -30,7 +30,21 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     String chat(@UserMessage String userMessage, @V("characteristic") String characteristic);
  * }
  * </pre>
- * When both {@code @SystemMessage} and {@link AiServices#systemMessageProvider(Function)} are configured,
+ * It can also be declared on the AI Service interface, in which case it applies to all methods of that interface.
+ * <br>
+ * An example:
+ * <pre>
+ * {@code @SystemMessage}("You are a helpful assistant")
+ * interface Assistant {
+ *
+ *     String chat(String userMessage);
+ * }
+ * </pre>
+ * A {@code @SystemMessage} declared on a method takes precedence over one declared on the interface.
+ * A {@code @SystemMessage} declared only on a parent interface is not inherited by a child AI Service interface.
+ * <br>
+ * When both {@code @SystemMessage} and a system message provider
+ * (see {@link AiServices#systemMessageProvider(Function)}) are configured,
  * {@code @SystemMessage} takes precedence.
  *
  * @see UserMessage
@@ -53,7 +67,8 @@ public @interface SystemMessage {
      * If the resource is not found, an {@link IllegalConfigurationException} is thrown.
      * <p>
      * The resource will be read by calling {@link Class#getResourceAsStream(String)}
-     * on the AI Service class (interface).
+     * on the interface this annotation is declared on: the AI Service interface for an
+     * interface-level annotation, or the interface declaring the method for a method-level one.
      */
     String fromResource() default "";
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesInterfaceLevelSystemMessageTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesInterfaceLevelSystemMessageTest.java
@@ -1,0 +1,243 @@
+package dev.langchain4j.service;
+
+import static dev.langchain4j.data.message.SystemMessage.systemMessage;
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+import static dev.langchain4j.service.AiServicesIT.verifyNoMoreInteractionsFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiServicesInterfaceLevelSystemMessageTest {
+
+    static final String SYSTEM_MESSAGE = "Given a name of a country, answer with a name of it's capital";
+
+    @Spy
+    ChatModel model = ChatModelMock.thatAlwaysResponds("Berlin");
+
+    @AfterEach
+    void afterEach() {
+        verifyNoMoreInteractionsFor(model);
+    }
+
+    @SystemMessage(SYSTEM_MESSAGE)
+    interface AiService {
+
+        String chat(String userMessage);
+    }
+
+    interface BaseAiService {
+
+        String chat(String userMessage);
+    }
+
+    @SystemMessage(SYSTEM_MESSAGE)
+    interface AiServiceWithInheritedMethod extends BaseAiService {}
+
+    @SystemMessage("This message should be ignored")
+    interface AiServiceWithMethodAnnotation {
+
+        @SystemMessage(SYSTEM_MESSAGE)
+        String chat(String userMessage);
+    }
+
+    @SystemMessage("This message should be ignored")
+    interface AnnotatedParentAiService {
+
+        String chat(String userMessage);
+    }
+
+    interface AiServiceExtendingAnnotatedParent extends AnnotatedParentAiService {}
+
+    interface BaseAiServiceWithMethodAnnotation {
+
+        @SystemMessage(SYSTEM_MESSAGE)
+        String chat(String userMessage);
+    }
+
+    @SystemMessage("This message should be ignored")
+    interface AiServiceWithInheritedAnnotatedMethod extends BaseAiServiceWithMethodAnnotation {}
+
+    @SystemMessage("Given a name of a country, answer with {{answerInstructions}}")
+    interface AiServiceWithTemplate {
+
+        String chat(@UserMessage String userMessage, @V("answerInstructions") String answerInstructions);
+    }
+
+    @SystemMessage(fromResource = "chefs-prompt-system-message.txt")
+    interface AiServiceWithResource {
+
+        String chat(@UserMessage String userMessage, @V("character") String character);
+    }
+
+    @SystemMessage(SYSTEM_MESSAGE)
+    interface StreamingAiService {
+
+        TokenStream chat(String userMessage);
+    }
+
+    @SystemMessage
+    interface AiServiceWithEmptySystemMessage {
+
+        String chat(String userMessage);
+    }
+
+    private void verifySystemMessage(String expectedSystemMessage) {
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(systemMessage(expectedSystemMessage), userMessage("Country: Germany"))
+                        .build());
+    }
+
+    @Test
+    void interface_level_system_message() {
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
+
+        assertThat(aiService.chat("Country: Germany")).containsIgnoringCase("Berlin");
+        verifySystemMessage(SYSTEM_MESSAGE);
+    }
+
+    @Test
+    void interface_level_system_message_on_ai_service_with_inherited_method() {
+        AiServiceWithInheritedMethod aiService = AiServices.builder(AiServiceWithInheritedMethod.class)
+                .chatModel(model)
+                .build();
+
+        assertThat(aiService.chat("Country: Germany")).containsIgnoringCase("Berlin");
+        verifySystemMessage(SYSTEM_MESSAGE);
+    }
+
+    @Test
+    void method_level_system_message_takes_precedence_over_interface_level() {
+        AiServiceWithMethodAnnotation aiService = AiServices.builder(AiServiceWithMethodAnnotation.class)
+                .chatModel(model)
+                .build();
+
+        assertThat(aiService.chat("Country: Germany")).containsIgnoringCase("Berlin");
+        verifySystemMessage(SYSTEM_MESSAGE);
+    }
+
+    @Test
+    void interface_level_system_message_is_not_inherited_from_parent_interface() {
+        AiServiceExtendingAnnotatedParent aiService = AiServices.builder(AiServiceExtendingAnnotatedParent.class)
+                .chatModel(model)
+                .build();
+
+        assertThat(aiService.chat("Country: Germany")).containsIgnoringCase("Berlin");
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(userMessage("Country: Germany"))
+                        .build());
+    }
+
+    @Test
+    void method_level_system_message_takes_precedence_over_interface_level_for_inherited_method() {
+        AiServiceWithInheritedAnnotatedMethod aiService = AiServices.builder(
+                        AiServiceWithInheritedAnnotatedMethod.class)
+                .chatModel(model)
+                .build();
+
+        assertThat(aiService.chat("Country: Germany")).containsIgnoringCase("Berlin");
+        verifySystemMessage(SYSTEM_MESSAGE);
+    }
+
+    @Test
+    void interface_level_system_message_takes_precedence_over_system_message_provider() {
+        AiService aiService = AiServices.builder(AiService.class)
+                .chatModel(model)
+                .systemMessageProvider(chatMemoryId -> "This message should be ignored")
+                .build();
+
+        assertThat(aiService.chat("Country: Germany")).containsIgnoringCase("Berlin");
+        verifySystemMessage(SYSTEM_MESSAGE);
+    }
+
+    @Test
+    void interface_level_system_message_takes_precedence_over_system_message_provider_with_context() {
+        AiService aiService = AiServices.builder(AiService.class)
+                .chatModel(model)
+                .systemMessageProviderWithContext(invocationContext -> "This message should be ignored")
+                .build();
+
+        assertThat(aiService.chat("Country: Germany")).containsIgnoringCase("Berlin");
+        verifySystemMessage(SYSTEM_MESSAGE);
+    }
+
+    @Test
+    void interface_level_system_message_with_template_variable() {
+        AiServiceWithTemplate aiService =
+                AiServices.builder(AiServiceWithTemplate.class).chatModel(model).build();
+
+        assertThat(aiService.chat("Country: Germany", "a name of it's capital")).containsIgnoringCase("Berlin");
+        verifySystemMessage(SYSTEM_MESSAGE);
+    }
+
+    @Test
+    void interface_level_system_message_from_resource() {
+        AiServiceWithResource aiService =
+                AiServices.builder(AiServiceWithResource.class).chatModel(model).build();
+
+        assertThat(aiService.chat("Country: Germany", "talented")).containsIgnoringCase("Berlin");
+        verifySystemMessage("You are very talented chef");
+    }
+
+    @Test
+    void interface_level_system_message_with_streaming_chat_model() throws Exception {
+        StreamingChatModelMock delegate = StreamingChatModelMock.thatAlwaysStreams(AiMessage.from("Berlin"));
+        List<ChatRequest> capturedRequests = new ArrayList<>();
+        StreamingChatModel streamingModel = new StreamingChatModel() {
+            @Override
+            public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                capturedRequests.add(chatRequest);
+                delegate.doChat(chatRequest, handler);
+            }
+        };
+
+        StreamingAiService aiService = AiServices.builder(StreamingAiService.class)
+                .streamingChatModel(streamingModel)
+                .build();
+
+        CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
+        aiService
+                .chat("Country: Germany")
+                .onPartialResponse(partialResponse -> {})
+                .onCompleteResponse(futureResponse::complete)
+                .onError(futureResponse::completeExceptionally)
+                .start();
+        futureResponse.get(10, TimeUnit.SECONDS);
+
+        assertThat(capturedRequests).hasSize(1);
+        assertThat(capturedRequests.get(0).messages())
+                .containsExactly(systemMessage(SYSTEM_MESSAGE), userMessage("Country: Germany"));
+    }
+
+    @Test
+    void empty_interface_level_system_message_fails() {
+        AiServiceWithEmptySystemMessage aiService = AiServices.builder(AiServiceWithEmptySystemMessage.class)
+                .chatModel(model)
+                .build();
+
+        assertThatThrownBy(() -> aiService.chat("Country: Germany"))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("@SystemMessage's template cannot be empty");
+    }
+}


### PR DESCRIPTION

## Issue
Closes #5990

## Change
`@SystemMessage` allows `ElementType.TYPE`, but the annotation was only read from the invoked
method, so an interface-level `@SystemMessage` compiled and was then ignored at runtime.

It is now also resolved from the AI Service interface, meaning the interface passed to
`AiServices`. That is a single, predictable rule: the annotation is read from the AI Service
itself, and is found whether the method is declared on that interface or inherited from a base
one. It is deliberately not searched up the interface hierarchy, since Java does not inherit
interface annotations and a partial search would be hard to reason about.

`getTemplate` now takes the annotated class so `fromResource` resolves against the interface the
annotation is declared on. The `@UserMessage` path is unchanged.

Precedence: method annotation, then interface annotation, then the system message providers.

Dropping `TYPE` from the target instead would break existing code, since #546 added it
deliberately.

Two consequences of the annotation no longer being ignored:
- an interface-level annotation combined with a `systemMessageProvider` now resolves to the
  annotation, as a method-level one already does
- a bare `@SystemMessage` on an interface now fails with `@SystemMessage's template cannot be
  empty`, the same error a bare method-level one produces. I chose consistency with the
  method-level behaviour, but I am happy to let the empty case fall through to the providers
  instead if you prefer that.

`OutputGuardrailRepromptingTests` declares `@SystemMessage("Say Hi!")` on its AI Service interface
and asserted a chat memory of `[USER, AI]`. That annotation was one of the ones being ignored, so
the memory is now `[SYSTEM, USER, AI]` and its three assertions were updated to match.

## Tests
`AiServicesClassLevelSystemMessageTest` adds 9 tests: interface-level, inherited method, precedence
over a method annotation, precedence over both `systemMessageProvider` and
`systemMessageProviderWithContext`, template variables, `fromResource`, streaming, and the empty
annotation. 8 of them fail on unmodified main.

```
mvn -pl langchain4j test                                   -> Tests run: 1287, Failures: 0, Errors: 0, Skipped: 0
mvn -pl langchain4j-core test                              -> Tests run: 1210, Failures: 0, Errors: 0, Skipped: 5
mvn -pl integration-tests/integration-tests-guardrails test -> Tests run: 107,  Failures: 0, Errors: 0, Skipped: 0
```

## General checklist
- [ ] There are no breaking changes (API, behaviour)
      No API change. Behaviour changes only where the annotation was previously ignored, as
      described above.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
