### PR TITLE
fix: apply retrieval constraints to Elasticsearch full text search

### DIFF
--- a/docs/docs/integrations/embedding-stores/elasticsearch.md
+++ b/docs/docs/integrations/embedding-stores/elasticsearch.md
@@ -245,9 +245,9 @@ public class MyElasticsearchConfiguration implements ElasticsearchConfiguration 
 
     @Override
     SearchResponse<Document> fullTextSearch(
-            ElasticsearchClient client, 
-            String indexName, 
-            String textQuery) {
+            ElasticsearchClient client,
+            String indexName,
+            FullTextSearchRequest request) {
         // Your optional custom full text search implementation here
     }
 
@@ -267,6 +267,15 @@ Please note that you can implement only the methods relevant to your use case:
 * `vectorSearch` for vector similarity search (used by both `ElasticsearchEmbeddingStore` and `ElasticsearchContentRetriever`).
 * `fullTextSearch` for full text search (used by `ElasticsearchContentRetriever` only).
 * `hybridSearch` for hybrid search (used by `ElasticsearchContentRetriever` only).
+
+The `FullTextSearchRequest` carries the `textQuery` to search for, together with the `maxResults`, `minScore` and
+`filter` configured on the `ElasticsearchContentRetriever`. Your implementation is responsible for applying them,
+otherwise documents which do not match the filter can be returned.
+
+> **Note:**
+> There is also a deprecated `fullTextSearch(ElasticsearchClient client, String indexName, String textQuery)` method.
+> Configurations which only implement that one keep working, but the `maxResults`, `minScore` and `filter` of the
+> retriever are ignored, and a warning is logged. Please implement the method taking a `FullTextSearchRequest` instead.
 
 ## Examples
 

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
@@ -105,7 +105,7 @@ public class ElasticsearchContentRetriever extends AbstractElasticsearchEmbeddin
     public List<Content> retrieve(final Query query) {
         if (configuration instanceof ElasticsearchConfigurationFullText) {
             log.debug("Using a full text search query");
-            return toContentList(this.fullTextSearchMatches(query.text()));
+            return toContentList(this.fullTextSearchMatches(query.text(), maxResults, minScore, filter));
         }
         Embedding referenceEmbedding = embeddingModel.embed(query.text()).content();
         EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetriever.java
@@ -18,6 +18,7 @@ import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationF
 import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationHybrid;
 import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationKnn;
 import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationScript;
+import dev.langchain4j.store.embedding.elasticsearch.FullTextSearchRequest;
 import dev.langchain4j.store.embedding.filter.Filter;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,13 @@ public class ElasticsearchContentRetriever extends AbstractElasticsearchEmbeddin
     public List<Content> retrieve(final Query query) {
         if (configuration instanceof ElasticsearchConfigurationFullText) {
             log.debug("Using a full text search query");
-            return toContentList(this.fullTextSearchMatches(query.text(), maxResults, minScore, filter));
+            FullTextSearchRequest request = FullTextSearchRequest.builder()
+                    .textQuery(query.text())
+                    .maxResults(maxResults)
+                    .minScore(minScore)
+                    .filter(filter)
+                    .build();
+            return toContentList(this.fullTextSearchMatches(request));
         }
         Embedding referenceEmbedding = embeddingModel.embed(query.text()).content();
         EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
@@ -204,7 +204,11 @@ public abstract class AbstractElasticsearchEmbeddingStore implements EmbeddingSt
      *
      * @param textQuery the text to search for
      * @return the matching documents, each carrying its Elasticsearch document ID and relevance score
+     * @deprecated Use {@link #fullTextSearchMatches(FullTextSearchRequest)} instead.
+     * It also applies the {@code maxResults}, {@code minScore} and {@code filter} of the request.
      */
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     public List<EmbeddingMatch<TextSegment>> fullTextSearchMatches(String textQuery) {
         log.debug("full text search([...{}...])", textQuery.length());
         try {
@@ -218,20 +222,19 @@ public abstract class AbstractElasticsearchEmbeddingStore implements EmbeddingSt
     }
 
     /**
-     * Searches the index with a full text (non-vector) query and retrieval constraints.
+     * Searches the index with a full text (non-vector) query.
      *
-     * @param textQuery  the text to search for
-     * @param maxResults the maximum number of results to return
-     * @param minScore   the minimum score of returned results
-     * @param filter     the metadata filter to apply, or {@code null}
+     * @param request the full text search request
      * @return the matching documents, each carrying its Elasticsearch document ID and relevance score
      */
-    public List<EmbeddingMatch<TextSegment>> fullTextSearchMatches(
-            String textQuery, int maxResults, double minScore, Filter filter) {
-        log.debug("full text search([...{}...], {}, {})", textQuery.length(), maxResults, minScore);
+    public List<EmbeddingMatch<TextSegment>> fullTextSearchMatches(FullTextSearchRequest request) {
+        log.debug(
+                "full text search([...{}...], {}, {})",
+                request.textQuery().length(),
+                request.maxResults(),
+                request.minScore());
         try {
-            SearchResponse<Document> response =
-                    this.configuration.fullTextSearch(client, indexName, textQuery, maxResults, minScore, filter);
+            SearchResponse<Document> response = this.configuration.fullTextSearch(client, indexName, request);
             log.trace("found [{}] results", response);
 
             return toMatches(response);
@@ -241,7 +244,7 @@ public abstract class AbstractElasticsearchEmbeddingStore implements EmbeddingSt
     }
 
     /**
-     * @deprecated Use {@link #fullTextSearchMatches(String)} instead. It returns the same text segments,
+     * @deprecated Use {@link #fullTextSearchMatches(FullTextSearchRequest)} instead. It returns the same text segments,
      * but also the Elasticsearch document ID and the relevance score of each match.
      */
     @Deprecated(forRemoval = true)

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/AbstractElasticsearchEmbeddingStore.java
@@ -218,6 +218,29 @@ public abstract class AbstractElasticsearchEmbeddingStore implements EmbeddingSt
     }
 
     /**
+     * Searches the index with a full text (non-vector) query and retrieval constraints.
+     *
+     * @param textQuery  the text to search for
+     * @param maxResults the maximum number of results to return
+     * @param minScore   the minimum score of returned results
+     * @param filter     the metadata filter to apply, or {@code null}
+     * @return the matching documents, each carrying its Elasticsearch document ID and relevance score
+     */
+    public List<EmbeddingMatch<TextSegment>> fullTextSearchMatches(
+            String textQuery, int maxResults, double minScore, Filter filter) {
+        log.debug("full text search([...{}...], {}, {})", textQuery.length(), maxResults, minScore);
+        try {
+            SearchResponse<Document> response =
+                    this.configuration.fullTextSearch(client, indexName, textQuery, maxResults, minScore, filter);
+            log.trace("found [{}] results", response);
+
+            return toMatches(response);
+        } catch (ElasticsearchException | IOException e) {
+            throw new ElasticsearchRequestFailedException(e);
+        }
+    }
+
+    /**
      * @deprecated Use {@link #fullTextSearchMatches(String)} instead. It returns the same text segments,
      * but also the Elasticsearch document ID and the relevance score of each match.
      */

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfiguration.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfiguration.java
@@ -4,7 +4,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
-
+import dev.langchain4j.store.embedding.filter.Filter;
 import java.io.IOException;
 
 public interface ElasticsearchConfiguration {
@@ -32,7 +32,8 @@ public interface ElasticsearchConfiguration {
     default SearchResponse<Document> vectorSearch(
             ElasticsearchClient client, String indexName, EmbeddingSearchRequest embeddingSearchRequest)
             throws ElasticsearchException, IOException {
-        throw new UnsupportedOperationException(this.getClass().getSimpleName() + " configuration does not support vector search");
+        throw new UnsupportedOperationException(
+                this.getClass().getSimpleName() + " configuration does not support vector search");
     }
 
     /**
@@ -47,7 +48,36 @@ public interface ElasticsearchConfiguration {
      */
     default SearchResponse<Document> fullTextSearch(ElasticsearchClient client, String indexName, String textQuery)
             throws ElasticsearchException, IOException {
-        throw new UnsupportedOperationException(this.getClass().getSimpleName() + " configuration does not support fulltext search");
+        throw new UnsupportedOperationException(
+                this.getClass().getSimpleName() + " configuration does not support fulltext search");
+    }
+
+    /**
+     * Used for full text search with retrieval constraints.
+     *
+     * <p>The default implementation delegates to {@link #fullTextSearch(ElasticsearchClient, String, String)}
+     * for backwards compatibility with custom configurations. Implementations that support these constraints
+     * should override this method.
+     *
+     * @param client     The Elasticsearch client
+     * @param indexName  The index name
+     * @param textQuery  The text query
+     * @param maxResults The maximum number of results to return
+     * @param minScore   The minimum score of returned results
+     * @param filter     The metadata filter to apply, or {@code null}
+     * @return The search response
+     * @throws ElasticsearchException if an error occurs during the search
+     * @throws IOException            if an I/O error occurs
+     */
+    default SearchResponse<Document> fullTextSearch(
+            ElasticsearchClient client,
+            String indexName,
+            String textQuery,
+            int maxResults,
+            double minScore,
+            Filter filter)
+            throws ElasticsearchException, IOException {
+        return fullTextSearch(client, indexName, textQuery);
     }
 
     /**
@@ -67,6 +97,7 @@ public interface ElasticsearchConfiguration {
             EmbeddingSearchRequest embeddingSearchRequest,
             String textQuery)
             throws ElasticsearchException, IOException {
-        throw new UnsupportedOperationException(this.getClass().getSimpleName() + " configuration does not support hybrid search");
+        throw new UnsupportedOperationException(
+                this.getClass().getSimpleName() + " configuration does not support hybrid search");
     }
 }

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfiguration.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfiguration.java
@@ -4,8 +4,8 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
-import dev.langchain4j.store.embedding.filter.Filter;
 import java.io.IOException;
+import org.slf4j.LoggerFactory;
 
 public interface ElasticsearchConfiguration {
     String VECTOR_FIELD = "vector";
@@ -45,7 +45,10 @@ public interface ElasticsearchConfiguration {
      * @return The search response
      * @throws ElasticsearchException if an error occurs during the search
      * @throws IOException            if an I/O error occurs
+     * @deprecated Use {@link #fullTextSearch(ElasticsearchClient, String, FullTextSearchRequest)} instead.
+     * It also applies the {@code maxResults}, {@code minScore} and {@code filter} of the request.
      */
+    @Deprecated(forRemoval = true)
     default SearchResponse<Document> fullTextSearch(ElasticsearchClient client, String indexName, String textQuery)
             throws ElasticsearchException, IOException {
         throw new UnsupportedOperationException(
@@ -53,31 +56,26 @@ public interface ElasticsearchConfiguration {
     }
 
     /**
-     * Used for full text search with retrieval constraints.
+     * Used for full text search.
      *
-     * <p>The default implementation delegates to {@link #fullTextSearch(ElasticsearchClient, String, String)}
-     * for backwards compatibility with custom configurations. Implementations that support these constraints
-     * should override this method.
-     *
-     * @param client     The Elasticsearch client
-     * @param indexName  The index name
-     * @param textQuery  The text query
-     * @param maxResults The maximum number of results to return
-     * @param minScore   The minimum score of returned results
-     * @param filter     The metadata filter to apply, or {@code null}
+     * @param client    The Elasticsearch client
+     * @param indexName The index name
+     * @param request   The full text search request
      * @return The search response
      * @throws ElasticsearchException if an error occurs during the search
      * @throws IOException            if an I/O error occurs
      */
     default SearchResponse<Document> fullTextSearch(
-            ElasticsearchClient client,
-            String indexName,
-            String textQuery,
-            int maxResults,
-            double minScore,
-            Filter filter)
+            ElasticsearchClient client, String indexName, FullTextSearchRequest request)
             throws ElasticsearchException, IOException {
-        return fullTextSearch(client, indexName, textQuery);
+        if (request.filter() != null) {
+            LoggerFactory.getLogger(ElasticsearchConfiguration.class)
+                    .warn(
+                            "[{}] does not implement fullTextSearch(ElasticsearchClient, String, FullTextSearchRequest), "
+                                    + "so the filter, maxResults and minScore are ignored and documents which do not match the filter can be returned.",
+                            this.getClass().getName());
+        }
+        return fullTextSearch(client, indexName, request.textQuery());
     }
 
     /**

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationFullText.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationFullText.java
@@ -2,7 +2,9 @@ package dev.langchain4j.store.embedding.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import dev.langchain4j.store.embedding.filter.Filter;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see <a href="https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-match-query">match query</a>
  */
-public class ElasticsearchConfigurationFullText implements ElasticsearchConfiguration{
+public class ElasticsearchConfigurationFullText implements ElasticsearchConfiguration {
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchConfigurationFullText.class);
 
     public static class Builder {
@@ -36,5 +38,29 @@ public class ElasticsearchConfigurationFullText implements ElasticsearchConfigur
                 s -> s.index(indexName)
                         .query(q -> q.match(m -> m.field(TEXT_FIELD).query(textQuery))),
                 Document.class);
+    }
+
+    @Override
+    public SearchResponse<Document> fullTextSearch(
+            ElasticsearchClient client,
+            String indexName,
+            String textQuery,
+            int maxResults,
+            double minScore,
+            Filter filter)
+            throws ElasticsearchException, IOException {
+        Query matchQuery = Query.of(q -> q.match(m -> m.field(TEXT_FIELD).query(textQuery)));
+        Query query = filter == null
+                ? matchQuery
+                : Query.of(q -> q.bool(b -> b.must(matchQuery).filter(ElasticsearchMetadataFilterMapper.map(filter))));
+
+        log.trace(
+                "Searching for text matches in index [{}] with query [{}] and filter [{}].",
+                indexName,
+                textQuery,
+                filter);
+
+        return client.search(
+                s -> s.index(indexName).query(query).size(maxResults).minScore(minScore), Document.class);
     }
 }

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationFullText.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationFullText.java
@@ -4,7 +4,6 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
-import dev.langchain4j.store.embedding.filter.Filter;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,39 +27,39 @@ public class ElasticsearchConfigurationFullText implements ElasticsearchConfigur
         return new ElasticsearchConfigurationFullText.Builder();
     }
 
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     @Override
     public SearchResponse<Document> fullTextSearch(
             final ElasticsearchClient client, final String indexName, final String textQuery)
             throws ElasticsearchException, IOException {
         log.trace("Searching for text matches in index [{}] with query [{}].", indexName, textQuery);
 
-        return client.search(
-                s -> s.index(indexName)
-                        .query(q -> q.match(m -> m.field(TEXT_FIELD).query(textQuery))),
-                Document.class);
+        return client.search(s -> s.index(indexName).query(matchQuery(textQuery)), Document.class);
     }
 
     @Override
     public SearchResponse<Document> fullTextSearch(
-            ElasticsearchClient client,
-            String indexName,
-            String textQuery,
-            int maxResults,
-            double minScore,
-            Filter filter)
+            final ElasticsearchClient client, final String indexName, final FullTextSearchRequest request)
             throws ElasticsearchException, IOException {
-        Query matchQuery = Query.of(q -> q.match(m -> m.field(TEXT_FIELD).query(textQuery)));
-        Query query = filter == null
+        Query matchQuery = matchQuery(request.textQuery());
+        Query query = request.filter() == null
                 ? matchQuery
-                : Query.of(q -> q.bool(b -> b.must(matchQuery).filter(ElasticsearchMetadataFilterMapper.map(filter))));
+                : Query.of(q -> q.bool(
+                        b -> b.must(matchQuery).filter(ElasticsearchMetadataFilterMapper.map(request.filter()))));
 
         log.trace(
                 "Searching for text matches in index [{}] with query [{}] and filter [{}].",
                 indexName,
-                textQuery,
-                filter);
+                request.textQuery(),
+                request.filter());
 
         return client.search(
-                s -> s.index(indexName).query(query).size(maxResults).minScore(minScore), Document.class);
+                s -> s.index(indexName).query(query).size(request.maxResults()).minScore(request.minScore()),
+                Document.class);
+    }
+
+    private static Query matchQuery(String textQuery) {
+        return Query.of(q -> q.match(m -> m.field(TEXT_FIELD).query(textQuery)));
     }
 }

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/FullTextSearchRequest.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/FullTextSearchRequest.java
@@ -1,0 +1,104 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.filter.Filter;
+
+/**
+ * Represents a full text (non-vector) search request.
+ *
+ * @see ElasticsearchConfiguration#fullTextSearch(co.elastic.clients.elasticsearch.ElasticsearchClient, String, FullTextSearchRequest)
+ */
+public class FullTextSearchRequest {
+
+    private final String textQuery;
+    private final int maxResults;
+    private final double minScore;
+    private final Filter filter;
+
+    public FullTextSearchRequest(Builder builder) {
+        this.textQuery = ensureNotBlank(builder.textQuery, "textQuery");
+        this.maxResults = ensureGreaterThanZero(getOrDefault(builder.maxResults, 3), "maxResults");
+        this.minScore = getOrDefault(builder.minScore, 0.0);
+        this.filter = builder.filter;
+    }
+
+    public String textQuery() {
+        return textQuery;
+    }
+
+    public int maxResults() {
+        return maxResults;
+    }
+
+    public double minScore() {
+        return minScore;
+    }
+
+    public Filter filter() {
+        return filter;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String textQuery;
+        private Integer maxResults;
+        private Double minScore;
+        private Filter filter;
+
+        /**
+         * The text to search for.
+         * This is a mandatory parameter.
+         */
+        public Builder textQuery(String textQuery) {
+            this.textQuery = textQuery;
+            return this;
+        }
+
+        /**
+         * The maximum number of results to return.
+         * This is an optional parameter.
+         * Default: 3
+         */
+        public Builder maxResults(Integer maxResults) {
+            this.maxResults = maxResults;
+            return this;
+        }
+
+        /**
+         * The minimum relevance score. Only results with a score &gt;= minScore will be returned.
+         * Unlike vector search, full text search scores are not normalized: they are
+         * <a href="https://www.elastic.co/docs/reference/query-languages/query-dsl/query-filter-context">BM25 scores</a>
+         * and can be greater than 1.
+         * This is an optional parameter.
+         * Default: 0
+         */
+        public Builder minScore(Double minScore) {
+            this.minScore = minScore;
+            return this;
+        }
+
+        /**
+         * The filter to be applied to the {@link Metadata} during search.
+         * Only {@link TextSegment}s whose {@link Metadata} matches the {@link Filter} will be returned.
+         * This is an optional parameter.
+         * Default: no filtering
+         */
+        public Builder filter(Filter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public FullTextSearchRequest build() {
+            return new FullTextSearchRequest(this);
+        }
+    }
+}

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverFullTextTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverFullTextTest.java
@@ -1,0 +1,111 @@
+package dev.langchain4j.rag.content.retriever.elasticsearch;
+
+import static co.elastic.clients.elasticsearch.core.search.TotalHitsRelation.Eq;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.DefaultTransportOptions;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationFullText;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchContentRetrieverFullTextTest {
+
+    @Test
+    void should_apply_retrieval_constraints_to_full_text_search() {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchContentRetriever retriever = ElasticsearchContentRetriever.builder()
+                .client(new ElasticsearchClient(transport))
+                .indexName("articles")
+                .configuration(ElasticsearchConfigurationFullText.builder().build())
+                .maxResults(7)
+                .minScore(0.5)
+                .filter(metadataKey("tenant").isEqualTo("acme"))
+                .build();
+
+        retriever.retrieve(Query.from("search text"));
+
+        SearchRequest request = transport.capturedRequest;
+        assertThat(request.index()).containsExactly("articles");
+        assertThat(request.size()).isEqualTo(7);
+        assertThat(request.minScore()).isEqualTo(0.5);
+
+        assertThat(request.query().isBool()).isTrue();
+        assertThat(request.query().bool().must()).singleElement().satisfies(matchQuery -> {
+            assertThat(matchQuery.match().field()).isEqualTo(ElasticsearchConfiguration.TEXT_FIELD);
+            assertThat(matchQuery.match().query().stringValue()).isEqualTo("search text");
+        });
+        assertThat(request.query().bool().filter()).singleElement().satisfies(filterQuery -> {
+            assertThat(filterQuery.bool().filter()).singleElement().satisfies(termQuery -> {
+                assertThat(termQuery.term().field()).isEqualTo("metadata.tenant.keyword");
+                assertThat(termQuery.term().value().anyValue().to(String.class)).isEqualTo("acme");
+            });
+        });
+    }
+
+    @Test
+    void should_keep_match_query_when_filter_is_not_configured() {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchContentRetriever retriever = ElasticsearchContentRetriever.builder()
+                .client(new ElasticsearchClient(transport))
+                .indexName("articles")
+                .configuration(ElasticsearchConfigurationFullText.builder().build())
+                .build();
+
+        retriever.retrieve(Query.from("search text"));
+
+        SearchRequest request = transport.capturedRequest;
+        assertThat(request.size()).isEqualTo(3);
+        assertThat(request.minScore()).isEqualTo(0.0);
+        assertThat(request.query().isMatch()).isTrue();
+        assertThat(request.query().match().field()).isEqualTo(ElasticsearchConfiguration.TEXT_FIELD);
+        assertThat(request.query().match().query().stringValue()).isEqualTo("search text");
+    }
+
+    private static class CapturingTransport implements ElasticsearchTransport {
+
+        private final JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+        private SearchRequest capturedRequest;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            capturedRequest = (SearchRequest) request;
+            return (ResponseT) SearchResponse.of(sr -> sr.took(0)
+                    .timedOut(false)
+                    .shards(s -> s.total(1).successful(1).failed(0))
+                    .hits(h -> h.total(t -> t.value(0).relation(Eq)).hits(emptyList())));
+        }
+
+        @Override
+        public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            return CompletableFuture.completedFuture(performRequest(request, endpoint, options));
+        }
+
+        @Override
+        public JsonpMapper jsonpMapper() {
+            return jsonpMapper;
+        }
+
+        @Override
+        public TransportOptions options() {
+            return DefaultTransportOptions.EMPTY;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchContentRetrieverIT.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.Utils.randomUUID;
 import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
 import static dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration.TEXT_FIELD;
 import static dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration.VECTOR_FIELD;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
@@ -11,6 +12,7 @@ import static org.junit.Assume.assumeThat;
 
 import co.elastic.clients.elasticsearch._types.mapping.DenseVectorIndexOptionsType;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
+import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -187,6 +189,35 @@ public class ElasticsearchContentRetrieverIT extends EmbeddingStoreWithFiltering
         log.info("#1 relevant item: {}", relevant2.get(0).textSegment().text());
         assertContent(relevant2.get(0));
         assertThat(relevant2.get(0).textSegment().text()).contains("Maurice Jean Jacques Merleau-Ponty");
+    }
+
+    @Test
+    void fullTextSearchWithMetadataFilter() {
+        TextSegment publicArticle =
+                TextSegment.from("Elasticsearch filtering guide", Metadata.from("tenant", "public"));
+        TextSegment privateArticle =
+                TextSegment.from("Elasticsearch private guide", Metadata.from("tenant", "private"));
+        contentRetrieverWithFullText.add(embeddingModel.embed(publicArticle).content(), publicArticle);
+        contentRetrieverWithFullText.add(embeddingModel.embed(privateArticle).content(), privateArticle);
+
+        awaitUntilAsserted(() -> assertThat(contentRetrieverWithFullText.retrieve(Query.from("Elasticsearch")))
+                .hasSize(2));
+
+        ElasticsearchContentRetriever filteredRetriever = ElasticsearchContentRetriever.builder()
+                .configuration(ElasticsearchConfigurationFullText.builder().build())
+                .client(elasticsearchClientHelper.client)
+                .indexName(indexName)
+                .maxResults(3)
+                .minScore(0.0)
+                .filter(metadataKey("tenant").isEqualTo("private"))
+                .build();
+
+        List<Content> relevant = filteredRetriever.retrieve(Query.from("Elasticsearch"));
+
+        assertThat(relevant).singleElement().satisfies(content -> {
+            assertThat(content.textSegment().text()).isEqualTo("Elasticsearch private guide");
+            assertThat(content.textSegment().metadata().getString("tenant")).isEqualTo("private");
+        });
     }
 
     @Test

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationTest.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchConfigurationTest {
+
+    private static final FullTextSearchRequest REQUEST = FullTextSearchRequest.builder()
+            .textQuery("search text")
+            .maxResults(7)
+            .minScore(0.5)
+            .filter(new IsEqualTo("tenant", "acme"))
+            .build();
+
+    /**
+     * Configurations written before {@link FullTextSearchRequest} existed only implement the deprecated
+     * {@link ElasticsearchConfiguration#fullTextSearch(ElasticsearchClient, String, String)}. They must keep working,
+     * even though the constraints of the request cannot be applied.
+     */
+    @Test
+    @SuppressWarnings("removal")
+    void should_fall_back_to_the_deprecated_full_text_search() throws IOException {
+        LegacyConfiguration configuration = new LegacyConfiguration();
+
+        SearchResponse<Document> response = configuration.fullTextSearch(null, "articles", REQUEST);
+
+        assertThat(configuration.capturedIndexName).isEqualTo("articles");
+        assertThat(configuration.capturedTextQuery).isEqualTo("search text");
+        assertThat(response.hits().hits()).isEmpty();
+    }
+
+    @Test
+    void should_fail_when_the_configuration_does_not_support_full_text_search() {
+        ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {};
+
+        assertThatThrownBy(() -> configuration.fullTextSearch(null, "articles", REQUEST))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("does not support fulltext search");
+    }
+
+    private static class LegacyConfiguration implements ElasticsearchConfiguration {
+
+        private String capturedIndexName;
+        private String capturedTextQuery;
+
+        @Deprecated(forRemoval = true)
+        @SuppressWarnings("removal")
+        @Override
+        public SearchResponse<Document> fullTextSearch(ElasticsearchClient client, String indexName, String textQuery) {
+            capturedIndexName = indexName;
+            capturedTextQuery = textQuery;
+
+            return SearchResponse.of(sr -> sr.took(0)
+                    .timedOut(false)
+                    .shards(s -> s.total(1).successful(1).failed(0))
+                    .hits(h -> h.total(t -> t.value(0).relation(TotalHitsRelation.Eq))
+                            .hits(Collections.emptyList())));
+        }
+    }
+}

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/FullTextSearchRequestTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/FullTextSearchRequestTest.java
@@ -1,0 +1,54 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import org.junit.jupiter.api.Test;
+
+class FullTextSearchRequestTest {
+
+    @Test
+    void should_use_default_values() {
+        FullTextSearchRequest request =
+                FullTextSearchRequest.builder().textQuery("search text").build();
+
+        assertThat(request.textQuery()).isEqualTo("search text");
+        assertThat(request.maxResults()).isEqualTo(3);
+        assertThat(request.minScore()).isEqualTo(0.0);
+        assertThat(request.filter()).isNull();
+    }
+
+    @Test
+    void should_keep_the_provided_values() {
+        IsEqualTo filter = new IsEqualTo("tenant", "acme");
+
+        FullTextSearchRequest request = FullTextSearchRequest.builder()
+                .textQuery("search text")
+                .maxResults(7)
+                .minScore(0.5)
+                .filter(filter)
+                .build();
+
+        assertThat(request.maxResults()).isEqualTo(7);
+        assertThat(request.minScore()).isEqualTo(0.5);
+        assertThat(request.filter()).isEqualTo(filter);
+    }
+
+    @Test
+    void should_fail_when_text_query_is_blank() {
+        assertThatThrownBy(() -> FullTextSearchRequest.builder().textQuery(" ").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("textQuery");
+    }
+
+    @Test
+    void should_fail_when_max_results_is_not_positive() {
+        assertThatThrownBy(() -> FullTextSearchRequest.builder()
+                        .textQuery("search text")
+                        .maxResults(0)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxResults");
+    }
+}


### PR DESCRIPTION
## Issue

  Closes #6045

  ## Change

  `ElasticsearchContentRetriever` ignored `filter`, `maxResults` and `minScore` when configured with
  `ElasticsearchConfigurationFullText`: the full text branch issued a bare `match` query. Documents whose
  metadata did not match the configured filter could therefore be returned, which is a real problem for
  multi-tenant indices.

  - Pass the retrieval constraints to the full text search path and apply them: the `match` query goes into
    `bool.must`, the mapped metadata filter into `bool.filter`, and `maxResults`/`minScore` are translated into
    `size`/`min_score`. This is the same treatment `ElasticsearchConfigurationHybrid` already gives them.
  - Introduce `FullTextSearchRequest` to carry `textQuery`, `maxResults`, `minScore` and `filter`, consistently
    with `vectorSearch(EmbeddingSearchRequest)`. It applies the usual defaults (`maxResults` 3, `minScore` 0) and
    rejects a non-positive `maxResults`, like the vector path does.
  - Keep existing custom `ElasticsearchConfiguration` implementations working: the new method delegates to the
    deprecated one by default. Since the constraints cannot be applied in that case, a warning is logged when a
    filter is silently dropped.
  - Document the new signature in the "Creating Custom Configurations" section.
  - Add unit tests for the produced Elasticsearch request, for the request defaults and validation, for the
    backwards compatible fallback, and an integration test for metadata filtering.

  ## Breaking Changes

  **1. The full text retriever now returns `maxResults` documents (default 3) instead of 10.**

  Previously the full text branch did not set `size`, so Elasticsearch applied its default of 10 and the
  `maxResults` of the retriever was ignored. It is now respected. If you were relying on the previous behaviour,
  set `maxResults` explicitly:

  ```java
  ElasticsearchContentRetriever retriever = ElasticsearchContentRetriever.builder()
          .client(client)
          .indexName("articles")
          .configuration(ElasticsearchConfigurationFullText.builder().build())
          .maxResults(10) // previously the implicit Elasticsearch default
          .build();
  ```

  Note that `minScore` and `filter` are now applied as well, so fewer documents may be returned even with the
  same `maxResults`. This is the point of the fix: documents which do not match the filter were being returned.

  **2. Two methods are deprecated (still working, to be removed in 2.0).**

  | Deprecated | Replacement |
  | --- | --- |
  | `ElasticsearchConfiguration.fullTextSearch(ElasticsearchClient, String, String)` | `ElasticsearchConfiguration.fullTextSearch(ElasticsearchClient, String, FullTextSearchRequest)` |
  | `AbstractElasticsearchEmbeddingStore.fullTextSearchMatches(String)` | `AbstractElasticsearchEmbeddingStore.fullTextSearchMatches(FullTextSearchRequest)` |

  Custom configurations which implement only the deprecated method keep working, but the `filter`, `maxResults`
  and `minScore` of the retriever are ignored and a warning is logged. To apply them, implement the new method:

  ```java
  public class MyElasticsearchConfiguration implements ElasticsearchConfiguration {

      @Override
      public SearchResponse<Document> fullTextSearch(
              ElasticsearchClient client, String indexName, FullTextSearchRequest request) {
          // request.textQuery(), request.maxResults(), request.minScore(), request.filter()
      }
  }
  ```

  Callers of the store method migrate like this:

  ```java
  // before
  List<EmbeddingMatch<TextSegment>> matches = store.fullTextSearchMatches("Elasticsearch");

  // after
  List<EmbeddingMatch<TextSegment>> matches = store.fullTextSearchMatches(FullTextSearchRequest.builder()
          .textQuery("Elasticsearch")
          .maxResults(3)
          .minScore(0.0)
          .filter(metadataKey("tenant").isEqualTo("private"))
          .build());
  ```

  ## General checklist
  - [ ] There are no breaking changes (API, behaviour) - see the "Breaking Changes" section above
  - [x] I have added unit and/or integration tests for my change
  - [x] The tests cover both positive and negative cases
  - [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
  - [x] Documentation is updated
  - [ ] I have added an example in the examples repo (not applicable for this bug fix)
  - [ ] I have added/updated Spring Boot starter(s) (not applicable)

  ## Validation

  - `./mvnw -pl langchain4j-elasticsearch -DskipITs test` - 18 unit tests, all green
  - `./mvnw -pl langchain4j-elasticsearch -Dit.test=ElasticsearchContentRetrieverIT verify` - 112 tests, all green
    (2 skipped, pre-existing), run against a real Elasticsearch container
  - `./mvnw -pl langchain4j-elasticsearch spotless:check` - green
  - `./mvnw -pl langchain4j-elasticsearch package revapi:check` - "API checks completed without failures"