### PR TITLE
Fix Bedrock default request parameters to preserve serviceTier and responseFormat

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -177,10 +177,12 @@ abstract class AbstractBedrockChatModel {
                 .stopSequences(commonParameters.stopSequences())
                 .toolSpecifications(commonParameters.toolSpecifications())
                 .toolChoice(commonParameters.toolChoice())
+                .responseFormat(commonParameters.responseFormat())
                 // Bedrock-specific parameters
                 .additionalModelRequestFields(bedrockParameters.additionalModelRequestFields())
                 .promptCaching(bedrockParameters.cachePointPlacement(), bedrockParameters.cacheTtl())
                 .guardrailConfiguration(bedrockParameters.bedrockGuardrailConfiguration())
+                .serviceTier(bedrockParameters.serviceTier())
                 .build();
     }
 

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockDefaultRequestParametersTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockDefaultRequestParametersTest.java
@@ -1,0 +1,48 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+
+class BedrockDefaultRequestParametersTest {
+
+    @Test
+    void should_preserve_default_request_parameters_in_chat_model() {
+
+        BedrockChatModel model = BedrockChatModel.builder()
+                .client(mock(BedrockRuntimeClient.class))
+                .modelId("test-model")
+                .defaultRequestParameters(defaultRequestParameters())
+                .build();
+
+        assertDefaultRequestParametersPreserved(model.defaultRequestParameters());
+    }
+
+    @Test
+    void should_preserve_default_request_parameters_in_streaming_chat_model() {
+
+        BedrockStreamingChatModel model = BedrockStreamingChatModel.builder()
+                .client(mock(BedrockRuntimeAsyncClient.class))
+                .modelId("test-model")
+                .defaultRequestParameters(defaultRequestParameters())
+                .build();
+
+        assertDefaultRequestParametersPreserved(model.defaultRequestParameters());
+    }
+
+    private static BedrockChatRequestParameters defaultRequestParameters() {
+        return BedrockChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.JSON)
+                .serviceTier(BedrockServiceTier.PRIORITY)
+                .build();
+    }
+
+    private static void assertDefaultRequestParametersPreserved(BedrockChatRequestParameters parameters) {
+        assertThat(parameters.responseFormat()).isEqualTo(ResponseFormat.JSON);
+        assertThat(parameters.serviceTier()).isEqualTo(BedrockServiceTier.PRIORITY);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6030

## Change

`AbstractBedrockChatModel` rebuilds the configured defaults into a new
`BedrockChatRequestParameters`, but the reconstruction never copied `serviceTier` or `responseFormat`.
Both are read when the Converse request is built (`parameters.serviceTier()` and
`chatRequest.responseFormat()`), and `ChatModel.chat` merges as
`defaultRequestParameters().overrideWith(chatRequest.parameters())`, so a value dropped here cannot be
recovered later: a model configured through `defaultRequestParameters(...)` silently lost both unless the
same values were repeated on every request.

`topK`, `frequencyPenalty` and `presencePenalty` are intentionally left out: `validate` rejects them with
`UnsupportedFeatureException`.

### Tests

New `BedrockDefaultRequestParametersTest` configures each model with only the two affected parameters and
asserts both survive construction, covering `BedrockChatModel` and `BedrockStreamingChatModel`:

- `should_preserve_default_request_parameters_in_chat_model`
- `should_preserve_default_request_parameters_in_streaming_chat_model`

Both fail on unmodified `main` (`expected: ResponseFormat { type = JSON ... } but was: null`).

The existing `BedrockChatRequestParametersTest` only covers the parameters object itself, so the
reconstruction in `AbstractBedrockChatModel` was never exercised.

```
mvn -pl langchain4j-bedrock verify
Tests run: 208, Failures: 0, Errors: 0, Skipped: 0   (revapi + spotless green)

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1327, Failures: 0, Errors: 0, Skipped: 0
```

The reconstruction runs entirely in the JVM, so the unit tests cover it fully. I also checked against a real
endpoint that the now-propagated value is accepted, since `serviceTier` had never actually reached a Converse
request before: a `us.deepseek.r1-v1:0` call configured only through `defaultRequestParameters(...)` returns
normally (`finishReason = STOP`, 212 tokens) with no validation error.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
