### PR TITLE
Azure AI Search: Expose bring-your-own index fields as metadata

### DIFF
--- a/docs/docs/integrations/embedding-stores/azure-ai-search.md
+++ b/docs/docs/integrations/embedding-stores/azure-ai-search.md
@@ -23,6 +23,34 @@ https://azure.microsoft.com/en-us/products/ai-services/ai-search/
 - `AzureAiSearchContentRetriever` - supports vector, full-text, hybrid searches and re-ranking
 
 
+## Metadata from a bring-your-own index
+
+By default `AzureAiSearchContentRetriever` and `AzureAiSearchEmbeddingStore` read segment metadata from the
+nested `metadata` field they write themselves. When you point them at a pre-existing index
+(`createOrUpdateIndex(false)`) whose fields are stored at the document root, use `metadataFieldNames` on
+either builder to list the top-level fields to expose as metadata:
+
+```java
+ContentRetriever retriever = AzureAiSearchContentRetriever.builder()
+        .endpoint(endpoint)
+        .tokenCredential(tokenCredential)
+        .indexName(indexName)
+        .createOrUpdateIndex(false)
+        .queryType(AzureAiSearchQueryType.FULL_TEXT)
+        .metadataFieldNames(List.of("sourcepage", "weburl", "topic", "role"))
+        .maxResults(4)
+        .build();
+```
+
+Each listed field is copied into the segment `Metadata` when its value is a type `Metadata` supports
+(`String`, `Integer`, `Long`, `Float`, `Double`, or `UUID`). Fields that are absent, `null` or of another
+type (for example the embedding vector) are skipped. A field must be marked as retrievable in the Azure
+index for its value to be returned, and when a field name matches a key in the nested `metadata`, the
+top-level value takes precedence.
+
+This option only configures metadata extraction; the existing requirements for the index's core ID,
+content, vector, and semantic-search fields remain unchanged.
+
 ## Examples
 
 - [AzureAiSearchEmbeddingStoreIT](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreIT.java)

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/AzureAiSearchContentRetriever.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/AzureAiSearchContentRetriever.java
@@ -25,6 +25,7 @@ import dev.langchain4j.store.embedding.azure.search.AzureAiSearchRuntimeExceptio
 import dev.langchain4j.store.embedding.azure.search.Document;
 import dev.langchain4j.store.embedding.filter.Filter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -305,6 +306,8 @@ public class AzureAiSearchContentRetriever extends AbstractAzureAiSearchEmbeddin
 
         private AzureAiSearchFilterMapper filterMapper;
 
+        private List<String> metadataFieldNames = List.of();
+
         /**
          * Sets the Azure AI Search endpoint. This is a mandatory parameter.
          *
@@ -451,8 +454,27 @@ public class AzureAiSearchContentRetriever extends AbstractAzureAiSearchEmbeddin
             return this;
         }
 
+        /**
+         * Sets the names of top-level index fields to copy into the {@link dev.langchain4j.data.document.Metadata} of
+         * each retrieved segment. Use this with a pre-existing (bring-your-own) index whose fields are stored at the
+         * document root rather than in the nested {@code metadata} field this store writes. A field is copied only if
+         * its value is a type {@link dev.langchain4j.data.document.Metadata} supports ({@code String}, {@code Integer},
+         * {@code Long}, {@code Float}, {@code Double}, or {@code UUID}); fields that are absent, {@code null} or of
+         * another type are skipped. Each field must be retrievable in the Azure index for its value to be returned.
+         * When a name matches a key already present in the nested {@code metadata} field, the top-level value takes
+         * precedence.
+         *
+         * @param metadataFieldNames The names of the index fields to expose as metadata; {@code null} is treated as no
+         *     configured fields.
+         * @return builder
+         */
+        public Builder metadataFieldNames(Collection<String> metadataFieldNames) {
+            this.metadataFieldNames = metadataFieldNames == null ? List.of() : List.copyOf(metadataFieldNames);
+            return this;
+        }
+
         public AzureAiSearchContentRetriever build() {
-            return new AzureAiSearchContentRetriever(
+            AzureAiSearchContentRetriever retriever = new AzureAiSearchContentRetriever(
                     endpoint,
                     keyCredential,
                     tokenCredential,
@@ -466,6 +488,8 @@ public class AzureAiSearchContentRetriever extends AbstractAzureAiSearchEmbeddin
                     azureAiSearchQueryType,
                     filterMapper,
                     filter);
+            retriever.metadataFieldNames = metadataFieldNames;
+            return retriever;
         }
     }
 }

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
@@ -60,6 +60,8 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
 
     protected AzureAiSearchFilterMapper filterMapper;
 
+    protected List<String> metadataFieldNames = List.of();
+
     protected void initialize(
             String endpoint,
             AzureKeyCredential keyCredential,
@@ -332,7 +334,7 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             String embeddedContent = (String) searchDocument.get(DEFAULT_FIELD_CONTENT);
             EmbeddingMatch<TextSegment> embeddingMatch;
             if (isNotNullOrBlank(embeddedContent)) {
-                Metadata langChainMetadata = metadataFrom(searchDocument.get(DEFAULT_FIELD_METADATA));
+                Metadata langChainMetadata = metadataFrom(searchDocument, metadataFieldNames);
                 TextSegment embedded = TextSegment.textSegment(embeddedContent, langChainMetadata);
                 embeddingMatch = new EmbeddingMatch<>(score, embeddingId, embedding, embedded);
             } else {
@@ -341,6 +343,21 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             result.add(embeddingMatch);
         }
         return result;
+    }
+
+    static Metadata metadataFrom(Map<String, Object> searchDocument, Collection<String> metadataFieldNames) {
+        Map<String, Object> metadata = new HashMap<>(
+                metadataFrom(searchDocument.get(DEFAULT_FIELD_METADATA)).toMap());
+        for (String fieldName : metadataFieldNames) {
+            if (isNullOrBlank(fieldName)) {
+                continue;
+            }
+            Object value = searchDocument.get(fieldName);
+            if (isSupportedMetadataValue(value)) {
+                metadata.put(fieldName, value);
+            }
+        }
+        return Metadata.from(metadata);
     }
 
     static Metadata metadataFrom(Object rawMetadata) {
@@ -365,6 +382,15 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             }
         }
         return Metadata.from(attributesMap);
+    }
+
+    private static boolean isSupportedMetadataValue(Object value) {
+        return value instanceof String
+                || value instanceof Integer
+                || value instanceof Long
+                || value instanceof Float
+                || value instanceof Double
+                || value instanceof UUID;
     }
 
     private void addInternal(String id, Embedding embedding, TextSegment embedded) {

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStore.java
@@ -1,33 +1,61 @@
 package dev.langchain4j.store.embedding.azure.search;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
+
 import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.search.documents.indexes.models.SearchIndex;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.rag.content.retriever.azure.search.AzureAiSearchFilterMapper;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Azure AI Search EmbeddingStore Implementation
  */
-public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
+public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingStore
+        implements EmbeddingStore<TextSegment> {
 
-    public AzureAiSearchEmbeddingStore(String endpoint, AzureKeyCredential keyCredential, boolean createOrUpdateIndex, int dimensions, String indexName, AzureAiSearchFilterMapper filterMapper) {
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            AzureKeyCredential keyCredential,
+            boolean createOrUpdateIndex,
+            int dimensions,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
         this.initialize(endpoint, keyCredential, null, createOrUpdateIndex, dimensions, null, indexName, filterMapper);
     }
 
-    public AzureAiSearchEmbeddingStore(String endpoint, AzureKeyCredential keyCredential, boolean createOrUpdateIndex, SearchIndex index, String indexName, AzureAiSearchFilterMapper filterMapper) {
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            AzureKeyCredential keyCredential,
+            boolean createOrUpdateIndex,
+            SearchIndex index,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
         this.initialize(endpoint, keyCredential, null, createOrUpdateIndex, 0, index, indexName, filterMapper);
     }
 
-    public AzureAiSearchEmbeddingStore(String endpoint, TokenCredential tokenCredential, boolean createOrUpdateIndex, int dimensions, String indexName, AzureAiSearchFilterMapper filterMapper) {
-        this.initialize(endpoint, null, tokenCredential, createOrUpdateIndex, dimensions, null, indexName, filterMapper);
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            TokenCredential tokenCredential,
+            boolean createOrUpdateIndex,
+            int dimensions,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
+        this.initialize(
+                endpoint, null, tokenCredential, createOrUpdateIndex, dimensions, null, indexName, filterMapper);
     }
 
-    public AzureAiSearchEmbeddingStore(String endpoint, TokenCredential tokenCredential, boolean createOrUpdateIndex, SearchIndex index, String indexName, AzureAiSearchFilterMapper filterMapper) {
+    public AzureAiSearchEmbeddingStore(
+            String endpoint,
+            TokenCredential tokenCredential,
+            boolean createOrUpdateIndex,
+            SearchIndex index,
+            String indexName,
+            AzureAiSearchFilterMapper filterMapper) {
         this.initialize(endpoint, null, tokenCredential, createOrUpdateIndex, 0, index, indexName, filterMapper);
     }
 
@@ -52,6 +80,8 @@ public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingS
         private String indexName;
 
         private AzureAiSearchFilterMapper filterMapper;
+
+        private List<String> metadataFieldNames = List.of();
 
         /**
          * Sets the Azure AI Search endpoint. This is a mandatory parameter.
@@ -142,23 +172,50 @@ public class AzureAiSearchEmbeddingStore extends AbstractAzureAiSearchEmbeddingS
             return this;
         }
 
+        /**
+         * Sets the names of top-level index fields to copy into the {@link dev.langchain4j.data.document.Metadata} of
+         * each search result. Use this with a pre-existing (bring-your-own) index whose fields are stored at the
+         * document root rather than in the nested {@code metadata} field this store writes. A field is copied only if
+         * its value is a type {@link dev.langchain4j.data.document.Metadata} supports ({@code String}, {@code Integer},
+         * {@code Long}, {@code Float}, {@code Double}, or {@code UUID}); fields that are absent, {@code null} or of
+         * another type are skipped. Each field must be retrievable in the Azure index for its value to be returned.
+         * When a name matches a key already present in the nested {@code metadata} field, the top-level value takes
+         * precedence.
+         *
+         * @param metadataFieldNames The names of the index fields to expose as metadata; {@code null} is treated as no
+         *     configured fields.
+         * @return builder
+         */
+        public Builder metadataFieldNames(Collection<String> metadataFieldNames) {
+            this.metadataFieldNames = metadataFieldNames == null ? List.of() : List.copyOf(metadataFieldNames);
+            return this;
+        }
+
         public AzureAiSearchEmbeddingStore build() {
             ensureNotNull(endpoint, "endpoint");
-            ensureTrue(keyCredential != null || tokenCredential != null, "either apiKey or tokenCredential must be set");
+            ensureTrue(
+                    keyCredential != null || tokenCredential != null, "either apiKey or tokenCredential must be set");
             ensureTrue(dimensions > 0 || index != null, "either dimensions or index must be set");
+            AzureAiSearchEmbeddingStore store;
             if (keyCredential == null) {
                 if (index == null) {
-                    return new AzureAiSearchEmbeddingStore(endpoint, tokenCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
+                    store = new AzureAiSearchEmbeddingStore(
+                            endpoint, tokenCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
                 } else {
-                    return new AzureAiSearchEmbeddingStore(endpoint, tokenCredential, createOrUpdateIndex, index, indexName, filterMapper);
+                    store = new AzureAiSearchEmbeddingStore(
+                            endpoint, tokenCredential, createOrUpdateIndex, index, indexName, filterMapper);
                 }
             } else {
                 if (index == null) {
-                    return new AzureAiSearchEmbeddingStore(endpoint, keyCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
+                    store = new AzureAiSearchEmbeddingStore(
+                            endpoint, keyCredential, createOrUpdateIndex, dimensions, indexName, filterMapper);
                 } else {
-                    return new AzureAiSearchEmbeddingStore(endpoint, keyCredential, createOrUpdateIndex, index, indexName, filterMapper);
+                    store = new AzureAiSearchEmbeddingStore(
+                            endpoint, keyCredential, createOrUpdateIndex, index, indexName, filterMapper);
                 }
             }
+            store.metadataFieldNames = metadataFieldNames;
+            return store;
         }
     }
 }

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreTest.java
@@ -10,6 +10,7 @@ import dev.langchain4j.data.document.Metadata;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class AzureAiSearchEmbeddingStoreTest {
@@ -122,5 +123,98 @@ class AzureAiSearchEmbeddingStoreTest {
         Metadata metadata = metadataFrom(rawMetadata);
 
         assertThat(metadata.toMap()).containsOnly(Map.entry("page", "3"));
+    }
+
+    @Test
+    void builder_configures_metadata_field_names() {
+        AzureAiSearchEmbeddingStore store = AzureAiSearchEmbeddingStore.builder()
+                .endpoint(endpoint)
+                .apiKey("test")
+                .createOrUpdateIndex(false)
+                .dimensions(dimensions)
+                .metadataFieldNames(List.of("sourcepage", "topic"))
+                .build();
+
+        assertThat(store.metadataFieldNames).containsExactly("sourcepage", "topic");
+    }
+
+    @Test
+    void builder_treats_null_metadata_field_names_as_none() {
+        AzureAiSearchEmbeddingStore store = AzureAiSearchEmbeddingStore.builder()
+                .endpoint(endpoint)
+                .apiKey("test")
+                .createOrUpdateIndex(false)
+                .dimensions(dimensions)
+                .metadataFieldNames(null)
+                .build();
+
+        assertThat(store.metadataFieldNames).isEmpty();
+    }
+
+    @Test
+    void copies_allowlisted_top_level_fields_into_metadata() {
+        Map<String, Object> searchDocument = new HashMap<>();
+        searchDocument.put("id", "doc-1");
+        searchDocument.put("content", "the document text");
+        searchDocument.put("content_vector", List.of(0.1f, 0.2f));
+        searchDocument.put("sourcepage", "guide.pdf");
+        searchDocument.put("topic", "Ambulatory");
+        searchDocument.put("unlisted", "ignored");
+
+        Metadata metadata = metadataFrom(searchDocument, List.of("sourcepage", "topic"));
+
+        assertThat(metadata.toMap())
+                .containsOnly(Map.entry("sourcepage", "guide.pdf"), Map.entry("topic", "Ambulatory"));
+    }
+
+    @Test
+    void preserves_supported_value_types_for_allowlisted_fields() {
+        UUID ref = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Map<String, Object> searchDocument = new HashMap<>();
+        searchDocument.put("pages", 12);
+        searchDocument.put("score", 4.5d);
+        searchDocument.put("ref", ref);
+
+        Metadata metadata = metadataFrom(searchDocument, List.of("pages", "score", "ref"));
+
+        assertThat(metadata.toMap())
+                .containsOnly(Map.entry("pages", 12), Map.entry("score", 4.5d), Map.entry("ref", ref));
+    }
+
+    @Test
+    void skips_absent_null_unsupported_and_blank_name_allowlisted_fields() {
+        Map<String, Object> searchDocument = new HashMap<>();
+        searchDocument.put("present", "value");
+        searchDocument.put("nullField", null);
+        searchDocument.put("vector", List.of(0.1f));
+        searchDocument.put("flag", true);
+        searchDocument.put(" ", "value-under-blank-key");
+
+        Metadata metadata =
+                metadataFrom(searchDocument, List.of("present", "nullField", "vector", "flag", "absent", " "));
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("present", "value"));
+    }
+
+    @Test
+    void merges_complex_attributes_with_allowlisted_fields() {
+        Map<String, Object> searchDocument = new HashMap<>();
+        searchDocument.put("metadata", Map.of("attributes", List.of(Map.of("key", "source", "value", "doc.pdf"))));
+        searchDocument.put("topic", "Ambulatory");
+
+        Metadata metadata = metadataFrom(searchDocument, List.of("topic"));
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("source", "doc.pdf"), Map.entry("topic", "Ambulatory"));
+    }
+
+    @Test
+    void allowlisted_field_takes_precedence_over_complex_metadata_on_key_collision() {
+        Map<String, Object> searchDocument = new HashMap<>();
+        searchDocument.put("metadata", Map.of("attributes", List.of(Map.of("key", "topic", "value", "from-complex"))));
+        searchDocument.put("topic", "from-root");
+
+        Metadata metadata = metadataFrom(searchDocument, List.of("topic"));
+
+        assertThat(metadata.toMap()).containsOnly(Map.entry("topic", "from-root"));
     }
 }


### PR DESCRIPTION
## Issue
Closes #2973. Also covers the metadata-mapping gap reported in #1098.

## Change
`AzureAiSearchContentRetriever` and `AzureAiSearchEmbeddingStore` mapped segment metadata
only from the nested complex `metadata` field this store writes itself. Against a
pre-existing index whose fields live at the document root (`createOrUpdateIndex(false)`),
those fields were unreachable, so results came back without their metadata.

Add `metadataFieldNames` to both builders: an explicit allowlist of top-level index fields
to expose as metadata.

```java
ContentRetriever retriever = AzureAiSearchContentRetriever.builder()
        .endpoint(endpoint)
        .tokenCredential(tokenCredential)
        .indexName(indexName)
        .createOrUpdateIndex(false)
        .queryType(AzureAiSearchQueryType.FULL_TEXT)
        .metadataFieldNames(List.of("sourcepage", "weburl", "topic", "role"))
        .build();
```

The listed fields are added to each result's `Metadata`, alongside the complex `metadata`
field when present. Both classes share `getEmbeddingMatches`, so vector, full-text, hybrid
and hybrid+reranking searches are all covered.

A field is copied only when its value is a type `Metadata` supports (`String`, `Integer`,
`Long`, `Float`, `Double`, or `UUID`), preserving the type; absent, `null` and other-typed
values (such as the embedding vector) are skipped. An explicit allowlist keeps field
selection predictable for bring-your-own indexes with arbitrary schemas. The default is an
empty list, so existing behaviour is unchanged and the API change is additive only: the
existing `metadataFrom(Object)` helper is kept as-is and the new behaviour is a delegating
overload, so no revapi entries and no changes to the existing tests. The reformatting in
`AzureAiSearchEmbeddingStore` is applied by Spotless (`ratchetFrom origin/main`).

This PR configures metadata extraction only; the index's core ID, content, vector and
semantic-search field names are unchanged (the broader field-name configuration in #1098
is out of scope here).

## Tests
`AzureAiSearchEmbeddingStoreTest`, offline. The existing nested-metadata tests are kept as-is
(the `metadataFrom(Object)` helper is unchanged); new tests cover the added overload:
- allowlisted fields copied; `Integer` / `Double` / `UUID` values preserved with their type
- absent / `null` / unsupported-typed / blank-name fields skipped
- complex metadata and allowlisted fields merged; top-level field wins on key collision
- the builder wires `metadataFieldNames` onto the store; `null` is treated as none

```
mvn -pl langchain4j-azure-ai-search verify
Tests run: 34, Failures: 0, Errors: 0, Skipped: 0   (revapi + spotless green)
```

Core and main modules are green as well:

```
mvn -pl langchain4j-core,langchain4j test
langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1327, Failures: 0, Errors: 0, Skipped: 0
```

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [X] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
