### PR TITLE
Raise MCP JSON-RPC errors from list operations instead of NullPointerException

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -503,8 +503,8 @@ public class DefaultMcpClient implements McpClient {
         JsonNode serverInfoNode = result.path("_meta").path("io.modelcontextprotocol/serverInfo");
         if (!serverInfoNode.isMissingNode() && !serverInfoNode.isNull()) {
             McpImplementation implementation = OBJECT_MAPPER.convertValue(serverInfoNode, McpImplementation.class);
-            serverInfo = new McpServerInfo(
-                    implementation.getName(), implementation.getVersion(), implementation.getTitle());
+            serverInfo =
+                    new McpServerInfo(implementation.getName(), implementation.getVersion(), implementation.getTitle());
         }
 
         Map<String, Object> capabilities = Map.of();
@@ -1285,6 +1285,8 @@ public class DefaultMcpClient implements McpClient {
             } finally {
                 pendingOperations.remove(operation.getId());
             }
+            // An error response carries no "result", so it has to be raised before anything reads that field.
+            McpErrorHelper.checkForErrors(result);
             if (modernProtocol) {
                 String resultType = getResultType(result);
                 // servers may only send an InputRequiredResult in response to prompts/get, resources/read and

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -191,6 +191,24 @@ public class DefaultMcpClientTest {
     }
 
     @Test
+    public void should_throw_mcp_exception_when_tool_list_is_refused() throws Exception {
+        // given
+        final McpTransport transport = getMinimalMcpTransportMock();
+        final DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+        final ObjectNode errorResponse = JsonNodeFactory.instance.objectNode();
+        errorResponse.put("jsonrpc", "2.0").put("id", 1);
+        errorResponse.putObject("error").put("code", -32600).put("message", "You are not allowed to use these tools");
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse));
+
+        // when + then: the server's reason reaches the caller instead of a NullPointerException
+        assertThatThrownBy(client::listTools)
+                .isInstanceOf(McpException.class)
+                .hasMessageContaining("You are not allowed to use these tools");
+    }
+
+    @Test
     public void should_cache_tool_list() throws Exception {
         // given
         final McpTransport transport = getMinimalMcpTransportMock();


### PR DESCRIPTION
## Issue

Closes #6071

## Change

`fetchPaginatedList` passed the raw response to the result parser without checking it for a JSON-RPC error. The parser `obtainToolList` supplies reads `result.get("result").get("tools")`, and `result` is absent on an error response, so a server that refuses `tools/list` made `listTools()` fail with a bare `NullPointerException` and its message was lost.

The fix raises the error where the response arrives, before anything reads `result`:

```java
McpErrorHelper.checkForErrors(result);
```

This is the same call `PromptsHelper` and `ResourcesHelper` already make, so a refused `prompts/list` or `resources/list` was already reported correctly as `McpException`; only the tools path was missing it. Putting it in `fetchPaginatedList` covers tools, resources, resource templates and prompts in one place, including the pages fetched after the first one.

It also has to run before the `modernProtocol` block, since `getResultType` reads `result` too.

**Behaviour change:** a list operation answered with a JSON-RPC error now throws `McpException` (carrying the server's code and message) where it previously threw `NullPointerException`. Anything that already succeeded keeps working unchanged.

One unrelated line was reflowed by `./mvnw spotless:apply` (`DefaultMcpClient:503`); I left it in rather than hand-editing the formatter's output.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Notes on the checklist: the new test `should_throw_mcp_exception_when_tool_list_is_refused` fails with the reported `NullPointerException` without the fix and passes with it; the existing `should_list_tools` covers the positive case. `mvn test` run on `langchain4j-mcp` (146), `langchain4j-core` (1247) and `langchain4j` (1331), all green — tests needing a provider API key were not run. No documentation change seemed warranted for an exception type that the prompts and resources paths already throw.
