### PR TITLE
Fix Bedrock guardrail assessment handling for ConverseTrace without a guardrail

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -819,7 +819,7 @@ abstract class AbstractBedrockChatModel {
 
     protected GuardrailAssessmentSummary guardrailAssessmentSummaryFrom(ConverseTrace trace) {
 
-        if (trace == null) {
+        if (trace == null || trace.guardrail() == null) {
             return null;
         }
 

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailAssessmentSummaryTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailAssessmentSummaryTest.java
@@ -1,0 +1,48 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseTrace;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailTraceAssessment;
+import software.amazon.awssdk.services.bedrockruntime.model.PromptRouterTrace;
+
+class BedrockGuardrailAssessmentSummaryTest {
+
+    private final BedrockChatModel model = BedrockChatModel.builder()
+            .client(mock(BedrockRuntimeClient.class))
+            .modelId("test-model")
+            .build();
+
+    @Test
+    void should_return_null_when_trace_is_null() {
+        assertThat(model.guardrailAssessmentSummaryFrom(null)).isNull();
+    }
+
+    @Test
+    void should_return_null_when_trace_has_no_guardrail() {
+
+        ConverseTrace trace = ConverseTrace.builder()
+                .promptRouter(PromptRouterTrace.builder()
+                        .invokedModelId("arn:aws:bedrock:us-east-1::foundation-model/model")
+                        .build())
+                .build();
+
+        assertThat(model.guardrailAssessmentSummaryFrom(trace)).isNull();
+    }
+
+    @Test
+    void should_return_summary_when_guardrail_is_present() {
+
+        ConverseTrace trace = ConverseTrace.builder()
+                .guardrail(GuardrailTraceAssessment.builder().build())
+                .build();
+
+        GuardrailAssessmentSummary summary = model.guardrailAssessmentSummaryFrom(trace);
+
+        assertThat(summary).isNotNull();
+        assertThat(summary.hasAssessments()).isFalse();
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6028

## Change

`guardrailAssessmentSummaryFrom` returned early only for a null trace and then dereferenced
`trace.guardrail()` four times. `guardrail` and `promptRouter` are independent optional members of
`ConverseTrace`, so a response produced with prompt routing but without guardrails carries a non-null trace
whose `guardrail` is null, and mapping it failed with:

```
java.lang.NullPointerException: Cannot invoke
"...GuardrailTraceAssessment.hasInputAssessment()" because the return value of
"...ConverseTrace.guardrail()" is null
```

`ConverseResponseFromStreamBuilder` already builds that shape, passing both members through independently.
Both `BedrockChatModel` and `BedrockStreamingChatModel` map every response through this method, so the whole
response failed rather than just the guardrail summary.

```diff
-if (trace == null) {
+if (trace == null || trace.guardrail() == null) {
     return null;
 }
```

Absent guardrail data now maps to no summary, the same as a null trace.

### Tests

New `BedrockGuardrailAssessmentSummaryTest`:

- `should_return_null_when_trace_is_null`
- `should_return_null_when_trace_has_no_guardrail` (prompt-router-only trace; fails on unmodified `main`
  with the NPE above)
- `should_return_summary_when_guardrail_is_present` (the guardrail branch is unchanged)

```
mvn -pl langchain4j-bedrock verify
Tests run: 209, Failures: 0, Errors: 0, Skipped: 0   (revapi + spotless green)

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1327, Failures: 0, Errors: 0, Skipped: 0
```

The method maps an SDK object in memory, so no live call is involved and the unit tests cover it fully.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)