### PR TITLE
Fix Convert a JSON null to a null `Document` instead of the string "null"

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AwsDocumentConverter.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AwsDocumentConverter.java
@@ -85,7 +85,9 @@ class AwsDocumentConverter {
 
     private static Document getDocument(JsonNode value) {
         Document doc;
-        if (value.isBoolean()) {
+        if (value.isNull()) {
+            doc = Document.fromNull();
+        } else if (value.isBoolean()) {
             doc = Document.fromBoolean(value.asBoolean());
         } else if (value.isDouble() || value.isFloat() || value.isBigDecimal()) {
             doc = Document.fromNumber(value.asDouble());

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/AwsDocumentConverterTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/AwsDocumentConverterTest.java
@@ -85,7 +85,8 @@ class AwsDocumentConverterTest {
                     "string": "test",
                     "integer": 42,
                     "double": 42.5,
-                    "boolean": true
+                    "boolean": true,
+                    "null": null
                 }
                 """;
 
@@ -97,6 +98,29 @@ class AwsDocumentConverterTest {
         assertThat(document.asMap().get("integer").asNumber().intValue()).isEqualTo(42);
         assertThat(document.asMap().get("double").asNumber().doubleValue()).isEqualTo(42.5);
         assertThat(document.asMap().get("boolean").asBoolean()).isTrue();
+        assertThat(document.asMap().get("null").isNull()).isTrue();
+    }
+
+    @Test
+    void convert_json_null_to_document_null_in_nested_structures() {
+        // Given
+        String json = """
+                {
+                    "top": null,
+                    "list": [1, null, 2],
+                    "nested": {
+                        "inner": null
+                    }
+                }
+                """;
+
+        // When
+        Document document = AwsDocumentConverter.documentFromJson(json);
+
+        // Then
+        assertThat(document.asMap().get("top").isNull()).isTrue();
+        assertThat(document.asMap().get("list").asList().get(1).isNull()).isTrue();
+        assertThat(document.asMap().get("nested").asMap().get("inner").isNull()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Issue

Closes #6057

## Change

`getDocument` branched on boolean, number, array and object, then fell through to
`Document.fromString(value.asText())`. There was no `isNull()` branch and `NullNode.asText()` is `"null"`, so
a JSON null became a `Document` holding the string `"null"`, at any depth:

```
{"a": null, "b": [1, null, 2]}   ->   {"a": "null", "b": [1, "null", 2]}
```

`documentFromJson` converts tool call arguments in `AbstractBedrockChatModel` and streamed tool input in
`ConverseResponseFromStreamBuilder`, so a tool argument the model set to null reached the tool as `"null"`.

```java
if (value.isNull()) {
    doc = Document.fromNull();
} else if (value.isBoolean()) {
```

The reverse direction was already correct, `documentToObject` maps a null `Document` back to a JSON null, so
this makes the two halves of the class agree. #5503 fixed the same method for long and `BigInteger` tool
arguments; this is the same shape of gap for a different node type.

### Tests

In `AwsDocumentConverterTest`, both failing on unmodified `main`:

- `convert_json_to_primitive_types` gains a null field. Its mirror, `convert_primitive_types_to_json`, has
  covered `Document.fromNull()` since before this change, so the pair was asymmetric.
- `convert_json_null_to_document_null_in_nested_structures` covers a top-level null, a null inside a list and
  a null inside a nested object, since `getDocument` recurses through both.

```
mvn -pl langchain4j-bedrock verify -DskipITs
Tests run: 215, Failures: 0, Errors: 0, Skipped: 0
revapi: API checks completed without failures

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1331, Failures: 0, Errors: 0, Skipped: 0
```

Bedrock integration tests need an AWS account and were not run.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)