### PR TITLE
fix: make Utils.copy return an actual copy instead of an unmodifiable view

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -398,7 +400,7 @@ public class Utils {
             return null;
         }
 
-        return unmodifiableSet(set);
+        return unmodifiableSet(new LinkedHashSet<>(set));
     }
 
     /**
@@ -414,7 +416,7 @@ public class Utils {
             return Set.of();
         }
 
-        return unmodifiableSet(set);
+        return unmodifiableSet(new LinkedHashSet<>(set));
     }
 
     /**
@@ -430,7 +432,7 @@ public class Utils {
             return null;
         }
 
-        return unmodifiableList(list);
+        return unmodifiableList(new ArrayList<>(list));
     }
 
     /**
@@ -446,7 +448,7 @@ public class Utils {
             return List.of();
         }
 
-        return unmodifiableList(list);
+        return unmodifiableList(new ArrayList<>(list));
     }
 
     /**
@@ -493,7 +495,7 @@ public class Utils {
             return null;
         }
 
-        return unmodifiableMap(map);
+        return unmodifiableMap(new LinkedHashMap<>(map));
     }
 
     /**
@@ -508,7 +510,7 @@ public class Utils {
             return Map.of();
         }
 
-        return unmodifiableMap(map);
+        return unmodifiableMap(new LinkedHashMap<>(map));
     }
 
     /**

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/UserMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/UserMessageTest.java
@@ -13,7 +13,8 @@ class UserMessageTest implements WithAssertions {
     @Test
     void toBuilder() {
         UserMessage message1 = UserMessage.from(TextContent.from("one"));
-        UserMessage message2 = message1.toBuilder().addContent(TextContent.from("two")).build();
+        UserMessage message2 =
+                message1.toBuilder().addContent(TextContent.from("two")).build();
         assertThat(message1.contents()).containsExactly(TextContent.from("one"));
         assertThat(message2.contents()).containsExactly(TextContent.from("one"), TextContent.from("two"));
     }
@@ -25,7 +26,23 @@ class UserMessageTest implements WithAssertions {
         assertThat(m.singleText()).isEqualTo("text");
         assertThat(m.contents()).containsExactly(TextContent.from("text"));
         assertThat(m.name()).isEqualTo("name");
-        assertThat(m).hasToString("UserMessage { name = \"name\", contents = [TextContent { text = \"text\" }], attributes = {} }");
+        assertThat(m)
+                .hasToString(
+                        "UserMessage { name = \"name\", contents = [TextContent { text = \"text\" }], attributes = {} }");
+    }
+
+    @Test
+    void contents_are_not_affected_by_mutations_of_the_source_list() {
+        List<Content> contents = new ArrayList<>();
+        contents.add(TextContent.from("one"));
+
+        UserMessage message = UserMessage.from(contents);
+        int hashCodeBeforeMutation = message.hashCode();
+
+        contents.add(TextContent.from("two"));
+
+        assertThat(message.contents()).containsExactly(TextContent.from("one"));
+        assertThat(message.hashCode()).isEqualTo(hashCodeBeforeMutation);
     }
 
     @Test
@@ -75,8 +92,8 @@ class UserMessageTest implements WithAssertions {
         assertThat(new UserMessage("text").singleText()).isEqualTo("text");
 
         assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(
-                        () -> new UserMessage("name", listOf(new TextContent("abc"), new TextContent("def"))).singleText())
+                .isThrownBy(() ->
+                        new UserMessage("name", listOf(new TextContent("abc"), new TextContent("def"))).singleText())
                 .withMessageContaining("Expecting single text content, but got:");
     }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -395,6 +397,113 @@ class UtilsTest {
         assertThat(Utils.copy((Map<?, ?>) null)).isEmpty();
         assertThat(Utils.copy(emptyMap())).isEmpty();
         assertThat(Utils.copy(singletonMap("key", "value"))).containsExactly(entry("key", "value"));
+    }
+
+    @Test
+    void copy_list_is_not_a_view_of_the_source() {
+        List<String> source = new ArrayList<>(List.of("one"));
+
+        List<String> copy = Utils.copy(source);
+        source.add("two");
+        source.remove("one");
+
+        assertThat(copy).containsExactly("one");
+    }
+
+    @Test
+    void copy_if_not_null_list_is_not_a_view_of_the_source() {
+        List<String> source = new ArrayList<>(List.of("one"));
+
+        List<String> copy = Utils.copyIfNotNull(source);
+        source.add("two");
+        source.remove("one");
+
+        assertThat(copy).containsExactly("one");
+    }
+
+    @Test
+    void copy_set_is_not_a_view_of_the_source() {
+        Set<String> source = new LinkedHashSet<>(List.of("one"));
+
+        Set<String> copy = Utils.copy(source);
+        source.add("two");
+        source.remove("one");
+
+        assertThat(copy).containsExactly("one");
+    }
+
+    @Test
+    void copy_if_not_null_set_is_not_a_view_of_the_source() {
+        Set<String> source = new LinkedHashSet<>(List.of("one"));
+
+        Set<String> copy = Utils.copyIfNotNull(source);
+        source.add("two");
+        source.remove("one");
+
+        assertThat(copy).containsExactly("one");
+    }
+
+    @Test
+    void copy_map_is_not_a_view_of_the_source() {
+        Map<String, String> source = new LinkedHashMap<>(Map.of("key", "value"));
+
+        Map<String, String> copy = Utils.copy(source);
+        source.put("key2", "value2");
+        source.remove("key");
+
+        assertThat(copy).containsExactly(entry("key", "value"));
+    }
+
+    @Test
+    void copy_if_not_null_map_is_not_a_view_of_the_source() {
+        Map<String, String> source = new LinkedHashMap<>(Map.of("key", "value"));
+
+        Map<String, String> copy = Utils.copyIfNotNull(source);
+        source.put("key2", "value2");
+        source.remove("key");
+
+        assertThat(copy).containsExactly(entry("key", "value"));
+    }
+
+    @Test
+    void copy_returns_unmodifiable_collections() {
+        List<String> list = Utils.copy(new ArrayList<>(List.of("one")));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> list.add("two"));
+
+        Set<String> set = Utils.copy(new LinkedHashSet<>(List.of("one")));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("two"));
+
+        Map<String, String> map = Utils.copy(new LinkedHashMap<>(Map.of("key", "value")));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> map.put("k", "v"));
+
+        List<String> listIfNotNull = Utils.copyIfNotNull(new ArrayList<>(List.of("one")));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> listIfNotNull.add("two"));
+
+        Set<String> setIfNotNull = Utils.copyIfNotNull(new LinkedHashSet<>(List.of("one")));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> setIfNotNull.add("two"));
+
+        Map<String, String> mapIfNotNull = Utils.copyIfNotNull(new LinkedHashMap<>(Map.of("key", "value")));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> mapIfNotNull.put("k", "v"));
+    }
+
+    @Test
+    void copy_preserves_iteration_order_and_null_elements() {
+        List<String> list = new ArrayList<>();
+        list.add("one");
+        list.add(null);
+        list.add("two");
+        assertThat(Utils.copy(list)).containsExactly("one", null, "two");
+
+        Set<String> set = new LinkedHashSet<>();
+        set.add("one");
+        set.add(null);
+        set.add("two");
+        assertThat(Utils.copy(set)).containsExactly("one", null, "two");
+
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("one", "1");
+        map.put("two", null);
+        assertThat(Utils.copy(map)).containsExactly(entry("one", "1"), entry("two", null));
     }
 
     @Test

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpHeaders.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpHeaders.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.http.client;
+
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Internal helpers for storing HTTP headers.
+ */
+final class HttpHeaders {
+
+    private HttpHeaders() {}
+
+    /**
+     * Returns an unmodifiable copy of the provided headers whose lookups
+     * ({@link Map#get(Object)}, {@link Map#containsKey(Object)}) are case-insensitive,
+     * as required by <a href="https://www.rfc-editor.org/rfc/rfc9110#section-5.1">RFC 9110</a>.
+     * Returns an empty map if the provided headers are {@code null}.
+     * <p>
+     * When the same header name is present more than once in different cases, the last one wins.
+     *
+     * @param headers The headers to copy.
+     * @return The copy of the provided headers or an empty map.
+     * @throws IllegalArgumentException if any header name is {@code null}.
+     */
+    static Map<String, List<String>> copyCaseInsensitive(Map<String, List<String>> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, List<String>> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.forEach((name, values) -> {
+            if (name == null) {
+                throw illegalArgument("Header name cannot be null");
+            }
+            copy.put(name, values);
+        });
+        return Collections.unmodifiableMap(copy);
+    }
+}

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
@@ -30,7 +30,7 @@ public class HttpRequest {
         validate(builder);
         this.method = ensureNotNull(builder.method, "method");
         this.url = buildUrl(builder);
-        this.headers = copy(builder.headers);
+        this.headers = HttpHeaders.copyCaseInsensitive(builder.headers);
         this.formDataFields = copy(builder.formDataFields);
         this.formDataFiles = copy(builder.formDataFiles);
         this.body = builder.body;

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/SuccessfulHttpResponse.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/SuccessfulHttpResponse.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.http.client;
 
-import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
 
 import java.nio.charset.Charset;
@@ -16,7 +15,7 @@ public class SuccessfulHttpResponse {
 
     public SuccessfulHttpResponse(Builder builder) {
         this.statusCode = ensureBetween(builder.statusCode, 200, 299, "statusCode");
-        this.headers = copy(builder.headers);
+        this.headers = HttpHeaders.copyCaseInsensitive(builder.headers);
         this.body = builder.body;
     }
 

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.http.client.HttpMethod.POST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -492,5 +493,67 @@ class HttpRequestTest {
         // then
         assertThat(builder.build().url()).isEqualTo("http://example.com/api");
         assertThat(builder.build().formDataFields()).isEmpty();
+    }
+
+    @Test
+    void should_look_up_headers_case_insensitively() {
+        HttpRequest request = HttpRequest.builder()
+                .method(GET)
+                .url("http://example.com/api")
+                .addHeader("Content-Type", "application/json")
+                .build();
+
+        assertThat(request.headers().get("content-type")).containsExactly("application/json");
+        assertThat(request.headers().get("CONTENT-TYPE")).containsExactly("application/json");
+        assertThat(request.headers().containsKey("content-type")).isTrue();
+    }
+
+    @Test
+    void should_not_be_affected_by_mutations_of_the_source_headers() {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        headers.put("Content-Type", List.of("application/json"));
+
+        HttpRequest request = HttpRequest.builder()
+                .method(GET)
+                .url("http://example.com/api")
+                .headers(headers)
+                .build();
+
+        headers.put("X-Added-Later", List.of("value"));
+
+        assertThat(request.headers()).containsOnlyKeys("Content-Type");
+    }
+
+    @Test
+    void should_return_unmodifiable_headers() {
+        HttpRequest request = HttpRequest.builder()
+                .method(GET)
+                .url("http://example.com/api")
+                .addHeader("Content-Type", "application/json")
+                .build();
+
+        assertThatThrownBy(() -> request.headers().put("X-Added-Later", List.of("value")))
+                .isExactlyInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void should_return_empty_headers_when_not_set() {
+        HttpRequest request =
+                HttpRequest.builder().method(GET).url("http://example.com/api").build();
+
+        assertThat(request.headers()).isEmpty();
+    }
+
+    @Test
+    void should_fail_with_clear_message_when_header_name_is_null() {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put(null, List.of("value"));
+
+        HttpRequest.Builder builder =
+                HttpRequest.builder().method(GET).url("http://example.com/api").headers(headers);
+
+        assertThatThrownBy(builder::build)
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Header name cannot be null");
     }
 }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/SuccessfulHttpResponseTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/SuccessfulHttpResponseTest.java
@@ -3,7 +3,9 @@ package dev.langchain4j.http.client;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -84,5 +86,51 @@ class SuccessfulHttpResponseTest {
 
         assertThat(response.body()).isNull();
         assertThat(response.bodyBytes()).isNull();
+    }
+
+    @Test
+    void should_look_up_headers_case_insensitively() {
+        SuccessfulHttpResponse response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .headers(Map.of("content-type", List.of("application/json")))
+                .build();
+
+        assertThat(response.headers().get("Content-Type")).containsExactly("application/json");
+        assertThat(response.headers().get("CONTENT-TYPE")).containsExactly("application/json");
+        assertThat(response.headers().containsKey("Content-Type")).isTrue();
+    }
+
+    @Test
+    void should_not_be_affected_by_mutations_of_the_source_headers() {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        headers.put("Content-Type", List.of("application/json"));
+
+        SuccessfulHttpResponse response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .headers(headers)
+                .build();
+
+        headers.put("X-Added-Later", List.of("value"));
+
+        assertThat(response.headers()).containsOnlyKeys("Content-Type");
+    }
+
+    @Test
+    void should_return_unmodifiable_headers() {
+        SuccessfulHttpResponse response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .headers(Map.of("Content-Type", List.of("application/json")))
+                .build();
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> response.headers().put("X-Added-Later", List.of("value")));
+    }
+
+    @Test
+    void should_return_empty_headers_when_not_set() {
+        SuccessfulHttpResponse response =
+                SuccessfulHttpResponse.builder().statusCode(200).build();
+
+        assertThat(response.headers()).isEmpty();
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -64,8 +64,7 @@ class AiServiceTokenStreamTest {
 
     List<ChatMessage> messages = new ArrayList<>();
 
-    @Mock
-    List<Content> content;
+    List<Content> content = new ArrayList<>();
 
     @Mock
     Object memoryId;


### PR DESCRIPTION
## Issue

  Closes #6019

  ## Change

  `Utils.copy(List)`, `Utils.copy(Set)`, `Utils.copy(Map)` and the three matching
  `Utils.copyIfNotNull(...)` overloads are documented as

  > Returns an (unmodifiable) copy of the provided list.

  but they returned `Collections.unmodifiableList/Set/Map(source)`, which is an
  unmodifiable **view backed by the caller's collection**, not a copy. The returned
  collection rejects writes through itself, but it still reflects every later mutation
  of the source.

  These helpers are the defensive-copy mechanism for the constructors of a large number 
  of value objects — `UserMessage`, `AiMessage`, `ChatRequest`, `ToolSpecification`,
  `DefaultChatRequestParameters`, `rag.query.Metadata`, and ~30 more in `langchain4j-core`
  alone. So a caller that holds on to the list it passed in can mutate an object that is
  documented as immutable, after construction:

  ```java
  List<Content> contents = new ArrayList<>();
  contents.add(TextContent.from("one"));

  UserMessage message = UserMessage.from(contents);
  int hash = message.hashCode();

  contents.add(TextContent.from("two"));

  message.contents();   // now [one, two] — the message changed under the caller
  message.hashCode();   // != hash — it is now corrupt as a HashMap/HashSet key
  ```

  **Fix:** wrap the source in a new `ArrayList`/`LinkedHashSet`/`LinkedHashMap` before
  making it unmodifiable.

  `LinkedHashSet`/`LinkedHashMap` are used deliberately in preference to
  `Set.copyOf`/`Map.copyOf`, so that iteration order is preserved and `null` elements,
  keys and values keep working exactly as they do today.

  This also makes the class self-consistent: `copy(Collection)` already returned a real
  copy via `List.copyOf`, and `mutableCopy(...)` already returned a real copy via
  `new ArrayList<>(...)`. The six view-returning methods were the outliers.

  ### HTTP headers

  `Utils.copy` is also how `HttpRequest` and `SuccessfulHttpResponse` store their headers,
  and returning a real copy there loses the source map's type. `JdkHttpClient` passes
  `java.net.http.HttpHeaders.map()`, which the JDK builds as a
  `TreeMap(String.CASE_INSENSITIVE_ORDER)`, so a plain copy would silently have turned
  `response.headers().get("Content-Type")` into `null` whenever the server sent
  `content-type`.

  Headers are therefore copied into a `TreeMap(String.CASE_INSENSITIVE_ORDER)`, so that the
  copy is a real copy *and* lookups stay case-insensitive, as required by
  [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-5.1).

  This additionally fixes a pre-existing inconsistency: `OkHttpClient` and
  `ApacheHttpClient` build plain `HashMap`s, so header lookups were already
  case-sensitive with those clients *before* this change. All three clients now behave
  the same.

  A `null` header name previously ended up in the map unnoticed, and now fails fast with
  `IllegalArgumentException("Header name cannot be null")` rather than a
  `NullPointerException` from inside `TreeMap`.

  ## Breaking Changes

  ### 1. Mutating a collection after passing it to a constructor no longer affects the constructed object

  This is the point of the fix, but it is a behaviour change and can break code that
  populates a collection *after* handing it over — for example when wiring tools during
  DI/context startup. It fails silently: no exception, just a request that goes out
  without the later additions.

  **Before** (worked by accident, through the shared view):

  ```java
  List<ToolSpecification> tools = new ArrayList<>();
  ChatRequestParameters parameters = ChatRequestParameters.builder()
          .toolSpecifications(tools)
          .build();

  tools.add(someTool);   // used to reach `parameters`
  ```

  **After** — populate the collection before building:

  ```java
  List<ToolSpecification> tools = new ArrayList<>();
  tools.add(someTool);

  ChatRequestParameters parameters = ChatRequestParameters.builder()
          .toolSpecifications(tools)
          .build();
  ```

  Objects documented as immutable are now genuinely immutable, so their
  `equals`/`hashCode` no longer change after construction and they are safe to use as
  `HashMap` keys or `HashSet` members.

  ### 2. `Set`/`Map` copies no longer keep the source's comparator

  `copy(Set)` and `copy(Map)` now return a `LinkedHashSet`/`LinkedHashMap`. Iteration
  order is preserved, but a source `TreeSet`/`TreeMap` with a custom comparator loses
  comparator-based `get`/`contains` semantics.

  HTTP headers — the one place in the repository where this mattered — are handled
  explicitly, as described above. If you pass a comparator-backed `SortedSet`/`SortedMap`
  into a LangChain4j value object and rely on its lookup semantics, do the lookup against
  your own collection instead.

  ## Tests

  - 9 tests in `UtilsTest`. The 7 that assert the copy is independent of the source **fail
    on current `main`** (`Tests run: 72, Failures: 7` before, `Failures: 0` after). The
    other 2 are guard tests that pass before and after, pinning the behaviour the fix must
    *not* change — that the result is still unmodifiable, and that iteration order and null
    elements still work.
  - 1 test in `UserMessageTest` covering the reproducer from #6019.
  - 9 tests in `HttpRequestTest` / `SuccessfulHttpResponseTest` covering case-insensitive
    lookup, independence from source mutation, unmodifiability, empty-when-unset, and the
    null header name message.

  ### One existing test had to change

  `AiServiceTokenStreamTest` declared its retrieved contents as `@Mock List<Content>`.
  Mockito returns `null` from `toArray()` on a mock, and copying a collection calls
  `toArray()`, so all 20 tests in that class started throwing `NullPointerException`.
  The mock was never stubbed and only ever passed through to `copy()`, so it is now a
  real `ArrayList`. This is the only mocked collection in the repository.

  ### Note on the diff

  `UserMessageTest.java` shows three unrelated line-wrapping hunks. That is the
  `spotless` ratchet (`ratchetFrom=origin/main`) reformatting the whole file because it
  was touched — the `spotless` check fails without them. `git diff -w` shows the real
  change.

  ## General checklist
  - [ ] There are no breaking changes (API, behaviour)
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)