### PR TITLE
fix: unescape doubled single quotes in SqlFilterParser string literals

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -230,7 +230,7 @@ public class SqlFilterParser implements FilterParser {
 
     private Comparable<?> getValue(Expression expression) {
         if (expression instanceof StringValue) {
-            return ((StringValue) expression).getValue();
+            return ((StringValue) expression).getNotExcapedValue();
         } else if (expression instanceof LongValue) {
             return ((LongValue) expression).getValue();
         } else if (expression instanceof DoubleValue) {

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -176,6 +176,25 @@ class SqlFilterParserTest {
                                         metadataKey("form").isEqualTo("circle")),
                                 metadataKey("area").isGreaterThan(7L))))
 
+                // escaped single quotes inside string literals
+                .add(of("name = 'O''Brien'", metadataKey("name").isEqualTo("O'Brien")))
+                .add(of("name != 'O''Brien'", metadataKey("name").isNotEqualTo("O'Brien")))
+                .add(of("name > 'O''Brien'", metadataKey("name").isGreaterThan("O'Brien")))
+                .add(of("name >= 'O''Brien'", metadataKey("name").isGreaterThanOrEqualTo("O'Brien")))
+                .add(of("name < 'O''Brien'", metadataKey("name").isLessThan("O'Brien")))
+                .add(of("name <= 'O''Brien'", metadataKey("name").isLessThanOrEqualTo("O'Brien")))
+                .add(of("name IN ('O''Brien', 'Klaus')", metadataKey("name").isIn("O'Brien", "Klaus")))
+                .add(of("name NOT IN ('O''Brien', 'Klaus')", metadataKey("name").isNotIn("O'Brien", "Klaus")))
+                .add(of("name = '''Klaus'", metadataKey("name").isEqualTo("'Klaus")))
+                .add(of("name = 'Klaus'''", metadataKey("name").isEqualTo("Klaus'")))
+                .add(of("name = ''''", metadataKey("name").isEqualTo("'")))
+                .add(of("name = 'it''s a ''test'''", metadataKey("name").isEqualTo("it's a 'test'")))
+
+                // string literals without escaping are unaffected
+                .add(of("name = ''", metadataKey("name").isEqualTo("")))
+                .add(of("name = 'back\\slash'", metadataKey("name").isEqualTo("back\\slash")))
+                .add(of("name = 'has \"double\" quotes'", metadataKey("name").isEqualTo("has \"double\" quotes")))
+
                 // complete SQL statements
                 .add(of(
                         "SELECT * from fake_table WHERE id = 7",
@@ -224,6 +243,17 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", "aa"),
                                 new Metadata().put("key", "a a"),
                                 new Metadata().put("key2", "a"))))
+
+                // escaped single quote
+                .add(Arguments.of(
+                        "key = 'O''Brien'",
+                        asList(
+                                new Metadata().put("key", "O'Brien"),
+                                new Metadata().put("key", "O'Brien").put("key2", "b")),
+                        asList(
+                                new Metadata().put("key", "O''Brien"),
+                                new Metadata().put("key", "OBrien"),
+                                new Metadata().put("key2", "O'Brien"))))
 
                 // integer
                 .add(Arguments.of(


### PR DESCRIPTION
## Issue

No separate issue was filed; the defect is described below.

## Change

SQL escapes a single quote inside a string literal by doubling it, so `name = 'O''Brien'` denotes the seven-character value `O'Brien`. JSqlParser splits that into two steps and exposes both: the lexer strips the delimiters and stores the raw text in `StringValue.value`, and `getNotExcapedValue()` folds `''` back into `'`. `getValue()` returns the field untouched:

```java
public String getValue() {
    return value;                                    // "O''Brien"
}

public String getNotExcapedValue() {
    StringBuilder buffer = new StringBuilder(value); // "O'Brien"
    ...
}
```

`getValue(Expression)` called the former, so every string literal carried the SQL source spelling into the `Filter` instead of the value it denotes. `metadataKey("name").isEqualTo("O''Brien")` never matches metadata holding `O'Brien`, and nothing reports it — no exception, no log, just an empty result set that is indistinguishable from "no such document".

The fix is to call the accessor that resolves the escape:

```diff
 private Comparable<?> getValue(Expression expression) {
     if (expression instanceof StringValue) {
-        return ((StringValue) expression).getValue();
+        return ((StringValue) expression).getNotExcapedValue();
     } else if (expression instanceof LongValue) {
```

One line covers all eight operators, because #6037 already funnelled `IN`/`NOT IN` element values through `getValue(Expression)`; before that change this would have needed a second fix in `mapInExpression`.

The numeric branches keep `getValue()` — escaping is not a concept for `LongValue`/`DoubleValue`, and those classes do not declare `getNotExcapedValue()`.

Note on the method name: `getNotExcapedValue` looks like a typo for `getNotEscapedValue`, but that is the spelling JSqlParser 4.9 declares, so it is used verbatim here.

### Impact on embedding stores

The stale value reaches the stores in two shapes. Mappers that build a query string re-escape what they are given, so `PgVectorFilterMapper.formatValue` turns `O''Brien` into the literal `'O''''Brien'`, which Postgres reads back as `O''Brien`. Mappers that build a structured query — `MongoDbMetadataFilterMapper` via `Filters.eq`, `PineconeMetadataFilterMapper` via `Struct`, and the rest — pass the string through unchanged, so the store compares against a value two characters too long. `InMemoryEmbeddingStore` reaches `actualValue.equals(comparisonValue)` and returns `false`. None of the 20 mappers is at fault; each faithfully forwards what the parser produced.

This is a correctness problem, not an injection one: the quotes are escaped more, never less, so they cannot break out of a literal.

### Behaviour delta

I replayed `getValue()` and `getNotExcapedValue()` side by side over a corpus of 14 operator contexts × 15 string literals, comparing the 270 `StringValue` nodes that construction produces. 186 are byte-identical and 84 differ, and the 84 are exactly the literals whose raw value contains `''`:

| SQL literal | Before | After |
|---|---|---|
| `'O''Brien'` | `O''Brien` | `O'Brien` |
| `'''Klaus'` | `''Klaus` | `'Klaus` |
| `'Klaus'''` | `Klaus''` | `Klaus'` |
| `''''` | `''` | `'` |
| `'a''''b'` | `a''''b` | `a''b` |
| `'it''s a ''test'''` | `it''s a ''test''` | `it's a 'test'` |

Everything without a doubled quote is unchanged, including `''` (empty string), `'back\slash'`, `'has "double" quotes'`, `'100%'`, `'a,b'`, `'  spaced  '` and non-ASCII text. JSqlParser treats a backslash as an ordinary character, so no other escape convention is involved.

No working query changes meaning. For a filter to have matched before, the stored metadata would have had to contain the SQL spelling `O''Brien` literally, which requires writing SQL escape syntax into a `Metadata` value that never passes through a SQL parser.

### Tests

`SqlFilterParserTest` gains twelve `should_parse` cases covering a doubled quote across all eight operators plus leading, trailing, consecutive and repeated positions; three cases pinning literals that must stay unchanged; and one `should_filter_by_metadata` case asserting that `key = 'O''Brien'` matches metadata holding `O'Brien` and rejects metadata holding `O''Brien`. On `main` the twelve escape cases and the metadata case fail with the doubled quote retained, while the three unchanged-literal cases pass either way.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- The class Javadoc documents the supported operations and gives `name = 'Klaus'` as a string example without describing literal syntax, so resolving the standard SQL escape needs no documentation change. -->

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
