### PR TITLE
fix: keep the sign of negative numbers in SqlFilterParser IN lists

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -64,6 +64,9 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
  *
  * - Parentheses: {@code (name = 'Klaus' OR name = 'Francine') AND age = 18}. Expressions within parentheses are evaluated first.
  * </pre>
+ * Values inside {@code IN}/{@code NOT IN} lists can be any of the expressions listed above,
+ * for example {@code age IN (-1, 2 + 3)} or {@code year IN (YEAR(CURDATE()), YEAR(CURDATE()) - 1)}.
+ * <br>
  * If you require additional operations,
  * please <a href="https://github.com/langchain4j/langchain4j/issues/new/choose">open an issue</a>.
  * <br>
@@ -232,15 +235,15 @@ public class SqlFilterParser implements FilterParser {
             return ((LongValue) expression).getValue();
         } else if (expression instanceof DoubleValue) {
             return ((DoubleValue) expression).getValue();
-        } else if (expression instanceof SignedExpression) {
-            SignedExpression signedExpression = (SignedExpression) expression;
-            if (signedExpression.getSign() == '-') {
-                if (signedExpression.getExpression() instanceof LongValue) {
-                    String stringValue = signedExpression.getExpression().toString();
-                    return Long.parseLong("-" + stringValue);
-                } else if (signedExpression.getExpression() instanceof DoubleValue) {
-                    String stringValue = signedExpression.getExpression().toString();
-                    return Double.parseDouble("-" + stringValue);
+        } else if (expression instanceof SignedExpression signedExpression) {
+            char sign = signedExpression.getSign();
+            if (sign == '-' || sign == '+') {
+                Expression innerExpression = signedExpression.getExpression();
+                String stringValue = sign + innerExpression.toString();
+                if (innerExpression instanceof LongValue) {
+                    return Long.parseLong(stringValue);
+                } else if (innerExpression instanceof DoubleValue) {
+                    return Double.parseDouble(stringValue);
                 }
             }
         } else if (expression instanceof Function) {

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -169,24 +169,16 @@ public class SqlFilterParser implements FilterParser {
     private Filter mapInExpression(InExpression inExpression) {
         String key = getKey(inExpression.getLeftExpression());
 
+        Expression rightExpression = inExpression.getRightExpression();
+        if (!(rightExpression instanceof ExpressionList<?> expressionList)) {
+            throw illegalArgument(
+                    "Unsupported expression: '%s'%s", rightExpression, createGithubIssueLink(rightExpression));
+        }
+
         Collection<Object> comparisonValues = new ArrayList<>();
-        inExpression.getRightExpression().accept(new ExpressionVisitorAdapter() {
-
-            @Override
-            public void visit(StringValue value) {
-                comparisonValues.add(value.getValue());
-            }
-
-            @Override
-            public void visit(LongValue value) {
-                comparisonValues.add(value.getValue());
-            }
-
-            @Override
-            public void visit(DoubleValue value) {
-                comparisonValues.add(value.getValue());
-            }
-        });
+        for (Expression expression : expressionList) {
+            comparisonValues.add(getValue(expression));
+        }
 
         if (inExpression.isNot()) {
             return new IsNotIn(key, comparisonValues);

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -46,7 +46,11 @@ class SqlFilterParserTest {
                 // eq
                 .add(of("name = 'Klaus'", metadataKey("name").isEqualTo("Klaus")))
                 .add(of("age = 18", metadataKey("age").isEqualTo(18L)))
+                .add(of("age = +18", metadataKey("age").isEqualTo(18L)))
+                .add(of("age = -18", metadataKey("age").isEqualTo(-18L)))
                 .add(of("weight = 67.8", metadataKey("weight").isEqualTo(67.8d)))
+                .add(of("weight = +67.8", metadataKey("weight").isEqualTo(67.8d)))
+                .add(of("weight = -67.8", metadataKey("weight").isEqualTo(-67.8d)))
 
                 // ne
                 .add(of("name != 'Klaus'", metadataKey("name").isNotEqualTo("Klaus")))
@@ -77,8 +81,11 @@ class SqlFilterParserTest {
                 .add(of("name IN ('Klaus', 'Francine')", metadataKey("name").isIn("Klaus", "Francine")))
                 .add(of("age IN (18, 42)", metadataKey("age").isIn(18L, 42L)))
                 .add(of("age IN (-18, 42)", metadataKey("age").isIn(-18L, 42L)))
+                .add(of("age IN (+18, 42)", metadataKey("age").isIn(18L, 42L)))
+                .add(of("age IN (-9223372036854775808)", metadataKey("age").isIn(Long.MIN_VALUE)))
                 .add(of("weight IN (67.8, 78.9)", metadataKey("weight").isIn(67.8d, 78.9d)))
                 .add(of("weight IN (-67.8, 78.9)", metadataKey("weight").isIn(-67.8d, 78.9d)))
+                .add(of("weight IN (+67.8, 78.9)", metadataKey("weight").isIn(67.8d, 78.9d)))
 
                 // nin
                 .add(of("name NOT IN ('Klaus', 'Francine')", metadataKey("name").isNotIn("Klaus", "Francine")))
@@ -1523,6 +1530,10 @@ class SqlFilterParserTest {
                 .hasMessageContaining("Unsupported expression");
 
         assertThatThrownBy(() -> parser.parse("age IN (SELECT age FROM other_table)"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported expression");
+
+        assertThatThrownBy(() -> parser.parse("age IN (other_column)"))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported expression");
     }

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -7,6 +7,7 @@ import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import dev.langchain4j.data.document.Metadata;
@@ -75,12 +76,16 @@ class SqlFilterParserTest {
                 // in
                 .add(of("name IN ('Klaus', 'Francine')", metadataKey("name").isIn("Klaus", "Francine")))
                 .add(of("age IN (18, 42)", metadataKey("age").isIn(18L, 42L)))
+                .add(of("age IN (-18, 42)", metadataKey("age").isIn(-18L, 42L)))
                 .add(of("weight IN (67.8, 78.9)", metadataKey("weight").isIn(67.8d, 78.9d)))
+                .add(of("weight IN (-67.8, 78.9)", metadataKey("weight").isIn(-67.8d, 78.9d)))
 
                 // nin
                 .add(of("name NOT IN ('Klaus', 'Francine')", metadataKey("name").isNotIn("Klaus", "Francine")))
                 .add(of("age NOT IN (18, 42)", metadataKey("age").isNotIn(18L, 42L)))
+                .add(of("age NOT IN (-18, -42)", metadataKey("age").isNotIn(-18L, -42L)))
                 .add(of("weight NOT IN (67.8, 78.9)", metadataKey("weight").isNotIn(67.8d, 78.9d)))
+                .add(of("weight NOT IN (-67.8, -78.9)", metadataKey("weight").isNotIn(-67.8d, -78.9d)))
 
                 // and
                 .add(of(
@@ -1501,6 +1506,25 @@ class SqlFilterParserTest {
                 .isEqualTo(metadataKey("year")
                         .isEqualTo(2024L)
                         .and(metadataKey("genre").isIn("comedy", "drama")));
+    }
+
+    @Test
+    void should_support_arithmetic_and_date_functions_inside_IN_list() {
+
+        assertThat(parser.parse("year IN (YEAR(CURDATE()), YEAR(CURDATE()) - 1)"))
+                .isEqualTo(metadataKey("year").isIn(currentYear(), currentYear() - 1));
+    }
+
+    @Test
+    void should_fail_on_unsupported_expression_inside_IN_list() {
+
+        assertThatThrownBy(() -> parser.parse("age IN (1, NULL)"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported expression");
+
+        assertThatThrownBy(() -> parser.parse("age IN (SELECT age FROM other_table)"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported expression");
     }
 
     @Test


### PR DESCRIPTION
## Issue

Closes #6036

## Change

`mapInExpression` collected the elements of an `IN` / `NOT IN` list with an `ExpressionVisitorAdapter` that overrode only `visit(StringValue)`, `visit(LongValue)` and `visit(DoubleValue)`. JSqlParser parses `-2` as a `SignedExpression` wrapping a `LongValue`, and the adapter has no override for it, so the default traversal descended into the wrapped value and the sign was dropped — silently, with no exception and no log.

The parser already knows how to read a negative literal: `getValue(Expression)` has an explicit `SignedExpression` branch, which is why `age = -2` parses correctly. Only the `IN` path went through the visitor. So the fix is to walk the list and reuse `getValue`:

```java
Expression rightExpression = inExpression.getRightExpression();
if (!(rightExpression instanceof ExpressionList<?> expressionList)) {
    throw illegalArgument(
            "Unsupported expression: '%s'%s", rightExpression, createGithubIssueLink(rightExpression));
}

Collection<Object> comparisonValues = new ArrayList<>();
for (Expression expression : expressionList) {
    comparisonValues.add(getValue(expression));
}
```

The guard is needed because `IN (SELECT ...)` gives a `ParenthesedSelect`, not an `ExpressionList`.

### Behaviour delta

I replayed the pre-change collection logic and the post-change parser side by side over a corpus of 33 `IN` / `NOT IN` expressions — the 19 that already appear in `SqlFilterParserTest`, verbatim, plus 14 probing the changed surface. Both sides are funnelled through the same `IsIn` construction so that the set-normalisation `IsIn` performs cannot masquerade as a delta. All 19 existing expressions are unchanged; the 7 deltas are:

| SQL | Before | After |
|---|---|---|
| `age IN (1, -2, 3)` | `[1, 2, 3]` | `[1, -2, 3]` |
| `age NOT IN (-1)` | `[1]` | `[-1]` |
| `weight IN (-1.5, 2.5)` | `[2.5, 1.5]` | `[2.5, -1.5]` |
| `weight NOT IN (-1.5, -2.5)` | `[2.5, 1.5]` | `[-2.5, -1.5]` |
| `age IN (1 + 1)` | `[1]` | `[2]` |
| `age IN (1, NULL)` | `[1]` | `IllegalArgumentException` |
| `year IN (YEAR(CURDATE()))` | `IllegalArgumentException` (`comparisonValues ... cannot be null or empty`) | `[2026]` |

The first four are the reported defect. The next two follow from reusing `getValue`: arithmetic and date functions now resolve inside a list exactly as they already do on the right-hand side of `=`.

The last two are the ones worth a second look. `IN (1, NULL)` previously produced a filter silently missing an element; it now raises the parser's standard `Unsupported expression` error with the issue link, which is how every other unsupported node in this class is already handled. `IN (SELECT ...)` also threw before and still throws — the message changes from `comparisonValues with key 'age' cannot be null or empty` (raised by `IsIn` on the empty collection the visitor produced) to `Unsupported expression`, which points at the actual cause.

### Tests

`SqlFilterParserTest` gains four `should_parse` cases (negative `IN`/`NOT IN`, long and double) and two `@Test`s covering arithmetic/date functions inside a list and the negative cases above. On `main` the four `should_parse` cases fail with the sign stripped; the rest of the suite is unaffected.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- The class Javadoc already documents `IsIn`/`IsNotIn` as supported, without restricting the literals allowed in the list, so no documentation change is needed. -->

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
