### PR TITLE
Fix `returnThinking` being ignored by `BedrockStreamingChatModel`

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -131,7 +131,7 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
                             } else if (currentContentType.get() == ContentBlockDelta.Type.REASONING_CONTENT) {
                                 ReasoningContentBlockDelta reasoningContent = delta.reasoningContent();
                                 String thinking = reasoningContent.text();
-                                if (isNotNullOrEmpty(thinking)) {
+                                if (returnThinking && isNotNullOrEmpty(thinking)) {
                                     onPartialThinking(handler, thinking, streamingHandle.get());
                                 }
                             } else if (currentContentType.get() == ContentBlockDelta.Type.TOOL_USE) {

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModelThinkingTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModelThinkingTest.java
@@ -1,0 +1,129 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDelta;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockDeltaEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlockStopEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetadataEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetrics;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStartEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.MessageStopEvent;
+import software.amazon.awssdk.services.bedrockruntime.model.ReasoningContentBlockDelta;
+import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
+
+class BedrockStreamingChatModelThinkingTest {
+
+    private static final String THINKING = "The user is asking about Germany.";
+    private static final String ANSWER = "Berlin";
+
+    @Test
+    void should_invoke_onPartialThinking_when_returnThinking_is_enabled() {
+
+        StreamingChatModel model = streamingChatModel(true);
+
+        TestStreamingChatResponseHandler handler = spy(new TestStreamingChatResponseHandler());
+        model.chat("What is the capital of Germany?", handler);
+
+        AiMessage aiMessage = handler.get().aiMessage();
+        assertThat(aiMessage.text()).isEqualTo(ANSWER);
+        assertThat(aiMessage.thinking()).isEqualTo(THINKING);
+        assertThat(handler.getThinking()).isEqualTo(THINKING);
+        verify(handler).onPartialThinking(any(), any());
+    }
+
+    @Test
+    void should_NOT_invoke_onPartialThinking_when_returnThinking_is_disabled() {
+
+        StreamingChatModel model = streamingChatModel(false);
+
+        TestStreamingChatResponseHandler handler = spy(new TestStreamingChatResponseHandler());
+        model.chat("What is the capital of Germany?", handler);
+
+        AiMessage aiMessage = handler.get().aiMessage();
+        assertThat(aiMessage.text()).isEqualTo(ANSWER);
+        assertThat(aiMessage.thinking()).isNull();
+        assertThat(handler.getThinking()).isEmpty();
+        verify(handler, never()).onPartialThinking(any(), any());
+    }
+
+    @Test
+    void should_NOT_invoke_onPartialThinking_when_returnThinking_is_not_set() {
+
+        StreamingChatModel model = streamingChatModel(null);
+
+        TestStreamingChatResponseHandler handler = spy(new TestStreamingChatResponseHandler());
+        model.chat("What is the capital of Germany?", handler);
+
+        AiMessage aiMessage = handler.get().aiMessage();
+        assertThat(aiMessage.text()).isEqualTo(ANSWER);
+        assertThat(aiMessage.thinking()).isNull();
+        assertThat(handler.getThinking()).isEmpty();
+        verify(handler, never()).onPartialThinking(any(), any());
+    }
+
+    private static StreamingChatModel streamingChatModel(Boolean returnThinking) {
+        BedrockStreamingChatModel.Builder builder = BedrockStreamingChatModel.builder()
+                .client(mockStreamingClient(thinkingAndAnswerEvents()))
+                .modelId("test-model");
+
+        if (returnThinking != null) {
+            builder.returnThinking(returnThinking);
+        }
+
+        return builder.build();
+    }
+
+    private static BedrockRuntimeAsyncClient mockStreamingClient(List<ConverseStreamOutput> events) {
+        BedrockRuntimeAsyncClient client = mock(BedrockRuntimeAsyncClient.class);
+        when(client.converseStream(any(ConverseStreamRequest.class), any(ConverseStreamResponseHandler.class)))
+                .thenAnswer(invocation -> {
+                    ConverseStreamResponseHandler responseHandler = invocation.getArgument(1);
+                    responseHandler.onEventStream(SdkPublisher.fromIterable(events));
+                    return CompletableFuture.completedFuture(null);
+                });
+        return client;
+    }
+
+    private static List<ConverseStreamOutput> thinkingAndAnswerEvents() {
+        return List.of(
+                MessageStartEvent.builder().role(ConversationRole.ASSISTANT).build(),
+                ContentBlockDeltaEvent.builder()
+                        .delta(ContentBlockDelta.fromReasoningContent(ReasoningContentBlockDelta.builder()
+                                .text(THINKING)
+                                .build()))
+                        .build(),
+                ContentBlockDeltaEvent.builder()
+                        .delta(ContentBlockDelta.fromText(ANSWER))
+                        .build(),
+                ContentBlockStopEvent.builder().build(),
+                MessageStopEvent.builder().stopReason(StopReason.END_TURN).build(),
+                ConverseStreamMetadataEvent.builder()
+                        .usage(TokenUsage.builder()
+                                .inputTokens(10)
+                                .outputTokens(20)
+                                .totalTokens(30)
+                                .build())
+                        .metrics(ConverseStreamMetrics.builder().latencyMs(1L).build())
+                        .build());
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6034

## Change

`returnThinking` is documented as controlling both whether thinking is stored in `AiMessage#thinking()`
and whether `onPartialThinking` is invoked, and it is disabled by default. `BedrockStreamingChatModel`
honoured only the first half: the `REASONING_CONTENT` branch invoked the callback for every reasoning
delta without checking the flag, so a reasoning model streamed its chain-of-thought to the handler while
the final `AiMessage` correctly carried none.

The `anthropic`, `open-ai`, `ollama`, `mistral-ai` and `google-ai-gemini` modules all gate the callback on
`returnThinking`; bedrock was the only one that did not. The non-streaming path in
`AbstractBedrockChatModel` and the final-message path in `ConverseResponseFromStreamBuilder` were already
gated, so only the streaming callback was missing it.

One knock-on effect: a suppressed delta is no longer mapped to a typed callback, so it now reaches
`onUnmappedRawEvent`, per `MappingTrackingStreamingChatResponseHandler`. If you would rather have the
suppressed deltas dropped entirely, I am happy to track them as mapped instead.

### Tests

New offline `BedrockStreamingChatModelThinkingTest` drives the streaming path through an injected
`BedrockRuntimeAsyncClient`, so it runs in CI without AWS credentials:

- `should_invoke_onPartialThinking_when_returnThinking_is_enabled`
- `should_NOT_invoke_onPartialThinking_when_returnThinking_is_disabled`
- `should_NOT_invoke_onPartialThinking_when_returnThinking_is_not_set`

Both negative tests fail on unmodified `main`. The "not set" case omits `returnThinking` from the builder
entirely so it exercises the real default.

```
mvn -pl langchain4j-bedrock verify
Tests run: 209, Failures: 0, Errors: 0, Skipped: 0   (revapi + spotless green)

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1327, Failures: 0, Errors: 0, Skipped: 0
```

`BedrockStreamingChatModelThinkingIT` is `@Disabled`; run manually against `us.deepseek.r1-v1:0` with this
change applied:

```
BedrockStreamingChatModelThinkingIT (us.deepseek.r1-v1:0)
  should_NOT_return_thinking                                  PASSED
  should_NOT_return_thinking_when_returnThinking_is_not_set   PASSED
  should_return_and_NOT_send_thinking                         PASSED
```

The `us.anthropic.*` parameterisations could not be run on my account: Bedrock rejects them with "Model
use case details have not been submitted for this account".

That IT already covers the disabled cases but asserts only on the final `AiMessage`, which is why this went
unnoticed. I left it untouched to keep the diff to the fix and its test; happy to add
`verify(spyHandler, never()).onPartialThinking(any(), any())` there too if you want it here.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)