### PR TITLE
fix: honor the negation in SqlFilterParser NOT BETWEEN

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -194,7 +194,8 @@ public class SqlFilterParser implements FilterParser {
         String key = getKey(between.getLeftExpression());
         Comparable<?> from = getValue(between.getBetweenExpressionStart());
         Comparable<?> to = getValue(between.getBetweenExpressionEnd());
-        return new IsGreaterThanOrEqualTo(key, from).and(new IsLessThanOrEqualTo(key, to));
+        Filter range = new IsGreaterThanOrEqualTo(key, from).and(new IsLessThanOrEqualTo(key, to));
+        return between.isNot() ? new Not(range) : range;
     }
 
     private String getKey(BinaryExpression binaryExpression) {

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -1501,6 +1501,92 @@ class SqlFilterParserTest {
     }
 
     @Test
+    void should_support_NOT_BETWEEN() {
+
+        // given
+        String sql = "SELECT name FROM movies WHERE year NOT BETWEEN 1990 AND 1999;";
+
+        // when
+        Filter filter = parser.parse(sql);
+
+        // then
+        assertThat(filter)
+                .isEqualTo(not(metadataKey("year")
+                        .isGreaterThanOrEqualTo(1990L)
+                        .and(metadataKey("year").isLessThanOrEqualTo(1999L))));
+    }
+
+    /**
+     * Every bound form is exercised against both {@code BETWEEN} and {@code NOT BETWEEN},
+     * so that a bound form supported by one and dropped by the other cannot go unnoticed.
+     */
+    @ParameterizedTest
+    @MethodSource
+    void should_parse_BETWEEN_with_and_without_negation(String sqlWhereExpression, Filter expectedFilter) {
+
+        // when
+        Filter filter = parser.parse(sqlWhereExpression);
+
+        // then
+        assertThat(filter).isEqualTo(expectedFilter);
+    }
+
+    static Stream<Arguments> should_parse_BETWEEN_with_and_without_negation() {
+        return Stream.of(
+                        bothBetweenForms(
+                                "18 AND 42",
+                                metadataKey("key")
+                                        .isGreaterThanOrEqualTo(18L)
+                                        .and(metadataKey("key").isLessThanOrEqualTo(42L))),
+                        bothBetweenForms(
+                                "-42 AND -18",
+                                metadataKey("key")
+                                        .isGreaterThanOrEqualTo(-42L)
+                                        .and(metadataKey("key").isLessThanOrEqualTo(-18L))),
+                        bothBetweenForms(
+                                "-18 AND 42",
+                                metadataKey("key")
+                                        .isGreaterThanOrEqualTo(-18L)
+                                        .and(metadataKey("key").isLessThanOrEqualTo(42L))),
+                        bothBetweenForms(
+                                "67.8 AND 78.9",
+                                metadataKey("key")
+                                        .isGreaterThanOrEqualTo(67.8d)
+                                        .and(metadataKey("key").isLessThanOrEqualTo(78.9d))),
+                        bothBetweenForms(
+                                "-78.9 AND -67.8",
+                                metadataKey("key")
+                                        .isGreaterThanOrEqualTo(-78.9d)
+                                        .and(metadataKey("key").isLessThanOrEqualTo(-67.8d))),
+                        bothBetweenForms(
+                                "'a' AND 'z'",
+                                metadataKey("key")
+                                        .isGreaterThanOrEqualTo("a")
+                                        .and(metadataKey("key").isLessThanOrEqualTo("z"))),
+                        bothBetweenForms(
+                                "1 + 1 AND 2 + 3",
+                                metadataKey("key")
+                                        .isGreaterThanOrEqualTo(2L)
+                                        .and(metadataKey("key").isLessThanOrEqualTo(5L))))
+                .flatMap(stream -> stream);
+    }
+
+    private static Stream<Arguments> bothBetweenForms(String bounds, Filter range) {
+        return Stream.of(of("key BETWEEN " + bounds, range), of("key NOT BETWEEN " + bounds, not(range)));
+    }
+
+    @Test
+    void NOT_BETWEEN_should_equal_the_explicit_NOT_form() {
+
+        assertThat(parser.parse("year NOT BETWEEN 1990 AND 1999"))
+                .isEqualTo(parser.parse("NOT (year BETWEEN 1990 AND 1999)"));
+        assertThat(parser.parse("age NOT BETWEEN -20 AND -10"))
+                .isEqualTo(parser.parse("NOT (age BETWEEN -20 AND -10)"));
+        assertThat(parser.parse("name NOT BETWEEN 'a' AND 'z'"))
+                .isEqualTo(parser.parse("NOT (name BETWEEN 'a' AND 'z')"));
+    }
+
+    @Test
     void should_support_YEAR_function_in_WHERE_clause() {
         // given
         String sql = "SELECT * FROM movies WHERE YEAR(year) = 2024 AND genre IN ('comedy', 'drama')";


### PR DESCRIPTION
## Issue

Closes #6062

## Change

`mapBetween` built the range filter but never read `Between#isNot()`, so `NOT BETWEEN` produced exactly the same `Filter` as `BETWEEN` — the query returned the range it asked to exclude. JSqlParser sets `isNot = true` on the node, so the information was available and simply not consumed.

```java
Filter range = new IsGreaterThanOrEqualTo(key, from).and(new IsLessThanOrEqualTo(key, to));
return between.isNot() ? new Not(range) : range;
```

`Not(And(gte, lte))` is the shape the parser already produces for the equivalent `NOT (x BETWEEN a AND b)` written with an explicit `NotExpression`, so after this change the two spellings of the same predicate parse identically. No embedding store mapper sees a filter shape it did not already handle.

I deliberately did not introduce an `IsNotBetween` filter type, nor route negation through a shared helper:

- There is no `IsBetween` either — `BETWEEN` has always been expressed as `And(gte, lte)` — so a negative-only type would be asymmetric, and adding both would change what `BETWEEN` currently parses into.
- Adding a `Filter` type is a `langchain4j-core` API change: every `Filter` mapper would have to handle it or throw `UnsupportedOperationException`, including `EmbeddingStore` implementations outside this repository.
- Folding `NOT IN` into the same `Not(positive)` treatment would replace `IsNotIn` with `Not(IsIn)`. The two are equivalent at `test()` level, but the mappers are not: most of them map `IsNotIn` to a native negative operator (`$nin`, `NOT IN`), and that mapping would be lost.

### Behaviour delta

Only `NOT BETWEEN` changes. `BETWEEN` is untouched — the new `range` local is the previous expression, returned unchanged when `isNot()` is false.

| SQL | Before | After |
|---|---|---|
| `year BETWEEN 1990 AND 1999` | `And(gte 1990, lte 1999)` | unchanged |
| `year NOT BETWEEN 1990 AND 1999` | `And(gte 1990, lte 1999)` | `Not(And(gte 1990, lte 1999))` |
| `NOT (year BETWEEN 1990 AND 1999)` | `Not(And(gte 1990, lte 1999))` | unchanged |

Evaluated with `Filter#test`, `age NOT BETWEEN 10 AND 20` now excludes 10, 15 and 20 and admits 5 and 25. A document without the key is admitted, which is what the explicit `NOT (...)` form has always done.

### Tests

`should_support_NOT_BETWEEN` covers the reported case, and `NOT_BETWEEN_should_equal_the_explicit_NOT_form` pins the two spellings together.

`should_parse_BETWEEN_with_and_without_negation` is a small matrix: seven bound forms (positive, negative, mixed-sign, decimal, negative decimal, string, arithmetic) each exercised against both `BETWEEN` and `NOT BETWEEN`, so a bound form supported by one and dropped by the other cannot pass unnoticed. That product is what this defect slipped through — the existing suite covered `IN` × negation and `BETWEEN` × bound forms, but never `BETWEEN` × negation.

On `main` the 9 new cases fail and the rest of the suite stays green; with the fix the module is at 189 passing.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- The class Javadoc documents BETWEEN without restricting it to the positive form, so no documentation change is needed. Happy to add an explicit NOT BETWEEN line there if you prefer. -->

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
