### PR TITLE
fix: ignore stale and duplicate tool names when restoring tools found earlier

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/search/ToolSearchService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/search/ToolSearchService.java
@@ -88,7 +88,23 @@ public class ToolSearchService {
 
         Map<String, ToolSpecification> toolsByName = new HashMap<>(availableTools.size());
         availableTools.forEach(tool -> toolsByName.put(tool.name(), tool));
-        toolNamesFoundEarlier.forEach(toolName -> effectiveTools.add(toolsByName.get(toolName)));
+
+        Set<String> effectiveToolNames = effectiveTools.stream()
+                .map(ToolSpecification::name)
+                .collect(toSet());
+
+        toolNamesFoundEarlier.forEach(toolName -> {
+            if (effectiveToolNames.contains(toolName)) {
+                // already effective (e.g. ALWAYS_VISIBLE), adding it again would duplicate the tool
+                return;
+            }
+            ToolSpecification toolFoundEarlier = toolsByName.get(toolName);
+            // the tool names come from the chat memory, so they can refer to tools
+            // that are no longer available in the current invocation
+            if (toolFoundEarlier != null) {
+                effectiveTools.add(toolFoundEarlier);
+            }
+        });
 
         return effectiveTools;
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/search/ToolSearchService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/search/ToolSearchService.java
@@ -1,24 +1,5 @@
 package dev.langchain4j.service.tool.search;
 
-import dev.langchain4j.Internal;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.invocation.InvocationContext;
-import dev.langchain4j.service.tool.ToolExecutionResult;
-import dev.langchain4j.service.tool.ToolExecutor;
-import dev.langchain4j.service.tool.ToolServiceContext;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
 import static dev.langchain4j.agent.tool.SearchBehavior.ALWAYS_VISIBLE;
 import static dev.langchain4j.agent.tool.ToolSpecification.METADATA_SEARCH_BEHAVIOR;
 import static dev.langchain4j.internal.Utils.copy;
@@ -28,13 +9,32 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolServiceContext;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 /**
  * @since 1.12.0
  */
 @Internal
 public class ToolSearchService {
 
-    private static final String FOUND_TOOLS_ATTRIBUTE = "found_tools"; // do not change, will break backward compatibility!
+    private static final String FOUND_TOOLS_ATTRIBUTE =
+            "found_tools"; // do not change, will break backward compatibility!
 
     private final ToolSearchStrategy strategy;
 
@@ -42,9 +42,8 @@ public class ToolSearchService {
         this.strategy = ensureNotNull(toolSearchStrategy, "toolSearchStrategy");
     }
 
-    public ToolServiceContext adjust(ToolServiceContext toolServiceContext,
-                                     List<ChatMessage> messages,
-                                     InvocationContext invocationContext) {
+    public ToolServiceContext adjust(
+            ToolServiceContext toolServiceContext, List<ChatMessage> messages, InvocationContext invocationContext) {
         List<ToolSpecification> toolSearchTools = strategy.getToolSearchTools(invocationContext);
         List<ToolSpecification> availableTools = toolServiceContext.availableTools();
         List<ToolSpecification> effectiveTools = calculateEffectiveTools(toolSearchTools, availableTools, messages);
@@ -56,9 +55,10 @@ public class ToolSearchService {
                 .build();
     }
 
-    private List<ToolSpecification> calculateEffectiveTools(List<ToolSpecification> toolSearchTools,
-                                                            List<ToolSpecification> availableTools,
-                                                            List<ChatMessage> messages) {
+    private List<ToolSpecification> calculateEffectiveTools(
+            List<ToolSpecification> toolSearchTools,
+            List<ToolSpecification> availableTools,
+            List<ChatMessage> messages) {
         List<ToolSpecification> effectiveTools = new ArrayList<>();
 
         availableTools.forEach(tool -> {
@@ -89,9 +89,8 @@ public class ToolSearchService {
         Map<String, ToolSpecification> toolsByName = new HashMap<>(availableTools.size());
         availableTools.forEach(tool -> toolsByName.put(tool.name(), tool));
 
-        Set<String> effectiveToolNames = effectiveTools.stream()
-                .map(ToolSpecification::name)
-                .collect(toSet());
+        Set<String> effectiveToolNames =
+                effectiveTools.stream().map(ToolSpecification::name).collect(toSet());
 
         toolNamesFoundEarlier.forEach(toolName -> {
             if (effectiveToolNames.contains(toolName)) {
@@ -109,15 +108,15 @@ public class ToolSearchService {
         return effectiveTools;
     }
 
-    private List<ToolSpecification> calculateSearchableTools(List<ToolSpecification> availableTools,
-                                                             List<ToolSpecification> effectiveTools) {
+    private List<ToolSpecification> calculateSearchableTools(
+            List<ToolSpecification> availableTools, List<ToolSpecification> effectiveTools) {
         Set<ToolSpecification> searchableTools = new LinkedHashSet<>(availableTools);
         searchableTools.removeAll(effectiveTools);
         return new ArrayList<>(searchableTools);
     }
 
-    private Map<String, ToolExecutor> createExecutors(List<ToolSpecification> toolSearchTools,
-                                                      List<ToolSpecification> searchableTools) {
+    private Map<String, ToolExecutor> createExecutors(
+            List<ToolSpecification> toolSearchTools, List<ToolSpecification> searchableTools) {
         Map<String, ToolExecutor> executors = new HashMap<>();
         for (ToolSpecification toolSearchTool : toolSearchTools) {
             executors.put(toolSearchTool.name(), new ToolSearchExecutor(searchableTools));
@@ -125,8 +124,8 @@ public class ToolSearchService {
         return executors;
     }
 
-    public static ToolServiceContext addFoundTools(ToolServiceContext toolServiceContext,
-                                                   Collection<ToolExecutionResult> toolResults) {
+    public static ToolServiceContext addFoundTools(
+            ToolServiceContext toolServiceContext, Collection<ToolExecutionResult> toolResults) {
         Set<String> foundToolNames = new LinkedHashSet<>();
         for (ToolExecutionResult toolResult : toolResults) {
             Object attribute = toolResult.attributes().get(FOUND_TOOLS_ATTRIBUTE);
@@ -142,7 +141,8 @@ public class ToolSearchService {
                 .map(ToolSpecification::name)
                 .collect(toSet());
 
-        Map<String, ToolSpecification> availableToolsByName = new HashMap<>(toolServiceContext.availableTools().size());
+        Map<String, ToolSpecification> availableToolsByName =
+                new HashMap<>(toolServiceContext.availableTools().size());
         toolServiceContext.availableTools().forEach(tool -> availableToolsByName.put(tool.name(), tool));
 
         List<ToolSpecification> foundTools = new ArrayList<>();

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/search/ToolSearchServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/search/ToolSearchServiceTest.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.service.tool.search;
 
+import static dev.langchain4j.agent.tool.SearchBehavior.ALWAYS_VISIBLE;
+import static dev.langchain4j.agent.tool.ToolSpecification.METADATA_SEARCH_BEHAVIOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
@@ -7,14 +11,9 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.ToolServiceContext;
 import dev.langchain4j.service.tool.search.simple.SimpleToolSearchStrategy;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.Map;
-
-import static dev.langchain4j.agent.tool.SearchBehavior.ALWAYS_VISIBLE;
-import static dev.langchain4j.agent.tool.ToolSpecification.METADATA_SEARCH_BEHAVIOR;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class ToolSearchServiceTest {
 
@@ -33,10 +32,8 @@ class ToolSearchServiceTest {
     void should_make_tool_found_earlier_effective_again() {
         ToolSpecification weather = tool("weather", "Returns the weather forecast");
 
-        ToolServiceContext context = adjust(
-                List.of(weather),
-                List.of(userMessage(), toolResultWithFoundTools("weather"))
-        );
+        ToolServiceContext context =
+                adjust(List.of(weather), List.of(userMessage(), toolResultWithFoundTools("weather")));
 
         assertThat(context.effectiveTools()).contains(weather);
     }
@@ -47,10 +44,8 @@ class ToolSearchServiceTest {
 
         // 'time' was found in an earlier invocation and is still referenced by the chat memory,
         // but it is no longer provided for the current invocation
-        ToolServiceContext context = adjust(
-                List.of(weather),
-                List.of(userMessage(), toolResultWithFoundTools("weather", "time"))
-        );
+        ToolServiceContext context =
+                adjust(List.of(weather), List.of(userMessage(), toolResultWithFoundTools("weather", "time")));
 
         assertThat(context.effectiveTools())
                 .doesNotContainNull()
@@ -60,10 +55,7 @@ class ToolSearchServiceTest {
 
     @Test
     void should_not_fail_when_no_tool_found_earlier_is_available_anymore() {
-        ToolServiceContext context = adjust(
-                List.of(),
-                List.of(userMessage(), toolResultWithFoundTools("time"))
-        );
+        ToolServiceContext context = adjust(List.of(), List.of(userMessage(), toolResultWithFoundTools("time")));
 
         assertThat(context.effectiveTools()).doesNotContainNull();
     }
@@ -76,14 +68,10 @@ class ToolSearchServiceTest {
                 .addMetadata(METADATA_SEARCH_BEHAVIOR, ALWAYS_VISIBLE)
                 .build();
 
-        ToolServiceContext context = adjust(
-                List.of(weather),
-                List.of(userMessage(), toolResultWithFoundTools("weather"))
-        );
+        ToolServiceContext context =
+                adjust(List.of(weather), List.of(userMessage(), toolResultWithFoundTools("weather")));
 
-        assertThat(context.effectiveTools())
-                .extracting(ToolSpecification::name)
-                .containsOnlyOnce("weather");
+        assertThat(context.effectiveTools()).extracting(ToolSpecification::name).containsOnlyOnce("weather");
     }
 
     private ToolServiceContext adjust(List<ToolSpecification> availableTools, List<ChatMessage> messages) {
@@ -96,10 +84,7 @@ class ToolSearchServiceTest {
     }
 
     private static ToolSpecification tool(String name, String description) {
-        return ToolSpecification.builder()
-                .name(name)
-                .description(description)
-                .build();
+        return ToolSpecification.builder().name(name).description(description).build();
     }
 
     private static UserMessage userMessage() {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/search/ToolSearchServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/search/ToolSearchServiceTest.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.service.tool.search;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.ToolServiceContext;
+import dev.langchain4j.service.tool.search.simple.SimpleToolSearchStrategy;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.agent.tool.SearchBehavior.ALWAYS_VISIBLE;
+import static dev.langchain4j.agent.tool.ToolSpecification.METADATA_SEARCH_BEHAVIOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ToolSearchServiceTest {
+
+    private static final String FOUND_TOOLS_ATTRIBUTE = "found_tools";
+
+    private static final InvocationContext INVOCATION_CONTEXT = InvocationContext.builder()
+            .interfaceName("SomeInterface")
+            .methodName("someMethod")
+            .chatMemoryId("default")
+            .build();
+
+    private final ToolSearchService toolSearchService =
+            new ToolSearchService(SimpleToolSearchStrategy.builder().build());
+
+    @Test
+    void should_make_tool_found_earlier_effective_again() {
+        ToolSpecification weather = tool("weather", "Returns the weather forecast");
+
+        ToolServiceContext context = adjust(
+                List.of(weather),
+                List.of(userMessage(), toolResultWithFoundTools("weather"))
+        );
+
+        assertThat(context.effectiveTools()).contains(weather);
+    }
+
+    @Test
+    void should_ignore_tool_found_earlier_that_is_no_longer_available() {
+        ToolSpecification weather = tool("weather", "Returns the weather forecast");
+
+        // 'time' was found in an earlier invocation and is still referenced by the chat memory,
+        // but it is no longer provided for the current invocation
+        ToolServiceContext context = adjust(
+                List.of(weather),
+                List.of(userMessage(), toolResultWithFoundTools("weather", "time"))
+        );
+
+        assertThat(context.effectiveTools())
+                .doesNotContainNull()
+                .extracting(ToolSpecification::name)
+                .doesNotContain("time");
+    }
+
+    @Test
+    void should_not_fail_when_no_tool_found_earlier_is_available_anymore() {
+        ToolServiceContext context = adjust(
+                List.of(),
+                List.of(userMessage(), toolResultWithFoundTools("time"))
+        );
+
+        assertThat(context.effectiveTools()).doesNotContainNull();
+    }
+
+    @Test
+    void should_not_duplicate_tool_found_earlier_that_is_always_visible() {
+        ToolSpecification weather = ToolSpecification.builder()
+                .name("weather")
+                .description("Returns the weather forecast")
+                .addMetadata(METADATA_SEARCH_BEHAVIOR, ALWAYS_VISIBLE)
+                .build();
+
+        ToolServiceContext context = adjust(
+                List.of(weather),
+                List.of(userMessage(), toolResultWithFoundTools("weather"))
+        );
+
+        assertThat(context.effectiveTools())
+                .extracting(ToolSpecification::name)
+                .containsOnlyOnce("weather");
+    }
+
+    private ToolServiceContext adjust(List<ToolSpecification> availableTools, List<ChatMessage> messages) {
+        ToolServiceContext context = ToolServiceContext.builder()
+                .availableTools(availableTools)
+                .effectiveTools(availableTools)
+                .build();
+
+        return toolSearchService.adjust(context, messages, INVOCATION_CONTEXT);
+    }
+
+    private static ToolSpecification tool(String name, String description) {
+        return ToolSpecification.builder()
+                .name(name)
+                .description(description)
+                .build();
+    }
+
+    private static UserMessage userMessage() {
+        return UserMessage.from("What is the weather?");
+    }
+
+    private static ToolExecutionResultMessage toolResultWithFoundTools(String... foundToolNames) {
+        return ToolExecutionResultMessage.builder()
+                .id("1")
+                .toolName("tool_search_tool")
+                .text("Tools found: " + String.join(", ", foundToolNames))
+                .attributes(Map.of(FOUND_TOOLS_ATTRIBUTE, List.of(foundToolNames)))
+                .build();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6079

## Change

`ToolSearchService.calculateEffectiveTools()` restores tools found by earlier tool searches, reading the names from the `found_tools` attribute of `ToolExecutionResultMessage`, which is persisted in the chat memory. The looked-up tool was added unconditionally:

```java
toolNamesFoundEarlier.forEach(toolName -> effectiveTools.add(toolsByName.get(toolName)));
```

This caused two problems:

1. **A `null` was added when the tool is no longer available.** The names come from the chat memory, so they can refer to tools that are not available in the current invocation (MCP server down, a changed tool filter, or a `ToolProvider` returning a different set of tools). `Utils.copy(List)` permits `null` elements, so the `null` survived into `ChatRequest.toolSpecifications(...)` and failed later with a `NullPointerException`, either in the model integration or back in `addFoundTools()` on `ToolSpecification::name` — far from its cause.

2. **A tool was added twice when it is `ALWAYS_VISIBLE`**, since it is added by the first loop and again by the lookup. Duplicate tool names are rejected by some model providers.

Unresolvable names are now skipped and already-effective tools are not added again. This is the behaviour the sibling method `addFoundTools()` already implements, so the two paths are now consistent. `addFoundTools()` itself is unchanged: there the name originates from the strategy within the same invocation, so an unknown name is a genuine invariant violation and throwing is correct. In `calculateEffectiveTools()` the name comes from the chat memory, where a stale entry is expected and must not break a new invocation.

Behaviour for tools that are still available is unchanged.

Added `ToolSearchServiceTest`, the first unit test for this class (it was covered only by ITs that require an LLM). Verified that 3 of its 4 tests fail without the fix.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- `langchain4j-core` is green. In `langchain4j`, 26 tests fail on my machine both with and without this change (streaming tests failing with `TimeoutException`, e.g. `ReturnBehaviorCombinationsTest`); I verified they fail identically on a clean `main`, so they are unrelated to this PR. All tool and tool-search tests are green. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — bug fix, no behaviour to document -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!--
Note on the diff size: `ToolSearchService.java` was not spotless-formatted on `main`, and the `spotless` profile uses `ratchetFrom origin/main`, so `spotless:apply` reformats the whole file once it is touched. The formatting is isolated in its own commit (`chore: apply spotless formatting`) so the fix itself can be reviewed on its own. This overlaps with the formatting-only changes to the same file in #5994.
-->