### PR TITLE
Make secret HTTP header masking independent of the default locale

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
@@ -9,6 +9,7 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.http.client.HttpRequest;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -21,18 +22,13 @@ class HttpRequestLogger {
 
     static void log(Logger log, HttpRequest httpRequest) {
         try {
-            log.info(
-                    """
+            log.info("""
                             HTTP request:
                             - method: {}
                             - url: {}
                             - headers: {}
                             - body: {}
-                            """,
-                    httpRequest.method(),
-                    httpRequest.url(),
-                    format(httpRequest.headers()),
-                    httpRequest.body());
+                            """, httpRequest.method(), httpRequest.url(), format(httpRequest.headers()), httpRequest.body());
         } catch (Exception e) {
             log.warn("Exception occurred while logging HTTP request: {}", e.getMessage());
         }
@@ -45,8 +41,8 @@ class HttpRequestLogger {
     }
 
     static String format(String headerKey, List<String> headerValues) {
-        if (COMMON_SECRET_HEADERS.contains(headerKey.toLowerCase())
-                || headerKey.toLowerCase().contains("api-key")) {
+        String lowerCaseHeaderKey = headerKey.toLowerCase(Locale.ROOT);
+        if (COMMON_SECRET_HEADERS.contains(lowerCaseHeaderKey) || lowerCaseHeaderKey.contains("api-key")) {
             headerValues =
                     headerValues.stream().map(HttpRequestLogger::maskSecretKey).collect(toList());
         }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/log/HttpRequestLoggerLocaleTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/log/HttpRequestLoggerLocaleTest.java
@@ -1,0 +1,67 @@
+package dev.langchain4j.http.client.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * in the same thread, mirroring {@code SimpleToolSearchStrategyLocaleTest} (#5861).
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class HttpRequestLoggerLocaleTest {
+
+    private static final String SECRET = "sk-1234567890abcdef";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ"})
+    void secret_header_should_be_masked_independently_of_default_locale(String languageTag) {
+        // Without Locale.ROOT, "X-API-Key".toLowerCase() yields "x-apı-key" (dotless i) under
+        // tr/az, matching neither COMMON_SECRET_HEADERS nor the "api-key" substring check, so
+        // the key is logged in clear text. Only tr/az map uppercase I to a dotless i; lt keeps
+        // the dot, so it is exercised in the non-secret test below instead.
+        withDefaultLocale(languageTag, () -> {
+            String formatted = HttpRequestLogger.format("X-API-Key", List.of(SECRET));
+
+            assertThat(formatted).doesNotContain(SECRET).isEqualTo("[X-API-Key: sk-12...ef]");
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ"})
+    void authorization_header_should_be_masked_independently_of_default_locale(String languageTag) {
+        withDefaultLocale(languageTag, () -> {
+            String formatted = HttpRequestLogger.format("AUTHORIZATION", List.of(SECRET));
+
+            assertThat(formatted).doesNotContain(SECRET);
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ", "lt-LT"})
+    void non_secret_header_should_not_be_masked_independently_of_default_locale(String languageTag) {
+        // The mirror image: a header that must stay readable in every locale.
+        withDefaultLocale(languageTag, () -> {
+            String formatted = HttpRequestLogger.format("Content-Type", List.of("application/json"));
+
+            assertThat(formatted).isEqualTo("[Content-Type: application/json]");
+        });
+    }
+
+    private static void withDefaultLocale(String languageTag, Runnable action) {
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
+            action.run();
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5960

## Change

`HttpRequestLogger.format(String, List)` lowercased the header name with `String#toLowerCase()` (no `Locale`) before comparing it against `COMMON_SECRET_HEADERS` and the `"api-key"` substring. Under a `tr` or `az` default locale, `"X-API-Key".toLowerCase()` yields `"x-apı-key"` (dotless i), which matches neither check, so `LoggingHttpClient` with `logRequests(true)` wrote the key in clear text at INFO level.

The header name is now lowercased once with `Locale.ROOT`, as `AwsLoggingInterceptor.maskHeaders()` already does, following #5778 and #5861:

```java
String lowerCaseHeaderKey = headerKey.toLowerCase(Locale.ROOT);
if (COMMON_SECRET_HEADERS.contains(lowerCaseHeaderKey) || lowerCaseHeaderKey.contains("api-key")) {
```

`HttpResponseLogger` reuses the same `format()`, so response headers are covered by the same change. ASCII header names are unaffected in every locale.

I grepped for other locale-sensitive lowercasing on the same code path (`header|secret|auth|api-key|token|mask`); the only remaining hits are two mock servers in `AnthropicCustomHeadersTest` (test-only, no masking) and `MetadataColumDefinition` (SQL type parsing, unrelated to this issue).

### Tests

`HttpRequestLoggerLocaleTest`, mirroring `SimpleToolSearchStrategyLocaleTest` from #5861 (`@Isolated` + `@Execution(SAME_THREAD)`, since the tests mutate the JVM default locale and restore it in a `finally`):

- `secret_header_should_be_masked_independently_of_default_locale` — `X-API-Key` under `tr-TR`/`az-AZ`. Fails on `main` with `[X-API-Key: sk-1234567890abcdef]`, passes here with `[X-API-Key: sk-12...ef]`. Verified by reverting the fix and re-running.
- `authorization_header_should_be_masked_independently_of_default_locale` — `AUTHORIZATION` spelled uppercase, the `COMMON_SECRET_HEADERS` path rather than the substring path.
- `non_secret_header_should_not_be_masked_independently_of_default_locale` — the mirror image: `Content-Type` must stay readable, in `lt-LT` too.

One note on locale choice: #5861 parameterises over `tr/az/lt`, but only `tr` and `az` map uppercase `I` to a dotless `i`. I verified this directly — under `lt-LT`, `"X-API-Key".toLowerCase()` still yields `"x-api-key"`, so including `lt` in the masking tests would add a case that passes with or without the fix. `lt-LT` is therefore only in the non-secret test, where it is a meaningful generality check.

### A note on the diff

The reformatting of the `log.info(...)` call is produced by `spotless:apply`: `<ratchetFrom>origin/main</ratchetFrom>` brings the whole touched file into scope, and `spotless:check` fails without it. `spotless:check` passes on unmodified `main`, so this is scope expansion from touching the file rather than a pre-existing violation. Unlike #5861 I could not isolate it into a separate formatting commit, since `spotless:apply` is a no-op on `main` for this file. Only the `Locale.ROOT` change and the new test are functional.

## General checklist

- [ ] There are no breaking changes (API, behaviour) — no API change; masking now also applies under `tr`/`az` locales, which is the fix itself
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green — see below
- [ ] I have added/updated the documentation — not applicable (internal logging behaviour, no API surface change)
- [ ] I have added an example in the examples repo — not applicable
- [ ] I have added/updated Spring Boot starter(s) — not applicable

## Verification

```
./mvnw -pl langchain4j-http-client test spotless:check
# Tests run: 80, Failures: 0, Errors: 0
# spotless:check BUILD SUCCESS

./mvnw -pl langchain4j-core,langchain4j-http-client,langchain4j -am test
# core:        Tests run: 1210, Failures: 0, Errors: 0, Skipped: 4
# main:        Tests run: 1278, Failures: 0, Errors: 0, Skipped: 0
# BUILD SUCCESS (also builds the downstream jdk-http-client and open-ai modules)
```

`*IT` classes needing network access or API keys were not run.
