### PR TITLE
fix: Read error response body as UTF-8 without reassembling line separators

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -2,7 +2,6 @@ package dev.langchain4j.http.client.apache;
 
 import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.TimeoutException;
@@ -11,12 +10,11 @@ import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -186,9 +184,8 @@ public class ApacheHttpClient implements HttpClient {
             if (entity == null) {
                 return "";
             }
-            try (InputStream inputStream = entity.getContent();
-                    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-                return reader.lines().collect(joining(System.lineSeparator()));
+            try (InputStream inputStream = entity.getContent()) {
+                return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
             }
         } catch (Exception e) {
             return "Cannot read error response body: " + e.getMessage();

--- a/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientErrorBodyTest.java
+++ b/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientErrorBodyTest.java
@@ -1,0 +1,110 @@
+package dev.langchain4j.http.client.apache;
+
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the error response body reaching {@link HttpException} is the one the server sent.
+ * Mirrors {@code JdkHttpClientErrorBodyTest} from #5809; here the body is read on the synchronous
+ * path, which is the caller of {@code readBody} in this client.
+ */
+class ApacheHttpClientErrorBodyTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void beforeEach() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void should_preserve_line_separators_of_error_response_body() {
+
+        // given
+        String body = "line1\r\nline2\r\n";
+        stubError(body);
+
+        // when / then
+        assertThatThrownBy(() -> ApacheHttpClient.builder().build().execute(request()))
+                .isInstanceOf(HttpException.class)
+                .hasMessage(body)
+                .satisfies(e -> assertThat(((HttpException) e).statusCode()).isEqualTo(400));
+    }
+
+    /**
+     * Pins the charset used to decode the body. This assertion only distinguishes the two
+     * implementations on a JVM whose default charset is not UTF-8 (Java 17, or Java 18+ started with
+     * {@code -Dfile.encoding}); on a UTF-8 JVM the old code happened to decode correctly. It is kept
+     * as a regression guard for those environments — #5808 reports the defect on Java 17.
+     */
+    @Test
+    void should_decode_error_response_body_as_utf8() {
+
+        // given
+        String body = "모델 오류";
+        stubError(body);
+
+        // when / then
+        assertThatThrownBy(() -> ApacheHttpClient.builder().build().execute(request()))
+                .isInstanceOf(HttpException.class)
+                .hasMessage(body);
+    }
+
+    @Test
+    void should_return_empty_message_when_error_response_has_no_body() {
+
+        // given
+        wireMockServer.stubFor(
+                WireMock.get("/endpoint").willReturn(WireMock.aResponse().withStatus(500)));
+
+        // when / then
+        assertThatThrownBy(() -> ApacheHttpClient.builder().build().execute(request()))
+                .isInstanceOf(HttpException.class)
+                .hasMessage("");
+    }
+
+    @Test
+    void should_not_fail_on_successful_response() throws Exception {
+
+        // given
+        wireMockServer.stubFor(WireMock.get("/endpoint").willReturn(WireMock.ok("hello")));
+
+        // when
+        var response = ApacheHttpClient.builder().build().execute(request());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("hello");
+    }
+
+    private void stubError(String body) {
+        wireMockServer.stubFor(WireMock.get("/endpoint")
+                .willReturn(WireMock.aResponse().withStatus(400).withBody(body.getBytes(UTF_8))));
+    }
+
+    private HttpRequest request() {
+        return HttpRequest.builder()
+                .method(GET)
+                .url("http://localhost:" + wireMockServer.port() + "/endpoint")
+                .build();
+    }
+}


### PR DESCRIPTION
## Issue

Follow-up to #5809, which noted:
> `ApacheHttpClient.readBody` has the same pattern. It is left alone so this one can be reviewed first.

The bug is the same as #5808 (which `JdkHttpClient` fixed in #5809): `readBody` builds the `HttpException` message using `BufferedReader(new InputStreamReader(inputStream))` with no charset, so decoding falls back to the JVM default charset. Under a JVM whose default is not UTF-8 (Java 17 without `-Dfile.encoding=UTF-8`, which is not guaranteed to be set by default), non-ASCII error messages are decoded incorrectly. Additionally, `reader.lines().collect(joining(System.lineSeparator()))` drops the original line separators and the trailing one, so the string put into `HttpException` is not what the server sent.

`readBodyBytes()` in the same class already reads raw bytes correctly; only this error-body helper was inconsistent.

## Change

Applies the identical fix used for `JdkHttpClient` in #5809:

```java
try (InputStream inputStream = entity.getContent()) {
    return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
}
```

Three now-unused imports (`BufferedReader`, `InputStreamReader`, `Collectors.joining`) are removed and `StandardCharsets` is added.

## Tests

New `ApacheHttpClientErrorBodyTest` (WireMock, no API key), mirroring `JdkHttpClientErrorBodyTest` from #5809. Tests use the synchronous `execute()` path, which is where this client calls `readBody()` (the streaming path uses `apacheResponse.getBodyText()` and is unaffected):

- `should_preserve_line_separators_of_error_response_body` — stubs a `400` with body `line1\r\nline2\r\n`; asserts the exception message matches exactly. **Fails on `main`** (`line1\nline2`, trailing newline dropped) and passes with the fix. Verified by reverting the fix and re-running.
- `should_decode_error_response_body_as_utf8` — Korean text sent as UTF-8 bytes; asserts the round-trip is correct. On a UTF-8 JVM (Java 18+ default, or any JVM with `file.encoding=UTF-8`) the old code happened to decode correctly, so this is a regression guard for Java 17 environments or explicit non-UTF-8 setups, matching the scenario described in #5808.
- `should_return_empty_message_when_error_response_has_no_body` — status 500 with no body; asserts empty message.
- `should_not_fail_on_successful_response` — sanity check that the happy path still works.

## General checklist

- [ ] There are no breaking changes (API, behaviour) — no API change; error messages now preserve their exact bytes and charset for non-UTF-8 JVMs, which is the fix itself
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green ��� see below
- [ ] I have added/updated the documentation ��� not applicable (internal HTTP detail, no API surface change)
- [ ] I have added an example in the examples repo ��� not applicable
- [ ] I have added/updated Spring Boot starter(s) ��� not applicable

## Verification

```
./mvnw -pl http-clients/langchain4j-http-client-apache test spotless:check
# Tests run: 12, Failures: 0, Errors: 0
# spotless:check BUILD SUCCESS

./mvnw -pl http-clients/langchain4j-http-client-apache,langchain4j-core,langchain4j -am test
# apache-http-client: Tests run: 12, Failures: 0, Errors: 0
# core:              Tests run: 1210, Failures: 0, Errors: 0
# main:              Tests run: 1278, Failures: 0, Errors: 0
# BUILD SUCCESS
```

`*IT` classes needing network access were not run.
