### PR TITLE
Fix Validate input sizes before the empty-input guard in `PgVectorEmbeddingStore`

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
@@ -5,11 +5,11 @@ import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.internal.ValidationUtils.ensureConsistentSizes;
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
 import static java.lang.String.join;
 import static java.util.Collections.nCopies;
 import static java.util.Collections.singletonList;
@@ -632,14 +632,11 @@ public class PgVectorEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     @Override
     public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> embedded) {
-        if (isNullOrEmpty(ids) || isNullOrEmpty(embeddings)) {
+        ensureConsistentSizes(ids, embeddings, embedded);
+        if (isNullOrEmpty(embeddings)) {
             log.info("Empty embeddings - no ops");
             return;
         }
-        ensureTrue(ids.size() == embeddings.size(), "ids size is not equal to embeddings size");
-        ensureTrue(
-                embedded == null || embeddings.size() == embedded.size(),
-                "embeddings size is not equal to embedded size");
 
         try (Connection connection = getConnection()) {
             String query = String.format(

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreValidationTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreValidationTest.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.store.embedding.pgvector;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class PgVectorEmbeddingStoreValidationTest {
+
+    private static final Embedding EMBEDDING = Embedding.from(new float[] {1, 2, 3});
+
+    @Test
+    void should_reject_empty_ids_with_non_empty_embeddings() {
+        DataSource dataSource = Mockito.mock(DataSource.class);
+
+        assertThatThrownBy(() -> store(dataSource).addAll(emptyList(), singletonList(EMBEDDING), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids size (0) is not equal to embeddings size (1)");
+
+        Mockito.verifyNoInteractions(dataSource);
+    }
+
+    @Test
+    void should_reject_empty_embeddings_with_non_empty_embedded() {
+        DataSource dataSource = Mockito.mock(DataSource.class);
+
+        assertThatThrownBy(() ->
+                        store(dataSource).addAll(emptyList(), emptyList(), singletonList(TextSegment.from("text"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("embeddings size (0) is not equal to embedded size (1)");
+
+        Mockito.verifyNoInteractions(dataSource);
+    }
+
+    @Test
+    void should_reject_more_ids_than_embeddings() {
+        DataSource dataSource = Mockito.mock(DataSource.class);
+
+        assertThatThrownBy(() -> store(dataSource).addAll(List.of("id-1", "id-2"), singletonList(EMBEDDING), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids size (2) is not equal to embeddings size (1)");
+
+        Mockito.verifyNoInteractions(dataSource);
+    }
+
+    @Test
+    void should_do_nothing_when_everything_is_empty() {
+        DataSource dataSource = Mockito.mock(DataSource.class);
+
+        assertThatCode(() -> store(dataSource).addAll(emptyList(), emptyList(), null))
+                .doesNotThrowAnyException();
+
+        Mockito.verifyNoInteractions(dataSource);
+    }
+
+    private static PgVectorEmbeddingStore store(DataSource dataSource) {
+        return PgVectorEmbeddingStore.datasourceBuilder()
+                .datasource(dataSource)
+                .table("embeddings")
+                .dropTableFirst(false)
+                .createTable(false)
+                .useIndex(false)
+                .build();
+    }
+}


### PR DESCRIPTION
# Issue

Closes #6089

## Change

`addAll` returned early when `ids` or `embeddings` was empty, before its size checks ran, so a mismatch was
reported only when both were non-empty. With one side empty the call returned quietly and stored nothing.

```java
ensureConsistentSizes(ids, embeddings, embedded);
if (isNullOrEmpty(embeddings)) {
    log.info("Empty embeddings - no ops");
    return;
}
```

| `ids` | `embeddings` | `embedded` | Before | After |
|---|---|---|---|---|
| `["a"]` | `[e1, e2]` | null | throws | throws |
| `[]` | `[e1]` | null | silent no-op | throws |
| `[]` | `[]` | `[s1]` | silent no-op | throws |
| `[]` | `[]` | null | no-op | no-op |

`ensureConsistentSizes` is null-safe, counting a null side as 0, so the all-empty no-op path is unchanged.
This is the ordering `ChromaEmbeddingStore.addAll` already uses. The two hand-rolled `ensureTrue` checks are
dropped because the helper covers both, which is why the production diff is a net reduction; the messages
change from "ids size is not equal to embeddings size" to "ids size (0) is not equal to embeddings size (1)".
If you would rather keep the existing message text, that part is easy to drop.



### Tests

- `PgVectorEmbeddingStoreValidationTest` (new): empty `ids` with one embedding, and empty `ids`/`embeddings`
  with one text segment, both now throw with the size in the message; more ids than embeddings still throws;
  the all-empty call remains a no-op. Every case also asserts `verifyNoInteractions` on the `DataSource`, so
  validation is proven to happen before any connection is taken

Three fail on unmodified `main`: the two silently-ignored shapes, plus the mismatch case whose message text
changes. The all-empty case passes either way, it pins the no-op that must not regress.

```
mvn -pl langchain4j-pgvector test
Tests run: 25, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-pgvector verify -DskipTests
revapi: API checks completed without failures

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1331, Failures: 0, Errors: 0, Skipped: 0
```

PgVector integration tests need a running Postgres and were not run.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
