### PR TITLE
Fix invalid Chroma relevance scores for collections that do not use cosine distance

### DIFF
--- a/docs/docs/integrations/embedding-stores/chroma.md
+++ b/docs/docs/integrations/embedding-stores/chroma.md
@@ -42,6 +42,29 @@ ChromaEmbeddingStore.builder()
     .build();
 ```
 
+## Distance Metric
+
+A Chroma collection is created with a distance metric, which determines how the distance between two embeddings
+is measured. Chroma supports `cosine`, `l2` (squared euclidean) and `ip` (inner product), and uses `l2` unless
+another metric is requested.
+
+When `ChromaEmbeddingStore` creates a collection, it creates it with the `cosine` distance metric.
+When the collection already exists, it is used as is, whichever distance metric it was created with:
+
+```java
+ChromaEmbeddingStore store = ChromaEmbeddingStore.builder()
+    .baseUrl("http://localhost:8000")
+    .collectionName("my-collection")
+    .build();
+```
+
+The relevance score returned by `EmbeddingMatch.score()` is always in the `[0, 1]` range, where 1 means the most
+relevant. It is derived from the distance metric of the collection, so scores obtained from collections with
+different distance metrics are not comparable with each other. The same applies to the `minScore` of an
+`EmbeddingSearchRequest`, which is compared against the score of the collection's own metric.
+
+For `ip`, the score is accurate only if the embeddings are normalized, which is the case for most embedding models.
+
 ## Current Limitations
 
 - Chroma cannot filter by greater and less than of alphanumeric metadata, only int and float are supported

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
@@ -34,6 +34,8 @@ import java.util.function.Supplier;
  */
 public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
 
+    private static final String COSINE_DISTANCE = "cosine";
+
     private final ChromaClient chromaClient;
     private String collectionId;
     private final String collectionName;
@@ -76,6 +78,7 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
         if (collection == null) {
             createCollection();
         } else {
+            ensureCosineDistance(collection);
             collectionId = collection.getId();
         }
     }
@@ -361,6 +364,16 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
         String text = queryResponse.getDocuments().get(0).get(i);
         Map<String, Object> metadata = queryResponse.getMetadatas().get(0).get(i);
         return text == null ? null : TextSegment.from(text, metadata == null ? new Metadata() : new Metadata(metadata));
+    }
+
+    private void ensureCosineDistance(Collection collection) {
+        String distanceFunction = collection.distanceFunction();
+        if (!COSINE_DISTANCE.equalsIgnoreCase(distanceFunction)) {
+            throw new IllegalStateException("Chroma collection '" + collectionName + "' uses distance metric '"
+                    + distanceFunction + "', but ChromaEmbeddingStore requires '" + COSINE_DISTANCE
+                    + "' to produce valid relevance scores. Use or recreate a collection configured with "
+                    + COSINE_DISTANCE + " distance.");
+        }
     }
 
     private void createCollection() {

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
@@ -20,6 +20,7 @@ import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.RelevanceScore;
 import dev.langchain4j.store.embedding.filter.Filter;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -30,14 +31,18 @@ import java.util.function.Supplier;
 
 /**
  * Represents a store for embeddings using the Chroma backend.
- * Always uses cosine distance as the distance metric.
+ * <p>
+ * Collections created by this store use cosine distance. When an already existing collection is used, the
+ * distance metric it was created with is detected and {@link EmbeddingMatch#score()} is derived from it.
  */
 public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     private static final String COSINE_DISTANCE = "cosine";
+    private static final String L2_DISTANCE = "l2";
 
     private final ChromaClient chromaClient;
     private String collectionId;
+    private String distanceFunction;
     private final String collectionName;
 
     /**
@@ -78,8 +83,8 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
         if (collection == null) {
             createCollection();
         } else {
-            ensureCosineDistance(collection);
             collectionId = collection.getId();
+            distanceFunction = collection.distanceFunction();
         }
     }
 
@@ -334,7 +339,7 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
         return matches.stream().filter(match -> match.score() >= minScore).collect(toList());
     }
 
-    private static List<EmbeddingMatch<TextSegment>> toEmbeddingMatches(QueryResponse queryResponse) {
+    private List<EmbeddingMatch<TextSegment>> toEmbeddingMatches(QueryResponse queryResponse) {
         List<EmbeddingMatch<TextSegment>> embeddingMatches = new ArrayList<>();
 
         for (int i = 0; i < queryResponse.getIds().get(0).size(); i++) {
@@ -350,14 +355,20 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
     }
 
     /**
-     * By default, cosine distance will be used. For details: <a href="https://docs.trychroma.com/usage-guide"></a>
-     * Converts a cosine distance in the range [0, 2] to a score in the range [0, 1].
+     * Converts a distance reported by Chroma into a relevance score in the range [0, 1],
+     * according to the distance metric of the collection.
+     * For details see <a href="https://docs.trychroma.com/docs/collections/configure">Chroma documentation</a>.
      *
      * @param distance The distance value.
      * @return The converted score.
      */
-    private static double distanceToScore(double distance) {
-        return 1 - (distance / 2);
+    private double distanceToScore(double distance) {
+        if (L2_DISTANCE.equalsIgnoreCase(distanceFunction)) {
+            // "l2" is the squared euclidean distance, which is unbounded
+            return 1 / (1 + distance);
+        }
+        // "cosine" distance is in the range [0, 2], "ip" distance is 1 minus the inner product
+        return RelevanceScore.fromCosineSimilarity(1 - distance);
     }
 
     private static TextSegment toTextSegment(QueryResponse queryResponse, int i) {
@@ -366,20 +377,11 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
         return text == null ? null : TextSegment.from(text, metadata == null ? new Metadata() : new Metadata(metadata));
     }
 
-    private void ensureCosineDistance(Collection collection) {
-        String distanceFunction = collection.distanceFunction();
-        if (!COSINE_DISTANCE.equalsIgnoreCase(distanceFunction)) {
-            throw new IllegalStateException("Chroma collection '" + collectionName + "' uses distance metric '"
-                    + distanceFunction + "', but ChromaEmbeddingStore requires '" + COSINE_DISTANCE
-                    + "' to produce valid relevance scores. Use or recreate a collection configured with "
-                    + COSINE_DISTANCE + " distance.");
-        }
-    }
-
     private void createCollection() {
         collectionId = chromaClient
                 .createCollection(new CreateCollectionRequest(this.collectionName))
                 .getId();
+        distanceFunction = COSINE_DISTANCE;
     }
 
     private void createTenantAndDbIfNotExists(ChromaClientV2 chromaClient) {

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/Collection.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/Collection.java
@@ -35,6 +35,8 @@ class Collection {
     }
 
     String distanceFunction() {
+        // "metadata" is checked first on purpose: Chroma 0.5.x reports the default "l2" in "configuration_json"
+        // even for a collection that was created with a different metric through "metadata"
         String space = metadataSpace();
         if (space != null) {
             return space;

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/Collection.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/Collection.java
@@ -6,9 +6,17 @@ import java.util.Map;
 @Internal
 class Collection {
 
+    private static final String DEFAULT_DISTANCE_FUNCTION = "l2";
+    private static final String SPACE_KEY = "space";
+    private static final String HNSW_SPACE_METADATA_KEY = "hnsw:space";
+    private static final String HNSW_KEY = "hnsw";
+    private static final String LEGACY_HNSW_KEY = "hnsw_configuration";
+    private static final String SPANN_KEY = "spann";
+
     private String id;
     private String name;
     private Map<String, Object> metadata;
+    private Map<String, Object> configurationJson;
 
     public String getId() {
         return id;
@@ -20,5 +28,53 @@ class Collection {
 
     public Map<String, Object> getMetadata() {
         return metadata;
+    }
+
+    public Map<String, Object> getConfigurationJson() {
+        return configurationJson;
+    }
+
+    String distanceFunction() {
+        String space = metadataSpace();
+        if (space != null) {
+            return space;
+        }
+
+        space = configuredSpace();
+        return space != null ? space : DEFAULT_DISTANCE_FUNCTION;
+    }
+
+    private String metadataSpace() {
+        if (metadata == null) {
+            return null;
+        }
+        Object space = metadata.get(HNSW_SPACE_METADATA_KEY);
+        return space == null ? null : space.toString();
+    }
+
+    private String configuredSpace() {
+        if (configurationJson == null) {
+            return null;
+        }
+
+        String space = spaceFrom(configurationJson.get(HNSW_KEY));
+        if (space != null) {
+            return space;
+        }
+
+        space = spaceFrom(configurationJson.get(LEGACY_HNSW_KEY));
+        if (space != null) {
+            return space;
+        }
+
+        return spaceFrom(configurationJson.get(SPANN_KEY));
+    }
+
+    private static String spaceFrom(Object configuration) {
+        if (!(configuration instanceof Map<?, ?> configurationMap)) {
+            return null;
+        }
+        Object space = configurationMap.get(SPACE_KEY);
+        return space == null ? null : space.toString();
     }
 }

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CapturingHttpClient.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CapturingHttpClient.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.store.embedding.chroma;
 
 import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpRequest;
@@ -9,6 +10,8 @@ import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
 
 /**
  * An {@link HttpClient} that records every request it receives and answers with a canned Chroma response,
@@ -20,14 +23,23 @@ class CapturingHttpClient implements HttpClient {
             "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{\"hnsw:space\":\"cosine\"}}";
 
     private final List<HttpRequest> requests = new ArrayList<>();
-    private final String collectionBody;
+    private String collectionBody = DEFAULT_COLLECTION;
+    private List<Double> distances = List.of(0.0);
 
-    CapturingHttpClient() {
-        this(DEFAULT_COLLECTION);
+    /**
+     * Answers the "get collection" call with the given JSON, to simulate a collection that already exists.
+     */
+    CapturingHttpClient withCollection(String collectionBody) {
+        this.collectionBody = collectionBody;
+        return this;
     }
 
-    CapturingHttpClient(String collectionBody) {
-        this.collectionBody = collectionBody;
+    /**
+     * Answers the "query collection" call with one match per given distance.
+     */
+    CapturingHttpClient withDistances(Double... distances) {
+        this.distances = List.of(distances);
+        return this;
     }
 
     List<HttpRequest> requests() {
@@ -59,6 +71,9 @@ class CapturingHttpClient implements HttpClient {
         if (url.endsWith("/add")) {
             return "true";
         }
+        if (url.endsWith("/query")) {
+            return queryResponse();
+        }
         if (url.endsWith("/api/v1/collections")) {
             return DEFAULT_COLLECTION;
         }
@@ -66,5 +81,19 @@ class CapturingHttpClient implements HttpClient {
             return collectionBody;
         }
         throw new IllegalArgumentException("Unexpected URL: " + url);
+    }
+
+    private String queryResponse() {
+        String ids = join(i -> "\"id" + i + "\"");
+        String embeddings = join(i -> "[1.0,2.0,3.0]");
+        String documents = join(i -> "\"document" + i + "\"");
+        String metadatas = join(i -> "{}");
+        String distanceValues = join(i -> String.valueOf(distances.get(i)));
+        return "{\"ids\":[[" + ids + "]],\"embeddings\":[[" + embeddings + "]],\"documents\":[[" + documents
+                + "]],\"metadatas\":[[" + metadatas + "]],\"distances\":[[" + distanceValues + "]]}";
+    }
+
+    private String join(IntFunction<String> element) {
+        return IntStream.range(0, distances.size()).mapToObj(element).collect(joining(","));
     }
 }

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CapturingHttpClient.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CapturingHttpClient.java
@@ -16,7 +16,19 @@ import java.util.List;
  */
 class CapturingHttpClient implements HttpClient {
 
+    private static final String DEFAULT_COLLECTION =
+            "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{\"hnsw:space\":\"cosine\"}}";
+
     private final List<HttpRequest> requests = new ArrayList<>();
+    private final String collectionBody;
+
+    CapturingHttpClient() {
+        this(DEFAULT_COLLECTION);
+    }
+
+    CapturingHttpClient(String collectionBody) {
+        this.collectionBody = collectionBody;
+    }
 
     List<HttpRequest> requests() {
         return requests;
@@ -37,7 +49,7 @@ class CapturingHttpClient implements HttpClient {
         throw new UnsupportedOperationException("SSE is not used by ChromaEmbeddingStore");
     }
 
-    private static String bodyFor(String url) {
+    private String bodyFor(String url) {
         if (url.endsWith("/api/v2/tenants/default")) {
             return "{\"name\":\"default\"}";
         }
@@ -48,10 +60,10 @@ class CapturingHttpClient implements HttpClient {
             return "true";
         }
         if (url.endsWith("/api/v1/collections")) {
-            return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
+            return DEFAULT_COLLECTION;
         }
         if (url.contains("/collections/test")) {
-            return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
+            return collectionBody;
         }
         throw new IllegalArgumentException("Unexpected URL: " + url);
     }

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreDistanceMetricIT.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreDistanceMetricIT.java
@@ -1,0 +1,54 @@
+package dev.langchain4j.store.embedding.chroma;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.chromadb.ChromaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class ChromaEmbeddingStoreDistanceMetricIT {
+
+    @Container
+    private static final ChromaDBContainer chroma = new ChromaDBContainer("chromadb/chroma:0.5.4");
+
+    @Test
+    void should_throw_when_existing_collection_uses_a_non_cosine_distance_metric() throws Exception {
+        createCollection("l2_collection", "l2");
+
+        assertThatThrownBy(() -> store("l2_collection"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Chroma collection 'l2_collection' uses distance metric 'l2', but ChromaEmbeddingStore "
+                        + "requires 'cosine' to produce valid relevance scores. Use or recreate a collection "
+                        + "configured with cosine distance.");
+    }
+
+    @Test
+    void should_accept_an_existing_collection_created_by_this_store() {
+        store("created_by_store");
+
+        assertThatCode(() -> store("created_by_store")).doesNotThrowAnyException();
+    }
+
+    private static ChromaEmbeddingStore store(String collectionName) {
+        return ChromaEmbeddingStore.builder()
+                .baseUrl(chroma.getEndpoint())
+                .collectionName(collectionName)
+                .build();
+    }
+
+    private static void createCollection(String name, String space) throws IOException {
+        ChromaHttpClient httpClient = new ChromaHttpClient(chroma.getEndpoint(), Duration.ofSeconds(10), false, false);
+
+        Collection created = httpClient.post(
+                "api/v1/collections", Map.of("name", name, "metadata", Map.of("hnsw:space", space)), Collection.class);
+
+        assertThat(created.distanceFunction()).isEqualTo(space);
+    }
+}

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreDistanceMetricIT.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreDistanceMetricIT.java
@@ -1,54 +1,158 @@
 package dev.langchain4j.store.embedding.chroma;
 
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.store.embedding.chroma.ChromaApiVersion.V1;
+import static dev.langchain4j.store.embedding.chroma.ChromaApiVersion.V2;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.chromadb.ChromaDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+/**
+ * Verifies that relevance scores stay in the [0, 1] range for an already existing collection,
+ * whichever distance metric that collection was created with.
+ */
 @Testcontainers
 class ChromaEmbeddingStoreDistanceMetricIT {
 
     @Container
-    private static final ChromaDBContainer chroma = new ChromaDBContainer("chromadb/chroma:0.5.4");
+    private static final ChromaDBContainer chromaV1 = new ChromaDBContainer("chromadb/chroma:0.5.4");
 
-    @Test
-    void should_throw_when_existing_collection_uses_a_non_cosine_distance_metric() throws Exception {
-        createCollection("l2_collection", "l2");
+    @Container
+    private static final ChromaDBContainer chromaV2 = new ChromaDBContainer("chromadb/chroma:1.1.0");
 
-        assertThatThrownBy(() -> store("l2_collection"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Chroma collection 'l2_collection' uses distance metric 'l2', but ChromaEmbeddingStore "
-                        + "requires 'cosine' to produce valid relevance scores. Use or recreate a collection "
-                        + "configured with cosine distance.");
+    private static final Embedding QUERY = Embedding.from(List.of(1f, 0f, 0f));
+    private static final Embedding NEAR = Embedding.from(List.of(2f, 0f, 0f));
+    private static final Embedding FAR = Embedding.from(List.of(10f, 0f, 0f));
+
+    static Stream<ChromaApiVersion> apiVersions() {
+        return Stream.of(V1, V2);
+    }
+
+    /**
+     * The container is deliberately not passed as a test argument: JUnit closes {@link AutoCloseable} arguments
+     * after each invocation, which would stop the container.
+     */
+    private static ChromaDBContainer chroma(ChromaApiVersion apiVersion) {
+        return apiVersion == V1 ? chromaV1 : chromaV2;
+    }
+
+    /**
+     * "l2" is the squared euclidean distance and is unbounded, so the distance to {@link #FAR} is 81.
+     * Converting it as if it were a cosine distance used to yield a score of -39.5.
+     */
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    void should_return_valid_scores_for_an_existing_l2_collection(ChromaApiVersion apiVersion) throws IOException {
+        String collectionName = randomUUID();
+        createCollection(apiVersion, collectionName, "l2");
+
+        ChromaEmbeddingStore store = store(apiVersion, collectionName);
+        store.addAll(List.of("near", "far"), List.of(NEAR, FAR), null);
+
+        List<EmbeddingMatch<TextSegment>> matches = search(store);
+
+        assertThat(matches).extracting(EmbeddingMatch::embeddingId).containsExactly("near", "far");
+        assertThat(matches)
+                .extracting(EmbeddingMatch::score)
+                .allSatisfy(score -> assertThat(score).isBetween(0.0, 1.0));
+        assertThat(matches.get(0).score()).isCloseTo(1.0 / 2, within(1e-4)); // distance 1
+        assertThat(matches.get(1).score()).isCloseTo(1.0 / 82, within(1e-4)); // distance 81
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    void should_return_valid_scores_for_an_existing_cosine_collection(ChromaApiVersion apiVersion) throws IOException {
+        String collectionName = randomUUID();
+        createCollection(apiVersion, collectionName, "cosine");
+
+        ChromaEmbeddingStore store = store(apiVersion, collectionName);
+        store.addAll(List.of("near", "far"), List.of(NEAR, FAR), null);
+
+        List<EmbeddingMatch<TextSegment>> matches = search(store);
+
+        // all embeddings point in the same direction, so the cosine distance is 0 for both
+        assertThat(matches)
+                .extracting(EmbeddingMatch::score)
+                .allSatisfy(score -> assertThat(score).isCloseTo(1.0, within(1e-4)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    void should_use_cosine_distance_for_a_collection_created_by_this_store(ChromaApiVersion apiVersion) {
+        String collectionName = randomUUID();
+
+        store(apiVersion, collectionName); // creates the collection
+
+        ChromaEmbeddingStore store = store(apiVersion, collectionName); // reopens it
+        store.addAll(List.of("near", "far"), List.of(NEAR, FAR), null);
+
+        assertThat(search(store))
+                .extracting(EmbeddingMatch::score)
+                .allSatisfy(score -> assertThat(score).isCloseTo(1.0, within(1e-4)));
     }
 
     @Test
-    void should_accept_an_existing_collection_created_by_this_store() {
-        store("created_by_store");
+    void should_switch_to_cosine_distance_when_remove_all_recreated_the_collection() throws IOException {
+        String collectionName = randomUUID();
+        createCollection(V2, collectionName, "l2");
+        ChromaEmbeddingStore store = store(V2, collectionName);
 
-        assertThatCode(() -> store("created_by_store")).doesNotThrowAnyException();
+        store.removeAll(); // deletes the "l2" collection and recreates it with cosine distance
+        store.addAll(List.of("near", "far"), List.of(NEAR, FAR), null);
+
+        assertThat(search(store))
+                .extracting(EmbeddingMatch::score)
+                .allSatisfy(score -> assertThat(score).isCloseTo(1.0, within(1e-4)));
     }
 
-    private static ChromaEmbeddingStore store(String collectionName) {
+    private static List<EmbeddingMatch<TextSegment>> search(ChromaEmbeddingStore store) {
+        return store.search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(QUERY)
+                        .maxResults(10)
+                        .build())
+                .matches();
+    }
+
+    private static ChromaEmbeddingStore store(ChromaApiVersion apiVersion, String collectionName) {
         return ChromaEmbeddingStore.builder()
-                .baseUrl(chroma.getEndpoint())
+                .apiVersion(apiVersion)
+                .baseUrl(chroma(apiVersion).getEndpoint())
                 .collectionName(collectionName)
                 .build();
     }
 
-    private static void createCollection(String name, String space) throws IOException {
-        ChromaHttpClient httpClient = new ChromaHttpClient(chroma.getEndpoint(), Duration.ofSeconds(10), false, false);
+    private static void createCollection(ChromaApiVersion apiVersion, String name, String space) throws IOException {
+        if (apiVersion == V2) {
+            // the tenant and the database the store defaults to have to exist before a collection can be created
+            store(V2, randomUUID());
+        }
 
-        Collection created = httpClient.post(
-                "api/v1/collections", Map.of("name", name, "metadata", Map.of("hnsw:space", space)), Collection.class);
+        Collection created = new ChromaHttpClient(
+                        chroma(apiVersion).getEndpoint(), Duration.ofSeconds(10), false, false)
+                .post(
+                        collectionsPath(apiVersion),
+                        Map.of("name", name, "metadata", Map.of("hnsw:space", space)),
+                        Collection.class);
 
         assertThat(created.distanceFunction()).isEqualTo(space);
+    }
+
+    private static String collectionsPath(ChromaApiVersion apiVersion) {
+        return apiVersion == V1 ? "api/v1/collections" : "api/v2/tenants/default/databases/default/collections";
     }
 }

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
@@ -2,7 +2,6 @@ package dev.langchain4j.store.embedding.chroma;
 
 import static dev.langchain4j.http.client.HttpMethod.POST;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -10,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -101,64 +102,84 @@ class ChromaEmbeddingStoreTest {
     }
 
     @Test
-    void should_throw_when_existing_collection_does_not_use_cosine_distance() {
+    void should_convert_cosine_distance_to_score() {
         // given
-        CapturingHttpClient httpClient =
-                new CapturingHttpClient(collection("\"configuration_json\":{\"hnsw\":{\"space\":\"l2\"}}"));
+        CapturingHttpClient httpClient = new CapturingHttpClient()
+                .withCollection(collection("\"configuration_json\":{\"hnsw\":{\"space\":\"cosine\"}}"))
+                .withDistances(0.0, 1.0, 2.0);
 
-        // when + then
-        assertThatThrownBy(() -> store(httpClient))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Chroma collection 'test' uses distance metric 'l2', but ChromaEmbeddingStore requires "
-                        + "'cosine' to produce valid relevance scores. Use or recreate a collection configured with "
-                        + "cosine distance.");
+        // when
+        List<EmbeddingMatch<TextSegment>> matches = search(httpClient);
+
+        // then
+        assertThat(matches).extracting(EmbeddingMatch::score).containsExactly(1.0, 0.5, 0.0);
     }
 
     @Test
-    void should_throw_when_existing_collection_declares_a_non_cosine_distance_metric_in_metadata() {
+    void should_convert_l2_distance_to_score() {
         // given
-        CapturingHttpClient httpClient = new CapturingHttpClient(collection("\"metadata\":{\"hnsw:space\":\"ip\"}"));
+        CapturingHttpClient httpClient = new CapturingHttpClient()
+                .withCollection(collection("\"configuration_json\":{\"hnsw\":{\"space\":\"l2\"}}"))
+                .withDistances(0.0, 1.0, 101.0);
 
-        // when + then
-        assertThatThrownBy(() -> store(httpClient))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Chroma collection 'test' uses distance metric 'ip', but ChromaEmbeddingStore requires "
-                        + "'cosine' to produce valid relevance scores. Use or recreate a collection configured with "
-                        + "cosine distance.");
+        // when
+        List<EmbeddingMatch<TextSegment>> matches = search(httpClient);
+
+        // then
+        // "l2" is unbounded, so a distance greater than 2 used to result in a negative score
+        assertThat(matches).extracting(EmbeddingMatch::score).containsExactly(1.0, 0.5, 1.0 / 102);
     }
 
     @Test
-    void should_accept_existing_collection_that_uses_cosine_distance() {
+    void should_convert_ip_distance_to_score() {
         // given
-        CapturingHttpClient httpClient =
-                new CapturingHttpClient(collection("\"configuration_json\":{\"hnsw\":{\"space\":\"cosine\"}}"));
+        CapturingHttpClient httpClient = new CapturingHttpClient()
+                .withCollection(collection("\"metadata\":{\"hnsw:space\":\"ip\"}"))
+                .withDistances(0.0, 1.0, 2.0);
 
-        // when + then
-        assertThatCode(() -> store(httpClient)).doesNotThrowAnyException();
+        // when
+        List<EmbeddingMatch<TextSegment>> matches = search(httpClient);
+
+        // then
+        assertThat(matches).extracting(EmbeddingMatch::score).containsExactly(1.0, 0.5, 0.0);
     }
 
     @Test
-    void should_throw_when_existing_collection_does_not_report_a_distance_metric() {
-        // given
-        CapturingHttpClient httpClient = new CapturingHttpClient(collection("\"metadata\":{}"));
+    void should_prefer_the_distance_metric_reported_in_metadata_over_the_configured_one() {
+        // given: this is what Chroma 0.5.x reports for a collection created by this store
+        CapturingHttpClient httpClient = new CapturingHttpClient()
+                .withCollection(
+                        collection(
+                                "\"configuration_json\":{\"hnsw_configuration\":{\"space\":\"l2\"}},\"metadata\":{\"hnsw:space\":\"cosine\"}"))
+                .withDistances(0.5);
 
-        // when + then
-        assertThatThrownBy(() -> store(httpClient))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Chroma collection 'test' uses distance metric 'l2', but ChromaEmbeddingStore requires "
-                        + "'cosine' to produce valid relevance scores. Use or recreate a collection configured with "
-                        + "cosine distance.");
+        // when
+        List<EmbeddingMatch<TextSegment>> matches = search(httpClient);
+
+        // then
+        assertThat(matches).extracting(EmbeddingMatch::score).containsExactly(0.75);
     }
 
     @Test
-    void should_accept_existing_collection_whose_metadata_reports_cosine_while_its_configuration_reports_l2() {
+    void should_fall_back_to_l2_when_the_existing_collection_does_not_report_a_distance_metric() {
         // given
-        CapturingHttpClient httpClient = new CapturingHttpClient(
-                collection(
-                        "\"configuration_json\":{\"hnsw_configuration\":{\"space\":\"l2\"}},\"metadata\":{\"hnsw:space\":\"cosine\"}"));
+        CapturingHttpClient httpClient = new CapturingHttpClient()
+                .withCollection(collection("\"metadata\":{}"))
+                .withDistances(0.5);
 
-        // when + then
-        assertThatCode(() -> store(httpClient)).doesNotThrowAnyException();
+        // when
+        List<EmbeddingMatch<TextSegment>> matches = search(httpClient);
+
+        // then
+        assertThat(matches).extracting(EmbeddingMatch::score).containsExactly(1.0 / 1.5);
+    }
+
+    private static List<EmbeddingMatch<TextSegment>> search(CapturingHttpClient httpClient) {
+        return store(httpClient)
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(EMBEDDING_1)
+                        .build())
+                .matches();
     }
 
     private static String collection(String distanceMetricField) {

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.store.embedding.chroma;
 
 import static dev.langchain4j.http.client.HttpMethod.POST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -97,6 +98,71 @@ class ChromaEmbeddingStoreTest {
 
         // then
         assertThat(httpClient.requests()).hasSize(requestsAfterInit);
+    }
+
+    @Test
+    void should_throw_when_existing_collection_does_not_use_cosine_distance() {
+        // given
+        CapturingHttpClient httpClient =
+                new CapturingHttpClient(collection("\"configuration_json\":{\"hnsw\":{\"space\":\"l2\"}}"));
+
+        // when + then
+        assertThatThrownBy(() -> store(httpClient))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Chroma collection 'test' uses distance metric 'l2', but ChromaEmbeddingStore requires "
+                        + "'cosine' to produce valid relevance scores. Use or recreate a collection configured with "
+                        + "cosine distance.");
+    }
+
+    @Test
+    void should_throw_when_existing_collection_declares_a_non_cosine_distance_metric_in_metadata() {
+        // given
+        CapturingHttpClient httpClient = new CapturingHttpClient(collection("\"metadata\":{\"hnsw:space\":\"ip\"}"));
+
+        // when + then
+        assertThatThrownBy(() -> store(httpClient))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Chroma collection 'test' uses distance metric 'ip', but ChromaEmbeddingStore requires "
+                        + "'cosine' to produce valid relevance scores. Use or recreate a collection configured with "
+                        + "cosine distance.");
+    }
+
+    @Test
+    void should_accept_existing_collection_that_uses_cosine_distance() {
+        // given
+        CapturingHttpClient httpClient =
+                new CapturingHttpClient(collection("\"configuration_json\":{\"hnsw\":{\"space\":\"cosine\"}}"));
+
+        // when + then
+        assertThatCode(() -> store(httpClient)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_when_existing_collection_does_not_report_a_distance_metric() {
+        // given
+        CapturingHttpClient httpClient = new CapturingHttpClient(collection("\"metadata\":{}"));
+
+        // when + then
+        assertThatThrownBy(() -> store(httpClient))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Chroma collection 'test' uses distance metric 'l2', but ChromaEmbeddingStore requires "
+                        + "'cosine' to produce valid relevance scores. Use or recreate a collection configured with "
+                        + "cosine distance.");
+    }
+
+    @Test
+    void should_accept_existing_collection_whose_metadata_reports_cosine_while_its_configuration_reports_l2() {
+        // given
+        CapturingHttpClient httpClient = new CapturingHttpClient(
+                collection(
+                        "\"configuration_json\":{\"hnsw_configuration\":{\"space\":\"l2\"}},\"metadata\":{\"hnsw:space\":\"cosine\"}"));
+
+        // when + then
+        assertThatCode(() -> store(httpClient)).doesNotThrowAnyException();
+    }
+
+    private static String collection(String distanceMetricField) {
+        return "{\"id\":\"collection-id\",\"name\":\"test\"," + distanceMetricField + "}";
     }
 
     private static ChromaEmbeddingStore store(CapturingHttpClient httpClient) {

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CollectionTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CollectionTest.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.store.embedding.chroma;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CollectionTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    static Stream<Arguments> should_report_the_distance_function_of_the_collection() {
+        return Stream.of(
+                Arguments.of("{\"configuration_json\":{\"hnsw\":{\"space\":\"cosine\"}}}", "cosine"),
+                Arguments.of("{\"configuration_json\":{\"hnsw\":{\"space\":\"l2\"}}}", "l2"),
+                Arguments.of("{\"configuration_json\":{\"hnsw_configuration\":{\"space\":\"cosine\"}}}", "cosine"),
+                Arguments.of("{\"configuration_json\":{\"spann\":{\"space\":\"ip\"}}}", "ip"),
+                Arguments.of("{\"metadata\":{\"hnsw:space\":\"cosine\"}}", "cosine"),
+                Arguments.of("{\"metadata\":{\"hnsw:space\":\"ip\"}}", "ip"),
+                Arguments.of("{\"configuration_json\":{\"hnsw\":null,\"spann\":null}}", "l2"),
+                Arguments.of("{\"configuration_json\":{}}", "l2"),
+                Arguments.of("{\"metadata\":{}}", "l2"),
+                Arguments.of("{}", "l2"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void should_report_the_distance_function_of_the_collection(String json, String expected) throws Exception {
+        Collection collection = OBJECT_MAPPER.readValue(json, Collection.class);
+
+        assertThat(collection.distanceFunction()).isEqualTo(expected);
+    }
+
+    @Test
+    void should_prefer_the_metadata_distance_function_over_the_configured_one() throws Exception {
+        String json = """
+                {
+                  "configuration_json": {"hnsw_configuration": {"space": "l2"}},
+                  "metadata": {"hnsw:space": "cosine"}
+                }
+                """;
+
+        Collection collection = OBJECT_MAPPER.readValue(json, Collection.class);
+
+        assertThat(collection.distanceFunction()).isEqualTo("cosine");
+    }
+
+    @Test
+    void should_read_the_distance_function_from_a_full_collection_response() throws Exception {
+        String json = "{\"id\":\"cad5dce9-b301-43de-bca4-97dbbd8cff97\",\"name\":\"probe_l2\","
+                + "\"configuration_json\":{\"hnsw\":{\"space\":\"l2\",\"ef_construction\":100,\"max_neighbors\":16},"
+                + "\"spann\":null,\"embedding_function\":null},"
+                + "\"metadata\":null,\"dimension\":null,\"tenant\":\"default_tenant\",\"version\":0}";
+
+        Collection collection = OBJECT_MAPPER.readValue(json, Collection.class);
+
+        assertThat(collection.getId()).isEqualTo("cad5dce9-b301-43de-bca4-97dbbd8cff97");
+        assertThat(collection.getName()).isEqualTo("probe_l2");
+        assertThat(collection.distanceFunction()).isEqualTo("l2");
+    }
+}

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CollectionTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/CollectionTest.java
@@ -54,7 +54,21 @@ class CollectionTest {
     }
 
     @Test
-    void should_read_the_distance_function_from_a_full_collection_response() throws Exception {
+    void should_read_the_distance_function_from_a_full_collection_response_of_chroma_0_5_x() throws Exception {
+        // chroma 0.5.x reports the default "l2" in "configuration_json" even though the collection uses cosine
+        String json = "{\"id\":\"8f335b05-d821-4a7b-a002-40355abbe1b8\",\"name\":\"probe_cosine\","
+                + "\"configuration_json\":{\"hnsw_configuration\":{\"space\":\"l2\",\"ef_construction\":100,\"M\":16,"
+                + "\"_type\":\"HNSWConfigurationInternal\"},\"_type\":\"CollectionConfigurationInternal\"},"
+                + "\"metadata\":{\"hnsw:space\":\"cosine\"},\"dimension\":null,\"tenant\":\"default_tenant\","
+                + "\"database\":\"default_database\",\"version\":0}";
+
+        Collection collection = OBJECT_MAPPER.readValue(json, Collection.class);
+
+        assertThat(collection.distanceFunction()).isEqualTo("cosine");
+    }
+
+    @Test
+    void should_read_the_distance_function_from_a_full_collection_response_of_chroma_1_x() throws Exception {
         String json = "{\"id\":\"cad5dce9-b301-43de-bca4-97dbbd8cff97\",\"name\":\"probe_l2\","
                 + "\"configuration_json\":{\"hnsw\":{\"space\":\"l2\",\"ef_construction\":100,\"max_neighbors\":16},"
                 + "\"spann\":null,\"embedding_function\":null},"


### PR DESCRIPTION
Closes #6076

  ## Change

  `ChromaEmbeddingStore` creates collections with `hnsw:space=cosine`, and converted every distance
  returned by Chroma as if it were a cosine distance:

  ```java
  private static double distanceToScore(double distance) {
      return 1 - (distance / 2);
  }
  ```

  Chroma's own default is `l2`, the squared euclidean distance, which is unbounded. When the store opened
  a collection created outside of it, `EmbeddingMatch.score()` was computed with the wrong conversion and
  went negative once the distance exceeded 2, and `minScore` was applied to those values. Against a real
  server, a distance of 101 produced a score of -49.5. Ordering was unaffected, because the conversion is
  monotonically decreasing, so nothing surfaced the problem.

  The distance metric of an existing collection is now detected, and the score is derived from it:

  ```java
  private double distanceToScore(double distance) {
      if (L2_DISTANCE.equalsIgnoreCase(distanceFunction)) {
          // "l2" is the squared euclidean distance, which is unbounded
          return 1 / (1 + distance);
      }
      // "cosine" distance is in the range [0, 2], "ip" distance is 1 minus the inner product
      return RelevanceScore.fromCosineSimilarity(1 - distance);
  }
  ```

  This follows `Mapper.toRelevanceScore` in `langchain4j-milvus`, which converts `l2` the same way and
  sends the remaining metrics through `RelevanceScore.fromCosineSimilarity`. For `ip` the result is exact
  for normalized embeddings, which is what most embedding models produce.

  Scores for cosine collections are unchanged, bit for bit: `RelevanceScore.fromCosineSimilarity(1 - d)`
  and `1 - d / 2` return the identical double for every distance in `[0, 2]`. Every collection this store
  created is therefore unaffected.

  ### Detecting the metric
`Collection` reports its own distance metric. Chroma exposes it under `configuration_json`, keyed `hnsw`
  on 1.x and `hnsw_configuration` on 0.5.x, with `spann` as the other index type, and collections created
  through the metadata form carry it as `metadata["hnsw:space"]`.

  The `metadata` representation takes precedence, which matters on 0.5.x: a collection created there
  through `metadata` reports the requested metric in `metadata` while `configuration_json` still reports
  the default. Reading `configuration_json` first would misread a cosine collection this store created
  itself.

  A collection that reports no metric at all is on Chroma's documented `l2` default. This is not a
  theoretical branch: Chroma 0.4.x and 0.5.0 do not return `configuration_json` at all, so an externally
  created collection on those versions is only identifiable through that default. Collections created by
  this store are unaffected either way, because their `hnsw:space` metadata is reported by every version
  from 0.4.24 through the current one.

  `removeAll()` deletes and recreates the collection, so a collection that was adopted with another metric
  becomes a cosine one at that point, and the conversion follows.

  ### Tests

  `CollectionTest` covers the detection matrix with a `@ParameterizedTest`: every location a server reports
  the metric in, the `metadata` precedence, an unreported metric falling back to `l2`, and the full
  responses of Chroma 0.5.x and 1.x.

  `ChromaEmbeddingStoreTest` asserts the resulting scores for `cosine`, `l2` and `ip`, for the `metadata`
  precedence and for the `l2` fallback, through the store and its production `ObjectMapper`.

  `ChromaEmbeddingStoreDistanceMetricIT` (new) runs against a real server, against both API versions:
  an existing `l2` collection, an existing `cosine` collection, a collection created by the store, and a
  collection recreated by `removeAll()`. The `l2` tests fail on unmodified `main`.

  ```
  mvn -pl langchain4j-chroma test
  Tests run: 42, Failures: 0, Errors: 0, Skipped: 0

  mvn -pl langchain4j-chroma verify
  ChromaEmbeddingStoreDistanceMetricIT  Tests run: 7,   Failures: 0, Errors: 0, Skipped: 0
  ChromaEmbeddingStoreIT                Tests run: 104, Failures: 0, Errors: 0, Skipped: 2
  ChromaEmbeddingStoreV2IT              Tests run: 104, Failures: 0, Errors: 0, Skipped: 2
  langchain4j-core and langchain4j: Tests run: 1331, Failures: 0, Errors: 0, Skipped: 0
  ```

  `ChromaEmbeddingStoreRemovalIT` and `ChromaEmbeddingStoreRemovalV2IT` each have 2 pre-existing errors in
  `should_do_nothing_when_removing_all_by_ids_null` and `..._empty`, identical on unmodified `main`.

  ## General checklist

  - [X] There are no breaking changes (API, behaviour)
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring)