### PR TITLE
fix: only serialize responseLogprobs and enableEnhancedCivicAnswers when explicitly set

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -74,7 +74,7 @@ class BaseGeminiChatModel {
         this.returnThinking = builder.returnThinking;
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
-        this.responseLogprobs = getOrDefault(builder.responseLogprobs, false);
+        this.responseLogprobs = builder.responseLogprobs;
         this.enableEnhancedCivicAnswers = builder.enableEnhancedCivicAnswers;
         this.logprobs = builder.logprobs;
         this.mediaResolution = builder.mediaResolution;

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -75,7 +75,7 @@ class BaseGeminiChatModel {
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
         this.responseLogprobs = getOrDefault(builder.responseLogprobs, false);
-        this.enableEnhancedCivicAnswers = getOrDefault(builder.enableEnhancedCivicAnswers, false);
+        this.enableEnhancedCivicAnswers = builder.enableEnhancedCivicAnswers;
         this.logprobs = builder.logprobs;
         this.mediaResolution = builder.mediaResolution;
         this.mediaResolutionPerPartEnabled = getOrDefault(builder.mediaResolutionPerPartEnabled, false);

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiGenerationConfigTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiGenerationConfigTest.java
@@ -22,7 +22,22 @@ class GeminiGenerationConfigTest {
         void defaultValues() {
             GeminiGenerationConfig result = GeminiGenerationConfig.builder().build();
 
-            assertThatCharSequence(Json.toJson(result)).doesNotContain("\"seed\"");
+            assertThatCharSequence(Json.toJson(result))
+                    .doesNotContain("\"seed\"")
+                    .doesNotContain("\"responseLogprobs\"")
+                    .doesNotContain("\"enableEnhancedCivicAnswers\"");
+        }
+
+        @Test
+        void settingOptionalFlagsToFalseProducesConfigWithOptionalFlags() {
+            GeminiGenerationConfig result = GeminiGenerationConfig.builder()
+                    .responseLogprobs(false)
+                    .enableEnhancedCivicAnswers(false)
+                    .build();
+
+            assertThatCharSequence(Json.toJson(result))
+                    .contains("\"responseLogprobs\" : false")
+                    .contains("\"enableEnhancedCivicAnswers\" : false");
         }
 
         @Test

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
@@ -395,7 +395,6 @@ class GoogleAiGeminiChatModelTest {
                             .stopSequences(List.of("STOP", "END"))
                             .seed(42)
                             .candidateCount(1)
-                            .responseLogprobs(false)
                             .build());
         }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
@@ -396,7 +396,6 @@ class GoogleAiGeminiChatModelTest {
                             .seed(42)
                             .candidateCount(1)
                             .responseLogprobs(false)
-                            .enableEnhancedCivicAnswers(false)
                             .build());
         }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiEnhancedCivicAnswersTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiEnhancedCivicAnswersTest.java
@@ -47,7 +47,7 @@ class GoogleAiGeminiEnhancedCivicAnswersTest {
     }
 
     @Test
-    void shouldDefaultEnableEnhancedCivicAnswersToFalse() {
+    void shouldDefaultEnableEnhancedCivicAnswersToNull() {
         var model = GoogleAiGeminiChatModel.builder()
                 .apiKey("test-key")
                 .modelName(TEST_MODEL_NAME)
@@ -61,7 +61,7 @@ class GoogleAiGeminiEnhancedCivicAnswersTest {
 
         verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
         assertThat(requestCaptor.getValue().generationConfig().enableEnhancedCivicAnswers())
-                .isFalse();
+                .isNull();
     }
 
     private GeminiGenerateContentResponse createSimpleResponse(String text) {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiEnhancedCivicAnswersTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiEnhancedCivicAnswersTest.java
@@ -47,6 +47,25 @@ class GoogleAiGeminiEnhancedCivicAnswersTest {
     }
 
     @Test
+    void shouldForwardEnableEnhancedCivicAnswersWhenExplicitlyDisabled() {
+        var model = GoogleAiGeminiChatModel.builder()
+                .apiKey("test-key")
+                .modelName(TEST_MODEL_NAME)
+                .enableEnhancedCivicAnswers(false)
+                .build(mockGeminiService);
+
+        var chatRequest =
+                ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+        when(mockGeminiService.generateContent(any(), any())).thenReturn(createSimpleResponse("Hi"));
+
+        model.chat(chatRequest);
+
+        verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().generationConfig().enableEnhancedCivicAnswers())
+                .isFalse();
+    }
+
+    @Test
     void shouldDefaultEnableEnhancedCivicAnswersToNull() {
         var model = GoogleAiGeminiChatModel.builder()
                 .apiKey("test-key")

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
@@ -200,7 +200,7 @@ class GoogleAiGeminiStreamingChatModelTest {
                     .build();
             GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
 
-            assertThat(result.generationConfig().enableEnhancedCivicAnswers()).isFalse();
+            assertThat(result.generationConfig().enableEnhancedCivicAnswers()).isNull();
         }
     }
 }

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
@@ -193,6 +193,29 @@ class GoogleAiGeminiStreamingChatModelTest {
         }
 
         @Test
+        void responseLogprobsInContentRequest() {
+            GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
+                    .apiKey("ApiKey")
+                    .modelName("ModelName")
+                    .responseLogprobs(false)
+                    .build();
+            GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
+
+            assertThat(result.generationConfig().responseLogprobs()).isFalse();
+        }
+
+        @Test
+        void defaultResponseLogprobsInContentRequest() {
+            GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
+                    .apiKey("ApiKey")
+                    .modelName("ModelName")
+                    .build();
+            GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
+
+            assertThat(result.generationConfig().responseLogprobs()).isNull();
+        }
+
+        @Test
         void defaultEnableEnhancedCivicAnswersInContentRequest() {
             GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
                     .apiKey("ApiKey")


### PR DESCRIPTION
## Issue
  Closes #6014

  ## Change

  `GeminiGenerationConfig` is annotated with `@JsonInclude(NON_EMPTY)`, but since Jackson 2.6 `NON_EMPTY` does **not** treat boxed booleans as empty — only `null`, empty strings and empty collections. Because
  `BaseGeminiChatModel` filled both flags in with `getOrDefault(..., false)`, they were serialized into `generationConfig` on **every** request, even when the user never configured them:

  ```json
  {"temperature":0.7,"responseLogprobs":false,"enableEnhancedCivicAnswers":false}
  ```

  For `enableEnhancedCivicAnswers` this breaks requests routed through API gateways/proxies (e.g. OneAPI, NewAPI) that reject unknown fields, producing:

  ```
  Unknown name "enableEnhancedCivicAnswers" at 'generation_config'
  ```

  Both fields were already nullable `Boolean`, so the fix is to stop defaulting them. When unset they now stay `null` and `@JsonInclude(NON_EMPTY)` omits them from the request JSON, letting the Gemini API apply
  its own server-side defaults — which matches Google's spec, where both are optional. Explicitly setting `true` or `false` still works exactly as before.

  `responseLogprobs` is included because it has the identical root cause and the identical failure mode; fixing only one of the two would leave the same hole open and the module internally inconsistent.

  - `BaseGeminiChatModel`: default `responseLogprobs` and `enableEnhancedCivicAnswers` from `false` to `null` 
  - `GeminiGenerationConfigTest`: `defaultValues` now asserts neither flag is present in the serialized JSON; added a case asserting that an explicit `false` **is** serialized
  - `GoogleAiGeminiEnhancedCivicAnswersTest`: added the explicit-`false` (negative) case; default-state assertion `isFalse()` -> `isNull()` (method renamed accordingly)
  - `GoogleAiGeminiStreamingChatModelTest`: default-state assertion `isFalse()` -> `isNull()`; added the matching `responseLogprobs` default/explicit pair
  - `GoogleAiGeminiChatModelTest`: removed `responseLogprobs(false)` and `enableEnhancedCivicAnswers(false)` from the full-config equality assertion

  The new serialization assertions go through `Json.toJson(...)`, the same mapper `GeminiService` uses for the actual request body, so they pin the real wire payload rather than just the record field.

  ## Breaking Changes

  This is not an API change — both fields were already `Boolean` and no signature is affected (`revapi:check` passes). There is, however, a **subtle behaviour change**: previously LangChain4j always sent an
  explicit `false` for these two flags; now it sends nothing at all when they are unset, and the Gemini API applies its own default.

  In practice this should be a no-op, as Google documents both fields as optional. If you were relying on LangChain4j forcing `false`, set the values explicitly to restore the previous request payload:

  ```java
  GoogleAiGeminiChatModel.builder()
          .apiKey(System.getenv("GEMINI_API_KEY"))
          .modelName("gemini-2.0-flash")
          .responseLogprobs(false)              // previously implicit
          .enableEnhancedCivicAnswers(false)    // previously implicit
          .build();
  ```

  No migration is needed if you never touched these builder methods, or if you already set them explicitly.

  ## General checklist
  - [ ] There are no breaking changes (API, behaviour) — see the "Breaking Changes" section above: no API change, but unset flags are no longer forced to `false`
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases 
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (371 tests, 0 failures)
  - [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — not applicable, the docs list these builder methods but never documented a default value
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) — not applicable 
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) — not applicable, the starter binds these as `Boolean` and passes `null` through unchanged