### PR TITLE
Fix Pinecone segment text being overwritten by reserved metadata key

### DIFF
--- a/langchain4j-pinecone/src/main/java/dev/langchain4j/store/embedding/pinecone/PineconeHelper.java
+++ b/langchain4j-pinecone/src/main/java/dev/langchain4j/store/embedding/pinecone/PineconeHelper.java
@@ -3,7 +3,6 @@ package dev.langchain4j.store.embedding.pinecone;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import dev.langchain4j.data.segment.TextSegment;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -40,17 +39,28 @@ class PineconeHelper {
     public static Struct metadataToStruct(TextSegment textSegment, String metadataTextKey) {
         Map<String, Object> metadata = textSegment.metadata().toMap();
         Struct.Builder metadataBuilder = Struct.newBuilder()
-                .putFields(metadataTextKey, Value.newBuilder().setStringValue(textSegment.text()).build());
-        if (!metadata.isEmpty()) {
-            for (Map.Entry<String, Object> entry : metadata.entrySet()) {
-                String key = entry.getKey();
-                Object value = entry.getValue();
+                .putFields(
+                        metadataTextKey,
+                        Value.newBuilder().setStringValue(textSegment.text()).build());
+        for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+            String key = entry.getKey();
+            if (key.equals(metadataTextKey)) {
+                continue;
+            }
+            Object value = entry.getValue();
 
-                if (value instanceof String || value instanceof UUID) {
-                    metadataBuilder.putFields(key, Value.newBuilder().setStringValue(value.toString()).build());
-                } else if (value instanceof Integer || value instanceof Long || value instanceof Float || value instanceof Double) {
-                    metadataBuilder.putFields(key, Value.newBuilder().setNumberValue(((Number) value).doubleValue()).build());
-                }
+            if (value instanceof String || value instanceof UUID) {
+                metadataBuilder.putFields(
+                        key, Value.newBuilder().setStringValue(value.toString()).build());
+            } else if (value instanceof Integer
+                    || value instanceof Long
+                    || value instanceof Float
+                    || value instanceof Double) {
+                metadataBuilder.putFields(
+                        key,
+                        Value.newBuilder()
+                                .setNumberValue(((Number) value).doubleValue())
+                                .build());
             }
         }
 

--- a/langchain4j-pinecone/src/test/java/dev/langchain4j/store/embedding/pinecone/PineconeHelperTest.java
+++ b/langchain4j-pinecone/src/test/java/dev/langchain4j/store/embedding/pinecone/PineconeHelperTest.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.store.embedding.pinecone;
+
+import static dev.langchain4j.store.embedding.pinecone.PineconeHelper.metadataToStruct;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Struct;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import org.junit.jupiter.api.Test;
+
+class PineconeHelperTest {
+
+    private static final String DEFAULT_METADATA_TEXT_KEY = "text_segment";
+
+    @Test
+    void metadataToStruct_should_preserve_text_and_other_metadata_when_metadata_uses_the_text_key() {
+        Metadata metadata =
+                new Metadata().put(DEFAULT_METADATA_TEXT_KEY, "another value").put("source", "manual");
+        TextSegment textSegment = TextSegment.from("the real document", metadata);
+
+        Struct struct = metadataToStruct(textSegment, DEFAULT_METADATA_TEXT_KEY);
+
+        assertThat(struct.getFieldsMap().get(DEFAULT_METADATA_TEXT_KEY).getStringValue())
+                .isEqualTo("the real document");
+        assertThat(struct.getFieldsMap().get("source").getStringValue()).isEqualTo("manual");
+    }
+
+    @Test
+    void metadataToStruct_should_preserve_text_when_metadata_uses_a_custom_text_key() {
+        TextSegment textSegment = TextSegment.from("the real document", Metadata.from("content", "another value"));
+
+        Struct struct = metadataToStruct(textSegment, "content");
+
+        assertThat(struct.getFieldsMap().get("content").getStringValue()).isEqualTo("the real document");
+    }
+
+    @Test
+    void metadataToStruct_should_store_text_and_metadata_when_there_is_no_collision() {
+        TextSegment textSegment = TextSegment.from("the real document", Metadata.from("source", "manual"));
+
+        Struct struct = metadataToStruct(textSegment, DEFAULT_METADATA_TEXT_KEY);
+
+        assertThat(struct.getFieldsMap().get(DEFAULT_METADATA_TEXT_KEY).getStringValue())
+                .isEqualTo("the real document");
+        assertThat(struct.getFieldsMap().get("source").getStringValue()).isEqualTo("manual");
+    }
+
+    @Test
+    void metadataToStruct_should_store_text_when_metadata_is_empty() {
+        TextSegment textSegment = TextSegment.from("the real document");
+
+        Struct struct = metadataToStruct(textSegment, DEFAULT_METADATA_TEXT_KEY);
+
+        assertThat(struct.getFieldsMap()).containsOnlyKeys(DEFAULT_METADATA_TEXT_KEY);
+        assertThat(struct.getFieldsMap().get(DEFAULT_METADATA_TEXT_KEY).getStringValue())
+                .isEqualTo("the real document");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6032

## Change

`metadataToStruct` seeded the `Struct` with the segment text under `metadataTextKey` and then wrote the
segment metadata into the same builder. `putFields` overwrites, so a metadata entry using that key
replaced the text. The segment is read back from the same key, so a search returned the metadata value
while the vector still corresponded to the original text.

The metadata loop now skips the reserved key, so the field written from the segment text is never
replaced. Skipping explicitly rather than relying on write order keeps the guarantee if this method is
ever reordered. `QdrantEmbeddingStore` makes the same guarantee around its own configurable text key:
the key that carries the segment text is owned by the store, not by user metadata.

The `if (!metadata.isEmpty())` guard is dropped, since iterating an empty map is already a no-op.

### Tests

New `PineconeHelperTest`:

- `metadataToStruct_should_preserve_text_and_other_metadata_when_metadata_uses_the_text_key`
  (fails on unmodified `main`; also covers that unrelated metadata still survives the skip)
- `metadataToStruct_should_preserve_text_when_metadata_uses_a_custom_text_key` (fails on unmodified
  `main`; proves the fix is not tied to the default key)
- `metadataToStruct_should_store_text_and_metadata_when_there_is_no_collision`
- `metadataToStruct_should_store_text_when_metadata_is_empty` (covers the dropped `isEmpty` guard)

```
mvn -pl langchain4j-pinecone test
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1327, Failures: 0, Errors: 0, Skipped: 0
```

`metadataToStruct` maps in memory, so the unit tests cover it without a Pinecone index.

Most of the diff is Spotless: `PineconeHelper` was not formatter-clean on `main`, so `spotless:apply`
reflowed the `putFields` calls and the `instanceof` chain in this file.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)