### PR TITLE
Add thinking support to google-genai

### DIFF
--- a/docs/docs/integrations/language-models/google-genai.md
+++ b/docs/docs/integrations/language-models/google-genai.md
@@ -447,7 +447,7 @@ ChatModel gemini = GoogleGenAiChatModel.builder()
 
 Set `includeThoughts(true)` to ask the model to return
 [thought summaries](https://ai.google.dev/gemini-api/docs/generate-content/thinking) along with the answer,
-and `returnThinking(true)` to have them mapped to `AiMessage.thinking()` instead of `AiMessage.text()`:
+and `returnThinking(true)` to have them mapped to `AiMessage.thinking()`:
 
 ```java
 ChatModel gemini = GoogleGenAiChatModel.builder()
@@ -472,8 +472,8 @@ To send thought summaries back to the model in follow-up requests, set `sendThin
 preserved, regardless of this setting.
 
 > [!NOTE]
-> `returnThinking` is not enabled by default. When it is left unset, thought summaries are included in
-> `AiMessage.text()`, which is how this integration behaved before these options were introduced.
+> `returnThinking` is disabled by default. Thought summaries returned by the model are then discarded and
+> never appear in `AiMessage.text()`.
 
 ## GoogleGenAiEmbeddingModel
 

--- a/docs/docs/integrations/language-models/google-genai.md
+++ b/docs/docs/integrations/language-models/google-genai.md
@@ -443,6 +443,38 @@ ChatModel gemini = GoogleGenAiChatModel.builder()
 > [!TIP]
 > The LangChain4j `google-genai` integration seamlessly manages the complex state required for multi-turn tool execution with thinking models. It automatically persists and injects the necessary hidden `thought_signature` tokens across conversation turns, ensuring robust and uninterrupted agentic workflows!
 
+### Thought summaries
+
+Set `includeThoughts(true)` to ask the model to return
+[thought summaries](https://ai.google.dev/gemini-api/docs/generate-content/thinking) along with the answer,
+and `returnThinking(true)` to have them mapped to `AiMessage.thinking()` instead of `AiMessage.text()`:
+
+```java
+ChatModel gemini = GoogleGenAiChatModel.builder()
+    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
+    .modelName("gemini-3.1-pro-preview")
+    .thinkingLevel("MEDIUM")
+    .includeThoughts(true)
+    .returnThinking(true)
+    .build();
+
+ChatResponse response = gemini.chat(UserMessage.from("What is 6 times 7?"));
+
+String thinking = response.aiMessage().thinking();
+String answer = response.aiMessage().text();
+```
+
+When streaming, thought summaries are delivered through `StreamingChatResponseHandler.onPartialThinking()`
+while the answer continues to arrive through `onPartialResponse()`.
+
+To send thought summaries back to the model in follow-up requests, set `sendThinking(true)`. The
+`thought_signature` tokens required for multi-turn tool execution are handled independently and are always
+preserved, regardless of this setting.
+
+> [!NOTE]
+> `returnThinking` is not enabled by default. When it is left unset, thought summaries are included in
+> `AiMessage.text()`, which is how this integration behaved before these options were introduced.
+
 ## GoogleGenAiEmbeddingModel
 
 The `GoogleGenAiEmbeddingModel` allows you to generate embeddings for text segments using models like `gemini-embedding-2`.

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
@@ -61,7 +61,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
     private final Integer thinkingBudget;
     private final String thinkingLevel;
     private final Boolean includeThoughts;
-    private final Boolean returnThinking;
+    private final boolean returnThinking;
     private final boolean sendThinking;
     private final Integer seed;
     private final boolean googleSearchEnabled;
@@ -81,7 +81,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
         this.thinkingBudget = builder.thinkingBudget;
         this.thinkingLevel = builder.thinkingLevel;
         this.includeThoughts = builder.includeThoughts;
-        this.returnThinking = builder.returnThinking;
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
         this.googleSearchEnabled = getOrDefault(builder.googleSearch, false);
@@ -379,10 +379,6 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
          * <p>
          * Disabled by default.
          * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
-         * <p>
-         * Please note that when {@code returnThinking} is not set (is {@code null}), thinking text is included
-         * in the {@link AiMessage#text()} field, preserving the behaviour of this module
-         * before this option was introduced.
          *
          * @see #includeThoughts(Boolean)
          * @see #sendThinking(Boolean)

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModel.java
@@ -21,6 +21,7 @@ import com.google.genai.types.JobState;
 import com.google.genai.types.JobState.Known;
 import com.google.genai.types.SafetySetting;
 import dev.langchain4j.Experimental;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.batch.BatchItemResult;
 import dev.langchain4j.model.batch.BatchPage;
 import dev.langchain4j.model.batch.BatchPagination;
@@ -59,6 +60,9 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
     private final List<SafetySetting> safetySettings;
     private final Integer thinkingBudget;
     private final String thinkingLevel;
+    private final Boolean includeThoughts;
+    private final Boolean returnThinking;
+    private final boolean sendThinking;
     private final Integer seed;
     private final boolean googleSearchEnabled;
     private final boolean googleMapsEnabled;
@@ -76,6 +80,9 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
         this.safetySettings = copy(builder.safetySettings);
         this.thinkingBudget = builder.thinkingBudget;
         this.thinkingLevel = builder.thinkingLevel;
+        this.includeThoughts = builder.includeThoughts;
+        this.returnThinking = builder.returnThinking;
+        this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
         this.googleSearchEnabled = getOrDefault(builder.googleSearch, false);
         this.googleMapsEnabled = getOrDefault(builder.googleMaps, false);
@@ -188,7 +195,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
 
     private InlinedRequest createInlinedRequest(ChatRequest request) {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(request.messages());
-        List<Content> contents = GoogleGenAiContentMapper.toContents(request.messages());
+        List<Content> contents = GoogleGenAiContentMapper.toContents(request.messages(), sendThinking);
 
         ChatRequestParameters params = defaultRequestParameters != null
                 ? defaultRequestParameters.overrideWith(request.parameters())
@@ -200,6 +207,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
                 safetySettings,
                 thinkingBudget,
                 thinkingLevel,
+                includeThoughts,
                 seed,
                 googleSearchEnabled,
                 googleMapsEnabled,
@@ -230,7 +238,7 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
                 for (var inlined : inlinedResponses) {
                     if (inlined.response().isPresent()) {
                         results.add(BatchItemResult.success(GoogleGenAiContentMapper.toChatResponse(
-                                inlined.response().get(), batchJob.model().orElse(modelName))));
+                                inlined.response().get(), batchJob.model().orElse(modelName), returnThinking)));
                     } else if (inlined.error().isPresent()) {
                         results.add(BatchItemResult.failure(GoogleGenAiBatchUtils.toBatchError(
                                 inlined.error().get())));
@@ -269,6 +277,9 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
         private Duration timeout;
         private Integer thinkingBudget;
         private String thinkingLevel;
+        private Boolean includeThoughts;
+        private Boolean returnThinking;
+        private Boolean sendThinking;
         private Integer seed;
         private Boolean googleSearch;
         private Boolean googleMaps;
@@ -341,6 +352,59 @@ public final class GoogleGenAiBatchChatModel implements BatchChatModel {
          */
         public Builder thinkingLevel(String thinkingLevel) {
             this.thinkingLevel = thinkingLevel;
+            return this;
+        }
+
+        /**
+         * Controls whether the model is asked to include
+         * <a href="https://ai.google.dev/gemini-api/docs/generate-content/thinking">thought summaries</a>
+         * in the response.
+         * <p>
+         * Not set by default. This does not control how much the model thinks;
+         * see {@link #thinkingBudget(Integer)} and {@link #thinkingLevel(String)} for that.
+         *
+         * @see #returnThinking(Boolean)
+         * @see #sendThinking(Boolean)
+         */
+        public Builder includeThoughts(Boolean includeThoughts) {
+            this.includeThoughts = includeThoughts;
+            return this;
+        }
+
+        /**
+         * Controls whether to return thinking/reasoning text (if available) inside {@link AiMessage#thinking()}.
+         * Please note that this does not enable thinking/reasoning for the LLM;
+         * it only controls whether to parse the {@code thought} parts of the API response
+         * and return them inside the {@link AiMessage}.
+         * <p>
+         * Disabled by default.
+         * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
+         * <p>
+         * Please note that when {@code returnThinking} is not set (is {@code null}), thinking text is included
+         * in the {@link AiMessage#text()} field, preserving the behaviour of this module
+         * before this option was introduced.
+         *
+         * @see #includeThoughts(Boolean)
+         * @see #sendThinking(Boolean)
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        /**
+         * Controls whether to send thinking/reasoning text to the LLM in follow-up requests.
+         * <p>
+         * Disabled by default.
+         * If enabled, the contents of {@link AiMessage#thinking()} will be sent in the API request.
+         * <p>
+         * Thought signatures required for function calling are handled independently of this setting.
+         *
+         * @see #includeThoughts(Boolean)
+         * @see #returnThinking(Boolean)
+         */
+        public Builder sendThinking(Boolean sendThinking) {
+            this.sendThinking = sendThinking;
             return this;
         }
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
@@ -11,6 +11,7 @@ import com.google.genai.types.Content;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.SafetySetting;
 import dev.langchain4j.Experimental;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.ChatModel;
@@ -44,6 +45,9 @@ public class GoogleGenAiChatModel implements ChatModel {
     private final List<SafetySetting> safetySettings;
     private final Integer thinkingBudget;
     private final String thinkingLevel;
+    private final Boolean includeThoughts;
+    private final Boolean returnThinking;
+    private final boolean sendThinking;
     private final Integer seed;
     private final boolean googleSearchEnabled;
     private final boolean googleMapsEnabled;
@@ -64,6 +68,9 @@ public class GoogleGenAiChatModel implements ChatModel {
         this.allowedFunctionNames = copy(builder.allowedFunctionNames);
         this.thinkingBudget = builder.thinkingBudget;
         this.thinkingLevel = builder.thinkingLevel;
+        this.includeThoughts = builder.includeThoughts;
+        this.returnThinking = builder.returnThinking;
+        this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
         this.safetySettings = copy(builder.safetySettings);
         this.vertexSearchDatastore = builder.vertexSearchDatastore;
@@ -108,7 +115,7 @@ public class GoogleGenAiChatModel implements ChatModel {
     @Override
     public ChatResponse doChat(ChatRequest chatRequest) {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
-        List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
+        List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages(), sendThinking);
 
         GoogleGenAiChatRequestParameters parameters = (GoogleGenAiChatRequestParameters) chatRequest.parameters();
 
@@ -118,6 +125,7 @@ public class GoogleGenAiChatModel implements ChatModel {
                 safetySettings,
                 thinkingBudget,
                 thinkingLevel,
+                includeThoughts,
                 seed,
                 googleSearchEnabled,
                 googleMapsEnabled,
@@ -141,7 +149,8 @@ public class GoogleGenAiChatModel implements ChatModel {
                 maxRetries,
                 GoogleGenAiExceptionMapper.INSTANCE);
 
-        ChatResponse response = GoogleGenAiContentMapper.toChatResponse(result, chatRequest.modelName());
+        ChatResponse response =
+                GoogleGenAiContentMapper.toChatResponse(result, chatRequest.modelName(), returnThinking);
 
         if (logResponses) {
             log.info("Response:\n- model: {}\n- response: {}", chatRequest.modelName(), response);
@@ -190,6 +199,9 @@ public class GoogleGenAiChatModel implements ChatModel {
         private Integer maxOutputTokens;
         private Integer thinkingBudget;
         private String thinkingLevel;
+        private Boolean includeThoughts;
+        private Boolean returnThinking;
+        private Boolean sendThinking;
         private Integer seed;
         private Integer maxRetries;
         private List<String> stopSequences;
@@ -390,6 +402,59 @@ public class GoogleGenAiChatModel implements ChatModel {
          */
         public Builder thinkingLevel(String thinkingLevel) {
             this.thinkingLevel = thinkingLevel;
+            return this;
+        }
+
+        /**
+         * Controls whether the model is asked to include
+         * <a href="https://ai.google.dev/gemini-api/docs/generate-content/thinking">thought summaries</a>
+         * in the response.
+         * <p>
+         * Not set by default. This does not control how much the model thinks;
+         * see {@link #thinkingBudget(Integer)} and {@link #thinkingLevel(String)} for that.
+         *
+         * @see #returnThinking(Boolean)
+         * @see #sendThinking(Boolean)
+         */
+        public Builder includeThoughts(Boolean includeThoughts) {
+            this.includeThoughts = includeThoughts;
+            return this;
+        }
+
+        /**
+         * Controls whether to return thinking/reasoning text (if available) inside {@link AiMessage#thinking()}.
+         * Please note that this does not enable thinking/reasoning for the LLM;
+         * it only controls whether to parse the {@code thought} parts of the API response
+         * and return them inside the {@link AiMessage}.
+         * <p>
+         * Disabled by default.
+         * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
+         * <p>
+         * Please note that when {@code returnThinking} is not set (is {@code null}), thinking text is included
+         * in the {@link AiMessage#text()} field, preserving the behaviour of this module
+         * before this option was introduced.
+         *
+         * @see #includeThoughts(Boolean)
+         * @see #sendThinking(Boolean)
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        /**
+         * Controls whether to send thinking/reasoning text to the LLM in follow-up requests.
+         * <p>
+         * Disabled by default.
+         * If enabled, the contents of {@link AiMessage#thinking()} will be sent in the API request.
+         * <p>
+         * Thought signatures required for function calling are handled independently of this setting.
+         *
+         * @see #includeThoughts(Boolean)
+         * @see #returnThinking(Boolean)
+         */
+        public Builder sendThinking(Boolean sendThinking) {
+            this.sendThinking = sendThinking;
             return this;
         }
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
@@ -46,7 +46,7 @@ public class GoogleGenAiChatModel implements ChatModel {
     private final Integer thinkingBudget;
     private final String thinkingLevel;
     private final Boolean includeThoughts;
-    private final Boolean returnThinking;
+    private final boolean returnThinking;
     private final boolean sendThinking;
     private final Integer seed;
     private final boolean googleSearchEnabled;
@@ -69,7 +69,7 @@ public class GoogleGenAiChatModel implements ChatModel {
         this.thinkingBudget = builder.thinkingBudget;
         this.thinkingLevel = builder.thinkingLevel;
         this.includeThoughts = builder.includeThoughts;
-        this.returnThinking = builder.returnThinking;
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
         this.safetySettings = copy(builder.safetySettings);
@@ -429,10 +429,6 @@ public class GoogleGenAiChatModel implements ChatModel {
          * <p>
          * Disabled by default.
          * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
-         * <p>
-         * Please note that when {@code returnThinking} is not set (is {@code null}), thinking text is included
-         * in the {@link AiMessage#text()} field, preserving the behaviour of this module
-         * before this option was introduced.
          *
          * @see #includeThoughts(Boolean)
          * @see #sendThinking(Boolean)

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiConfigBuilder.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiConfigBuilder.java
@@ -35,6 +35,7 @@ class GoogleGenAiConfigBuilder {
             List<SafetySetting> safetySettings,
             Integer thinkingBudget,
             String thinkingLevel,
+            Boolean includeThoughts,
             Integer seed,
             boolean googleSearchEnabled,
             boolean googleMapsEnabled,
@@ -49,6 +50,7 @@ class GoogleGenAiConfigBuilder {
                 safetySettings,
                 thinkingBudget,
                 thinkingLevel,
+                includeThoughts,
                 seed,
                 googleSearchEnabled,
                 googleMapsEnabled,
@@ -66,6 +68,7 @@ class GoogleGenAiConfigBuilder {
             List<SafetySetting> safetySettings,
             Integer thinkingBudget,
             String thinkingLevel,
+            Boolean includeThoughts,
             Integer seed,
             boolean googleSearchEnabled,
             boolean googleMapsEnabled,
@@ -118,13 +121,16 @@ class GoogleGenAiConfigBuilder {
             throw new IllegalArgumentException("Cannot use both thinkingBudget and thinkingLevel at the same time");
         }
 
-        if (thinkingBudget != null || thinkingLevel != null) {
+        if (thinkingBudget != null || thinkingLevel != null || includeThoughts != null) {
             ThinkingConfig.Builder thinkingBuilder = ThinkingConfig.builder();
             if (thinkingBudget != null) {
                 thinkingBuilder.thinkingBudget(thinkingBudget);
             }
             if (thinkingLevel != null) {
                 thinkingBuilder.thinkingLevel(new ThinkingLevel(thinkingLevel));
+            }
+            if (includeThoughts != null) {
+                thinkingBuilder.includeThoughts(includeThoughts);
             }
             configBuilder.thinkingConfig(thinkingBuilder.build());
         }

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
@@ -225,10 +225,10 @@ class GoogleGenAiContentMapper {
     }
 
     static ChatResponse toChatResponse(GenerateContentResponse response, String modelName) {
-        return toChatResponse(response, modelName, null);
+        return toChatResponse(response, modelName, false);
     }
 
-    static ChatResponse toChatResponse(GenerateContentResponse response, String modelName, Boolean returnThinking) {
+    static ChatResponse toChatResponse(GenerateContentResponse response, String modelName, boolean returnThinking) {
         List<Candidate> candidates = response.candidates().orElse(List.of());
 
         if (candidates.isEmpty()) {
@@ -255,10 +255,8 @@ class GoogleGenAiContentMapper {
             for (Part part : parts) {
                 if (part.text().isPresent()) {
                     if (part.thought().orElse(false)) {
-                        if (Boolean.TRUE.equals(returnThinking)) {
+                        if (returnThinking) {
                             thinkingBuilder.append(part.text().get());
-                        } else if (returnThinking == null) {
-                            textBuilder.append(part.text().get());
                         }
                     } else {
                         textBuilder.append(part.text().get());

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
@@ -103,6 +103,9 @@ class GoogleGenAiContentMapper {
     private static final String MODEL_ROLE = "model";
     private static final String FUNCTION_ROLE = "function";
 
+    private static final String THOUGHT_SIGNATURE_KEY_PREFIX =
+            "thought_signature_"; // do not change, will break backward compatibility!
+
     static Content toSystemInstruction(List<ChatMessage> messages) {
         String systemInstructions = messages.stream()
                 .filter(m -> m instanceof SystemMessage)
@@ -210,7 +213,7 @@ class GoogleGenAiContentMapper {
                     Part.Builder partBuilder = Part.builder().functionCall(fcBuilder.build());
 
                     if (req.id() != null) {
-                        String sigBase64 = aiMsg.attribute("thought_signature_" + req.id(), String.class);
+                        String sigBase64 = aiMsg.attribute(THOUGHT_SIGNATURE_KEY_PREFIX + req.id(), String.class);
                         if (sigBase64 != null) {
                             partBuilder.thoughtSignature(Base64.getDecoder().decode(sigBase64));
                         }
@@ -278,7 +281,8 @@ class GoogleGenAiContentMapper {
                     if (part.thoughtSignature().isPresent()) {
                         byte[] sig = part.thoughtSignature().get();
                         attributes.put(
-                                "thought_signature_" + id, Base64.getEncoder().encodeToString(sig));
+                                THOUGHT_SIGNATURE_KEY_PREFIX + id,
+                                Base64.getEncoder().encodeToString(sig));
                     }
 
                     toolRequests.add(ToolExecutionRequest.builder()

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
@@ -120,6 +120,10 @@ class GoogleGenAiContentMapper {
     }
 
     static List<Content> toContents(List<ChatMessage> messages) {
+        return toContents(messages, false);
+    }
+
+    static List<Content> toContents(List<ChatMessage> messages, boolean sendThinking) {
         List<Content> contents = new ArrayList<>();
         List<Part> currentFunctionParts = new ArrayList<>();
 
@@ -156,7 +160,7 @@ class GoogleGenAiContentMapper {
                             .build());
                     currentFunctionParts = new ArrayList<>();
                 }
-                contents.add(toContent(message));
+                contents.add(toContent(message, sendThinking));
             }
         }
 
@@ -171,11 +175,18 @@ class GoogleGenAiContentMapper {
     }
 
     static Content toContent(ChatMessage message) {
+        return toContent(message, false);
+    }
+
+    static Content toContent(ChatMessage message, boolean sendThinking) {
         if (message instanceof UserMessage userMessage) {
             return Content.builder().role(USER_ROLE).parts(toParts(userMessage)).build();
 
         } else if (message instanceof AiMessage aiMsg) {
             List<Part> parts = new ArrayList<>();
+            if (sendThinking && !isNullOrEmpty(aiMsg.thinking())) {
+                parts.add(Part.builder().text(aiMsg.thinking()).thought(true).build());
+            }
             if (aiMsg.text() != null) {
                 parts.add(Part.builder().text(aiMsg.text()).build());
             }
@@ -214,6 +225,10 @@ class GoogleGenAiContentMapper {
     }
 
     static ChatResponse toChatResponse(GenerateContentResponse response, String modelName) {
+        return toChatResponse(response, modelName, null);
+    }
+
+    static ChatResponse toChatResponse(GenerateContentResponse response, String modelName, Boolean returnThinking) {
         List<Candidate> candidates = response.candidates().orElse(List.of());
 
         if (candidates.isEmpty()) {
@@ -231,13 +246,24 @@ class GoogleGenAiContentMapper {
         Content content = candidate.content().orElse(null);
 
         StringBuilder textBuilder = new StringBuilder();
+        StringBuilder thinkingBuilder = new StringBuilder();
         List<ToolExecutionRequest> toolRequests = new ArrayList<>();
         Map<String, Object> attributes = new HashMap<>();
 
         if (content != null) {
             List<Part> parts = content.parts().orElse(List.of());
             for (Part part : parts) {
-                if (part.text().isPresent()) textBuilder.append(part.text().get());
+                if (part.text().isPresent()) {
+                    if (part.thought().orElse(false)) {
+                        if (Boolean.TRUE.equals(returnThinking)) {
+                            thinkingBuilder.append(part.text().get());
+                        } else if (returnThinking == null) {
+                            textBuilder.append(part.text().get());
+                        }
+                    } else {
+                        textBuilder.append(part.text().get());
+                    }
+                }
 
                 if (part.functionCall().isPresent()) {
                     FunctionCall fc = part.functionCall().get();
@@ -276,6 +302,10 @@ class GoogleGenAiContentMapper {
             aiMessageBuilder.toolExecutionRequests(toolRequests);
         } else {
             aiMessageBuilder.text(text);
+        }
+
+        if (thinkingBuilder.length() > 0) {
+            aiMessageBuilder.thinking(thinkingBuilder.toString());
         }
 
         if (!attributes.isEmpty()) {

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
@@ -27,6 +27,7 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
@@ -55,6 +56,9 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
     private final List<SafetySetting> safetySettings;
     private final Integer thinkingBudget;
     private final String thinkingLevel;
+    private final Boolean includeThoughts;
+    private final Boolean returnThinking;
+    private final boolean sendThinking;
     private final Integer seed;
     private final boolean googleSearchEnabled;
     private final boolean googleMapsEnabled;
@@ -76,6 +80,9 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         this.allowedFunctionNames = copy(builder.allowedFunctionNames);
         this.thinkingBudget = builder.thinkingBudget;
         this.thinkingLevel = builder.thinkingLevel;
+        this.includeThoughts = builder.includeThoughts;
+        this.returnThinking = builder.returnThinking;
+        this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
         this.safetySettings = copy(builder.safetySettings);
         this.vertexSearchDatastore = builder.vertexSearchDatastore;
@@ -124,7 +131,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         String modelName = chatRequest.modelName();
 
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
-        List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
+        List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages(), sendThinking);
 
         GoogleGenAiChatRequestParameters parameters = (GoogleGenAiChatRequestParameters) chatRequest.parameters();
 
@@ -134,6 +141,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                 safetySettings,
                 thinkingBudget,
                 thinkingLevel,
+                includeThoughts,
                 seed,
                 googleSearchEnabled,
                 googleMapsEnabled,
@@ -161,6 +169,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                         client.models.generateContentStream(modelName, contents, config);
 
                 StringBuilder textBuilder = new StringBuilder();
+                StringBuilder thinkingBuilder = new StringBuilder();
                 List<ToolExecutionRequest> toolRequests = new ArrayList<>();
                 Map<String, Object> attributes = new java.util.HashMap<>();
                 TokenUsage tokenUsage = new TokenUsage();
@@ -172,12 +181,22 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                 for (GenerateContentResponse chunk : stream) {
                     trackingHandler.resetMappingTracking();
                     lastChunk = chunk;
-                    ChatResponse partialResponse = GoogleGenAiContentMapper.toChatResponse(chunk, modelName);
+                    ChatResponse partialResponse =
+                            GoogleGenAiContentMapper.toChatResponse(chunk, modelName, returnThinking);
                     AiMessage aiMessage = partialResponse.aiMessage();
 
                     if (aiMessage.attributes() != null
                             && !aiMessage.attributes().isEmpty()) {
                         attributes.putAll(aiMessage.attributes());
+                    }
+
+                    if (aiMessage.thinking() != null && !aiMessage.thinking().isEmpty()) {
+                        thinkingBuilder.append(aiMessage.thinking());
+                        try {
+                            trackingHandler.onPartialThinking(new PartialThinking(aiMessage.thinking()));
+                        } catch (Exception userException) {
+                            trackingHandler.onError(userException);
+                        }
                     }
 
                     if (aiMessage.text() != null && !aiMessage.text().isEmpty()) {
@@ -222,6 +241,12 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                     finalAiMessage = AiMessage.from(toolRequests);
                 } else {
                     finalAiMessage = AiMessage.from(textBuilder.toString());
+                }
+
+                if (thinkingBuilder.length() > 0) {
+                    finalAiMessage = finalAiMessage.toBuilder()
+                            .thinking(thinkingBuilder.toString())
+                            .build();
                 }
 
                 if (!attributes.isEmpty()) {
@@ -287,6 +312,9 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         private Double temperature, topP, frequencyPenalty, presencePenalty;
         private Integer topK, maxOutputTokens, thinkingBudget, seed;
         private String thinkingLevel;
+        private Boolean includeThoughts;
+        private Boolean returnThinking;
+        private Boolean sendThinking;
         private List<String> stopSequences;
         private Duration timeout;
         private Boolean googleSearch;
@@ -486,6 +514,61 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
          */
         public Builder thinkingLevel(String thinkingLevel) {
             this.thinkingLevel = thinkingLevel;
+            return this;
+        }
+
+        /**
+         * Controls whether the model is asked to include
+         * <a href="https://ai.google.dev/gemini-api/docs/generate-content/thinking">thought summaries</a>
+         * in the response.
+         * <p>
+         * Not set by default. This does not control how much the model thinks;
+         * see {@link #thinkingBudget(Integer)} and {@link #thinkingLevel(String)} for that.
+         *
+         * @see #returnThinking(Boolean)
+         * @see #sendThinking(Boolean)
+         */
+        public Builder includeThoughts(Boolean includeThoughts) {
+            this.includeThoughts = includeThoughts;
+            return this;
+        }
+
+        /**
+         * Controls whether to return thinking/reasoning text (if available) inside {@link AiMessage#thinking()}
+         * and to invoke {@link StreamingChatResponseHandler#onPartialThinking(PartialThinking)}.
+         * Please note that this does not enable thinking/reasoning for the LLM;
+         * it only controls whether to parse the {@code thought} parts of the API response
+         * and return them inside the {@link AiMessage}.
+         * <p>
+         * Disabled by default.
+         * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
+         * <p>
+         * Please note that when {@code returnThinking} is not set (is {@code null}), thinking text is streamed
+         * through {@link StreamingChatResponseHandler#onPartialResponse(String)} and included in the
+         * {@link AiMessage#text()} field, preserving the behaviour of this module
+         * before this option was introduced.
+         *
+         * @see #includeThoughts(Boolean)
+         * @see #sendThinking(Boolean)
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        /**
+         * Controls whether to send thinking/reasoning text to the LLM in follow-up requests.
+         * <p>
+         * Disabled by default.
+         * If enabled, the contents of {@link AiMessage#thinking()} will be sent in the API request.
+         * <p>
+         * Thought signatures required for function calling are handled independently of this setting.
+         *
+         * @see #includeThoughts(Boolean)
+         * @see #returnThinking(Boolean)
+         */
+        public Builder sendThinking(Boolean sendThinking) {
+            this.sendThinking = sendThinking;
             return this;
         }
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
@@ -57,7 +57,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
     private final Integer thinkingBudget;
     private final String thinkingLevel;
     private final Boolean includeThoughts;
-    private final Boolean returnThinking;
+    private final boolean returnThinking;
     private final boolean sendThinking;
     private final Integer seed;
     private final boolean googleSearchEnabled;
@@ -81,7 +81,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         this.thinkingBudget = builder.thinkingBudget;
         this.thinkingLevel = builder.thinkingLevel;
         this.includeThoughts = builder.includeThoughts;
-        this.returnThinking = builder.returnThinking;
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.seed = builder.seed;
         this.safetySettings = copy(builder.safetySettings);
@@ -542,11 +542,6 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
          * <p>
          * Disabled by default.
          * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
-         * <p>
-         * Please note that when {@code returnThinking} is not set (is {@code null}), thinking text is streamed
-         * through {@link StreamingChatResponseHandler#onPartialResponse(String)} and included in the
-         * {@link AiMessage#text()} field, preserving the behaviour of this module
-         * before this option was introduced.
          *
          * @see #includeThoughts(Boolean)
          * @see #sendThinking(Boolean)

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiBatchChatModelTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -11,18 +12,30 @@ import com.google.genai.Batches;
 import com.google.genai.Client;
 import com.google.genai.Pager;
 import com.google.genai.types.BatchJob;
+import com.google.genai.types.BatchJobDestination;
+import com.google.genai.types.BatchJobSource;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.CreateBatchJobConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.InlinedRequest;
+import com.google.genai.types.InlinedResponse;
 import com.google.genai.types.JobState;
 import com.google.genai.types.JobState.Known;
 import com.google.genai.types.ListBatchJobsConfig;
+import com.google.genai.types.Part;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.batch.BatchPage;
 import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class GoogleGenAiBatchChatModelTest {
 
@@ -84,5 +97,91 @@ class GoogleGenAiBatchChatModelTest {
                                 .messages(UserMessage.from("hello"))
                                 .build())))
                 .isSameAs(fromCustomizer);
+    }
+
+    @Test
+    void should_wire_thinking_options_into_the_batch_request() throws Exception {
+        Client client = mock(Client.class);
+        Batches batchesService = mock(Batches.class);
+        Field batchesField = Client.class.getDeclaredField("batches");
+        batchesField.setAccessible(true);
+        batchesField.set(client, batchesService);
+
+        BatchJob batchJob = mock(BatchJob.class);
+        when(batchJob.name()).thenReturn(Optional.of("batches/1"));
+        JobState jobState = mock(JobState.class);
+        when(jobState.knownEnum()).thenReturn(Known.JOB_STATE_RUNNING);
+        when(batchJob.state()).thenReturn(Optional.of(jobState));
+        when(batchesService.create(any(String.class), any(BatchJobSource.class), any(CreateBatchJobConfig.class)))
+                .thenReturn(batchJob);
+
+        GoogleGenAiBatchChatModel batchModel = GoogleGenAiBatchChatModel.builder()
+                .client(client)
+                .modelName("gemini-2.5-flash")
+                .includeThoughts(true)
+                .sendThinking(true)
+                .build();
+
+        AiMessage previousAnswer =
+                AiMessage.builder().text("42").thinking("Six times seven.").build();
+        ChatRequest request = ChatRequest.builder()
+                .modelName("gemini-2.5-flash")
+                .messages(UserMessage.from("What is 6 times 7?"), previousAnswer, UserMessage.from("Are you sure?"))
+                .build();
+
+        batchModel.submit(new BatchRequest<>(List.of(request)));
+
+        ArgumentCaptor<BatchJobSource> sourceCaptor = ArgumentCaptor.forClass(BatchJobSource.class);
+        verify(batchesService).create(any(String.class), sourceCaptor.capture(), any(CreateBatchJobConfig.class));
+
+        InlinedRequest inlined =
+                sourceCaptor.getValue().inlinedRequests().orElseThrow().get(0);
+
+        assertThat(inlined.config().orElseThrow().thinkingConfig().orElseThrow().includeThoughts())
+                .hasValue(true);
+
+        List<Part> aiParts = inlined.contents().orElseThrow().get(1).parts().orElseThrow();
+        assertThat(aiParts.get(0).thought()).hasValue(true);
+        assertThat(aiParts.get(0).text()).hasValue("Six times seven.");
+    }
+
+    @Test
+    void should_map_thought_summary_from_a_completed_batch_when_return_thinking_is_enabled() throws Exception {
+        Client client = mock(Client.class);
+        Batches batchesService = mock(Batches.class);
+        Field batchesField = Client.class.getDeclaredField("batches");
+        batchesField.setAccessible(true);
+        batchesField.set(client, batchesService);
+
+        Content content = Content.builder()
+                .parts(
+                        Part.builder().text("Six times seven.").thought(true).build(),
+                        Part.builder().text("42").build())
+                .build();
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(Candidate.builder().content(content).build())
+                .build();
+        BatchJob batchJob = BatchJob.builder()
+                .name("batches/1")
+                .model("gemini-2.5-flash")
+                .state(new JobState(Known.JOB_STATE_SUCCEEDED.toString()))
+                .dest(BatchJobDestination.builder()
+                        .inlinedResponses(
+                                InlinedResponse.builder().response(response).build())
+                        .build())
+                .build();
+        when(batchesService.get(any(String.class), any())).thenReturn(batchJob);
+
+        GoogleGenAiBatchChatModel batchModel = GoogleGenAiBatchChatModel.builder()
+                .client(client)
+                .modelName("gemini-2.5-flash")
+                .returnThinking(true)
+                .build();
+
+        AiMessage aiMessage =
+                batchModel.retrieve("batches/1").results().get(0).response().aiMessage();
+
+        assertThat(aiMessage.thinking()).isEqualTo("Six times seven.");
+        assertThat(aiMessage.text()).isEqualTo("42");
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelTest.java
@@ -123,6 +123,9 @@ class GoogleGenAiChatModelTest {
                 .presencePenalty(0.3)
                 .maxOutputTokens(1024)
                 .thinkingBudget(500)
+                .includeThoughts(true)
+                .returnThinking(true)
+                .sendThinking(true)
                 .seed(42)
                 .stopSequences(List.of("STOP"))
                 .maxRetries(5)
@@ -166,6 +169,9 @@ class GoogleGenAiChatModelTest {
         assertThat(builder.presencePenalty(0.3)).isSameAs(builder);
         assertThat(builder.maxOutputTokens(100)).isSameAs(builder);
         assertThat(builder.thinkingBudget(500)).isSameAs(builder);
+        assertThat(builder.includeThoughts(true)).isSameAs(builder);
+        assertThat(builder.returnThinking(true)).isSameAs(builder);
+        assertThat(builder.sendThinking(true)).isSameAs(builder);
         assertThat(builder.seed(42)).isSameAs(builder);
         assertThat(builder.stopSequences(List.of("STOP"))).isSameAs(builder);
         assertThat(builder.maxRetries(3)).isSameAs(builder);

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelThinkingIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelThinkingIT.java
@@ -15,7 +15,6 @@ class GoogleGenAiChatModelThinkingIT {
     private static final String MODEL_NAME = "gemini-2.5-flash";
 
     private static final UserMessage QUESTION = UserMessage.from("What are the best tourist spots in San Francisco?");
-    private static final UserMessage QUESTION_WITH_A_SHORT_ANSWER = UserMessage.from("What is the capital of Germany?");
 
     private static GoogleGenAiChatModel.Builder modelBuilder() {
         return GoogleGenAiChatModel.builder()
@@ -45,18 +44,12 @@ class GoogleGenAiChatModelThinkingIT {
     }
 
     @Test
-    void should_return_thinking_inside_text_when_return_thinking_is_not_set() {
-        AiMessage notSet =
-                modelBuilder().build().chat(QUESTION_WITH_A_SHORT_ANSWER).aiMessage();
-        AiMessage answerOnly = modelBuilder()
-                .returnThinking(true)
-                .build()
-                .chat(QUESTION_WITH_A_SHORT_ANSWER)
-                .aiMessage();
+    void should_not_return_thinking_when_return_thinking_is_not_set() {
+        ChatResponse chatResponse = modelBuilder().build().chat(QUESTION);
 
-        assertThat(notSet.thinking()).isNull();
-        assertThat(notSet.text()).containsIgnoringCase("Berlin");
-        assertThat(notSet.text().length()).isGreaterThan(answerOnly.text().length());
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Golden Gate");
+        assertThat(aiMessage.thinking()).isNull();
     }
 
     @Test

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelThinkingIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelThinkingIT.java
@@ -1,0 +1,78 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
+class GoogleGenAiChatModelThinkingIT {
+
+    private static final String GOOGLE_AI_GEMINI_API_KEY = System.getenv("GOOGLE_AI_GEMINI_API_KEY");
+    private static final String MODEL_NAME = "gemini-2.5-flash";
+
+    private static final UserMessage QUESTION = UserMessage.from("What are the best tourist spots in San Francisco?");
+    private static final UserMessage QUESTION_WITH_A_SHORT_ANSWER = UserMessage.from("What is the capital of Germany?");
+
+    private static GoogleGenAiChatModel.Builder modelBuilder() {
+        return GoogleGenAiChatModel.builder()
+                .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                .modelName(MODEL_NAME)
+                .thinkingBudget(1024)
+                .includeThoughts(true);
+    }
+
+    @Test
+    void should_return_thinking() {
+        ChatResponse chatResponse = modelBuilder().returnThinking(true).build().chat(QUESTION);
+
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Golden Gate");
+        assertThat(aiMessage.thinking()).isNotBlank();
+        assertThat(aiMessage.text()).doesNotContain(aiMessage.thinking());
+    }
+
+    @Test
+    void should_not_return_thinking() {
+        ChatResponse chatResponse = modelBuilder().returnThinking(false).build().chat(QUESTION);
+
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Golden Gate");
+        assertThat(aiMessage.thinking()).isNull();
+    }
+
+    @Test
+    void should_return_thinking_inside_text_when_return_thinking_is_not_set() {
+        AiMessage notSet =
+                modelBuilder().build().chat(QUESTION_WITH_A_SHORT_ANSWER).aiMessage();
+        AiMessage answerOnly = modelBuilder()
+                .returnThinking(true)
+                .build()
+                .chat(QUESTION_WITH_A_SHORT_ANSWER)
+                .aiMessage();
+
+        assertThat(notSet.thinking()).isNull();
+        assertThat(notSet.text()).containsIgnoringCase("Berlin");
+        assertThat(notSet.text().length()).isGreaterThan(answerOnly.text().length());
+    }
+
+    @Test
+    void should_send_thinking_in_a_follow_up_request() {
+        AiMessage answer = AiMessage.builder()
+                .text("Start with the Golden Gate Bridge.")
+                .thinking("The user wants sightseeing recommendations for San Francisco. The landmark most visitors "
+                        + "start with is the Golden Gate Bridge, followed by Alcatraz Island and Fisherman's Wharf.")
+                .build();
+        UserMessage followUp = UserMessage.from("Which of those is best at sunset?");
+
+        ChatResponse sent = modelBuilder().sendThinking(true).build().chat(QUESTION, answer, followUp);
+        ChatResponse notSent = modelBuilder().sendThinking(false).build().chat(QUESTION, answer, followUp);
+
+        assertThat(sent.aiMessage().text()).isNotBlank();
+        assertThat(sent.tokenUsage().inputTokenCount())
+                .isGreaterThan(notSent.tokenUsage().inputTokenCount());
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiConfigBuilderTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiConfigBuilderTest.java
@@ -36,7 +36,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config).isNotNull();
         assertThat(config.temperature().get()).isEqualTo(0.7f);
@@ -54,7 +54,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config).isNotNull();
     }
@@ -68,7 +68,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build());
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, safetySettings, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, safetySettings, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config.safetySettings().get()).hasSize(1);
     }
@@ -79,7 +79,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, List.of(), null, null, null, false, false, false, null, null, null, null);
+                parameters, null, List.of(), null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config).isNotNull();
     }
@@ -92,7 +92,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config.responseMimeType().get()).isEqualTo("application/json");
         assertThat(config.responseSchema().isPresent()).isFalse();
@@ -112,7 +112,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config.responseMimeType().get()).isEqualTo("application/json");
         assertThat(config.responseSchema().isPresent()).isTrue();
@@ -125,7 +125,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, 1024, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, 1024, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config.thinkingConfig().get().thinkingBudget().get()).isEqualTo(1024);
     }
@@ -136,7 +136,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, "MEDIUM", null, false, false, false, null, null, null, null);
+                parameters, null, null, null, "MEDIUM", null, null, false, false, false, null, null, null, null);
 
         assertThat(config.thinkingConfig().get().thinkingLevel().get().toString())
                 .contains("MEDIUM");
@@ -148,7 +148,20 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         assertThatThrownBy(() -> GoogleGenAiConfigBuilder.buildConfig(
-                        parameters, null, null, 1024, "MEDIUM", null, false, false, false, null, null, null, null))
+                        parameters,
+                        null,
+                        null,
+                        1024,
+                        "MEDIUM",
+                        null,
+                        null,
+                        false,
+                        false,
+                        false,
+                        null,
+                        null,
+                        null,
+                        null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Cannot use both thinkingBudget and thinkingLevel at the same time");
     }
@@ -160,6 +173,7 @@ class GoogleGenAiConfigBuilderTest {
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
                 parameters,
+                null,
                 null,
                 null,
                 null,
@@ -183,7 +197,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, 42, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, 42, false, false, false, null, null, null, null);
 
         assertThat(config.seed().get()).isEqualTo(42);
     }
@@ -198,7 +212,20 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, systemInstruction, null, null, null, null, false, false, false, null, null, null, null);
+                parameters,
+                systemInstruction,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                false,
+                null,
+                null,
+                null,
+                null);
 
         assertThat(config.systemInstruction().get().parts().get().get(0).text().get())
                 .isEqualTo("Be helpful");
@@ -219,7 +246,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config.tools().get()).isNotEmpty();
         assertThat(config.toolConfig()
@@ -245,7 +272,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config.toolConfig()
                         .get()
@@ -270,7 +297,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config.toolConfig()
                         .get()
@@ -294,7 +321,20 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, List.of("getWeather"), null, null, null);
+                parameters,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                false,
+                List.of("getWeather"),
+                null,
+                null,
+                null);
 
         assertThat(config.toolConfig()
                         .get()
@@ -311,7 +351,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, true, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, true, false, false, null, null, null, null);
 
         assertThat(config.tools().get()).hasSize(1);
         assertThat(config.tools().get().get(0).googleSearch().isPresent()).isTrue();
@@ -323,7 +363,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, true, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, true, false, null, null, null, null);
 
         assertThat(config.tools().get()).hasSize(1);
         assertThat(config.tools().get().get(0).googleMaps().isPresent()).isTrue();
@@ -335,7 +375,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, true, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, true, null, null, null, null);
 
         assertThat(config.tools().get()).hasSize(1);
         assertThat(config.tools().get().get(0).urlContext().isPresent()).isTrue();
@@ -347,7 +387,7 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, true, true, true, null, null, null, null);
+                parameters, null, null, null, null, null, null, true, true, true, null, null, null, null);
 
         assertThat(config.tools().get()).hasSize(3);
         assertThat(config.tools().get().get(0).googleSearch().isPresent()).isTrue();
@@ -367,7 +407,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, true, true, true, null, null, null, null);
+                parameters, null, null, null, null, null, null, true, true, true, null, null, null, null);
 
         assertThat(config.tools().get()).hasSize(4);
         assertThat(config.tools().get().get(0).functionDeclarations().get()).isNotEmpty();
@@ -388,7 +428,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, true, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, true, false, false, null, null, null, null);
 
         assertThat(config.tools().get()).hasSize(2);
         assertThat(config.tools().get().get(0).functionDeclarations().get()).isNotEmpty();
@@ -403,7 +443,7 @@ class GoogleGenAiConfigBuilderTest {
                 .build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
 
         assertThat(config).isNotNull();
     }
@@ -415,6 +455,7 @@ class GoogleGenAiConfigBuilderTest {
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
                 parameters,
+                null,
                 null,
                 null,
                 null,
@@ -460,7 +501,7 @@ class GoogleGenAiConfigBuilderTest {
         labels.put("team", "billing");
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, labels, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, labels, null);
 
         assertThat(config.labels().isPresent()).isTrue();
         assertThat(config.labels().get()).containsEntry("env", "prod").containsEntry("team", "billing");
@@ -473,6 +514,7 @@ class GoogleGenAiConfigBuilderTest {
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
                 parameters,
+                null,
                 null,
                 null,
                 null,
@@ -497,6 +539,7 @@ class GoogleGenAiConfigBuilderTest {
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
                 parameters,
+                null,
                 null,
                 null,
                 null,
@@ -531,6 +574,7 @@ class GoogleGenAiConfigBuilderTest {
                 null,
                 null,
                 null,
+                null,
                 false,
                 false,
                 false,
@@ -550,8 +594,66 @@ class GoogleGenAiConfigBuilderTest {
                 DefaultChatRequestParameters.builder().temperature(0.7).build();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                parameters, null, null, null, null, null, false, false, false, null, null, null, null, null);
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null, null);
 
         assertThat(config.temperature().get()).isEqualTo(0.7f);
+    }
+
+    @Test
+    void should_set_include_thoughts() {
+        ChatRequestParameters parameters =
+                DefaultChatRequestParameters.builder().build();
+
+        GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
+                parameters, null, null, null, null, true, null, false, false, false, null, null, null, null);
+
+        assertThat(config.thinkingConfig().get().includeThoughts()).hasValue(true);
+    }
+
+    @Test
+    void should_set_include_thoughts_to_false() {
+        ChatRequestParameters parameters =
+                DefaultChatRequestParameters.builder().build();
+
+        GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
+                parameters, null, null, null, null, false, null, false, false, false, null, null, null, null);
+
+        assertThat(config.thinkingConfig().get().includeThoughts()).hasValue(false);
+    }
+
+    @Test
+    void should_not_set_thinking_config_when_no_thinking_option_is_set() {
+        ChatRequestParameters parameters =
+                DefaultChatRequestParameters.builder().build();
+
+        GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
+                parameters, null, null, null, null, null, null, false, false, false, null, null, null, null);
+
+        assertThat(config.thinkingConfig()).isEmpty();
+    }
+
+    @Test
+    void should_set_include_thoughts_together_with_thinking_budget() {
+        ChatRequestParameters parameters =
+                DefaultChatRequestParameters.builder().build();
+
+        GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
+                parameters, null, null, 1024, null, true, null, false, false, false, null, null, null, null);
+
+        assertThat(config.thinkingConfig().get().thinkingBudget()).hasValue(1024);
+        assertThat(config.thinkingConfig().get().includeThoughts()).hasValue(true);
+    }
+
+    @Test
+    void should_set_include_thoughts_together_with_thinking_level() {
+        ChatRequestParameters parameters =
+                DefaultChatRequestParameters.builder().build();
+
+        GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
+                parameters, null, null, null, "MEDIUM", true, null, false, false, false, null, null, null, null);
+
+        assertThat(config.thinkingConfig().get().thinkingLevel().get().toString())
+                .contains("MEDIUM");
+        assertThat(config.thinkingConfig().get().includeThoughts()).hasValue(true);
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
@@ -628,12 +628,11 @@ class GoogleGenAiContentMapperTest {
     }
 
     @Test
-    void should_keep_thought_summary_in_text_when_return_thinking_is_not_set() {
-        ChatResponse result =
-                GoogleGenAiContentMapper.toChatResponse(responseWithThoughtAndAnswer(), "test-model", null);
+    void should_drop_thought_summary_when_return_thinking_is_not_set() {
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(responseWithThoughtAndAnswer(), "test-model");
 
         assertThat(result.aiMessage().thinking()).isNull();
-        assertThat(result.aiMessage().text()).isEqualTo("Let me work through this.42");
+        assertThat(result.aiMessage().text()).isEqualTo("42");
     }
 
     @Test

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
@@ -592,4 +592,190 @@ class GoogleGenAiContentMapperTest {
     void should_map_null_finish_reason_to_other() {
         assertThat(GoogleGenAiContentMapper.mapFinishReason(null)).isEqualTo(FinishReason.OTHER);
     }
+
+    private static GenerateContentResponse responseWithThoughtAndAnswer() {
+        return GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(
+                                        Part.builder()
+                                                .text("Let me work through this.")
+                                                .thought(true)
+                                                .build(),
+                                        Part.builder().text("42").build()))
+                                .build())
+                        .build()))
+                .build();
+    }
+
+    @Test
+    void should_return_thought_summary_in_thinking_when_return_thinking_is_true() {
+        ChatResponse result =
+                GoogleGenAiContentMapper.toChatResponse(responseWithThoughtAndAnswer(), "test-model", true);
+
+        assertThat(result.aiMessage().thinking()).isEqualTo("Let me work through this.");
+        assertThat(result.aiMessage().text()).isEqualTo("42");
+    }
+
+    @Test
+    void should_drop_thought_summary_when_return_thinking_is_false() {
+        ChatResponse result =
+                GoogleGenAiContentMapper.toChatResponse(responseWithThoughtAndAnswer(), "test-model", false);
+
+        assertThat(result.aiMessage().thinking()).isNull();
+        assertThat(result.aiMessage().text()).isEqualTo("42");
+    }
+
+    @Test
+    void should_keep_thought_summary_in_text_when_return_thinking_is_not_set() {
+        ChatResponse result =
+                GoogleGenAiContentMapper.toChatResponse(responseWithThoughtAndAnswer(), "test-model", null);
+
+        assertThat(result.aiMessage().thinking()).isNull();
+        assertThat(result.aiMessage().text()).isEqualTo("Let me work through this.42");
+    }
+
+    @Test
+    void should_concatenate_multiple_thought_parts() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(
+                                        Part.builder().text("foo").thought(true).build(),
+                                        Part.builder().text("bar").thought(true).build(),
+                                        Part.builder().text("answer").build()))
+                                .build())
+                        .build()))
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model", true);
+
+        assertThat(result.aiMessage().thinking()).isEqualTo("foobar");
+        assertThat(result.aiMessage().text()).isEqualTo("answer");
+    }
+
+    @Test
+    void should_treat_part_without_thought_flag_as_regular_text() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(Part.builder().text("plain").build()))
+                                .build())
+                        .build()))
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model", true);
+
+        assertThat(result.aiMessage().thinking()).isNull();
+        assertThat(result.aiMessage().text()).isEqualTo("plain");
+    }
+
+    @Test
+    void should_return_thought_summary_alongside_tool_call_and_signature() {
+        FunctionCall functionCall = FunctionCall.builder()
+                .name("get_weather")
+                .id("call_1")
+                .args(Map.of("city", "Paris"))
+                .build();
+
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(
+                                        Part.builder()
+                                                .text("I should call the tool.")
+                                                .thought(true)
+                                                .build(),
+                                        Part.builder()
+                                                .functionCall(functionCall)
+                                                .thoughtSignature("sig".getBytes())
+                                                .build()))
+                                .build())
+                        .build()))
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model", true);
+
+        assertThat(result.aiMessage().thinking()).isEqualTo("I should call the tool.");
+        assertThat(result.aiMessage().hasToolExecutionRequests()).isTrue();
+        assertThat(result.aiMessage().attribute("thought_signature_call_1", String.class))
+                .isEqualTo(Base64.getEncoder().encodeToString("sig".getBytes()));
+    }
+
+    @Test
+    void should_send_thinking_as_thought_part_before_text_when_send_thinking_is_true() {
+        AiMessage message = AiMessage.builder()
+                .text("The answer is 42.")
+                .thinking("Working it out.")
+                .build();
+
+        Content result = GoogleGenAiContentMapper.toContent(message, true);
+
+        List<Part> parts = result.parts().orElseThrow();
+        assertThat(parts).hasSize(2);
+        assertThat(parts.get(0).text()).hasValue("Working it out.");
+        assertThat(parts.get(0).thought()).hasValue(true);
+        assertThat(parts.get(1).text()).hasValue("The answer is 42.");
+        assertThat(parts.get(1).thought()).isEmpty();
+    }
+
+    @Test
+    void should_not_send_thinking_when_send_thinking_is_false() {
+        AiMessage message = AiMessage.builder()
+                .text("The answer is 42.")
+                .thinking("Working it out.")
+                .build();
+
+        Content result = GoogleGenAiContentMapper.toContent(message, false);
+
+        List<Part> parts = result.parts().orElseThrow();
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).text()).hasValue("The answer is 42.");
+    }
+
+    @Test
+    void should_not_add_thought_part_when_message_has_no_thinking() {
+        AiMessage message = AiMessage.from("The answer is 42.");
+
+        Content result = GoogleGenAiContentMapper.toContent(message, true);
+
+        List<Part> parts = result.parts().orElseThrow();
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).thought()).isEmpty();
+    }
+
+    @Test
+    void should_reattach_function_call_thought_signature_when_send_thinking_is_false() {
+        AiMessage message = AiMessage.builder()
+                .toolExecutionRequests(List.of(ToolExecutionRequest.builder()
+                        .id("call_1")
+                        .name("get_weather")
+                        .arguments("{\"city\":\"Paris\"}")
+                        .build()))
+                .attributes(
+                        Map.of("thought_signature_call_1", Base64.getEncoder().encodeToString("sig".getBytes())))
+                .build();
+
+        Content result = GoogleGenAiContentMapper.toContent(message, false);
+
+        List<Part> parts = result.parts().orElseThrow();
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).thoughtSignature()).hasValue("sig".getBytes());
+    }
+
+    @Test
+    void should_preserve_empty_text_part_when_send_thinking_is_false() {
+        AiMessage message = AiMessage.from("");
+
+        Content result = GoogleGenAiContentMapper.toContent(message, false);
+
+        List<Part> parts = result.parts().orElseThrow();
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).text()).hasValue("");
+        assertThat(parts.get(0).thought()).isEmpty();
+    }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
@@ -471,7 +471,7 @@ class GoogleGenAiStreamingChatModelTest {
     }
 
     @Test
-    void should_stream_thought_summary_as_partial_response_when_return_thinking_is_not_set() throws Exception {
+    void should_drop_thought_summary_when_return_thinking_is_not_set() throws Exception {
         GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
                 .client(clientStreamingThoughtAndAnswer())
                 .modelName("gemini-3.5-flash")
@@ -482,9 +482,9 @@ class GoogleGenAiStreamingChatModelTest {
         ChatResponse response = stream(model, partialResponses, partialThinking);
 
         assertThat(partialThinking).isEmpty();
-        assertThat(partialResponses).containsExactly("Thinking it over.42");
+        assertThat(partialResponses).containsExactly("42");
         assertThat(response.aiMessage().thinking()).isNull();
-        assertThat(response.aiMessage().text()).isEqualTo("Thinking it over.42");
+        assertThat(response.aiMessage().text()).isEqualTo("42");
     }
 
     @Test

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
@@ -24,10 +24,12 @@ import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -133,6 +135,9 @@ class GoogleGenAiStreamingChatModelTest {
                 .presencePenalty(0.3)
                 .maxOutputTokens(1024)
                 .thinkingBudget(500)
+                .includeThoughts(true)
+                .returnThinking(true)
+                .sendThinking(true)
                 .seed(42)
                 .stopSequences(List.of("STOP"))
                 .safetySettings(List.of(SafetySetting.builder().build()))
@@ -176,6 +181,9 @@ class GoogleGenAiStreamingChatModelTest {
         assertThat(builder.presencePenalty(0.3)).isSameAs(builder);
         assertThat(builder.maxOutputTokens(100)).isSameAs(builder);
         assertThat(builder.thinkingBudget(500)).isSameAs(builder);
+        assertThat(builder.includeThoughts(true)).isSameAs(builder);
+        assertThat(builder.returnThinking(true)).isSameAs(builder);
+        assertThat(builder.sendThinking(true)).isSameAs(builder);
         assertThat(builder.seed(42)).isSameAs(builder);
         assertThat(builder.stopSequences(List.of("STOP"))).isSameAs(builder);
         assertThat(builder.timeout(Duration.ofSeconds(10))).isSameAs(builder);
@@ -389,5 +397,217 @@ class GoogleGenAiStreamingChatModelTest {
 
         assertThat(configCaptor.getValue().cachedContent())
                 .contains("projects/123/locations/us-central1/cachedContents/per-request");
+    }
+
+    private static Client clientStreamingThoughtAndAnswer() throws Exception {
+        Client client = mock(Client.class);
+        Models models = mock(Models.class);
+        Field modelsField = Client.class.getDeclaredField("models");
+        modelsField.setAccessible(true);
+        modelsField.set(client, models);
+
+        @SuppressWarnings("unchecked")
+        ResponseStream<GenerateContentResponse> stream = mock(ResponseStream.class);
+        when(models.generateContentStream(any(String.class), any(List.class), any()))
+                .thenReturn(stream);
+
+        Content content = Content.builder()
+                .role("model")
+                .parts(List.of(
+                        Part.builder().text("Thinking it over.").thought(true).build(),
+                        Part.builder().text("42").build()))
+                .build();
+        GenerateContentResponse chunk = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder().content(content).build()))
+                .build();
+        when(stream.iterator()).thenReturn(List.of(chunk).iterator());
+        return client;
+    }
+
+    private static ChatResponse stream(
+            GoogleGenAiStreamingChatModel model, List<String> partialResponses, List<String> partialThinking)
+            throws Exception {
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        model.chat(List.of(UserMessage.from("What is 6 times 7?")), new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                partialResponses.add(partialResponse);
+            }
+
+            @Override
+            public void onPartialThinking(PartialThinking thinking) {
+                partialThinking.add(thinking.text());
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+        return future.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void should_report_thought_summary_through_on_partial_thinking_when_return_thinking_is_true() throws Exception {
+        GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
+                .client(clientStreamingThoughtAndAnswer())
+                .modelName("gemini-3.5-flash")
+                .returnThinking(true)
+                .build();
+
+        List<String> partialResponses = new ArrayList<>();
+        List<String> partialThinking = new ArrayList<>();
+        ChatResponse response = stream(model, partialResponses, partialThinking);
+
+        assertThat(partialThinking).containsExactly("Thinking it over.");
+        assertThat(partialResponses).containsExactly("42");
+        assertThat(response.aiMessage().thinking()).isEqualTo("Thinking it over.");
+        assertThat(response.aiMessage().text()).isEqualTo("42");
+    }
+
+    @Test
+    void should_stream_thought_summary_as_partial_response_when_return_thinking_is_not_set() throws Exception {
+        GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
+                .client(clientStreamingThoughtAndAnswer())
+                .modelName("gemini-3.5-flash")
+                .build();
+
+        List<String> partialResponses = new ArrayList<>();
+        List<String> partialThinking = new ArrayList<>();
+        ChatResponse response = stream(model, partialResponses, partialThinking);
+
+        assertThat(partialThinking).isEmpty();
+        assertThat(partialResponses).containsExactly("Thinking it over.42");
+        assertThat(response.aiMessage().thinking()).isNull();
+        assertThat(response.aiMessage().text()).isEqualTo("Thinking it over.42");
+    }
+
+    @Test
+    void should_drop_thought_summary_when_return_thinking_is_false() throws Exception {
+        GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
+                .client(clientStreamingThoughtAndAnswer())
+                .modelName("gemini-3.5-flash")
+                .returnThinking(false)
+                .build();
+
+        List<String> partialResponses = new ArrayList<>();
+        List<String> partialThinking = new ArrayList<>();
+        ChatResponse response = stream(model, partialResponses, partialThinking);
+
+        assertThat(partialThinking).isEmpty();
+        assertThat(partialResponses).containsExactly("42");
+        assertThat(response.aiMessage().thinking()).isNull();
+        assertThat(response.aiMessage().text()).isEqualTo("42");
+    }
+
+    @Test
+    void should_accumulate_thought_summaries_across_streaming_chunks() throws Exception {
+        Client client = mock(Client.class);
+        Models models = mock(Models.class);
+        Field modelsField = Client.class.getDeclaredField("models");
+        modelsField.setAccessible(true);
+        modelsField.set(client, models);
+
+        @SuppressWarnings("unchecked")
+        ResponseStream<GenerateContentResponse> stream = mock(ResponseStream.class);
+        when(models.generateContentStream(any(String.class), any(List.class), any()))
+                .thenReturn(stream);
+
+        GenerateContentResponse firstChunk = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(Part.builder()
+                                        .text("Six ")
+                                        .thought(true)
+                                        .build()))
+                                .build())
+                        .build()))
+                .build();
+        GenerateContentResponse secondChunk = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(
+                                        Part.builder()
+                                                .text("times seven.")
+                                                .thought(true)
+                                                .build(),
+                                        Part.builder().text("42").build()))
+                                .build())
+                        .build()))
+                .build();
+        when(stream.iterator()).thenReturn(List.of(firstChunk, secondChunk).iterator());
+
+        GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
+                .client(client)
+                .modelName("gemini-3.5-flash")
+                .returnThinking(true)
+                .build();
+
+        List<String> partialResponses = new ArrayList<>();
+        List<String> partialThinking = new ArrayList<>();
+        ChatResponse response = stream(model, partialResponses, partialThinking);
+
+        assertThat(partialThinking).containsExactly("Six ", "times seven.");
+        assertThat(partialResponses).containsExactly("42");
+        assertThat(response.aiMessage().thinking()).isEqualTo("Six times seven.");
+        assertThat(response.aiMessage().text()).isEqualTo("42");
+    }
+
+    @Test
+    void should_keep_both_thought_summary_and_tool_call_signature_when_streaming() throws Exception {
+        Client client = mock(Client.class);
+        Models models = mock(Models.class);
+        Field modelsField = Client.class.getDeclaredField("models");
+        modelsField.setAccessible(true);
+        modelsField.set(client, models);
+
+        @SuppressWarnings("unchecked")
+        ResponseStream<GenerateContentResponse> stream = mock(ResponseStream.class);
+        when(models.generateContentStream(any(String.class), any(List.class), any()))
+                .thenReturn(stream);
+
+        FunctionCall functionCall = FunctionCall.builder()
+                .name("get_weather")
+                .id("call_1")
+                .args(Map.of("city", "Paris"))
+                .build();
+        GenerateContentResponse chunk = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(
+                                        Part.builder()
+                                                .text("I should call the tool.")
+                                                .thought(true)
+                                                .build(),
+                                        Part.builder()
+                                                .functionCall(functionCall)
+                                                .thoughtSignature("sig".getBytes())
+                                                .build()))
+                                .build())
+                        .build()))
+                .build();
+        when(stream.iterator()).thenReturn(List.of(chunk).iterator());
+
+        GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
+                .client(client)
+                .modelName("gemini-3.5-flash")
+                .returnThinking(true)
+                .build();
+
+        ChatResponse response = stream(model, new ArrayList<>(), new ArrayList<>());
+        AiMessage aiMessage = response.aiMessage();
+
+        assertThat(aiMessage.thinking()).isEqualTo("I should call the tool.");
+        assertThat(aiMessage.hasToolExecutionRequests()).isTrue();
+        assertThat(aiMessage.attribute("thought_signature_call_1", String.class))
+                .isEqualTo(Base64.getEncoder().encodeToString("sig".getBytes()));
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelThinkingIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelThinkingIT.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
+class GoogleGenAiStreamingChatModelThinkingIT {
+
+    private static final String GOOGLE_AI_GEMINI_API_KEY = System.getenv("GOOGLE_AI_GEMINI_API_KEY");
+    private static final String MODEL_NAME = "gemini-2.5-flash";
+
+    private static GoogleGenAiStreamingChatModel.Builder modelBuilder() {
+        return GoogleGenAiStreamingChatModel.builder()
+                .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                .modelName(MODEL_NAME)
+                .thinkingBudget(1024)
+                .includeThoughts(true);
+    }
+
+    private static ChatResponse chat(
+            StreamingChatModel model, List<String> partialResponses, List<String> partialThinking) throws Exception {
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        model.chat(
+                List.of(UserMessage.from("What are the best tourist spots in San Francisco?")),
+                new StreamingChatResponseHandler() {
+                    @Override
+                    public void onPartialResponse(String partialResponse) {
+                        partialResponses.add(partialResponse);
+                    }
+
+                    @Override
+                    public void onPartialThinking(PartialThinking thinking) {
+                        partialThinking.add(thinking.text());
+                    }
+
+                    @Override
+                    public void onCompleteResponse(ChatResponse completeResponse) {
+                        future.complete(completeResponse);
+                    }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        future.completeExceptionally(error);
+                    }
+                });
+        return future.get(120, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void should_stream_thinking() throws Exception {
+        StreamingChatModel model = modelBuilder().returnThinking(true).build();
+
+        List<String> partialResponses = new ArrayList<>();
+        List<String> partialThinking = new ArrayList<>();
+        ChatResponse chatResponse = chat(model, partialResponses, partialThinking);
+
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(partialThinking).isNotEmpty();
+        assertThat(aiMessage.thinking()).isEqualTo(String.join("", partialThinking));
+        assertThat(aiMessage.text()).containsIgnoringCase("Golden Gate");
+        assertThat(String.join("", partialResponses)).isEqualTo(aiMessage.text());
+    }
+
+    @Test
+    void should_not_stream_thinking() throws Exception {
+        StreamingChatModel model = modelBuilder().returnThinking(false).build();
+
+        List<String> partialResponses = new ArrayList<>();
+        List<String> partialThinking = new ArrayList<>();
+        ChatResponse chatResponse = chat(model, partialResponses, partialThinking);
+
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(partialThinking).isEmpty();
+        assertThat(aiMessage.thinking()).isNull();
+        assertThat(aiMessage.text()).containsIgnoringCase("Golden Gate");
+    }
+}


### PR DESCRIPTION
## Issue

  Closes #5965

  ## Change

  Adds `includeThoughts`, `returnThinking` and `sendThinking` to `GoogleGenAiChatModel`,
  `GoogleGenAiStreamingChatModel` and `GoogleGenAiBatchChatModel`.

  - `includeThoughts` maps onto `ThinkingConfig.includeThoughts`, next to `thinkingBudget` and
    `thinkingLevel`, which `GoogleGenAiConfigBuilder` already mapped. Setting it through
    `generateContentConfigCustomizer` is not equivalent: that replaces `thinkingConfig` wholesale, so it
    silently drops a `thinkingBudget` or `thinkingLevel` configured on the builder.
  - With `returnThinking` enabled, parts carrying the `thought` flag map to `AiMessage.thinking()`
    instead of being appended to `AiMessage.text()`, and streaming reports them through
    `onPartialThinking()`.
  - With `sendThinking` enabled, `AiMessage.thinking()` is sent back as a `thought` part.

  `returnThinking` and `sendThinking` are both disabled by default, matching `langchain4j-anthropic`
  and `langchain4j-open-ai`. When `returnThinking` is disabled, thought summaries returned by the model
  are discarded and never reach `AiMessage.text()`.

  `sendThinking` covers thinking text only. Function-call `thought_signature` round-tripping is
  unchanged and stays independent of it, because Gemini expects the signature back on the part it
  arrived on.

  ## Breaking Changes

  **Thought summaries are no longer included in `AiMessage.text()`.**

  Before this PR there was no supported way to request thought summaries from this module, but they
  could be enabled through `generateContentConfigCustomizer`. In that case the thought text was
  appended into `AiMessage.text()` alongside the answer. It is now discarded unless
  `returnThinking(true)` is set.

  To keep receiving thought summaries, set `includeThoughts(true)` and `returnThinking(true)`, and read
  them from `AiMessage.thinking()`:

  ```java
  // Before: thought summaries arrived merged into AiMessage.text()
  ChatModel gemini = GoogleGenAiChatModel.builder()
      .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
      .modelName("gemini-2.5-flash")      .generateContentConfigCustomizer(config -> config.thinkingConfig(
              ThinkingConfig.builder().includeThoughts(true).build()))
      .build();

  String thinkingAndAnswer = gemini.chat(UserMessage.from("...")).aiMessage().text();
  ```

  ```java
  // After: thought summaries are separate from the answer
  ChatModel gemini = GoogleGenAiChatModel.builder()
      .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
      .modelName("gemini-2.5-flash")
      .includeThoughts(true)
      .returnThinking(true)
      .build();

  AiMessage aiMessage = gemini.chat(UserMessage.from("...")).aiMessage();
  String thinking = aiMessage.thinking();
  String answer = aiMessage.text();
  ```

  When streaming, thought summaries are now delivered through
  `StreamingChatResponseHandler.onPartialThinking()` instead of `onPartialResponse()`.

  `GoogleGenAiChatModel` and `GoogleGenAiStreamingChatModel` are annotated `@Experimental`.

  ## Tests

  ```
  mvn -pl langchain4j-google-genai verify
  Tests run: 163, Failures: 0, Errors: 0, Skipped: 0   (revapi green, spotless:check clean)

  langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
  langchain4j:      Tests run: 1327, Failures: 0, Errors: 0, Skipped: 0
  ```

  Offline tests cover each flag on and off: thought summary separated or dropped; thought part emitted
  or not; the function-call signature still re-attached with `sendThinking` disabled; the streaming
  callbacks; and the batch request wiring.
  ```
  mvn -pl langchain4j-google-genai verify -Dtest='GoogleGenAi*ThinkingIT'
  Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
  ```

  `GoogleGenAiChatModelThinkingIT` and `GoogleGenAiStreamingChatModelThinkingIT` run against
  `gemini-2.5-flash` and cover each flag on and off, including that thinking reaches a follow-up
  request and that streaming delivers summaries through `onPartialThinking()`. Both are gated on
  `GOOGLE_AI_GEMINI_API_KEY` and are skipped without it. Note that CI does not expose this secret to
  PRs from forks, so these integration tests do not run there and need to be executed locally.

  ## Checklist

  - [ ] There are no breaking changes (API, behaviour)
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [X] I have manually run all the unit and integration tests in the `langchain4j-core` and `langchain4j` modules, and they are all green
  - [X] I have added/updated the documentation
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)