### PR TITLE
MCP: surface tool result `_meta` in `ToolExecutionResult.attributes()`

### DIFF
--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -256,6 +256,58 @@ that is retrieved from annotations - that one is exposed under the `McpToolMetad
 
 If the tool has icons, they are exposed under the `McpToolMetadataKeys.ICONS` key in the metadata map.
 
+### MCP tool result metadata
+
+Besides the actual result, an MCP server can attach a `_meta` object to the response of a tool call.
+This is useful for data that your application needs, but the LLM does not, for example an identifier
+of the record the tool has created, or a widget that your UI should render.
+
+The entries of the `_meta` object are exposed through `ToolExecutionResult.attributes()`, using their
+original keys, with the JSON values converted into nested maps. They are never sent to the LLM.
+Keys that are reserved by the MCP specification, such as `io.modelcontextprotocol/serverInfo`,
+are skipped, because they describe the protocol interaction and not the tool result.
+
+When calling a tool directly on the client, the attributes are always available:
+
+```java
+ToolExecutionResult result = mcpClient.executeTool(toolExecutionRequest);
+Object widget = result.attributes().get("example.org/widget");
+```
+
+When tools are called by an AI service, the attributes are dropped by default,
+because their size and contents are controlled by the MCP server.
+To keep them, enable `returnToolResultAttributes` on the tool provider:
+
+```java
+McpToolProvider toolProvider = McpToolProvider.builder()
+    .mcpClients(mcpClient)
+    .returnToolResultAttributes(true)
+    .build();
+```
+
+They can then be read from the tool executions of the result:
+
+```java
+interface Assistant {
+
+    Result<String> chat(String userMessage);
+}
+
+Result<String> result = assistant.chat("What is the weather in Munich?");
+for (ToolExecution toolExecution : result.toolExecutions()) {
+    Object widget = toolExecution.attributes().get("example.org/widget");
+}
+```
+
+The attributes are also propagated into the `ToolExecutionResultMessage`,
+so they are stored in the chat memory together with the message.
+Keep this in mind when the chat memory is persisted, and see
+[Tool Result Attributes](/tutorials/tools#tool-result-attributes) for more details.
+
+If the tool returns an application-level error, the call ends with a `ToolExecutionException`
+and the `_meta` of the failed response is not available.
+It is still delivered to `McpClientListener.afterExecuteTool()`, which receives the complete raw response.
+
 ## Providing `_meta` fields
 
 The MCP protocol allows clients to attach a `_meta` object to the `params` of every

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -1042,6 +1042,7 @@ ToolExecutionRequest request = toolExecution.request();
 String result = toolExecution.result(); // tool execution result as text
 List<Content> resultContents = toolExecution.resultContents(); // tool execution result as content list (may include images)
 Object resultObject = toolExecution.resultObject(); // actual value returned by the tool
+Map<String, Object> attributes = toolExecution.attributes(); // attributes of the tool execution result, see below
 ```
 
 In streaming mode, you can do so by specifying `onToolExecuted` callback:
@@ -1060,6 +1061,38 @@ tokenStream
     .onError(...)
     .start();
 ```
+
+### Tool Result Attributes
+
+A tool execution result can carry attributes: a `Map<String, Object>` that is **not** sent to the LLM.
+Attributes are useful for data that only your application needs, for example the ID of a record
+that the tool has created, or a widget that your UI should render.
+
+Attributes can be set by a custom `ToolExecutor`:
+```java
+ToolExecutor toolExecutor = (toolExecutionRequest, context) -> ToolExecutionResult.builder()
+        .resultText("Sunny, 22 degrees") // sent to the LLM
+        .attributes(Map.of("widget", weatherWidget)) // not sent to the LLM
+        .build();
+```
+For [MCP](/tutorials/mcp) tools, they originate from the `_meta` field of the tool call response.
+For those, the tool provider needs to be configured with
+[`returnToolResultAttributes(true)`](/tutorials/mcp#mcp-tool-result-metadata).
+
+Attributes can be read from the `ToolExecution` (see [Accessing Executed Tools](#accessing-executed-tools) above).
+They are also propagated into `ToolExecutionResultMessage.attributes()`,
+so they are stored in the [`ChatMemory`](/tutorials/chat-memory) together with the message.
+
+:::note
+If you use a `ChatMemoryStore` that persists messages, they are serialized to JSON.
+Make sure that all attribute values can be serialized to JSON and are useful once deserialized:
+- A value that cannot be serialized (for example an `InputStream`) will fail the whole store operation.
+- Values are deserialized as plain JSON types, so a custom object stored as an attribute
+comes back as a `Map` and can no longer be cast to its original type.
+
+Attributes are also stored for every message, so avoid putting large values there
+if the conversation is persisted.
+:::
 
 ### Specifying Tools Programmatically
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
@@ -7,6 +7,7 @@ import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -20,13 +21,20 @@ public class McpToolExecutor implements ToolExecutor {
     // this executor will always execute the tool with this name
     private final Optional<String> fixedToolName;
 
+    private final boolean returnToolResultAttributes;
+
     public McpToolExecutor(McpClient mcpClient) {
         this(mcpClient, null);
     }
 
     public McpToolExecutor(McpClient mcpClient, String fixedToolName) {
+        this(mcpClient, fixedToolName, false);
+    }
+
+    McpToolExecutor(McpClient mcpClient, String fixedToolName, boolean returnToolResultAttributes) {
         this.mcpClient = ensureNotNull(mcpClient, "mcpClient");
         this.fixedToolName = Optional.ofNullable(fixedToolName);
+        this.returnToolResultAttributes = returnToolResultAttributes;
     }
 
     @Override
@@ -41,7 +49,11 @@ public class McpToolExecutor implements ToolExecutor {
     @Override
     public ToolExecutionResult executeWithContext(
             ToolExecutionRequest executionRequest, InvocationContext invocationContext) {
-        return mcpClient.executeTool(sanitizeToolName(executionRequest), invocationContext);
+        ToolExecutionResult result = mcpClient.executeTool(sanitizeToolName(executionRequest), invocationContext);
+        if (returnToolResultAttributes || result.attributes().isEmpty()) {
+            return result;
+        }
+        return result.toBuilder().attributes(Map.of()).build();
     }
 
     private ToolExecutionRequest sanitizeToolName(ToolExecutionRequest executionRequest) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
@@ -46,6 +46,7 @@ public class McpToolProvider implements ToolProvider {
     private final AtomicReference<BiFunction<McpClient, ToolSpecification, String>> toolNameMapper;
     private final AtomicReference<BiFunction<McpClient, ToolSpecification, ToolSpecification>> toolSpecificationMapper;
     private final Set<String> alwaysVisibleToolNames;
+    private final boolean returnToolResultAttributes;
 
     private McpToolProvider(Builder builder) {
         this.mcpClients = new CopyOnWriteArrayList<>(builder.mcpClients);
@@ -56,6 +57,7 @@ public class McpToolProvider implements ToolProvider {
         this.toolNameMapper = new AtomicReference<>(builder.toolNameMapper);
         this.toolSpecificationMapper = new AtomicReference<>(builder.toolSpecificationMapper);
         this.alwaysVisibleToolNames = copy(builder.alwaysVisibleToolNames);
+        this.returnToolResultAttributes = Utils.getOrDefault(builder.returnToolResultAttributes, false);
     }
 
     protected McpToolProvider(
@@ -74,6 +76,7 @@ public class McpToolProvider implements ToolProvider {
         this.toolNameMapper = new AtomicReference<>(toolNameMapper);
         this.toolSpecificationMapper = new AtomicReference<>(toolSpecificationMapper);
         this.alwaysVisibleToolNames = Set.of();
+        this.returnToolResultAttributes = false;
     }
 
     /**
@@ -187,7 +190,8 @@ public class McpToolProvider implements ToolProvider {
                             newSpec = addSearchBehaviorMetadata(newSpec);
                         }
                         // lock down the created McpToolExecutor to the original 'real' tool name, not the mapped one
-                        ToolExecutor defaultToolExecutor = new McpToolExecutor(mcpClient, originalSpec.name());
+                        ToolExecutor defaultToolExecutor =
+                                new McpToolExecutor(mcpClient, originalSpec.name(), returnToolResultAttributes);
                         builder.add(newSpec, toolWrapper.apply(defaultToolExecutor));
                     }
                 }
@@ -241,6 +245,7 @@ public class McpToolProvider implements ToolProvider {
         private BiFunction<McpClient, ToolSpecification, String> toolNameMapper;
         private BiFunction<McpClient, ToolSpecification, ToolSpecification> toolSpecificationMapper;
         private Set<String> alwaysVisibleToolNames;
+        private Boolean returnToolResultAttributes;
 
         /**
          * The list of MCP clients to use for retrieving tools.
@@ -377,6 +382,21 @@ public class McpToolProvider implements ToolProvider {
          */
         public McpToolProvider.Builder alwaysVisibleToolNames(String... alwaysVisibleToolNames) {
             return alwaysVisibleToolNames(new HashSet<>(asList(alwaysVisibleToolNames)));
+        }
+
+        /**
+         * Controls whether the attributes of an MCP tool result, which for MCP tools originate from the
+         * {@code _meta} field of the tool call response, are returned to the AI service.
+         * Default: {@code false}.
+         * <p>
+         * Attributes are never sent to the LLM, but they are propagated into
+         * {@code ToolExecutionResultMessage.attributes()} and are therefore stored in the chat memory.
+         * Because their size and contents are controlled by the MCP server, they are dropped
+         * unless this option is enabled.
+         */
+        public McpToolProvider.Builder returnToolResultAttributes(Boolean returnToolResultAttributes) {
+            this.returnToolResultAttributes = returnToolResultAttributes;
+            return this;
         }
 
         public McpToolProvider build() {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
@@ -19,6 +19,8 @@ class ToolExecutionHelper {
      * Extracts a response from a CallToolResult message. This may be an error response.
      * If the response contains both 'content' and 'structuredContent' elements, the
      * structured content is given precedence.
+     * The entries of the '_meta' element, if present, are stored in
+     * {@link ToolExecutionResult#attributes()} and are not sent to the LLM.
      */
     static ToolExecutionResult extractResult(
             JsonNode result, boolean ignoreApplicationLevelErrors, McpToolResultExtractor toolResultExtractor) {
@@ -34,6 +36,7 @@ class ToolExecutionHelper {
                         .result(toObject(content))
                         .resultText(content.toString())
                         .isError(isError(resultNode))
+                        .attributes(extractMeta(resultNode))
                         .build();
             } else if (resultNode.has("content")) {
                 boolean applicationError = isError(resultNode);
@@ -42,7 +45,7 @@ class ToolExecutionHelper {
                 if (applicationError && !ignoreApplicationLevelErrors) {
                     throw new ToolExecutionException(errorMessage(toolExecutionResult, resultNode.get("content")));
                 }
-                return toolExecutionResult;
+                return withAttributes(toolExecutionResult, extractMeta(resultNode));
             } else {
                 throw new RuntimeException("Result does not contain 'content' element: " + result);
             }
@@ -58,6 +61,52 @@ class ToolExecutionHelper {
             }
             throw new RuntimeException("Result contains neither 'result' nor 'error' element: " + result);
         }
+    }
+
+    /**
+     * Converts the entries of the '_meta' element of a CallToolResult into tool execution attributes.
+     * Keys reserved by the MCP specification, such as 'io.modelcontextprotocol/serverInfo',
+     * are skipped, as they describe the protocol interaction and not the tool result.
+     */
+    private static Map<String, Object> extractMeta(JsonNode resultNode) {
+        JsonNode meta = resultNode.get("_meta");
+        if (meta == null || !meta.isObject()) {
+            return Map.of();
+        }
+        Map<String, Object> attributes = new HashMap<>();
+        for (Map.Entry<String, JsonNode> property : meta.properties()) {
+            if (!isReservedByMcp(property.getKey())) {
+                attributes.put(property.getKey(), toObject(property.getValue()));
+            }
+        }
+        return attributes;
+    }
+
+    /**
+     * A '_meta' key can start with a prefix: a series of labels separated by dots, followed by a slash.
+     * Prefixes whose second label is 'modelcontextprotocol' or 'mcp' are reserved by the MCP specification,
+     * for example 'io.modelcontextprotocol/serverInfo' or 'com.mcp.tools/something'.
+     */
+    private static boolean isReservedByMcp(String key) {
+        int slashIndex = key.indexOf('/');
+        if (slashIndex < 0) {
+            return false;
+        }
+        String[] labels = key.substring(0, slashIndex).split("\\.");
+        return labels.length > 1 && (labels[1].equals("modelcontextprotocol") || labels[1].equals("mcp"));
+    }
+
+    /**
+     * Adds the given attributes to a {@link ToolExecutionResult} produced by a {@link McpToolResultExtractor}.
+     * Attributes set by the extractor take precedence.
+     */
+    private static ToolExecutionResult withAttributes(ToolExecutionResult result, Map<String, Object> attributes) {
+        if (attributes.isEmpty()) {
+            return result;
+        }
+        Map<String, Object> mergedAttributes = new HashMap<>(attributes);
+        mergedAttributes.putAll(result.attributes());
+        return result.toBuilder().attributes(mergedAttributes).build();
     }
 
     private static String errorMessage(ToolExecutionResult toolExecutionResult, JsonNode content) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/McpToolExecutorTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/McpToolExecutorTest.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class McpToolExecutorTest {
+
+    private final ToolExecutionRequest request =
+            ToolExecutionRequest.builder().name("getWeather").build();
+    private final InvocationContext invocationContext =
+            InvocationContext.builder().build();
+
+    private McpClient mcpClientReturning(ToolExecutionResult result) {
+        McpClient mcpClient = mock(McpClient.class);
+        when(mcpClient.executeTool(any(), any())).thenReturn(result);
+        return mcpClient;
+    }
+
+    @Test
+    void should_drop_attributes_by_default() {
+        McpClient mcpClient = mcpClientReturning(ToolExecutionResult.builder()
+                .resultText("Sunny, 22 degrees")
+                .attributes(Map.of("example.org/traceId", "abc-123"))
+                .build());
+
+        McpToolExecutor executor = new McpToolExecutor(mcpClient);
+
+        ToolExecutionResult result = executor.executeWithContext(request, invocationContext);
+
+        assertThat(result.resultText()).isEqualTo("Sunny, 22 degrees");
+        assertThat(result.attributes()).isEmpty();
+    }
+
+    @Test
+    void should_return_attributes_when_enabled() {
+        McpClient mcpClient = mcpClientReturning(ToolExecutionResult.builder()
+                .resultText("Sunny, 22 degrees")
+                .attributes(Map.of("example.org/traceId", "abc-123"))
+                .build());
+
+        McpToolExecutor executor = new McpToolExecutor(mcpClient, null, true);
+
+        ToolExecutionResult result = executor.executeWithContext(request, invocationContext);
+
+        assertThat(result.resultText()).isEqualTo("Sunny, 22 degrees");
+        assertThat(result.attributes()).containsExactly(Map.entry("example.org/traceId", "abc-123"));
+    }
+
+    @Test
+    void should_return_result_as_is_when_there_are_no_attributes() {
+        ToolExecutionResult originalResult =
+                ToolExecutionResult.builder().resultText("Sunny, 22 degrees").build();
+        McpToolExecutor executor = new McpToolExecutor(mcpClientReturning(originalResult));
+
+        assertThat(executor.executeWithContext(request, invocationContext)).isSameAs(originalResult);
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpToolResultMetaParsingTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpToolResultMetaParsingTest.java
@@ -1,0 +1,201 @@
+package dev.langchain4j.mcp.client;
+
+import static dev.langchain4j.mcp.client.DefaultMcpClient.OBJECT_MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class McpToolResultMetaParsingTest {
+
+    private final McpToolResultExtractor extractor = new DefaultMcpToolResultExtractor();
+
+    @Test
+    void should_map_meta_of_text_result_into_attributes() throws Exception {
+        JsonNode response = OBJECT_MAPPER.readTree(
+                // language=json
+                """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "result": {
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "Sunny, 22 degrees"
+                              }
+                            ],
+                            "_meta": {
+                              "example.org/widget": {
+                                "temperature": 22,
+                                "conditions": ["sunny", "windy"]
+                              },
+                              "example.org/traceId": "abc-123"
+                            }
+                          }
+                        }
+                        """);
+
+        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, extractor);
+
+        assertThat(result.resultText()).isEqualTo("Sunny, 22 degrees");
+        assertThat(result.attributes())
+                .containsEntry("example.org/traceId", "abc-123")
+                .containsEntry(
+                        "example.org/widget", Map.of("temperature", 22, "conditions", List.of("sunny", "windy")));
+    }
+
+    @Test
+    void should_map_meta_of_structured_content_result_into_attributes() throws Exception {
+        JsonNode response = OBJECT_MAPPER.readTree(
+                // language=json
+                """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 2,
+                          "result": {
+                            "structuredContent": {
+                              "temperature": 22
+                            },
+                            "_meta": {
+                              "example.org/traceId": "abc-123"
+                            }
+                          }
+                        }
+                        """);
+
+        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, extractor);
+
+        assertThat(result.result()).isEqualTo(Map.of("temperature", 22));
+        assertThat(result.attributes()).containsExactly(Map.entry("example.org/traceId", "abc-123"));
+    }
+
+    @Test
+    void should_return_no_attributes_when_there_is_no_meta() throws Exception {
+        JsonNode response = OBJECT_MAPPER.readTree(
+                // language=json
+                """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 3,
+                          "result": {
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "Sunny, 22 degrees"
+                              }
+                            ]
+                          }
+                        }
+                        """);
+
+        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, extractor);
+
+        assertThat(result.attributes()).isEmpty();
+    }
+
+    @Test
+    void should_keep_meta_of_error_result_when_application_level_errors_are_ignored() throws Exception {
+        JsonNode response = OBJECT_MAPPER.readTree(
+                // language=json
+                """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 4,
+                          "result": {
+                            "isError": true,
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "City not found"
+                              }
+                            ],
+                            "_meta": {
+                              "example.org/traceId": "abc-123"
+                            }
+                          }
+                        }
+                        """);
+
+        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, true, extractor);
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultText()).isEqualTo("City not found");
+        assertThat(result.attributes()).containsExactly(Map.entry("example.org/traceId", "abc-123"));
+    }
+
+    @Test
+    void should_give_precedence_to_attributes_set_by_the_extractor() throws Exception {
+        JsonNode response = OBJECT_MAPPER.readTree(
+                // language=json
+                """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 5,
+                          "result": {
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "Sunny, 22 degrees"
+                              }
+                            ],
+                            "_meta": {
+                              "source": "meta",
+                              "example.org/traceId": "abc-123"
+                            }
+                          }
+                        }
+                        """);
+
+        McpToolResultExtractor customExtractor = (content, isError) -> ToolExecutionResult.builder()
+                .resultText("custom")
+                .isError(isError)
+                .attributes(Map.of("source", "extractor"))
+                .build();
+
+        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, customExtractor);
+
+        assertThat(result.resultText()).isEqualTo("custom");
+        assertThat(result.attributes())
+                .containsEntry("source", "extractor")
+                .containsEntry("example.org/traceId", "abc-123");
+    }
+
+    @Test
+    void should_skip_meta_keys_reserved_by_mcp() throws Exception {
+        JsonNode response = OBJECT_MAPPER.readTree(
+                // language=json
+                """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 6,
+                          "result": {
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "Sunny, 22 degrees"
+                              }
+                            ],
+                            "_meta": {
+                              "io.modelcontextprotocol/serverInfo": {
+                                "name": "weather-server",
+                                "version": "1.0.0"
+                              },
+                              "org.modelcontextprotocol.api/hint": "reserved",
+                              "com.mcp.tools/hint": "reserved",
+                              "dev.mcp/hint": "reserved",
+                              "com.example.mcp/traceId": "not-reserved",
+                              "traceId": "not-reserved"
+                            }
+                          }
+                        }
+                        """);
+
+        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, extractor);
+
+        assertThat(result.attributes()).containsOnlyKeys("com.example.mcp/traceId", "traceId");
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
@@ -3,6 +3,7 @@ package dev.langchain4j.service.tool;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -73,6 +74,19 @@ public class ToolExecution {
      */
     public Object resultObject() {
         return result.result();
+    }
+
+    /**
+     * Returns the attributes associated with the tool execution.
+     * Attributes can be set by the tool itself or, in case of MCP tools,
+     * originate from the {@code _meta} field of the tool call response.
+     * They are not sent to the LLM.
+     *
+     * @return an unmodifiable map of attributes, or an empty map if none were set.
+     * @since 1.19.0
+     */
+    public Map<String, Object> attributes() {
+        return result.attributes();
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
@@ -186,6 +186,26 @@ public class ToolExecutionResult {
         return new Builder();
     }
 
+    /**
+     * Returns a {@link Builder} pre-populated with the values of this {@link ToolExecutionResult}.
+     * Useful for creating a modified copy, for example to add attributes.
+     *
+     * <p>When this result was built with {@link Builder#resultTextSupplier(Supplier)},
+     * the supplier is carried over as is, so the copy stays lazy and may invoke the supplier again.
+     *
+     * @return a builder pre-populated with the values of this result.
+     * @since 1.19.0
+     */
+    public Builder toBuilder() {
+        Builder builder = builder().isError(isError).result(result).attributes(attributes);
+        if (resultTextSupplier != null) {
+            builder.resultTextSupplier(resultTextSupplier);
+        } else {
+            builder.resultContents(resultContents.get());
+        }
+        return builder;
+    }
+
     public static class Builder {
 
         private boolean isError;

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionResultTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionResultTest.java
@@ -406,4 +406,64 @@ class ToolExecutionResultTest {
         assertThat(toolExecutionResult.resultContents()).containsExactly(TextContent.from(text));
         assertThat(toolExecutionResult.resultText()).isEqualTo(text);
     }
+
+    @Test
+    void should_copy_all_values_with_to_builder() {
+        // given
+        Object result = new Object();
+        ToolExecutionResult original = ToolExecutionResult.builder()
+                .isError(true)
+                .result(result)
+                .resultContents(List.of(TextContent.from("first"), TextContent.from("second")))
+                .attributes(Map.of("key", "value"))
+                .build();
+
+        // when
+        ToolExecutionResult copy = original.toBuilder().build();
+
+        // then
+        assertThat(copy).isEqualTo(original);
+        assertThat(copy.isError()).isTrue();
+        assertThat(copy.result()).isSameAs(result);
+        assertThat(copy.resultContents()).containsExactly(TextContent.from("first"), TextContent.from("second"));
+        assertThat(copy.attributes()).containsExactly(Map.entry("key", "value"));
+    }
+
+    @Test
+    void should_add_attributes_with_to_builder() {
+        // given
+        ToolExecutionResult original = ToolExecutionResult.builder()
+                .resultText("test result")
+                .attributes(Map.of("key", "value"))
+                .build();
+
+        // when
+        ToolExecutionResult copy =
+                original.toBuilder().attributes(Map.of("anotherKey", "anotherValue")).build();
+
+        // then
+        assertThat(copy.resultText()).isEqualTo("test result");
+        assertThat(copy.attributes()).containsExactly(Map.entry("anotherKey", "anotherValue"));
+        assertThat(original.attributes()).containsExactly(Map.entry("key", "value"));
+    }
+
+    @Test
+    void should_not_invoke_supplier_when_copying_with_to_builder() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+        ToolExecutionResult original = ToolExecutionResult.builder()
+                .resultTextSupplier(() -> {
+                    callCount.incrementAndGet();
+                    return "lazy result";
+                })
+                .build();
+
+        // when
+        ToolExecutionResult copy = original.toBuilder().build();
+
+        // then
+        assertThat(callCount).hasValue(0);
+        assertThat(copy.resultText()).isEqualTo("lazy result");
+        assertThat(callCount).hasValue(1);
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.invocation.InvocationContext;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ToolExecutionTest {
@@ -30,5 +31,25 @@ class ToolExecutionTest {
         assertThat(toolExecution.result()).isEqualTo(textResult);
         assertThat(toolExecution.resultObject()).isNull();
         assertThat(toolExecution.invocationContext()).isSameAs(invocationContext);
+    }
+
+    @Test
+    void should_return_attributes_of_the_result() {
+
+        ToolExecutionResult result = ToolExecutionResult.builder()
+                .resultText("text result")
+                .attributes(Map.of("key", "value"))
+                .build();
+
+        ToolExecution toolExecution = ToolExecution.builder()
+                .request(ToolExecutionRequest.builder().build())
+                .result(result)
+                .invocationContext(InvocationContext.builder()
+                        .interfaceName("SomeInterface")
+                        .methodName("someMethod")
+                        .build())
+                .build();
+
+        assertThat(toolExecution.attributes()).containsExactly(Map.entry("key", "value"));
     }
 }


### PR DESCRIPTION
## Issue
  Addresses the MCP part of #5943 (tool artifacts).

  Note: this does **not** close the issue. The other gap discussed there — an ergonomic way for
  `@Tool`-annotated methods to set attributes — is not covered by this PR.

  ## Change

  An MCP server can attach a `_meta` object to a tool call response. Until now it was dropped;
  this PR maps it into `ToolExecutionResult.attributes()`, which is the existing channel for data
  that the application needs but the LLM must not see (a widget to render, the ID of a created
  record, a trace ID, ...).

  **1. `_meta` mapping (client layer)**

  `ToolExecutionHelper` reads `_meta` for both the `content` and the `structuredContent` branches.
  Entries are stored under their original keys, JSON values are converted into nested maps, using the
  same converter that is already used for `structuredContent`. The `McpToolResultExtractor` SPI is
  unchanged.

  Keys reserved by the MCP specification are skipped, i.e. those whose prefix has
  `modelcontextprotocol` or `mcp` as its second label (`io.modelcontextprotocol/serverInfo`,
  `dev.mcp/...`, `com.mcp.tools/...`). This matters for protocol version `2026-07-28`, where servers
  SHOULD send `io.modelcontextprotocol/serverInfo` on *every* response — that is protocol plumbing,
  not tool data, and it should not end up in the chat memory of every message. If it is ever needed,
  the complete raw response is still delivered to `McpClientListener.afterExecuteTool()`.

  **2. Opt-in for the AI service path (tool provider layer)**

  Attributes are propagated into `ToolExecutionResultMessage.attributes()` and are therefore stored in
  the chat memory. Since the size and contents of `_meta` are controlled by the MCP server, they are
  dropped by default in the AI service path and have to be enabled explicitly:

  ```java
  McpToolProvider toolProvider = McpToolProvider.builder()
      .mcpClients(mcpClient)
      .returnToolResultAttributes(true)
      .build();
```

  When calling `McpClient.executeTool()` directly, the attributes are always available — the client
  stays a faithful protocol client, and the knob sits at the layer where the storage cost is incurred.
  The flag is wired into `McpToolExecutor` through a package-private constructor, so no public
  constructor changes.

  **3. Two additions in the core module**

  - `ToolExecutionResult.toBuilder()` — creates a modified copy (used here to add/remove attributes).
    A lazy `resultTextSupplier` is carried over as is, so copying does not force its evaluation.
  - `ToolExecution.attributes()` — attributes were previously only reachable via
    `ToolExecutionResultMessage`; now they can be read directly from `Result.toolExecutions()`.

  **4. Documentation**

  - `mcp.md`: new "MCP tool result metadata" section (mapping, reserved keys, the opt-in flag,
    behaviour on application-level errors).
  - `tools.md`: new "Tool Result Attributes" section, including a warning that attribute values must
    be JSON-serializable when a persisting `ChatMemoryStore` is used, and that non-JSON types do not
    survive a round trip.

  **Relation to #5881 (MCP client for `2026-07-28`)**

  Verified against the `2026-07-28` schema: `CallToolResult extends Result`, and `Result._meta` still
  exists, so this feature stays valid. The only file touched by both PRs is `ToolExecutionHelper`
  (one added helper plus two call sites); `DefaultMcpClient` is not modified here.

  Per-content-block `_meta` (`TextContent._meta` etc., new in `2026-07-28`) is intentionally out of
  scope.

  ## General checklist
  - [X] There are no breaking changes (API, behaviour)
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)