### PR TITLE
Support UUID and java.time types in structured outputs

### DIFF
--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -815,10 +815,25 @@ If LLM and LLM provider supports the methods described above, it is better to us
 | `BigInteger`                                               | ✅           | ✅         |
 | `BigDecimal`                                               | ✅           | ✅         |
 | `Date`                                                     | ❌           | ✅         |
-| `LocalDate`                                                | ❌           | ✅         |
-| `LocalTime`                                                | ❌           | ✅         |
-| `LocalDateTime`                                            | ❌           | ✅         |
+| `LocalDate`                                                | ✅           | ✅         |
+| `LocalTime`                                                | ✅           | ✅         |
+| `LocalDateTime`                                            | ✅           | ✅         |
+| `Instant`                                                  | ✅           | ✅         |
+| `OffsetDateTime`                                           | ✅           | ✅         |
+| `ZonedDateTime`                                            | ✅           | ✅         |
+| `Duration`                                                 | ✅           | ✅         |
+| `UUID`                                                     | ✅           | ✅         |
 | `Map<?, ?>`                                                | ❌           | ✅         |
+
+When a `UUID` or java.time type is used in structured outputs, it is mapped to a JSON Schema string with the
+corresponding `format`: `UUID` → `uuid`, `LocalDate` → `date`, `LocalTime` → `time`, `LocalDateTime` → `date-time`,
+`Instant` → `date-time`, `OffsetDateTime` → `date-time`, `ZonedDateTime` → `date-time`,
+`Duration` → `duration`. LLMs honoring these formats may emit strings with a timezone offset
+(e.g., `2023-01-15T10:20:00Z`), which is accepted and discarded when parsing back into
+`LocalDateTime` and `LocalTime` (they cannot represent an offset). `Instant`, `OffsetDateTime`,
+`ZonedDateTime`, and `Duration` are serialized as ISO-8601 strings and deserialize back preserving
+the offset (e.g., `+02:00` is not shifted to UTC). Note that `ZonedDateTime` is serialized
+offset-only, so on round-trip the region (e.g., `[Europe/Paris]`) is lost.
 
 A few examples:
 ```java

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
@@ -2,9 +2,12 @@ package dev.langchain4j.internal;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.PropertyAccessor.FIELD;
+import static com.fasterxml.jackson.databind.DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS;
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
@@ -13,7 +16,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -23,10 +25,10 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import dev.langchain4j.Internal;
@@ -35,6 +37,8 @@ import java.lang.reflect.Type;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,6 +50,27 @@ import java.util.Optional;
  */
 @Internal
 class JacksonJsonCodec implements Json.JsonCodec {
+
+    // The schema advertises RFC 3339 "date-time"/"time" for LocalDateTime/LocalTime, which LLMs may honor
+    // with offset-bearing strings. Accept and drop the offset (Local* cannot represent one); the stock
+    // ISO_LOCAL_* formatters reject such strings.
+    private static final DateTimeFormatter ISO_LOCAL_DATE_TIME_WITH_OPTIONAL_OFFSET = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .append(DateTimeFormatter.ISO_LOCAL_TIME)
+            .optionalStart()
+            .appendOffsetId()
+            .optionalEnd()
+            .toFormatter();
+
+    private static final DateTimeFormatter ISO_LOCAL_TIME_WITH_OPTIONAL_OFFSET = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_TIME)
+            .optionalStart()
+            .appendOffsetId()
+            .optionalEnd()
+            .toFormatter();
 
     private final ObjectMapper objectMapper;
 
@@ -97,7 +122,7 @@ class JacksonJsonCodec implements Json.JsonCodec {
                             .orElse(0);
                     return LocalTime.of(hour, minute, second, nano);
                 } else {
-                    return LocalTime.parse(node.asText(), ISO_LOCAL_TIME);
+                    return LocalTime.parse(node.asText(), ISO_LOCAL_TIME_WITH_OPTIONAL_OFFSET);
                 }
             }
         });
@@ -130,7 +155,7 @@ class JacksonJsonCodec implements Json.JsonCodec {
                             .orElse(0);
                     return LocalDateTime.of(year, month, day, hour, minute, second, nano);
                 } else {
-                    return LocalDateTime.parse(node.asText(), ISO_LOCAL_DATE_TIME);
+                    return LocalDateTime.parse(node.asText(), ISO_LOCAL_DATE_TIME_WITH_OPTIONAL_OFFSET);
                 }
             }
         });
@@ -140,6 +165,10 @@ class JacksonJsonCodec implements Json.JsonCodec {
                 .disable(INDENT_OUTPUT) // disabled on purpose to save tokens when sending tool results to LLM
                 .enable(FAIL_ON_UNKNOWN_PROPERTIES) // enabled on purpose to prevent issues caused by LLM hallucinations
                 .enable(ACCEPT_CASE_INSENSITIVE_ENUMS)
+                // Preserve the offset/zone parsed from ISO-8601 "date-time" strings instead of
+                // normalizing it to UTC (ADJUST_DATES_TO_CONTEXT_TIME_ZONE defaults to true).
+                .disable(ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .disable(WRITE_DATES_AS_TIMESTAMPS, WRITE_DURATIONS_AS_TIMESTAMPS)
                 .build()
                 .findAndRegisterModules()
                 .registerModule(module);
@@ -148,7 +177,8 @@ class JacksonJsonCodec implements Json.JsonCodec {
         // having to add @JsonTypeInfo+@JsonSubTypes. We synthesize equivalent metadata via a
         // custom AnnotationIntrospector consulted ahead of Jackson's default one.
         mapper.setAnnotationIntrospector(AnnotationIntrospectorPair.pair(
-                new SealedTypePolymorphicIntrospector(), mapper.getDeserializationConfig().getAnnotationIntrospector()));
+                new SealedTypePolymorphicIntrospector(),
+                mapper.getDeserializationConfig().getAnnotationIntrospector()));
         return mapper;
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementJsonUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementJsonUtils.java
@@ -39,7 +39,7 @@ public class JsonSchemaElementJsonUtils {
     // that cannot be represented by the corresponding JsonSchemaElement subtype.
     // When a map contains keys outside this set, fromMap() falls back to JsonRawSchema.
     // NOTE: When adding new JsonSchemaElement subtypes, update these sets accordingly.
-    private static final Set<String> STRING_KEYS = Set.of("type", "description");
+    private static final Set<String> STRING_KEYS = Set.of("type", "description", "format");
     private static final Set<String> INTEGER_KEYS = Set.of("type", "description");
     private static final Set<String> NUMBER_KEYS = Set.of("type", "description");
     private static final Set<String> BOOLEAN_KEYS = Set.of("type", "description");
@@ -74,7 +74,13 @@ public class JsonSchemaElementJsonUtils {
         }
 
         // Simple typed schemas: type + description
-        if (element instanceof JsonStringSchema s) return typedSchema("string", s.description());
+        if (element instanceof JsonStringSchema s) {
+            Map<String, Object> map = typedSchema("string", s.description());
+            if (s.format() != null) {
+                map.put("format", s.format());
+            }
+            return map;
+        }
         if (element instanceof JsonIntegerSchema i) return typedSchema("integer", i.description());
         if (element instanceof JsonNumberSchema n) return typedSchema("number", n.description());
         if (element instanceof JsonBooleanSchema b) return typedSchema("boolean", b.description());
@@ -162,8 +168,8 @@ public class JsonSchemaElementJsonUtils {
      * Converts a standard JSON Schema {@link Map} representation back to a {@link JsonSchemaElement}.
      * <p>
      * Only the subset of JSON Schema expressible by {@link JsonSchemaElement} subtypes is supported.
-     * When a map contains additional JSON Schema keywords (e.g., {@code format}, {@code pattern},
-     * {@code minimum}, schema-valued {@code additionalProperties}) that cannot be represented by
+     * When a map contains additional JSON Schema keywords (e.g., {@code pattern}, {@code minimum},
+     * schema-valued {@code additionalProperties}) that cannot be represented by
      * the corresponding typed schema, the entire node falls back to {@link JsonRawSchema} to
      * preserve round-trip fidelity. The fallback granularity is per-node: a parent
      * {@link JsonObjectSchema} can still be typed even if a child property falls back to raw.
@@ -246,6 +252,7 @@ public class JsonSchemaElementJsonUtils {
                 isRepresentable(map, STRING_KEYS)
                         ? JsonStringSchema.builder()
                                 .description(optionalString(map, "description"))
+                                .format(optionalString(map, "format"))
                                 .build()
                         : rawFallback(map);
             case "integer" ->

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -33,6 +33,13 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -51,6 +58,14 @@ public class JsonSchemaElementUtils {
             String fieldDescription,
             boolean areSubFieldsRequiredByDefault,
             Map<Class<?>, VisitedClassMetadata> visited) {
+        String stringFormat = jsonStringFormatOf(clazz);
+        if (stringFormat != null) {
+            return JsonStringSchema.builder()
+                    .format(stringFormat)
+                    .description(Optional.ofNullable(fieldDescription).orElse(descriptionFrom(clazz)))
+                    .build();
+        }
+
         if (isJsonString(clazz)) {
             return JsonStringSchema.builder()
                     .description(Optional.ofNullable(fieldDescription).orElse(descriptionFrom(clazz)))
@@ -479,6 +494,9 @@ public class JsonSchemaElementUtils {
             if (jsonStringSchema.description() != null) {
                 map.put("description", jsonStringSchema.description());
             }
+            if (jsonStringSchema.format() != null) {
+                map.put("format", jsonStringSchema.format());
+            }
             return map;
         } else if (jsonSchemaElement instanceof JsonIntegerSchema jsonIntegerSchema) {
             Map<String, Object> map = new LinkedHashMap<>();
@@ -570,6 +588,28 @@ public class JsonSchemaElementUtils {
                 || type == Character.class
                 || CharSequence.class.isAssignableFrom(type)
                 || type == UUID.class;
+    }
+
+    static String jsonStringFormatOf(Class<?> type) {
+        if (type == UUID.class) {
+            return "uuid";
+        }
+        if (type == LocalDate.class) {
+            return "date";
+        }
+        if (type == LocalTime.class) {
+            return "time";
+        }
+        if (type == LocalDateTime.class
+                || type == Instant.class
+                || type == OffsetDateTime.class
+                || type == ZonedDateTime.class) {
+            return "date-time";
+        }
+        if (type == Duration.class) {
+            return "duration";
+        }
+        return null;
     }
 
     static boolean isJsonArray(Class<?> type) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
@@ -1,24 +1,31 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
+
+import java.util.Objects;
 
 public class JsonStringSchema implements JsonSchemaElement {
 
     private final String description;
+    private final String format;
 
     public JsonStringSchema() {
         this.description = null;
+        this.format = null;
     }
 
     public JsonStringSchema(Builder builder) {
         this.description = builder.description;
+        this.format = builder.format;
     }
 
     @Override
     public String description() {
         return description;
+    }
+
+    public String format() {
+        return format;
     }
 
     public static Builder builder() {
@@ -28,9 +35,15 @@ public class JsonStringSchema implements JsonSchemaElement {
     public static class Builder {
 
         private String description;
+        private String format;
 
         public Builder description(String description) {
             this.description = description;
+            return this;
+        }
+
+        public Builder format(String format) {
+            this.format = format;
             return this;
         }
 
@@ -44,18 +57,16 @@ public class JsonStringSchema implements JsonSchemaElement {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JsonStringSchema that = (JsonStringSchema) o;
-        return Objects.equals(this.description, that.description);
+        return Objects.equals(this.description, that.description) && Objects.equals(this.format, that.format);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(description);
+        return Objects.hash(description, format);
     }
 
     @Override
     public String toString() {
-        return "JsonStringSchema {" +
-                "description = " + quoted(description) +
-                " }";
+        return "JsonStringSchema {" + "description = " + quoted(description) + ", format = " + quoted(format) + " }";
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementJsonUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementJsonUtilsTest.java
@@ -37,6 +37,9 @@ class JsonSchemaElementJsonUtilsTest {
     void should_round_trip_scalar_types() {
         assertRoundTrip(JsonStringSchema.builder().description("a name").build());
         assertRoundTrip(new JsonStringSchema());
+        assertRoundTrip(JsonStringSchema.builder().format("uuid").build());
+        assertRoundTrip(
+                JsonStringSchema.builder().description("a name").format("uuid").build());
         assertRoundTrip(JsonIntegerSchema.builder().description("count").build());
         assertRoundTrip(new JsonIntegerSchema());
         assertRoundTrip(JsonNumberSchema.builder().description("price").build());
@@ -44,6 +47,15 @@ class JsonSchemaElementJsonUtilsTest {
         assertRoundTrip(JsonBooleanSchema.builder().description("active").build());
         assertRoundTrip(new JsonBooleanSchema());
         assertRoundTrip(new JsonNullSchema());
+    }
+
+    @Test
+    void toMap_should_omit_format_when_null() {
+        Map<String, Object> map = JsonSchemaElementJsonUtils.toMap(
+                JsonStringSchema.builder().description("a name").build());
+
+        assertThat(map).containsEntry("type", "string").containsEntry("description", "a name");
+        assertThat(map).doesNotContainKey("format");
     }
 
     @Test
@@ -269,11 +281,17 @@ class JsonSchemaElementJsonUtilsTest {
     // ---- raw fallback for extra keywords ----
 
     @Test
-    void should_fallback_to_raw_for_string_with_format() {
+    void should_round_trip_string_with_format() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("type", "string");
         map.put("format", "date-time");
-        assertRawFallback(map);
+
+        JsonSchemaElement element = JsonSchemaElementJsonUtils.fromMap(map);
+        assertThat(element).isInstanceOf(JsonStringSchema.class);
+        assertThat(((JsonStringSchema) element).format()).isEqualTo("date-time");
+
+        Map<String, Object> restored = JsonSchemaElementJsonUtils.toMap(element);
+        assertThat(restored).isEqualTo(map);
     }
 
     @Test
@@ -309,10 +327,10 @@ class JsonSchemaElementJsonUtilsTest {
 
     @Test
     void should_round_trip_nested_with_raw_fallback_child() {
-        // outer object is typed, child with format falls back to raw
+        // outer object is typed, child with pattern falls back to raw
         Map<String, Object> childMap = new LinkedHashMap<>();
         childMap.put("type", "string");
-        childMap.put("format", "date-time");
+        childMap.put("pattern", "^\\d{4}-\\d{2}-\\d{2}$");
 
         Map<String, Object> propsMap = new LinkedHashMap<>();
         propsMap.put("name", Map.of("type", "string"));
@@ -330,6 +348,28 @@ class JsonSchemaElementJsonUtilsTest {
         assertThat(obj.properties().get("timestamp")).isInstanceOf(JsonRawSchema.class);
 
         // round-trip should preserve structure
+        Map<String, Object> restored = JsonSchemaElementJsonUtils.toMap(element);
+        assertThat(restored).isEqualTo(objectMap);
+    }
+
+    @Test
+    void should_round_trip_nested_string_with_format() {
+        Map<String, Object> childMap = new LinkedHashMap<>();
+        childMap.put("type", "string");
+        childMap.put("format", "date");
+
+        Map<String, Object> propsMap = new LinkedHashMap<>();
+        propsMap.put("birthDate", childMap);
+
+        Map<String, Object> objectMap = new LinkedHashMap<>();
+        objectMap.put("type", "object");
+        objectMap.put("properties", propsMap);
+
+        JsonSchemaElement element = JsonSchemaElementJsonUtils.fromMap(objectMap);
+        assertThat(element).isInstanceOf(JsonObjectSchema.class);
+        assertThat(((JsonObjectSchema) element).properties().get("birthDate"))
+                .isEqualTo(JsonStringSchema.builder().format("date").build());
+
         Map<String, Object> restored = JsonSchemaElementJsonUtils.toMap(element);
         assertThat(restored).isEqualTo(objectMap);
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
@@ -18,7 +18,13 @@ import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.output.structured.Description;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
@@ -94,6 +100,7 @@ class JsonSchemaElementUtilsTest {
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonStringSchema.builder()
                         .description("String in a UUID format")
+                        .format("uuid")
                         .build());
     }
 
@@ -114,9 +121,96 @@ class JsonSchemaElementUtilsTest {
         // then
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonObjectSchema.builder()
-                        .addStringProperty("uuid", "String in a UUID format")
+                        .addProperty(
+                                "uuid",
+                                JsonStringSchema.builder()
+                                        .description("String in a UUID format")
+                                        .format("uuid")
+                                        .build())
                         .required("uuid")
                         .build());
+    }
+
+    @Test
+    void should_map_java_time_types_to_string_schema_with_format() {
+
+        assertThat(jsonSchemaElementFrom(LocalDate.class))
+                .isEqualTo(JsonStringSchema.builder().format("date").build());
+        assertThat(jsonSchemaElementFrom(LocalTime.class))
+                .isEqualTo(JsonStringSchema.builder().format("time").build());
+        assertThat(jsonSchemaElementFrom(LocalDateTime.class))
+                .isEqualTo(JsonStringSchema.builder().format("date-time").build());
+        assertThat(jsonSchemaElementFrom(Instant.class))
+                .isEqualTo(JsonStringSchema.builder().format("date-time").build());
+        assertThat(jsonSchemaElementFrom(OffsetDateTime.class))
+                .isEqualTo(JsonStringSchema.builder().format("date-time").build());
+        assertThat(jsonSchemaElementFrom(ZonedDateTime.class))
+                .isEqualTo(JsonStringSchema.builder().format("date-time").build());
+        assertThat(jsonSchemaElementFrom(Duration.class))
+                .isEqualTo(JsonStringSchema.builder().format("duration").build());
+    }
+
+    static class MyClassWithLocalDate {
+
+        LocalDate birthDate;
+    }
+
+    @Test
+    void should_map_java_time_field_to_string_schema_with_format() {
+
+        // when
+        JsonSchemaElement jsonSchemaElement =
+                jsonSchemaElementFrom(MyClassWithLocalDate.class, null, null, true, new LinkedHashMap<>());
+
+        // then
+        assertThat(jsonSchemaElement)
+                .isEqualTo(JsonObjectSchema.builder()
+                        .addProperty(
+                                "birthDate",
+                                JsonStringSchema.builder().format("date").build())
+                        .required("birthDate")
+                        .build());
+    }
+
+    static class MyClassWithDescribedLocalDate {
+
+        @Description("birth date")
+        LocalDate birthDate;
+    }
+
+    @Test
+    void should_use_non_null_description_for_java_time_field() {
+
+        // given
+        Class<MyClassWithDescribedLocalDate> clazz = MyClassWithDescribedLocalDate.class;
+
+        // when
+        JsonSchemaElement jsonSchemaElement = jsonSchemaElementFrom(clazz, null, null, true, new LinkedHashMap<>());
+
+        // then
+        assertThat(jsonSchemaElement)
+                .isEqualTo(JsonObjectSchema.builder()
+                        .addProperty(
+                                "birthDate",
+                                JsonStringSchema.builder()
+                                        .format("date")
+                                        .description("birth date")
+                                        .build())
+                        .required("birthDate")
+                        .build());
+    }
+
+    @Test
+    void shouldConvertJsonStringSchemaWithFormatToMap() {
+
+        // given
+        JsonStringSchema schema = JsonStringSchema.builder().format("date").build();
+
+        // when
+        Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
+
+        // then
+        assertThat(map).containsEntry("type", "string").containsEntry("format", "date");
     }
 
     static class MyClassWithDescribedUuid {
@@ -137,7 +231,12 @@ class JsonSchemaElementUtilsTest {
         // then
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonObjectSchema.builder()
-                        .addStringProperty("uuid", "My UUID")
+                        .addProperty(
+                                "uuid",
+                                JsonStringSchema.builder()
+                                        .description("My UUID")
+                                        .format("uuid")
+                                        .build())
                         .required("uuid")
                         .build());
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonTest.java
@@ -3,8 +3,14 @@ package dev.langchain4j.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 
 class JsonTest {
@@ -27,6 +33,81 @@ class JsonTest {
         assertThat(deserializedData.getSampleDate()).isEqualTo(testData.getSampleDate());
         assertThat(deserializedData.getSampleDateTime()).isEqualTo(testData.getSampleDateTime());
         assertThat(deserializedData.getSomeValue()).isEqualTo(testData.getSomeValue());
+    }
+
+    @Test
+    void should_parse_local_date_time_with_rfc3339_offset() {
+        // JSON Schema maps LocalDateTime to format "date-time" (RFC 3339), which requires an offset.
+        // LLMs honoring that format may emit e.g. "2023-01-15T10:20:00Z", which must not fail parsing.
+        TestData testData = Json.fromJson(
+                "{\"sampleDate\":\"2023-01-15\",\"sampleDateTime\":\"2023-01-15T10:20:00Z\",\"some_value\":\"value\"}",
+                TestData.class);
+
+        assertThat(testData.getSampleDate()).isEqualTo(LocalDate.of(2023, 1, 15));
+        assertThat(testData.getSampleDateTime()).isEqualTo(LocalDateTime.of(2023, 1, 15, 10, 20));
+    }
+
+    @Test
+    void should_parse_local_time_with_rfc3339_offset() {
+        // JSON Schema maps LocalTime to format "time" (RFC 3339), which requires an offset.
+        LocalTime time = Json.fromJson("\"10:15:30Z\"", LocalTime.class);
+
+        assertThat(time).isEqualTo(LocalTime.of(10, 15, 30));
+    }
+
+    @Test
+    void should_serialize_zoned_date_time_types_as_iso_strings() {
+        ZonedData data = new ZonedData();
+        data.instant = Instant.parse("2023-01-15T10:20:00Z");
+        data.offsetDateTime = OffsetDateTime.parse("2023-01-15T10:20:00+02:00");
+        data.zonedDateTime = ZonedDateTime.parse("2023-01-15T10:20:00+01:00[Europe/Paris]");
+        data.duration = Duration.ofHours(2);
+
+        String json = Json.toJson(data);
+
+        // ZonedDateTime is serialized offset-only (RFC 3339 date-time has no zone id).
+        assertThat(json)
+                .isEqualTo("{\"instant\":\"2023-01-15T10:20:00Z\",\"offsetDateTime\":\"2023-01-15T10:20:00+02:00\","
+                        + "\"zonedDateTime\":\"2023-01-15T10:20:00+01:00\",\"duration\":\"PT2H\"}");
+    }
+
+    @Test
+    void should_deserialize_zoned_date_time_types_preserving_offset() {
+        ZonedData data = Json.fromJson(
+                "{\"instant\":\"2023-01-15T10:20:00Z\",\"offsetDateTime\":\"2023-01-15T10:20:00+02:00\","
+                        + "\"zonedDateTime\":\"2023-01-15T10:20:00+01:00[Europe/Paris]\",\"duration\":\"PT2H\"}",
+                ZonedData.class);
+
+        // Offsets must be preserved, not normalized to UTC (ADJUST_DATES_TO_CONTEXT_TIME_ZONE is disabled).
+        assertThat(data.instant).isEqualTo(Instant.parse("2023-01-15T10:20:00Z"));
+        assertThat(data.offsetDateTime).isEqualTo(OffsetDateTime.parse("2023-01-15T10:20:00+02:00"));
+        assertThat(data.zonedDateTime).isEqualTo(ZonedDateTime.parse("2023-01-15T10:20:00+01:00[Europe/Paris]"));
+        assertThat(data.duration).isEqualTo(Duration.ofHours(2));
+    }
+
+    @Test
+    void should_round_trip_zoned_date_time_types() {
+        ZonedData data = new ZonedData();
+        data.instant = Instant.parse("2023-01-15T10:20:00Z");
+        data.offsetDateTime = OffsetDateTime.parse("2023-01-15T10:20:00+02:00");
+        data.zonedDateTime = ZonedDateTime.parse("2023-01-15T10:20:00+01:00[Europe/Paris]");
+        data.duration = Duration.ofHours(2);
+
+        ZonedData deserialized = Json.fromJson(Json.toJson(data), ZonedData.class);
+
+        assertThat(deserialized.instant).isEqualTo(data.instant);
+        assertThat(deserialized.offsetDateTime).isEqualTo(data.offsetDateTime);
+        // Offset-only serialization drops the zone id, so compare instant + offset.
+        assertThat(deserialized.zonedDateTime.isEqual(data.zonedDateTime)).isTrue();
+        assertThat(deserialized.zonedDateTime.getOffset()).isEqualTo(ZoneOffset.ofHours(1));
+        assertThat(deserialized.duration).isEqualTo(data.duration);
+    }
+
+    private static class ZonedData {
+        private Instant instant;
+        private OffsetDateTime offsetDateTime;
+        private ZonedDateTime zonedDateTime;
+        private Duration duration;
     }
 
     private static class TestData {

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithJsonSchemaIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithJsonSchemaIT.java
@@ -1105,7 +1105,12 @@ public abstract class AbstractAiServiceWithJsonSchemaIT {
                                 .jsonSchema(JsonSchema.builder()
                                         .name("Person")
                                         .rootElement(JsonObjectSchema.builder()
-                                                .addStringProperty("id", "String in a UUID format")
+                                                .addProperty(
+                                                        "id",
+                                                        JsonStringSchema.builder()
+                                                                .description("String in a UUID format")
+                                                                .format("uuid")
+                                                                .build())
                                                 .addStringProperty("name")
                                                 .build())
                                         .build())

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithToolsIT.java
@@ -755,7 +755,12 @@ public abstract class AbstractAiServiceWithToolsIT {
         static ToolSpecification EXPECTED_SPECIFICATION = ToolSpecification.builder()
                 .name("getUsernameFromId")
                 .parameters(JsonObjectSchema.builder()
-                        .addStringProperty("arg0", "String in a UUID format")
+                        .addProperty(
+                                "arg0",
+                                JsonStringSchema.builder()
+                                        .description("String in a UUID format")
+                                        .format("uuid")
+                                        .build())
                         .required("arg0")
                         .build())
                 .build();
@@ -1213,7 +1218,8 @@ public abstract class AbstractAiServiceWithToolsIT {
     protected Image catImage() {
         if (catImage == null) {
             String base64Data = java.util.Base64.getEncoder().encodeToString(readBytes(CAT_IMAGE_URL));
-            catImage = Image.builder().base64Data(base64Data).mimeType("image/png").build();
+            catImage =
+                    Image.builder().base64Data(base64Data).mimeType("image/png").build();
         }
         return catImage;
     }


### PR DESCRIPTION
## Issue

Closes #4934

## Change

Adds end-to-end support for `UUID` and java.time types in structured outputs, so they round-trip through the JSON Schema and the default `JacksonJsonCodec` instead of falling back to raw schema.

- **Schema mapping**: `UUID`, `LocalDate`, `LocalTime`, `LocalDateTime`, `Instant`, `OffsetDateTime`, `ZonedDateTime`, and `Duration` are now mapped to string schemas with the corresponding JSON Schema `format` (`uuid`, `date`, `time`, `date-time`, `duration`).
- **Schema round-trip**: `JsonStringSchema` gains a `format` field, preserved through both `toMap`/`fromMap` representations, so a schema survives serialization without degrading to `JsonRawSchema`.
- **JSON codec**: the default `JacksonJsonCodec` now round-trips the zoned java.time types. It registers `jackson-datatype-jsr310` and disables `WRITE_DATES_AS_TIMESTAMPS`, `WRITE_DURATIONS_AS_TIMESTAMPS`, and `ADJUST_DATES_TO_CONTEXT_TIME_ZONE`, so `Instant`/`OffsetDateTime`/`ZonedDateTime`/`Duration` serialize as ISO-8601 strings and deserialize preserving the original offset (no silent re-base to UTC). `LocalDateTime`/`LocalTime` accept and discard an optional offset, since LLMs honoring the RFC 3339 `date-time`/`time` formats may emit offset-bearing strings.
- **Docs**: structured-outputs tutorial updated with the type → format mapping and the offset/zone-id behavior on round-trip.

**Notes:**
- `ZonedDateTime` is serialized offset-only (RFC 3339 `date-time` has no zone id), so the region (e.g. `[Europe/Paris]`) is dropped on round-trip; this is documented.
- This PR supersedes the schema-only draft PR #4960, adding the missing codec round-trip support and documentation.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
