### PR TITLE
Support the Ollama truncate field so an over-long prompt can fail instead of being trimmed

### DIFF
--- a/docs/docs/integrations/language-models/ollama.md
+++ b/docs/docs/integrations/language-models/ollama.md
@@ -289,6 +289,7 @@ params with the builder pattern:
 | `minP`                     |                                                                                                                                                                                   | `Double`                  |                             |
 | `responseFormat`           | The desired format for the generated output. TEXT or JSON with optional JSON Schema definition                                                                                    | `ResponseFormat`          |                             |
 | `think`                    | Controls [thinking](https://ollama.com/blog/thinking).                                                                                                                            | `Boolean`                 |                             |
+| `truncate`                 | Controls what the server does with a prompt that does not fit the context window. See below.                                                                                       | `Boolean`                 | `true` (server default)     |
 | `returnThinking`           |                                                                                                                                                                                   | `Boolean`                 |                             |
 | `timeout`                  | The maximum time allowed for the API call to complete.                                                                                                                            | `Duration`                | PT60S                       |
 | `customHeaders`            | Custom HTTP headers.                                                                                                                                                              | `Map<String, String>`     |                             |
@@ -408,6 +409,28 @@ OllamaChatModel ollamaChatModel = OllamaChatModel.builder()
     .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)    
     .build();
 ```
+
+### Prompts that exceed the context window
+
+By default, Ollama drops the part of a prompt that does not fit the context window and answers from
+the rest. The response is a normal `200`, and `promptEvalCount` counts the prompt after the trim, so
+neither the response nor the token usage shows that input was lost.
+
+Set `truncate` to `false` to get an error instead. The server then rejects the request with HTTP 400
+and reports both the prompt size and the context size:
+
+```java
+ChatModel model = OllamaChatModel.builder()
+        .baseUrl("http://localhost:11434")
+        .modelName("llama3.1:8b")
+        .numCtx(4096)
+        .truncate(false)
+        .build();
+```
+
+This is useful in a multi-turn agent loop, where the conversation grows with every tool result and a
+silently shortened prompt is worse than a failed request. Leave `truncate` unset to keep the server
+default.
 
 ### Thinking / Reasoning
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -191,6 +191,7 @@ class InternalOllamaHelper {
                 .tools(toOllamaTools(chatRequest.toolSpecifications()))
                 .keepAlive(requestParameters.keepAlive())
                 .think(requestParameters.think())
+                .truncate(requestParameters.truncate())
                 .build();
     }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaBaseChatModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaBaseChatModel.java
@@ -76,6 +76,7 @@ abstract class OllamaBaseChatModel {
                 .minP(getOrDefault(builder.minP, ollamaParameters.minP()))
                 .keepAlive(ollamaParameters.keepAlive())
                 .think(getOrDefault(builder.think, ollamaParameters.think()))
+                .truncate(getOrDefault(builder.truncate, ollamaParameters.truncate()))
                 .numThread(ollamaParameters.numThread())
                 .numKeep(ollamaParameters.numKeep())
                 .typicalP(ollamaParameters.typicalP())
@@ -116,6 +117,7 @@ abstract class OllamaBaseChatModel {
         protected Double minP;
         protected ResponseFormat responseFormat;
         protected Boolean think;
+        protected Boolean truncate;
         protected Boolean returnThinking;
         protected Duration timeout;
         protected Supplier<Map<String, String>> customHeadersSupplier;
@@ -237,6 +239,23 @@ abstract class OllamaBaseChatModel {
          */
         public B think(Boolean think) {
             this.think = think;
+            return self();
+        }
+
+        /**
+         * Controls what Ollama does with a prompt that does not fit the context window.
+         * <pre>
+         * <code>true</code>: the server drops the part of the prompt that does not fit and answers from the rest
+         * <code>false</code>: the server rejects the request with HTTP 400, reporting the prompt size and the context size
+         * <code>null</code> (not set): the server default applies, which is <code>true</code>
+         * </pre>
+         * <p>The default discards input without reporting it, so a shortened prompt is not visible in the
+         * response or in the token usage. Set this to {@code false} to get an error instead.</p>
+         *
+         * @see #numCtx(Integer)
+         */
+        public B truncate(Boolean truncate) {
+            this.truncate = truncate;
             return self();
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequest.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequest.java
@@ -27,6 +27,8 @@ class OllamaChatRequest {
 
     private Boolean think;
 
+    private Boolean truncate;
+
     OllamaChatRequest() {}
 
     OllamaChatRequest(Builder builder) {
@@ -38,6 +40,7 @@ class OllamaChatRequest {
         this.format = builder.format;
         this.keepAlive = builder.keepAlive;
         this.think = builder.think;
+        this.truncate = builder.truncate;
     }
 
     static Builder builder() {
@@ -108,6 +111,14 @@ class OllamaChatRequest {
         this.think = think;
     }
 
+    public Boolean getTruncate() {
+        return truncate;
+    }
+
+    public void setTruncate(Boolean truncate) {
+        this.truncate = truncate;
+    }
+
     static class Builder {
 
         private String model;
@@ -118,6 +129,7 @@ class OllamaChatRequest {
         private List<Tool> tools;
         private Integer keepAlive;
         private Boolean think;
+        private Boolean truncate;
 
         Builder model(String model) {
             this.model = model;
@@ -156,6 +168,11 @@ class OllamaChatRequest {
 
         Builder think(Boolean think) {
             this.think = think;
+            return this;
+        }
+
+        Builder truncate(Boolean truncate) {
+            this.truncate = truncate;
             return this;
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequestParameters.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequestParameters.java
@@ -23,6 +23,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
     private final Double minP;
     private final Integer keepAlive;
     private final Boolean think;
+    private final Boolean truncate;
     private final Integer numKeep;
     private final Double typicalP;
     private final Integer numBatch;
@@ -43,6 +44,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         this.minP = builder.minP;
         this.keepAlive = builder.keepAlive;
         this.think = builder.think;
+        this.truncate = builder.truncate;
         this.numKeep = builder.numKeep;
         this.typicalP = builder.typicalP;
         this.numBatch = builder.numBatch;
@@ -119,6 +121,10 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         return think;
     }
 
+    public Boolean truncate() {
+        return truncate;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (o == null || getClass() != o.getClass()) return false;
@@ -140,7 +146,8 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 && Objects.equals(seed, that.seed)
                 && Objects.equals(minP, that.minP)
                 && Objects.equals(keepAlive, that.keepAlive)
-                && Objects.equals(think, that.think);
+                && Objects.equals(think, that.think)
+                && Objects.equals(truncate, that.truncate);
     }
 
     @Override
@@ -163,7 +170,8 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 seed,
                 minP,
                 keepAlive,
-                think);
+                think,
+                truncate);
     }
 
     @Override
@@ -197,6 +205,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 + ", minP=" + minP
                 + ", keepAlive=" + keepAlive
                 + ", think=" + think
+                + ", truncate=" + truncate
                 + '}';
     }
 
@@ -233,6 +242,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         private Double minP;
         private Integer keepAlive;
         private Boolean think;
+        private Boolean truncate;
         private Integer numKeep;
         private Double typicalP;
         private Integer numBatch;
@@ -261,6 +271,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 minP(getOrDefault(ollamaChatRequestParameters.minP, minP));
                 keepAlive(getOrDefault(ollamaChatRequestParameters.keepAlive, keepAlive));
                 think(getOrDefault(ollamaChatRequestParameters.think, think));
+                truncate(getOrDefault(ollamaChatRequestParameters.truncate, truncate));
             }
             return this;
         }
@@ -401,6 +412,24 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
          */
         public Builder think(Boolean think) {
             this.think = think;
+            return this;
+        }
+
+        /**
+         * Controls what Ollama does with a prompt that does not fit the context window.
+         * <pre>
+         * <code>true</code>: the server drops the part of the prompt that does not fit and answers from the rest
+         * <code>false</code>: the server rejects the request with HTTP 400, reporting the prompt size and the context size
+         * <code>null</code> (not set): the server default applies, which is <code>true</code>
+         * </pre>
+         * <p>Set this to {@code false} when a silently shortened prompt is worse than a failed
+         * request, as in a multi-turn agent loop where the conversation grows with every tool result.</p>
+         *
+         * @return builder
+         * @see OllamaChatModel.Builder#truncate(Boolean)
+         */
+        public Builder truncate(Boolean truncate) {
+            this.truncate = truncate;
             return this;
         }
 

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
@@ -2,11 +2,13 @@ package dev.langchain4j.model.ollama;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -75,5 +77,71 @@ class InternalOllamaHelperTest {
         List<ToolExecutionRequest> result = InternalOllamaHelper.toToolExecutionRequests(List.of());
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void toOllamaChatRequest_carriesTruncate() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Hello"))
+                .parameters(OllamaChatRequestParameters.builder()
+                        .modelName("llama3")
+                        .truncate(false)
+                        .build())
+                .build();
+
+        OllamaChatRequest result = InternalOllamaHelper.toOllamaChatRequest(chatRequest, false);
+
+        assertThat(result.getTruncate()).isFalse();
+    }
+
+    @Test
+    void toOllamaChatRequest_leavesTruncateNullWhenNotSet() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Hello"))
+                .parameters(OllamaChatRequestParameters.builder()
+                        .modelName("llama3")
+                        .build())
+                .build();
+
+        OllamaChatRequest result = InternalOllamaHelper.toOllamaChatRequest(chatRequest, false);
+
+        assertThat(result.getTruncate())
+                .as("the field must be absent from the request so the server default applies")
+                .isNull();
+    }
+
+    @Test
+    void toOllamaChatRequest_serializesTruncateAsATopLevelField() throws Exception {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Hello"))
+                .parameters(OllamaChatRequestParameters.builder()
+                        .modelName("llama3")
+                        .numCtx(256)
+                        .truncate(false)
+                        .build())
+                .build();
+
+        String json =
+                new ObjectMapper().writeValueAsString(InternalOllamaHelper.toOllamaChatRequest(chatRequest, false));
+
+        // truncate is a sibling of model and messages, not a member of options, which carries num_ctx.
+        assertThat(json).contains("\"truncate\":false");
+        assertThat(json).contains("\"num_ctx\":256");
+        assertThat(json.replaceAll("\"options\":\\{[^}]*}", "")).contains("\"truncate\":false");
+    }
+
+    @Test
+    void toOllamaChatRequest_omitsTruncateWhenNotSet() throws Exception {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Hello"))
+                .parameters(OllamaChatRequestParameters.builder()
+                        .modelName("llama3")
+                        .build())
+                .build();
+
+        String json =
+                new ObjectMapper().writeValueAsString(InternalOllamaHelper.toOllamaChatRequest(chatRequest, false));
+
+        assertThat(json).doesNotContain("truncate");
     }
 }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatModelTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatModelTest.java
@@ -29,6 +29,7 @@ class OllamaChatModelTest {
                         .minP(0.05)
                         .keepAlive(300)
                         .think(true)
+                        .truncate(false)
                         .build())
                 .build();
 
@@ -45,6 +46,7 @@ class OllamaChatModelTest {
         assertThat(parameters.minP()).isEqualTo(0.05);
         assertThat(parameters.keepAlive()).isEqualTo(300);
         assertThat(parameters.think()).isTrue();
+        assertThat(parameters.truncate()).isFalse();
 
         // Parameters that were previously dropped by init()
         assertThat(parameters.numThread()).isEqualTo(4);

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatRequestParametersTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatRequestParametersTest.java
@@ -158,4 +158,72 @@ class OllamaChatRequestParametersTest {
         assertThat(ollamaResult.mainGPU()).isEqualTo(0);
         assertThat(ollamaResult.useMmap()).isTrue();
     }
+
+    @Test
+    void should_build_with_truncate() {
+        OllamaChatRequestParameters params =
+                OllamaChatRequestParameters.builder().truncate(false).build();
+
+        assertThat(params.truncate()).isFalse();
+    }
+
+    @Test
+    void truncate_should_be_null_when_not_set() {
+        OllamaChatRequestParameters params =
+                OllamaChatRequestParameters.builder().build();
+
+        assertThat(params.truncate())
+                .as("unset must stay unset, so the server default of true applies")
+                .isNull();
+    }
+
+    @Test
+    void overrideWith_should_apply_truncate_from_override() {
+        OllamaChatRequestParameters original =
+                OllamaChatRequestParameters.builder().truncate(true).build();
+        OllamaChatRequestParameters override =
+                OllamaChatRequestParameters.builder().truncate(false).build();
+
+        ChatRequestParameters result = original.overrideWith(override);
+
+        assertThat(result).isInstanceOf(OllamaChatRequestParameters.class);
+        assertThat(((OllamaChatRequestParameters) result).truncate()).isFalse();
+    }
+
+    @Test
+    void overrideWith_should_keep_original_truncate_when_override_is_null() {
+        OllamaChatRequestParameters original =
+                OllamaChatRequestParameters.builder().truncate(false).build();
+        OllamaChatRequestParameters override =
+                OllamaChatRequestParameters.builder().build();
+
+        ChatRequestParameters result = original.overrideWith(override);
+
+        assertThat(result).isInstanceOf(OllamaChatRequestParameters.class);
+        assertThat(((OllamaChatRequestParameters) result).truncate())
+                .as("a per-request override that omits truncate must not re-enable the trim")
+                .isFalse();
+    }
+
+    @Test
+    void equals_and_hashCode_should_include_truncate() {
+        OllamaChatRequestParameters params1 =
+                OllamaChatRequestParameters.builder().truncate(false).build();
+        OllamaChatRequestParameters params2 =
+                OllamaChatRequestParameters.builder().truncate(false).build();
+        OllamaChatRequestParameters params3 =
+                OllamaChatRequestParameters.builder().truncate(true).build();
+
+        assertThat(params1).isEqualTo(params2);
+        assertThat(params1.hashCode()).isEqualTo(params2.hashCode());
+        assertThat(params1).isNotEqualTo(params3);
+    }
+
+    @Test
+    void toString_should_include_truncate() {
+        OllamaChatRequestParameters params =
+                OllamaChatRequestParameters.builder().truncate(false).build();
+
+        assertThat(params.toString()).contains("truncate=false");
+    }
 }


### PR DESCRIPTION
## Issue
Closes #6017

## Change
Ollama drops the part of a prompt that does not fit the context window and answers from the rest. The response is a normal `200`, and neither the response nor the token usage shows that input was lost. Ollama's top-level `truncate` field makes the server reject the request instead, and `langchain4j-ollama` had no way to send it.

This adds `truncate` as a request parameter and as a model builder option. It is unset by default, so the server default (`true`) still applies and existing callers see no change.

Where the field was missing, on `main` at `4db5a63d4`:

- `OllamaChatRequest` declared `model`, `messages`, `options`, `format`, `stream`, `tools`, `keepAlive` and `think` (lines 17-28). There was no `truncate`.
- `InternalOllamaHelper.toOllamaChatRequest` (line 161) builds the request for both the blocking and the streaming path (`OllamaChatModel:39`, `OllamaClient:169`), so one mapping covers both.
- `Options` has 20 named fields and no `Map` field. `OllamaChatRequestParameters` also had no `Map` field. So an application could not add the field itself.
- `truncate` is a top-level field, beside `model` and `messages`. It is **not** a member of Ollama's `options` object, which is why it goes on `OllamaChatRequest` rather than on `Options`.

### Changes per file
- `OllamaChatRequest`: `truncate` field, getter, setter, builder method
- `OllamaChatRequestParameters`: `truncate` in the field set, accessor, `equals`, `hashCode`, `toString`, builder, and `overrideWith`
- `InternalOllamaHelper`: maps `requestParameters.truncate()` onto the request, beside `think` and `keepAlive` |
- `OllamaBaseChatModel`: `truncate(Boolean)` on the shared builder, merged with the request parameters like `numCtx` |
- `ollama.md`: parameter table row, and a section on prompts that exceed the context window |

### Tests

`InternalOllamaHelperTest`

- `toOllamaChatRequest_carriesTruncate`: the parameter reaches the request.
- `toOllamaChatRequest_leavesTruncateNullWhenNotSet`: an unset parameter stays unset.
- `toOllamaChatRequest_serializesTruncateAsATopLevelField`: asserts `"truncate":false` is still present after `options` is removed from the JSON, so the test fails if the field is ever moved inside `options`. Also asserts `num_ctx` stays in `options`.

`toOllamaChatRequest_omitsTruncateWhenNotSet`: the serialized request contains no `truncate` at all.
                                                                                                                                                                `OllamaChatRequestParametersTest`: six tests mirroring the existing `numThread` set: build, null-when-unset, both `overrideWith` directions, `equals`/`hashCode`, and `toString`.
                                                                                                                                                                                   `OllamaChatModelTest`: `truncate` added to `default_request_parameters_should_preserve_all_ollama_specific_parameters`, which is what catches a missing line in the builder merge.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
