### PR TITLE
Fix Milvus vector lookup for IDs containing special characters

### DIFF
--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/CollectionRequestBuilder.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/CollectionRequestBuilder.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.store.embedding.milvus.v2;
 
+import static dev.langchain4j.store.embedding.milvus.v2.MilvusV2MetadataFilterMapper.formatValues;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.joining;
 
 import com.google.gson.JsonObject;
 import dev.langchain4j.data.embedding.Embedding;
@@ -232,6 +232,6 @@ class CollectionRequestBuilder {
     }
 
     private static String buildQueryExpression(List<String> rowIds, String idFieldName) {
-        return rowIds.stream().map(id -> format("%s == '%s'", idFieldName, id)).collect(joining(" || "));
+        return format("%s in %s", idFieldName, formatValues(rowIds));
     }
 }

--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapper.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapper.java
@@ -116,8 +116,7 @@ class MilvusV2MetadataFilterMapper {
 
     private static String formatValue(Object value) {
         if (value instanceof String stringValue) {
-            // Escape double quotes by replacing them with \"
-            final String escapedValue = stringValue.replace("\"", "\\\"");
+            final String escapedValue = stringValue.replace("\\", "\\\\").replace("\"", "\\\"");
             return "\"" + escapedValue + "\"";
         } else if (value instanceof UUID) {
             return "\"" + value + "\"";

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/CollectionRequestBuilderTest.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/CollectionRequestBuilderTest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.store.embedding.milvus.v2;
 
 import static dev.langchain4j.store.embedding.milvus.v2.CollectionRequestBuilder.buildHybridSearchRequest;
+import static dev.langchain4j.store.embedding.milvus.v2.CollectionRequestBuilder.buildQueryRequest;
 import static dev.langchain4j.store.embedding.milvus.v2.CollectionRequestBuilder.buildSearchRequest;
 import static dev.langchain4j.store.embedding.milvus.v2.CollectionRequestBuilder.createDenseAnnSearchReq;
 import static dev.langchain4j.store.embedding.milvus.v2.CollectionRequestBuilder.createDenseSearchReq;
@@ -11,8 +12,10 @@ import dev.langchain4j.data.embedding.Embedding;
 import io.milvus.v2.common.ConsistencyLevel;
 import io.milvus.v2.common.IndexParam;
 import io.milvus.v2.service.vector.request.HybridSearchReq;
+import io.milvus.v2.service.vector.request.QueryReq;
 import io.milvus.v2.service.vector.request.SearchReq;
 import java.util.Arrays;
+import java.util.List;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +49,18 @@ class CollectionRequestBuilderTest implements WithAssertions {
         assertThat(result.getMetricType()).isEqualTo(IndexParam.MetricType.COSINE);
         assertThat(result.getLimit()).isEqualTo(5);
         assertThat(result.getOutputFields()).containsExactly("id", "text", "metadata");
+    }
+
+    @Test
+    void should_quote_and_escape_row_ids_in_query_expression() {
+        List<String> rowIds = Arrays.asList("normal-id", "id'with'apostrophe", "id\"with-quote", "id\\with-backslash");
+
+        QueryReq result = buildQueryRequest(COLLECTION_NAME, FIELD_DEFINITION, rowIds, ConsistencyLevel.STRONG);
+
+        assertThat(result.getFilter())
+                .isEqualTo(
+                        "id in [\"normal-id\", \"id'with'apostrophe\", \"id\\\"with-quote\", \"id\\\\with-backslash\"]");
+        assertThat(result.getLimit()).isEqualTo(4);
     }
 
     @Test

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStoreIT.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStoreIT.java
@@ -18,6 +18,7 @@ import io.milvus.v2.client.MilvusClientV2;
 import io.milvus.v2.common.ConsistencyLevel;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
@@ -113,6 +114,31 @@ class MilvusV2EmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
         assertThat(matches).hasSize(2);
         assertThat(matches.get(0).embedding()).isNull();
         assertThat(matches.get(1).embedding()).isNull();
+    }
+
+    @Test
+    void should_retrieve_embeddings_for_ids_containing_special_characters() {
+
+        Map<String, Embedding> embeddingsById = Map.of(
+                "normal-id", embeddingModel.embed("hello").content(),
+                "id'with'apostrophe", embeddingModel.embed("hi").content(),
+                "id\"with-quote", embeddingModel.embed("hey").content(),
+                "id\\with-backslash", embeddingModel.embed("howdy").content());
+
+        embeddingsById.forEach(embeddingStore::add);
+
+        // retrieveEmbeddingsOnSearch(true) queries Milvus a second time by these ids to fetch the vectors,
+        // which only works when the ids are quoted and escaped in the query expression
+        List<EmbeddingMatch<TextSegment>> matches = embeddingStore
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(embeddingModel.embed("hello").content())
+                        .maxResults(10)
+                        .build())
+                .matches();
+
+        assertThat(matches).hasSize(embeddingsById.size());
+        assertThat(matches)
+                .allSatisfy(match -> assertThat(match.embedding()).isEqualTo(embeddingsById.get(match.embeddingId())));
     }
 
     @Test

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapperTest.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapperTest.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.store.embedding.milvus.v2;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import org.junit.jupiter.api.Test;
+
+class MilvusV2MetadataFilterMapperTest {
+
+    @Test
+    void should_escape_backslash_in_string_value() {
+        Filter filter = metadataKey("key").isEqualTo("a\\b");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] == \"a\\\\b\"");
+    }
+
+    @Test
+    void should_escape_both_backslash_and_double_quote_in_string_value() {
+        Filter filter = metadataKey("key").isEqualTo("a\\b\"c");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] == \"a\\\\b\\\"c\"");
+    }
+
+    @Test
+    void should_escape_backslash_in_collection_values() {
+        Filter filter = metadataKey("key").isIn("a\\b");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] in [\"a\\\\b\"]");
+    }
+
+    @Test
+    void should_not_change_value_without_special_characters() {
+        Filter filter = metadataKey("key").isEqualTo("foo");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] == \"foo\"");
+    }
+}

--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/CollectionRequestBuilder.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/CollectionRequestBuilder.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.store.embedding.milvus;
 
+import static dev.langchain4j.store.embedding.milvus.MilvusMetadataFilterMapper.formatValues;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.store.embedding.filter.Filter;
 import io.milvus.common.clientenum.ConsistencyLevelEnum;
@@ -100,6 +100,6 @@ class CollectionRequestBuilder {
     }
 
     private static String buildQueryExpression(List<String> rowIds, String idFieldName) {
-        return rowIds.stream().map(id -> format("%s == '%s'", idFieldName, id)).collect(joining(" || "));
+        return format("%s in %s", idFieldName, formatValues(rowIds));
     }
 }

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/CollectionRequestBuilderTest.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/CollectionRequestBuilderTest.java
@@ -1,0 +1,34 @@
+package dev.langchain4j.store.embedding.milvus;
+
+import static dev.langchain4j.store.embedding.milvus.CollectionRequestBuilder.buildQueryRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.milvus.common.clientenum.ConsistencyLevelEnum;
+import io.milvus.param.dml.QueryParam;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CollectionRequestBuilderTest {
+
+    private static final String COLLECTION_NAME = "test_collection";
+    private static final FieldDefinition FIELD_DEFINITION = new FieldDefinition("id", "text", "metadata", "vector");
+
+    @Test
+    void should_quote_and_escape_row_ids_in_query_expression() {
+        List<String> rowIds = List.of("normal-id", "id'with'apostrophe", "id\"with-quote", "id\\with-backslash");
+
+        QueryParam request = buildQueryRequest(COLLECTION_NAME, FIELD_DEFINITION, rowIds, ConsistencyLevelEnum.STRONG);
+
+        assertThat(request.getExpr())
+                .isEqualTo(
+                        "id in [\"normal-id\", \"id'with'apostrophe\", \"id\\\"with-quote\", \"id\\\\with-backslash\"]");
+    }
+
+    @Test
+    void should_build_query_expression_for_a_single_row_id() {
+        QueryParam request =
+                buildQueryRequest(COLLECTION_NAME, FIELD_DEFINITION, List.of("id-1"), ConsistencyLevelEnum.STRONG);
+
+        assertThat(request.getExpr()).isEqualTo("id in [\"id-1\"]");
+    }
+}

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
@@ -109,6 +109,31 @@ class MilvusEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
     }
 
     @Test
+    void should_retrieve_embeddings_for_ids_containing_special_characters() {
+
+        Map<String, Embedding> embeddingsById = Map.of(
+                "normal-id", embeddingModel.embed("hello").content(),
+                "id'with'apostrophe", embeddingModel.embed("hi").content(),
+                "id\"with-quote", embeddingModel.embed("hey").content(),
+                "id\\with-backslash", embeddingModel.embed("howdy").content());
+
+        embeddingsById.forEach(embeddingStore::add);
+
+        // retrieveEmbeddingsOnSearch(true) queries Milvus a second time by these ids to fetch the vectors,
+        // which only works when the ids are quoted and escaped in the query expression
+        List<EmbeddingMatch<TextSegment>> matches = embeddingStore
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(embeddingModel.embed("hello").content())
+                        .maxResults(10)
+                        .build())
+                .matches();
+
+        assertThat(matches).hasSize(embeddingsById.size());
+        assertThat(matches)
+                .allSatisfy(match -> assertThat(match.embedding()).isEqualTo(embeddingsById.get(match.embeddingId())));
+    }
+
+    @Test
     void milvus_with_existing_client() {
 
         ConnectParam.Builder connectBuilder = ConnectParam.newBuilder()


### PR DESCRIPTION

## Issue

Closes #6087

## Change

`buildQueryExpression` concatenated caller-supplied ids into `id == '<id>' || ...` without quoting or
escaping them. It now uses the `in` form with the module's existing value formatter:

```java
return format("%s in %s", idFieldName, formatValues(rowIds));
```

That is the same shape `MilvusEmbeddingStore.removeAll(Collection<String> ids)` already uses for
caller-supplied ids, down to the static import of `formatValues` from the metadata filter mapper, so the id
query path now formats values the way the delete path and the metadata filters do instead of hand-rolling
it. It also collapses the expression from one `==` term per id to a single `in`.

Both modules carried the identical line, so both are fixed.

One dependent change: `MilvusV2MetadataFilterMapper.formatValue` escaped double quotes but not backslashes,
so it never received the fix `MilvusMetadataFilterMapper` got in #5577. Since the id expression is now routed
through that formatter, v2 would still mishandle an id containing a backslash without it. The v2 formatter
now matches v1.

`rowIds` is never empty at this point: both callers guard on the search result being non-empty before
querying for vectors, so the expression shape is unchanged for every reachable input.

### Tests

- `langchain4j-milvus/CollectionRequestBuilderTest` (new): a normal id, an id with an apostrophe, an id with
  a double quote and an id with a backslash, plus a single-id expression
- `langchain4j-milvus-v2/CollectionRequestBuilderTest`: the same matrix, added to the existing class
- `langchain4j-milvus-v2/MilvusV2MetadataFilterMapperTest` (new): mirrors the backslash tests #5577 added to
  the v1 mapper, which had no v2 counterpart

Six fail on unmodified `main` (2 in v1, 1 in the v2 builder, 3 in the v2 mapper). The
no-special-characters case passes either way, it pins formatting that must not change.

```
mvn -pl langchain4j-milvus test
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-milvus-v2 test
Tests run: 27, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-milvus verify -DskipTests
mvn -pl langchain4j-milvus-v2 verify -DskipTests
revapi: API checks completed without failures (both)

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 4
langchain4j:      Tests run: 1331, Failures: 0, Errors: 0, Skipped: 0
```

Milvus integration tests need a running Milvus and were not run.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
