### PR TITLE
fix: Use a new Jlama session id for each request

### DIFF
--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaLanguageModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaLanguageModel.java
@@ -20,7 +20,6 @@ public class JlamaLanguageModel implements LanguageModel {
     private final AbstractModel model;
     private final Float temperature;
     private final Integer maxTokens;
-    private final UUID id = UUID.randomUUID();
 
     public JlamaLanguageModel(
             Path modelCachePath,
@@ -71,8 +70,8 @@ public class JlamaLanguageModel implements LanguageModel {
 
     @Override
     public Response<String> generate(String prompt) {
-        Generator.Response r =
-                model.generate(id, PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {});
+        Generator.Response r = model.generate(
+                UUID.randomUUID(), PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {});
         return Response.from(
                 r.responseText, new TokenUsage(r.promptTokens, r.generatedTokens), toFinishReason(r.finishReason));
     }
@@ -152,7 +151,8 @@ public class JlamaLanguageModel implements LanguageModel {
 
         public String toString() {
             return "JlamaLanguageModel.JlamaLanguageModelBuilder(modelCachePath=" + this.modelCachePath + ", modelName="
-                    + this.modelName + ", authToken=" + (this.authToken == null ? null : "********") + ", threadCount=" + this.threadCount
+                    + this.modelName + ", authToken=" + (this.authToken == null ? null : "********") + ", threadCount="
+                    + this.threadCount
                     + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime + ", workingDirectory="
                     + this.workingDirectory + ", workingQuantizedType=" + this.workingQuantizedType + ", temperature="
                     + this.temperature + ", maxTokens=" + this.maxTokens + ")";

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
@@ -47,7 +47,6 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
     private final AbstractModel model;
     private final Float temperature;
     private final Integer maxTokens;
-    private final UUID id = UUID.randomUUID();
 
     public JlamaStreamingChatModel(
             Path modelCachePath,
@@ -186,9 +185,10 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
         PromptContext promptContext = tools.isEmpty() ? promptBuilder.build() : promptBuilder.build(tools);
 
         try {
-            Generator.Response r = model.generate(id, promptContext, temperature, maxTokens, (token, time) -> {
-                handler.onNext(token);
-            });
+            Generator.Response r =
+                    model.generate(UUID.randomUUID(), promptContext, temperature, maxTokens, (token, time) -> {
+                        handler.onNext(token);
+                    });
 
             if (r.finishReason == Generator.FinishReason.TOOL_CALL) {
                 List<ToolExecutionRequest> toolCalls = r.toolCalls.stream()
@@ -289,7 +289,8 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
 
         public String toString() {
             return "JlamaStreamingChatModel.JlamaStreamingChatModelBuilder(modelCachePath=" + this.modelCachePath
-                    + ", modelName=" + this.modelName + ", authToken=" + (this.authToken == null ? null : "********") + ", threadCount="
+                    + ", modelName=" + this.modelName + ", authToken=" + (this.authToken == null ? null : "********")
+                    + ", threadCount="
                     + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime
                     + ", workingDirectory=" + this.workingDirectory + ", workingQuantizedType="
                     + this.workingQuantizedType + ", temperature=" + this.temperature + ", maxTokens=" + this.maxTokens

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingLanguageModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingLanguageModel.java
@@ -21,7 +21,6 @@ public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
     private final AbstractModel model;
     private final Float temperature;
     private final Integer maxTokens;
-    private final UUID id = UUID.randomUUID();
 
     public JlamaStreamingLanguageModel(
             Path modelCachePath,
@@ -64,8 +63,8 @@ public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
     @Override
     public void generate(String prompt, StreamingResponseHandler<String> handler) {
         try {
-            Generator.Response r =
-                    model.generate(id, PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {
+            Generator.Response r = model.generate(
+                    UUID.randomUUID(), PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {
                         handler.onNext(token);
                     });
 
@@ -151,7 +150,8 @@ public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
 
         public String toString() {
             return "JlamaStreamingLanguageModel.JlamaStreamingLanguageModelBuilder(modelCachePath="
-                    + this.modelCachePath + ", modelName=" + this.modelName + ", authToken=" + (this.authToken == null ? null : "********")
+                    + this.modelCachePath + ", modelName=" + this.modelName + ", authToken="
+                    + (this.authToken == null ? null : "********")
                     + ", threadCount=" + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime
                     + ", workingDirectory=" + this.workingDirectory + ", workingQuantizedType="
                     + this.workingQuantizedType + ", temperature=" + this.temperature + ", maxTokens=" + this.maxTokens

--- a/langchain4j-jlama/src/test/java/dev/langchain4j/model/jlama/JlamaLanguageModelIT.java
+++ b/langchain4j-jlama/src/test/java/dev/langchain4j/model/jlama/JlamaLanguageModelIT.java
@@ -1,21 +1,19 @@
 package dev.langchain4j.model.jlama;
 
-import dev.langchain4j.model.language.LanguageModel;
-import dev.langchain4j.model.output.Response;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import java.io.File;
-
 import static dev.langchain4j.model.output.FinishReason.LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.language.LanguageModel;
+import dev.langchain4j.model.output.Response;
+import java.io.File;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 class JlamaLanguageModelIT {
 
     static File tmpDir;
 
     static LanguageModel model;
-
 
     @BeforeAll
     static void setup() {
@@ -44,5 +42,23 @@ class JlamaLanguageModelIT {
 
         assertThat(response.tokenUsage()).isNotNull();
         assertThat(response.finishReason()).isEqualTo(LENGTH);
+    }
+
+    @Test
+    void should_not_carry_context_over_between_requests() {
+
+        // given
+        String prompt = "When is the best time of year to visit Japan?";
+
+        // when
+        Response<String> firstResponse = model.generate(prompt);
+        Response<String> secondResponse = model.generate(prompt);
+
+        // then
+        assertThat(firstResponse.tokenUsage().outputTokenCount()).isPositive();
+
+        assertThat(secondResponse.content()).isNotBlank();
+        assertThat(secondResponse.tokenUsage().outputTokenCount())
+                .isEqualTo(firstResponse.tokenUsage().outputTokenCount());
     }
 }


### PR DESCRIPTION
## Issue

Closes #6025

## Change

The three classes each held `private final UUID id = UUID.randomUUID();` and passed it to `AbstractModel.generate(...)` as the Jlama session id. Jlama finds the KV cache by that id and starts at the context position the previous request left there, so from the second request on the prompt sits at a shifted position, attention also reads the stale KV slots below it, and the generation budget shrinks by the tokens already generated. Each call now passes a fresh id, as `JlamaChatModel` already does.

The test asserts `outputTokenCount()`, not `finishReason`: Jlama initialises the reason to `MAX_TOKENS`, so `LENGTH` is reported even when nothing is generated.

The reformatted `toString()` lines and the reordered IT imports are spotless output - its ratchet works per file, and commit b3a70729d left lines over 120 characters there.

CI skips this test: `main.yaml` and the nightly workflows pass `-DskipJlamaITs`, which the module pom wires into failsafe. Local run, macOS aarch64, JDK 25, `tjake/Llama-3.2-1B-Instruct-JQ4`:

```
before: 52 output tokens on call 1, 0 on call 2 (fails)
after:  52 on both calls (passes)
```

#5442 touches these files but is docs-only and needs a full rebase already.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
  There is one behaviour to check: a second request on the same model instance must generate as much as the first.
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  Ran: unit tests (10, green) and `JlamaLanguageModelIT` (2, green). The module's other 9 `*IT` classes each download a model and were not run.
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
  Not run: the change is confined to langchain4j-jlama and touches no core or main module code.
- [ ] I have added/updated the documentation
  `docs/docs/integrations/language-models/jlama.md` says nothing about session or KV cache handling.
- [ ] I have added an example in the examples repo (only for "big" features)
  Bug fix.
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
  No builder or public API change.

<!-- The "new maven module" and "new/changed embedding store integration" checklists are omitted: no module and no embedding store is involved. -->
