### PR TITLE
Add voyage-code-4 embedding model to VoyageAI integration

### DIFF
--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingModelName.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingModelName.java
@@ -15,7 +15,8 @@ public enum VoyageAiEmbeddingModelName {
     VOYAGE_LAW_2("voyage-law-2", 1024),
 
     VOYAGE_CODE_2("voyage-code-2", 1536),
-    VOYAGE_CODE_3("voyage-code-3", 1024);
+    VOYAGE_CODE_3("voyage-code-3", 1024),
+    VOYAGE_CODE_4("voyage-code-4", 1024);
 
     private final String stringValue;
     private final Integer dimension;


### PR DESCRIPTION
## What

Adds the `voyage-code-4` model to the `VoyageAiEmbeddingModelName` enum.

Since `voyage-code-4` is not officially released yet, it reuses the `voyage-code-3` configuration (dimension 1024) as instructed.

## Why

Makes the upcoming `voyage-code-4` code embedding model selectable through the existing enum, matching how other VoyageAI models are exposed.

## Validation

- `mvn -pl langchain4j-voyage-ai compile` passes.