### PR TITLE
Fix Pinecone reserved text key being returned in metadata

### DIFF
--- a/langchain4j-pinecone/src/main/java/dev/langchain4j/store/embedding/pinecone/PineconeHelper.java
+++ b/langchain4j-pinecone/src/main/java/dev/langchain4j/store/embedding/pinecone/PineconeHelper.java
@@ -24,6 +24,9 @@ class PineconeHelper {
         Map<String, Object> metadataMap = new HashMap<>(filedsMap.size() - 1);
         for (Map.Entry<String, Value> entry : filedsMap.entrySet()) {
             String key = entry.getKey();
+            if (key.equals(metadataTextKey)) {
+                continue;
+            }
             Value value = entry.getValue();
 
             if (value.hasNumberValue()) {

--- a/langchain4j-pinecone/src/test/java/dev/langchain4j/store/embedding/pinecone/PineconeHelperTest.java
+++ b/langchain4j-pinecone/src/test/java/dev/langchain4j/store/embedding/pinecone/PineconeHelperTest.java
@@ -1,11 +1,14 @@
 package dev.langchain4j.store.embedding.pinecone;
 
 import static dev.langchain4j.store.embedding.pinecone.PineconeHelper.metadataToStruct;
+import static dev.langchain4j.store.embedding.pinecone.PineconeHelper.structToMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.segment.TextSegment;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class PineconeHelperTest {
@@ -54,5 +57,32 @@ class PineconeHelperTest {
         assertThat(struct.getFieldsMap()).containsOnlyKeys(DEFAULT_METADATA_TEXT_KEY);
         assertThat(struct.getFieldsMap().get(DEFAULT_METADATA_TEXT_KEY).getStringValue())
                 .isEqualTo("the real document");
+    }
+
+    @Test
+    void structToMetadata_should_exclude_the_text_key() {
+        Map<String, Value> fields =
+                Map.of(DEFAULT_METADATA_TEXT_KEY, string("the real document"), "source", string("manual"));
+
+        Map<String, Object> metadata = structToMetadata(fields, DEFAULT_METADATA_TEXT_KEY);
+
+        assertThat(metadata).containsExactly(Map.entry("source", "manual"));
+    }
+
+    @Test
+    void structToMetadata_should_exclude_a_custom_text_key() {
+        Map<String, Value> fields = Map.of("content", string("the real document"), "page", number(7));
+
+        Map<String, Object> metadata = structToMetadata(fields, "content");
+
+        assertThat(metadata).containsExactly(Map.entry("page", 7.0));
+    }
+
+    private static Value string(String value) {
+        return Value.newBuilder().setStringValue(value).build();
+    }
+
+    private static Value number(double value) {
+        return Value.newBuilder().setNumberValue(value).build();
     }
 }


### PR DESCRIPTION
## Issue

Closes #6042

## Change

`structToMetadata` copied every field of the record into the metadata map, including `metadataTextKey`,
so a retrieved `TextSegment` carried a metadata entry holding a second copy of its own text.

Excluding that key was already the intent: an early return handles the case where it is the only field,
and the map is sized `filedsMap.size() - 1`. It was just never skipped when other metadata was present.
Skipping it in the loop is the whole change, nothing else in the method is touched.

### Tests

Added to `PineconeHelperTest`, both failing on unmodified `main`:

- `structToMetadata_should_exclude_the_text_key`
- `structToMetadata_should_exclude_a_custom_text_key` (not tied to the default key)

```
mvn -pl langchain4j-pinecone test
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1327, Failures: 0, Errors: 0, Skipped: 0
```

`structToMetadata` maps in memory, so the unit tests cover it without a Pinecone index.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

