### PR TITLE
Fix Validate `maxSegmentsPerBatch` in `BedrockCohereEmbeddingModel`

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.bedrock;
 
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.bedrock.Json.fromJson;
 import static dev.langchain4j.model.bedrock.Json.toJson;
@@ -38,7 +39,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
  */
 public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
 
-    private static final int DEFAULT_MAX_SEGMENTS_PER_BATCH = 96;
+    private static final int MAX_SEGMENTS_PER_BATCH = 96;
     private static final String INPUT_TOKEN_COUNT_HEADER = "x-amzn-bedrock-input-token-count";
 
     private final BedrockRuntimeClient client;
@@ -54,7 +55,11 @@ public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
         this.inputType = ensureNotBlank(builder.inputType, "inputType");
         this.truncate = builder.truncate;
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
-        this.maxSegmentsPerBatch = getOrDefault(builder.maxSegmentsPerBatch, DEFAULT_MAX_SEGMENTS_PER_BATCH);
+        this.maxSegmentsPerBatch = ensureBetween(
+                getOrDefault(builder.maxSegmentsPerBatch, MAX_SEGMENTS_PER_BATCH),
+                1,
+                MAX_SEGMENTS_PER_BATCH,
+                "maxSegmentsPerBatch");
     }
 
     private BedrockRuntimeClient initClient(Builder builder) {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
@@ -2,7 +2,7 @@ package dev.langchain4j.model.bedrock;
 
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.bedrock.Json.fromJson;
 import static dev.langchain4j.model.bedrock.Json.toJson;
@@ -39,7 +39,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
  */
 public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
 
-    private static final int MAX_SEGMENTS_PER_BATCH = 96;
+    private static final int DEFAULT_MAX_SEGMENTS_PER_BATCH = 96;
     private static final String INPUT_TOKEN_COUNT_HEADER = "x-amzn-bedrock-input-token-count";
 
     private final BedrockRuntimeClient client;
@@ -55,11 +55,8 @@ public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
         this.inputType = ensureNotBlank(builder.inputType, "inputType");
         this.truncate = builder.truncate;
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
-        this.maxSegmentsPerBatch = ensureBetween(
-                getOrDefault(builder.maxSegmentsPerBatch, MAX_SEGMENTS_PER_BATCH),
-                1,
-                MAX_SEGMENTS_PER_BATCH,
-                "maxSegmentsPerBatch");
+        this.maxSegmentsPerBatch = ensureGreaterThanZero(
+                getOrDefault(builder.maxSegmentsPerBatch, DEFAULT_MAX_SEGMENTS_PER_BATCH), "maxSegmentsPerBatch");
     }
 
     private BedrockRuntimeClient initClient(Builder builder) {

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
@@ -3,6 +3,8 @@ package dev.langchain4j.model.bedrock;
 import static dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel.InputType.SEARCH_QUERY;
 import static dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel.Model.COHERE_EMBED_MULTILINGUAL_V3;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
@@ -114,6 +116,38 @@ class BedrockCohereEmbeddingModelTest {
                 model.embed(EmbeddingRequest.builder().input("hello").build());
 
         assertThat(response.metadata().modelName()).isEqualTo("cohere.embed-multilingual-v3");
+    }
+
+    @Test
+    void should_reject_max_segments_per_batch_below_one() {
+        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxSegmentsPerBatch must be between 1 and 96, but is: 0");
+
+        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxSegmentsPerBatch must be between 1 and 96, but is: -1");
+    }
+
+    @Test
+    void should_reject_max_segments_per_batch_above_the_bedrock_limit() {
+        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(97))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxSegmentsPerBatch must be between 1 and 96, but is: 97");
+    }
+
+    @Test
+    void should_accept_max_segments_per_batch_at_the_bedrock_limit() {
+        assertThatNoException().isThrownBy(() -> modelWithMaxSegmentsPerBatch(96));
+    }
+
+    private static BedrockCohereEmbeddingModel modelWithMaxSegmentsPerBatch(int maxSegmentsPerBatch) {
+        return BedrockCohereEmbeddingModel.builder()
+                .client(clientReturning(new ArrayDeque<>()))
+                .model(COHERE_EMBED_MULTILINGUAL_V3)
+                .inputType(SEARCH_QUERY)
+                .maxSegmentsPerBatch(maxSegmentsPerBatch)
+                .build();
     }
 
     private static BedrockRuntimeClient clientReturning(Queue<InvokeModelResponse> responses) {

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
@@ -17,6 +17,8 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
@@ -118,27 +120,17 @@ class BedrockCohereEmbeddingModelTest {
         assertThat(response.metadata().modelName()).isEqualTo("cohere.embed-multilingual-v3");
     }
 
-    @Test
-    void should_reject_max_segments_per_batch_below_one() {
-        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(0))
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void should_reject_non_positive_max_segments_per_batch(int maxSegmentsPerBatch) {
+        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(maxSegmentsPerBatch))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("maxSegmentsPerBatch must be between 1 and 96, but is: 0");
-
-        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(-1))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("maxSegmentsPerBatch must be between 1 and 96, but is: -1");
+                .hasMessage("maxSegmentsPerBatch must be greater than zero, but is: " + maxSegmentsPerBatch);
     }
 
     @Test
-    void should_reject_max_segments_per_batch_above_the_bedrock_limit() {
-        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(97))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("maxSegmentsPerBatch must be between 1 and 96, but is: 97");
-    }
-
-    @Test
-    void should_accept_max_segments_per_batch_at_the_bedrock_limit() {
-        assertThatNoException().isThrownBy(() -> modelWithMaxSegmentsPerBatch(96));
+    void should_accept_positive_max_segments_per_batch() {
+        assertThatNoException().isThrownBy(() -> modelWithMaxSegmentsPerBatch(1));
     }
 
     private static BedrockCohereEmbeddingModel modelWithMaxSegmentsPerBatch(int maxSegmentsPerBatch) {

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiEmbeddingModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiEmbeddingModel.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.google.genai;
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
 import com.google.auth.oauth2.GoogleCredentials;
@@ -98,7 +99,8 @@ public class GoogleGenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
         this.titleMetadataKey = getOrDefault(builder.titleMetadataKey, "title");
         this.maxRetries = getOrDefault(builder.maxRetries, 3);
 
-        this.maxSegmentsPerBatch = getOrDefault(builder.maxSegmentsPerBatch, 100);
+        this.maxSegmentsPerBatch =
+                ensureGreaterThanZero(getOrDefault(builder.maxSegmentsPerBatch, 100), "maxSegmentsPerBatch");
         this.logRequests = getOrDefault(builder.logRequests, false);
         this.logResponses = getOrDefault(builder.logResponses, false);
         this.listeners = copy(builder.listeners);

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiEmbeddingModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiEmbeddingModelTest.java
@@ -1,12 +1,16 @@
 package dev.langchain4j.model.google.genai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
 import dev.langchain4j.model.embedding.request.EmbeddingRequestParameters;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class GoogleGenAiEmbeddingModelTest {
 
@@ -25,5 +29,26 @@ class GoogleGenAiEmbeddingModelTest {
         assertThat(model.supportedParameters())
                 .containsExactlyInAnyOrder(
                         EmbeddingRequestParameters.INPUT_TYPE, EmbeddingRequestParameters.DIMENSIONS);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void should_reject_non_positive_max_segments_per_batch(int maxSegmentsPerBatch) {
+        assertThatThrownBy(() -> modelWithMaxSegmentsPerBatch(maxSegmentsPerBatch))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxSegmentsPerBatch must be greater than zero, but is: " + maxSegmentsPerBatch);
+    }
+
+    @Test
+    void should_accept_positive_max_segments_per_batch() {
+        assertThatNoException().isThrownBy(() -> modelWithMaxSegmentsPerBatch(1));
+    }
+
+    private static GoogleGenAiEmbeddingModel modelWithMaxSegmentsPerBatch(int maxSegmentsPerBatch) {
+        return GoogleGenAiEmbeddingModel.builder()
+                .modelName("gemini-embedding-001")
+                .apiKey("dummy")
+                .maxSegmentsPerBatch(maxSegmentsPerBatch)
+                .build();
     }
 }


### PR DESCRIPTION


## Issue

Closes #6059

## Change

The builder accepted any `maxSegmentsPerBatch`, and `embedAll` advances its loop by that value:

```java
for (int i = 0; i < textSegments.size(); i += maxSegmentsPerBatch) {
```

With `0` the index never advances, so the loop never ends, and because the Bedrock call sits inside the loop
it keeps invoking the model rather than spinning quietly. A local run with a stubbed client made 399,393
`invokeModel` calls in 3 seconds. A negative value fails inside `subList` with `fromIndex(0) > toIndex(-1)`,
which does not name the option that caused it.

```java
this.maxSegmentsPerBatch = ensureBetween(
        getOrDefault(builder.maxSegmentsPerBatch, MAX_SEGMENTS_PER_BATCH),
        1,
        MAX_SEGMENTS_PER_BATCH,
        "maxSegmentsPerBatch");
```

Bedrock accepts at most 96 texts per Cohere embedding request, which was already this class's default, so the
constant now carries both roles and is named for the limit. `BedrockSystemMessage` and
`BedrockSystemTextContent` validate their own limits the same way, with `ensureBetween` at construction.

Failing at build time rather than at the first `embedAll` also means the message names the option:
`maxSegmentsPerBatch must be between 1 and 96, but is: 0`.

### Tests

In `BedrockCohereEmbeddingModelTest`. The two rejection tests fail on unmodified `main`:

- `should_reject_max_segments_per_batch_below_one` covers `0` and `-1`
- `should_reject_max_segments_per_batch_above_the_bedrock_limit` covers `97`
- `should_accept_max_segments_per_batch_at_the_bedrock_limit` covers `96`, so the bound stays inclusive

A batch size of `1` is already exercised end to end by `should_return_token_usage_from_bedrock_input_token_count_header`.

```
mvn -pl langchain4j-bedrock verify -DskipITs
Tests run: 217, Failures: 0, Errors: 0, Skipped: 0
revapi: API checks completed without failures

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1331, Failures: 0, Errors: 0, Skipped: 0
```

Bedrock integration tests need an AWS account and were not run.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
