### PR TITLE
Send tool parameters as JSON Schema when they have no typed form

### DIFF
--- a/docs/docs/integrations/language-models/google-ai-gemini.md
+++ b/docs/docs/integrations/language-models/google-ai-gemini.md
@@ -256,6 +256,13 @@ System.out.println("Gemini> " + tokyoWeather);
 //         with a temperature of 32 degrees.
 ```
 
+### Raw Tool Parameters
+
+Tool parameters are normally sent through the `parameters` field of the Gemini API, which accepts a fixed set of
+schema fields. When the parameters contain a `JsonRawSchema` or a `JsonReferenceSchema`, they are sent through
+`parametersJsonSchema` instead, which accepts plain JSON Schema. This keeps keywords such as `minimum`, along with
+`$ref` and `$defs`, instead of dropping them.
+
 ## Structured Outputs
 
 See more info on Structured Outputs [here](/tutorials/structured-outputs).

--- a/docs/docs/integrations/language-models/google-ai-gemini.md
+++ b/docs/docs/integrations/language-models/google-ai-gemini.md
@@ -256,12 +256,50 @@ System.out.println("Gemini> " + tokyoWeather);
 //         with a temperature of 32 degrees.
 ```
 
-### Raw Tool Parameters
+### Tool Parameters Using `$ref`, `$defs` Or Raw JSON Schema
 
-Tool parameters are normally sent through the `parameters` field of the Gemini API, which accepts a fixed set of
-schema fields. When the parameters contain a `JsonRawSchema` or a `JsonReferenceSchema`, they are sent through
-`parametersJsonSchema` instead, which accepts plain JSON Schema. This keeps keywords such as `minimum`, along with
-`$ref` and `$defs`, instead of dropping them.
+Tool parameters are usually described with the Gemini `parameters` field, which understands a fixed set of
+schema keywords. Standard JSON Schema goes further than that: it can point one part of a document at another
+with `$ref` and `$defs`, and it has keywords such as `minimum` and `maximum` that `parameters` has no place for.
+
+When the tool parameters contain anything of that kind, LangChain4j sends them through `parametersJsonSchema`
+instead, the Gemini field that takes plain JSON Schema, and the schema reaches the API unchanged. There is
+nothing to configure and nothing to switch on:
+
+```java
+JsonObjectSchema priceRange = JsonObjectSchema.builder()
+        .addNumberProperty("min")
+        .addNumberProperty("max")
+        .build();
+
+ToolSpecification searchProducts = ToolSpecification.builder()
+        .name("search_products")
+        .description("Search the catalog")
+        .parameters(JsonObjectSchema.builder()
+                .definitions(Map.of("PriceRange", priceRange))
+                .addStringProperty("query")
+                // a reference to the definition above, resolved by Gemini
+                .addProperty("retail_price", JsonReferenceSchema.builder()
+                        .reference("PriceRange")
+                        .build())
+                // a fragment of JSON Schema, sent exactly as written
+                .addProperty("max_results", JsonRawSchema.from(
+                        "{\"type\":\"integer\",\"minimum\":1,\"maximum\":50}"))
+                .required("query")
+                .build())
+        .build();
+```
+
+This is not limited to schemas you write by hand. It also covers tools LangChain4j builds for you: a `@Tool`
+method whose parameter type refers to itself, and MCP tools whose schema uses `$ref`.
+
+Response schemas are treated the same way, see [Raw Response Schema](#raw-response-schema).
+
+:::note
+Gemini rejects the `$schema` keyword. Documents coming out of a schema generator usually start with
+`"$schema": "https://json-schema.org/draft/2020-12/schema"`, so drop that line before passing the document
+to `JsonRawSchema`, otherwise the request fails with a `400`.
+:::
 
 ## Structured Outputs
 
@@ -386,6 +424,7 @@ System.out.println(chatResponse.aiMessage().text());
 #### Raw Response Schema
 Another example shows how we can use the `responseJsonSchema` of the Gemini API to provide a raw JSON schema using `JsonRawSchema` class.  
 Please be cautious to use only the [supported types](https://ai.google.dev/gemini-api/docs/structured-output?example=recipe#json_schema_support) of the Gemini API.
+The same field is used whenever a response schema contains a `JsonRawSchema` or a `JsonReferenceSchema` anywhere inside it, so `$ref` and `$defs` work here too.
 ```
 String rawSchema = """
 {

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.googleai;
 
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.copyIfNotNull;
 import static dev.langchain4j.internal.Utils.getOrDefault;
@@ -7,6 +8,7 @@ import static dev.langchain4j.model.googleai.FinishReasonMapper.fromGFinishReaso
 import static dev.langchain4j.model.googleai.FunctionMapper.fromToolSpecsToGTools;
 import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromGPartsToAiMessage;
 import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromMessageToGContent;
+import static dev.langchain4j.model.googleai.SchemaMapper.canBeMapped;
 import static dev.langchain4j.model.googleai.SchemaMapper.fromJsonSchemaToGSchema;
 import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
 
@@ -20,7 +22,7 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
-import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.googleai.GeminiGenerateContentRequest.GeminiToolConfig;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate;
@@ -140,10 +142,11 @@ class BaseGeminiChatModel {
 
         if (responseFormat != null) {
             if (responseFormat.jsonSchema() != null) {
-                if (responseFormat.jsonSchema().rootElement() instanceof JsonRawSchema jsonRawSchema) {
-                    rawSchema = Json.fromJson(jsonRawSchema.schema(), Map.class);
+                JsonSchemaElement rootElement = responseFormat.jsonSchema().rootElement();
+                if (canBeMapped(rootElement)) {
+                    schema = fromJsonSchemaToGSchema(rootElement);
                 } else {
-                    schema = fromJsonSchemaToGSchema(responseFormat.jsonSchema());
+                    rawSchema = toMap(rootElement);
                 }
             }
         }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FunctionMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FunctionMapper.java
@@ -53,7 +53,6 @@ class FunctionMapper {
                     }
 
                     if (specification.parameters() != null) {
-                        // The two parameter fields are mutually exclusive, so only one is ever set.
                         if (canBeMapped(specification.parameters())) {
                             fnBuilder.parameters(fromJsonSchemaToGSchema(specification.parameters()));
                         } else {

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FunctionMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FunctionMapper.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.model.googleai;
 
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.googleai.Json.toJsonWithoutIndent;
+import static dev.langchain4j.model.googleai.SchemaMapper.canBeMapped;
 import static dev.langchain4j.model.googleai.SchemaMapper.fromJsonSchemaToGSchema;
 import static java.util.Collections.singletonList;
 
@@ -51,7 +53,12 @@ class FunctionMapper {
                     }
 
                     if (specification.parameters() != null) {
-                        fnBuilder.parameters(fromJsonSchemaToGSchema(specification.parameters()));
+                        // The two parameter fields are mutually exclusive, so only one is ever set.
+                        if (canBeMapped(specification.parameters())) {
+                            fnBuilder.parameters(fromJsonSchemaToGSchema(specification.parameters()));
+                        } else {
+                            fnBuilder.parametersJsonSchema(toMap(specification.parameters()));
+                        }
                     }
 
                     return fnBuilder.build();

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFunctionDeclaration.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFunctionDeclaration.java
@@ -2,12 +2,22 @@ package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 
+/**
+ * A function the model can call.
+ *
+ * <p>The parameters are described either by {@code parameters}, the typed {@link GeminiSchema}, or by
+ * {@code parametersJsonSchema}, plain JSON Schema. The API treats the two as mutually exclusive, so
+ * at most one of them is set, and neither is when the function takes no parameters. A null field is
+ * omitted by the module's object mapper.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiFunctionDeclaration(
         @JsonProperty("name") String name,
         @JsonProperty("description") String description,
-        @JsonProperty("parameters") GeminiSchema parameters) {
+        @JsonProperty("parameters") GeminiSchema parameters,
+        @JsonProperty("parametersJsonSchema") Map<String, Object> parametersJsonSchema) {
 
     static Builder builder() {
         return new Builder();
@@ -17,6 +27,7 @@ record GeminiFunctionDeclaration(
         private String name;
         private String description;
         private GeminiSchema parameters;
+        private Map<String, Object> parametersJsonSchema;
 
         private Builder() {}
 
@@ -35,8 +46,13 @@ record GeminiFunctionDeclaration(
             return this;
         }
 
+        Builder parametersJsonSchema(Map<String, Object> parametersJsonSchema) {
+            this.parametersJsonSchema = parametersJsonSchema;
+            return this;
+        }
+
         GeminiFunctionDeclaration build() {
-            return new GeminiFunctionDeclaration(name, description, parameters);
+            return new GeminiFunctionDeclaration(name, description, parameters, parametersJsonSchema);
         }
     }
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/SchemaMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/SchemaMapper.java
@@ -8,6 +8,8 @@ import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
 import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
@@ -15,6 +17,30 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 class SchemaMapper {
+
+    /**
+     * Whether {@link #fromJsonSchemaToGSchema} can convert this element and everything below it.
+     * {@link JsonRawSchema} and {@link JsonReferenceSchema} are the two the typed {@link GeminiSchema}
+     * has no shape for.
+     */
+    static boolean canBeMapped(JsonSchemaElement jsonSchema) {
+        if (jsonSchema instanceof JsonRawSchema || jsonSchema instanceof JsonReferenceSchema) {
+            return false;
+        }
+        if (jsonSchema instanceof JsonObjectSchema jsonObjectSchema) {
+            // Definitions exist to be referenced, and a reference has no typed form.
+            return jsonObjectSchema.definitions().isEmpty()
+                    && jsonObjectSchema.properties().values().stream().allMatch(SchemaMapper::canBeMapped);
+        }
+        if (jsonSchema instanceof JsonArraySchema jsonArraySchema) {
+            return jsonArraySchema.items() == null || canBeMapped(jsonArraySchema.items());
+        }
+        if (jsonSchema instanceof JsonAnyOfSchema jsonAnyOfSchema) {
+            return jsonAnyOfSchema.anyOf().stream().allMatch(SchemaMapper::canBeMapped);
+        }
+        return true;
+    }
+
     static GeminiSchema fromJsonSchemaToGSchema(JsonSchema jsonSchema) {
         return fromJsonSchemaToGSchema(jsonSchema.rootElement());
     }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/SchemaMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/SchemaMapper.java
@@ -20,13 +20,14 @@ class SchemaMapper {
 
     /**
      * Whether {@link #fromJsonSchemaToGSchema} can convert this element and everything below it.
-     * {@link JsonRawSchema} and {@link JsonReferenceSchema} are the two the typed {@link GeminiSchema}
-     * has no shape for.
+     * Callers that have an alternative, such as sending plain JSON Schema, should ask this first
+     * instead of catching the exception the mapper throws.
+     *
+     * <p>The listed types are exactly the ones the mapper handles. Anything else, including
+     * {@link JsonRawSchema}, {@link JsonReferenceSchema} and any element type added later, is
+     * reported as not mappable, so a new element type takes the alternative instead of throwing.
      */
     static boolean canBeMapped(JsonSchemaElement jsonSchema) {
-        if (jsonSchema instanceof JsonRawSchema || jsonSchema instanceof JsonReferenceSchema) {
-            return false;
-        }
         if (jsonSchema instanceof JsonObjectSchema jsonObjectSchema) {
             // Definitions exist to be referenced, and a reference has no typed form.
             return jsonObjectSchema.definitions().isEmpty()
@@ -38,7 +39,12 @@ class SchemaMapper {
         if (jsonSchema instanceof JsonAnyOfSchema jsonAnyOfSchema) {
             return jsonAnyOfSchema.anyOf().stream().allMatch(SchemaMapper::canBeMapped);
         }
-        return true;
+        return jsonSchema instanceof JsonStringSchema
+                || jsonSchema instanceof JsonBooleanSchema
+                || jsonSchema instanceof JsonNumberSchema
+                || jsonSchema instanceof JsonIntegerSchema
+                || jsonSchema instanceof JsonEnumSchema
+                || jsonSchema instanceof JsonNullSchema;
     }
 
     static GeminiSchema fromJsonSchemaToGSchema(JsonSchema jsonSchema) {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/FunctionMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/FunctionMapperTest.java
@@ -7,7 +7,11 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.googleai.GeminiGenerateContentRequest.GeminiTool;
 import dev.langchain4j.model.output.structured.Description;
@@ -338,6 +342,151 @@ class FunctionMapperTest {
         assertThat(geminiTool.codeExecution()).isNull();
         assertThat(geminiTool.googleMaps()).isNotNull();
         assertThat(geminiTool.googleMaps().enableWidget()).isTrue();
+    }
+
+    @Test
+    void should_use_typed_parameters_when_every_element_has_a_typed_form() {
+        // given
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .addStringProperty("query")
+                .addIntegerProperty("maxResults")
+                .required("query")
+                .build();
+
+        // when
+        GeminiFunctionDeclaration declaration = declarationFor(parameters);
+
+        // then
+        assertThat(declaration.parametersJsonSchema()).isNull();
+        assertThat(declaration.parameters().getType()).isEqualTo(GeminiType.OBJECT);
+        assertThat(declaration.parameters().getProperties().keySet()).containsExactlyInAnyOrder("query", "maxResults");
+    }
+
+    @Test
+    void should_use_json_schema_for_a_raw_element() {
+        // given
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .addStringProperty("query")
+                .addProperty("maxResults", JsonRawSchema.from("{\"type\":\"integer\",\"minimum\":1,\"maximum\":50}"))
+                .required("query")
+                .build();
+
+        // when
+        GeminiFunctionDeclaration declaration = declarationFor(parameters);
+
+        // then
+        assertThat(declaration.parameters()).isNull();
+
+        Map<String, Object> properties = propertiesOf(declaration.parametersJsonSchema());
+        assertThat(properties).containsKeys("query", "maxResults");
+        // The constraints the typed model has no field for survive.
+        assertThat((Map<String, Object>) properties.get("maxResults")).containsEntry("minimum", 1);
+        assertThat((Map<String, Object>) properties.get("maxResults")).containsEntry("maximum", 50);
+    }
+
+    @Test
+    void should_use_json_schema_for_a_reference_element() {
+        // given
+        JsonObjectSchema priceRange = JsonObjectSchema.builder()
+                .addProperty("min", new JsonNumberSchema())
+                .addProperty("max", new JsonNumberSchema())
+                .build();
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .definitions(Map.of("PriceRange", priceRange))
+                .addStringProperty("query")
+                // A reference holds the bare definition name; toMap() writes the "#/$defs/" prefix.
+                .addProperty(
+                        "retailPrice",
+                        JsonReferenceSchema.builder().reference("PriceRange").build())
+                .required("query")
+                .build();
+
+        // when
+        GeminiFunctionDeclaration declaration = declarationFor(parameters);
+
+        // then
+        assertThat(declaration.parameters()).isNull();
+
+        Map<String, Object> jsonSchema = declaration.parametersJsonSchema();
+        assertThat(jsonSchema).containsKey("$defs");
+        assertThat((Map<String, Object>) propertiesOf(jsonSchema).get("retailPrice"))
+                .containsEntry("$ref", "#/$defs/PriceRange");
+    }
+
+    @Test
+    void should_use_json_schema_for_definitions_that_nothing_references() {
+        // given
+        JsonObjectSchema priceRange = JsonObjectSchema.builder()
+                .addProperty("min", new JsonNumberSchema())
+                .addProperty("max", new JsonNumberSchema())
+                .build();
+        // Every property has a typed form. Only the definitions rule out the typed field, since
+        // GeminiSchema has nowhere to put them and they would be dropped without a word.
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .definitions(Map.of("PriceRange", priceRange))
+                .addStringProperty("query")
+                .required("query")
+                .build();
+
+        // when
+        GeminiFunctionDeclaration declaration = declarationFor(parameters);
+
+        // then
+        assertThat(declaration.parameters()).isNull();
+
+        Map<String, Object> jsonSchema = declaration.parametersJsonSchema();
+        assertThat(propertiesOf(jsonSchema)).containsKey("query");
+        assertThat((Map<String, Object>) jsonSchema.get("$defs")).containsKey("PriceRange");
+    }
+
+    @Test
+    void should_use_json_schema_for_an_element_nested_below_the_root() {
+        // given
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .addProperty(
+                        "filters",
+                        JsonArraySchema.builder()
+                                .items(JsonObjectSchema.builder()
+                                        .addProperty("size", JsonRawSchema.from("{\"type\":\"integer\",\"minimum\":1}"))
+                                        .build())
+                                .build())
+                .build();
+
+        // when
+        GeminiFunctionDeclaration declaration = declarationFor(parameters);
+
+        // then
+        assertThat(declaration.parameters()).isNull();
+        assertThat(declaration.parametersJsonSchema()).isNotNull();
+    }
+
+    @Test
+    void canBeMapped_covers_every_element_type() {
+        assertThat(SchemaMapper.canBeMapped(new JsonStringSchema())).isTrue();
+        assertThat(SchemaMapper.canBeMapped(new JsonIntegerSchema())).isTrue();
+        assertThat(SchemaMapper.canBeMapped(JsonRawSchema.from("{\"type\":\"integer\"}")))
+                .isFalse();
+        assertThat(SchemaMapper.canBeMapped(
+                        JsonReferenceSchema.builder().reference("X").build()))
+                .isFalse();
+    }
+
+    private static GeminiFunctionDeclaration declarationFor(JsonObjectSchema parameters) {
+        ToolSpecification specification = ToolSpecification.builder()
+                .name("search_products")
+                .description("Search the catalog")
+                .parameters(parameters)
+                .build();
+
+        return FunctionMapper.fromToolSpecsToGTools(List.of(specification), false, false, false, false, false)
+                .get(0)
+                .functionDeclarations()
+                .get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> propertiesOf(Map<String, Object> jsonSchema) {
+        return (Map<String, Object>) jsonSchema.get("properties");
     }
 
     private static String withoutNullValues(String toString) {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/FunctionMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/FunctionMapperTest.java
@@ -7,7 +7,6 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
-import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonRawSchema;
@@ -461,14 +460,21 @@ class FunctionMapperTest {
     }
 
     @Test
-    void canBeMapped_covers_every_element_type() {
-        assertThat(SchemaMapper.canBeMapped(new JsonStringSchema())).isTrue();
-        assertThat(SchemaMapper.canBeMapped(new JsonIntegerSchema())).isTrue();
-        assertThat(SchemaMapper.canBeMapped(JsonRawSchema.from("{\"type\":\"integer\"}")))
-                .isFalse();
-        assertThat(SchemaMapper.canBeMapped(
-                        JsonReferenceSchema.builder().reference("X").build()))
-                .isFalse();
+    void should_omit_the_unused_parameter_field_from_the_serialized_request() {
+        // given
+        JsonObjectSchema typed =
+                JsonObjectSchema.builder().addStringProperty("query").build();
+        JsonObjectSchema raw = JsonObjectSchema.builder()
+                .addProperty("query", JsonRawSchema.from("{\"type\":\"string\",\"minLength\":1}"))
+                .build();
+
+        // when
+        String typedJson = Json.toJson(declarationFor(typed));
+        String rawJson = Json.toJson(declarationFor(raw));
+
+        // then
+        assertThat(typedJson).contains("\"parameters\"").doesNotContain("parametersJsonSchema");
+        assertThat(rawJson).contains("\"parametersJsonSchema\"").doesNotContain("\"parameters\"");
     }
 
     private static GeminiFunctionDeclaration declarationFor(JsonObjectSchema parameters) {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
@@ -18,7 +18,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.AudioContent;
@@ -36,8 +38,10 @@ import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -408,6 +412,61 @@ class GoogleAiGeminiChatModelIT {
     }
 
     @Test
+    void should_support_tool_parameters_without_a_typed_form() throws JsonProcessingException {
+        // given
+        GoogleAiGeminiChatModel model = GoogleAiGeminiChatModel.builder()
+                .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                .modelName("gemini-flash-latest")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        JsonObjectSchema priceRange = JsonObjectSchema.builder()
+                .addProperty("min", new JsonNumberSchema())
+                .addProperty("max", new JsonNumberSchema())
+                .build();
+
+        ToolSpecification searchProducts = ToolSpecification.builder()
+                .name("search_products")
+                .description("Search the catalog")
+                .parameters(JsonObjectSchema.builder()
+                        .definitions(Map.of("PriceRange", priceRange))
+                        .addStringProperty("query")
+                        .addProperty(
+                                "retail_price",
+                                JsonReferenceSchema.builder()
+                                        .reference("PriceRange")
+                                        .build())
+                        .addProperty(
+                                "max_results",
+                                JsonRawSchema.from("{\"type\":\"integer\",\"minimum\":1,\"maximum\":50}"))
+                        .required("query")
+                        .build())
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Find blue shirts priced 10 to 50, at most 5 results."))
+                .toolSpecifications(searchProducts)
+                .build();
+
+        // when
+        ChatResponse response = model.chat(request);
+
+        // then
+        assertThat(response.aiMessage().hasToolExecutionRequests()).isTrue();
+
+        ToolExecutionRequest toolExecutionRequest =
+                response.aiMessage().toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.name()).isEqualTo("search_products");
+
+        // Only "query" is required, so the optional properties are the model's call and are not asserted.
+        Map<String, Object> arguments =
+                new ObjectMapper().readValue(toolExecutionRequest.arguments(), new TypeReference<>() {});
+        assertThat(arguments).containsKey("query");
+        assertThat(arguments.keySet()).isSubsetOf("query", "retail_price", "max_results");
+    }
+
+    @Test
     void should_support_tool_config() {
         // given
         GoogleAiGeminiChatModel model1 = GoogleAiGeminiChatModel.builder()
@@ -564,8 +623,7 @@ class GoogleAiGeminiChatModelIT {
         ResponseFormat responseFormat =
                 ResponseFormat.builder().type(JSON).jsonSchema(jsonSchema).build();
 
-        UserMessage userMessage = UserMessage.from(
-                """
+        UserMessage userMessage = UserMessage.from("""
                         Extract information from the following text:
                         1. A circle with a radius of 5
                         2. A rectangle with a width of 10 and a height of 20
@@ -596,8 +654,7 @@ class GoogleAiGeminiChatModelIT {
     @Test
     void should_support_raw_json_schema() throws JsonProcessingException {
         // given
-        String rawSchema =
-                """
+        String rawSchema = """
         {
           "type": "object",
           "properties": {
@@ -663,8 +720,7 @@ class GoogleAiGeminiChatModelIT {
                 .build();
 
         // when
-        UserMessage userMessage = UserMessage.from(
-                """
+        UserMessage userMessage = UserMessage.from("""
                    Tell me about a software engineer named Sherlock Holmes,
                    who was born on November 28 1990 and sees the world over six feet from the ground.
                    He is an open-source contributor, an active volunteer and lives in London at 221B Baker Street.

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
@@ -11,6 +11,13 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate.GeminiFinishReason;
@@ -502,6 +509,101 @@ class GoogleAiGeminiChatModelTest {
                             .aspectRatio("16:9")
                             .imageSize("2K")
                             .build());
+        }
+    }
+
+    @Nested
+    class ResponseFormatTest {
+        @Captor
+        ArgumentCaptor<GeminiGenerateContentRequest> requestCaptor;
+
+        @Test
+        void shouldSendTypedResponseSchemaWhenEveryElementHasATypedForm() {
+            // Given
+            var subject = modelReturning("Response");
+            var responseFormat = jsonResponseFormat(
+                    JsonObjectSchema.builder().addStringProperty("name").build());
+
+            // When
+            subject.chat(ChatRequest.builder()
+                    .messages(new UserMessage("Hi"))
+                    .responseFormat(responseFormat)
+                    .build());
+
+            // Then
+            verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
+
+            var generationConfig = requestCaptor.getValue().generationConfig();
+            assertThat(generationConfig.responseJsonSchema()).isNull();
+            assertThat(generationConfig.responseSchema().getType()).isEqualTo(GeminiType.OBJECT);
+        }
+
+        @Test
+        void shouldSendResponseJsonSchemaWhenTheRootIsRaw() {
+            // Given
+            var subject = modelReturning("Response");
+            var responseFormat = jsonResponseFormat(
+                    JsonRawSchema.from("{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}}}"));
+
+            // When
+            subject.chat(ChatRequest.builder()
+                    .messages(new UserMessage("Hi"))
+                    .responseFormat(responseFormat)
+                    .build());
+
+            // Then
+            verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
+
+            var generationConfig = requestCaptor.getValue().generationConfig();
+            assertThat(generationConfig.responseSchema()).isNull();
+            assertThat(generationConfig.responseJsonSchema()).containsEntry("type", "object");
+        }
+
+        @Test
+        void shouldSendResponseJsonSchemaWhenAnElementBelowTheRootHasNoTypedForm() {
+            // Given
+            var subject = modelReturning("Response");
+            var address = JsonObjectSchema.builder().addStringProperty("city").build();
+            var responseFormat = jsonResponseFormat(JsonObjectSchema.builder()
+                    .definitions(Map.of("Address", address))
+                    .addStringProperty("name")
+                    .addProperty(
+                            "address",
+                            JsonReferenceSchema.builder().reference("Address").build())
+                    .build());
+
+            // When
+            subject.chat(ChatRequest.builder()
+                    .messages(new UserMessage("Hi"))
+                    .responseFormat(responseFormat)
+                    .build());
+
+            // Then
+            verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
+
+            var generationConfig = requestCaptor.getValue().generationConfig();
+            assertThat(generationConfig.responseSchema()).isNull();
+            assertThat(generationConfig.responseJsonSchema()).containsKey("$defs");
+        }
+
+        private GoogleAiGeminiChatModel modelReturning(String text) {
+            when(mockGeminiService.generateContent(eq(TEST_MODEL_NAME), any(GeminiGenerateContentRequest.class)))
+                    .thenReturn(createGeminiResponse(text));
+
+            return GoogleAiGeminiChatModel.builder()
+                    .apiKey("test-api-key")
+                    .modelName(TEST_MODEL_NAME)
+                    .build(mockGeminiService);
+        }
+
+        private ResponseFormat jsonResponseFormat(JsonSchemaElement rootElement) {
+            return ResponseFormat.builder()
+                    .type(ResponseFormatType.JSON)
+                    .jsonSchema(JsonSchema.builder()
+                            .name("Response")
+                            .rootElement(rootElement)
+                            .build())
+                    .build();
         }
     }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/SchemaMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/SchemaMapperTest.java
@@ -10,6 +10,8 @@ import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
 import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
@@ -257,5 +259,79 @@ public class SchemaMapperTest {
 
         // then
         assertThat(result.getType()).isEqualTo(GeminiType.NULL);
+    }
+
+    @Test
+    public void should_report_every_element_the_mapper_handles_as_mappable() {
+        assertThat(SchemaMapper.canBeMapped(new JsonStringSchema())).isTrue();
+        assertThat(SchemaMapper.canBeMapped(new JsonBooleanSchema())).isTrue();
+        assertThat(SchemaMapper.canBeMapped(new JsonNumberSchema())).isTrue();
+        assertThat(SchemaMapper.canBeMapped(new JsonIntegerSchema())).isTrue();
+        assertThat(SchemaMapper.canBeMapped(new JsonNullSchema())).isTrue();
+        assertThat(SchemaMapper.canBeMapped(
+                        JsonEnumSchema.builder().enumValues("A", "B").build()))
+                .isTrue();
+        assertThat(SchemaMapper.canBeMapped(
+                        JsonObjectSchema.builder().addStringProperty("query").build()))
+                .isTrue();
+        assertThat(SchemaMapper.canBeMapped(JsonArraySchema.builder().build())).isTrue();
+    }
+
+    @Test
+    public void should_report_raw_and_reference_elements_as_not_mappable() {
+        assertThat(SchemaMapper.canBeMapped(JsonRawSchema.from("{\"type\":\"integer\",\"minimum\":1}")))
+                .isFalse();
+        assertThat(SchemaMapper.canBeMapped(
+                        JsonReferenceSchema.builder().reference("PriceRange").build()))
+                .isFalse();
+    }
+
+    @Test
+    public void should_report_an_unknown_element_as_not_mappable() {
+        // An element type the mapper does not handle must take the alternative rather than throw.
+        JsonSchemaElement unknown = () -> "unknown";
+
+        assertThat(SchemaMapper.canBeMapped(unknown)).isFalse();
+    }
+
+    @Test
+    public void should_look_below_containers() {
+        JsonSchemaElement raw = JsonRawSchema.from("{\"type\":\"integer\"}");
+
+        assertThat(SchemaMapper.canBeMapped(
+                        JsonObjectSchema.builder().addProperty("size", raw).build()))
+                .isFalse();
+        assertThat(SchemaMapper.canBeMapped(JsonArraySchema.builder().items(raw).build()))
+                .isFalse();
+        assertThat(SchemaMapper.canBeMapped(JsonAnyOfSchema.builder()
+                        .anyOf(new JsonStringSchema(), raw)
+                        .build()))
+                .isFalse();
+        assertThat(SchemaMapper.canBeMapped(JsonObjectSchema.builder()
+                        .addProperty(
+                                "filters",
+                                JsonArraySchema.builder()
+                                        .items(JsonObjectSchema.builder()
+                                                .addProperty("size", raw)
+                                                .build())
+                                        .build())
+                        .build()))
+                .isFalse();
+    }
+
+    @Test
+    public void should_report_definitions_as_not_mappable() {
+        // GeminiSchema has nowhere to put $defs, so the typed form would drop them without a word.
+        JsonObjectSchema withDefinitions = JsonObjectSchema.builder()
+                .definitions(Map.of(
+                        "PriceRange",
+                        JsonObjectSchema.builder()
+                                .addNumberProperty("min")
+                                .addNumberProperty("max")
+                                .build()))
+                .addStringProperty("query")
+                .build();
+
+        assertThat(SchemaMapper.canBeMapped(withDefinitions)).isFalse();
     }
 }


### PR DESCRIPTION
## Issue
Closes #6013

## Change
`SchemaMapper` throws for any `JsonSchemaElement` that the typed `GeminiSchema` cannot represent, and `FunctionMapper` called it unconditionally. A tool whose parameters contain a `JsonRawSchema` or a `JsonReferenceSchema` therefore failed while the request was built, and no request reached the API.

The Gemini API's `FunctionDeclaration` accepts `parametersJsonSchema` next to parameters, taking plain JSON Schema. It is the tool-side counterpart of the `responseJsonSchema` field that #4150 already uses for response format. The two are mutually exclusive, so at most one is set.

- `GeminiFunctionDeclaration` gains a `parametersJsonSchema` field. The module's object mapper omits nulls, so requests that use the typed field are byte-identical to before.
- `SchemaMapper.canBeMapped` reports whether a tree has a typed form. `JsonRawSchema` and `JsonReferenceSchema` are the only two elements without one, and an object carrying `$defs` also has nowhere to put them.
- `FunctionMapper` converts through `JsonSchemaElementUtils.toMap` for those trees, and keeps the existing typed path for everything else.

Verified against the API: a tool declaring `$defs`, a `$ref` and `minimum`/`maximum` is now called
correctly, with the reference resolved on Google's side.

Note on the diff: three text blocks in `GoogleAiGeminiChatModelIT` are reformatted. That file was not
spotless clean on `main`, and `ratchetFrom origin/main` formats the whole file once it is touched.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
N/A


## Checklist for adding new embedding store integration
N/A

## Checklist for changing existing embedding store integration
N/A
