### PR TITLE
fix: split text without detectable sentences instead of failing or dropping it

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/DocumentBySentenceSplitter.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/DocumentBySentenceSplitter.java
@@ -20,6 +20,9 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
  * <p>
  * Sentence boundaries are detected using the Apache OpenNLP library with the English sentence model.
  * <p>
+ * If no sentence can be detected in the text at all (for example, a run of non-breaking spaces,
+ * which document parsers often produce), the whole text is treated as a single sentence.
+ * <p>
  * If multiple sentences fit within {@code maxSegmentSize}, they are joined together using a space (" ").
  * <p>
  * If a single sentence is too long and exceeds {@code maxSegmentSize},
@@ -88,7 +91,14 @@ public class DocumentBySentenceSplitter extends HierarchicalDocumentSplitter {
     @Override
     public String[] split(String text) {
         SentenceDetectorME sentenceDetector = new SentenceDetectorME(sentenceModel);
-        return sentenceDetector.sentDetect(text);
+        String[] sentences = sentenceDetector.sentDetect(text);
+        if (sentences.length == 0) {
+            // Text with no recognizable sentence content (e.g. a run of non-breaking spaces coming
+            // from PDF extraction) yields no sentence at all. It is treated as a single sentence so
+            // that the subSplitter can still break it down, instead of the text being lost.
+            return new String[] {text};
+        }
+        return sentences;
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitter.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitter.java
@@ -168,12 +168,27 @@ public abstract class HierarchicalDocumentSplitter implements DocumentSplitter {
 
             // Delegate the splitting of the part to the sub-splitter.
             segmentBuilder.append(part);
-            for (TextSegment segment : subSplitter.split(Document.from(segmentBuilder.toString()))) {
+            String textToSubSplit = segmentBuilder.toString();
+            List<TextSegment> subSegments = subSplitter.split(Document.from(textToSubSplit));
+
+            if (subSegments.isEmpty()) {
+                // The sub-splitter found no unit it recognizes. A run of non-breaking spaces, which
+                // real PDF extraction produces, is not blank, so it reaches this point, but
+                // DocumentBySentenceSplitter finds no sentence in it and returns nothing. The
+                // hierarchy is meant to bottom out at DocumentByCharacterSplitter, which always
+                // yields at least one segment for non-empty text, so the text is kept here instead
+                // of being lost when the recursion stops early. Previously this dropped the text
+                // silently, or threw IndexOutOfBoundsException when no segment had been flushed yet.
+                subSegments = List.of(TextSegment.from(textToSubSplit));
+            }
+
+            for (TextSegment segment : subSegments) {
                 segments.add(createSegment(segment.text(), document, index.getAndIncrement()));
             }
 
-            TextSegment lastSegment = segments.get(segments.size() - 1);
-            overlap = overlapFrom(lastSegment.text());
+            // The overlap comes from what this sub-split produced, not from whatever happened to be
+            // last in the accumulated list.
+            overlap = overlapFrom(subSegments.get(subSegments.size() - 1).text());
 
             segmentBuilder.reset();
             segmentBuilder.append(overlap);

--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitter.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitter.java
@@ -171,23 +171,21 @@ public abstract class HierarchicalDocumentSplitter implements DocumentSplitter {
             String textToSubSplit = segmentBuilder.toString();
             List<TextSegment> subSegments = subSplitter.split(Document.from(textToSubSplit));
 
+            // Enforce that the sub-splitter produced something to work with.
             if (subSegments.isEmpty()) {
-                // The sub-splitter found no unit it recognizes. A run of non-breaking spaces, which
-                // real PDF extraction produces, is not blank, so it reaches this point, but
-                // DocumentBySentenceSplitter finds no sentence in it and returns nothing. The
-                // hierarchy is meant to bottom out at DocumentByCharacterSplitter, which always
-                // yields at least one segment for non-empty text, so the text is kept here instead
-                // of being lost when the recursion stops early. Previously this dropped the text
-                // silently, or threw IndexOutOfBoundsException when no segment had been flushed yet.
-                subSegments = List.of(TextSegment.from(textToSubSplit));
+                throw new RuntimeException(String.format(
+                        "The subSplitter %s returned no segments for the text \"%s...\" (%s %s long), "
+                                + "so it cannot be split further.",
+                        subSplitter.getClass().getSimpleName(),
+                        firstChars(textToSubSplit, 30),
+                        estimateSize(textToSubSplit),
+                        tokenCountEstimator == null ? "characters" : "tokens"));
             }
 
             for (TextSegment segment : subSegments) {
                 segments.add(createSegment(segment.text(), document, index.getAndIncrement()));
             }
 
-            // The overlap comes from what this sub-split produced, not from whatever happened to be
-            // last in the accumulated list.
             overlap = overlapFrom(subSegments.get(subSegments.size() - 1).text());
 
             segmentBuilder.reset();

--- a/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/DocumentBySentenceSplitterTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/DocumentBySentenceSplitterTest.java
@@ -13,6 +13,7 @@ import static dev.langchain4j.data.document.Metadata.metadata;
 import static dev.langchain4j.data.segment.TextSegment.textSegment;
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_3_5_TURBO;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DocumentBySentenceSplitterTest {
@@ -173,5 +174,32 @@ class DocumentBySentenceSplitterTest {
                 textSegment(s15 + " " + s16 + " " + s17, metadata("index", "9").put("document", "0")),
                 textSegment(s18, metadata("index", "10").put("document", "0"))
         );
+    }
+
+    @Test
+    void should_treat_text_without_any_sentence_as_a_single_sentence() {
+
+        // A run of non-breaking spaces, as produced by PDF extraction, is not blank but contains no
+        // sentence OpenNLP can detect. See issue #6085.
+        String nbspRun = "\u00A0".repeat(200);
+
+        DocumentBySentenceSplitter splitter = new DocumentBySentenceSplitter(50, 0);
+
+        assertThat(splitter.split(nbspRun)).containsExactly(nbspRun);
+    }
+
+    @Test
+    void should_split_text_without_any_sentence_into_segments_within_the_limit() {
+
+        int maxSegmentSize = 50;
+        String nbspRun = "\u00A0".repeat(200);
+
+        DocumentSplitter splitter = new DocumentBySentenceSplitter(maxSegmentSize, 0);
+
+        List<TextSegment> segments = splitter.split(Document.from(nbspRun));
+
+        assertThat(segments).hasSize(4);
+        segments.forEach(segment -> assertThat(segment.text()).hasSizeLessThanOrEqualTo(maxSegmentSize));
+        assertThat(segments.stream().map(TextSegment::text).collect(joining())).isEqualTo(nbspRun);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitterTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitterTest.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.data.document.splitter;
 
+import static java.util.stream.Collectors.joining;
+
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
 import dev.langchain4j.data.segment.TextSegment;
@@ -122,47 +124,75 @@ class HierarchicalDocumentSplitterTest implements WithAssertions {
         }
     }
 
-    // A run of non-breaking spaces is not blank, so it reaches the sub-splitter, but
-    // DocumentBySentenceSplitter finds no sentence in it and returns nothing. The hierarchy is meant
-    // to bottom out at DocumentByCharacterSplitter, which always produces at least one segment, so
-    // such a part still has to be kept rather than dropped. See issue #6085.
+    // A part with no recognizable sentence, such as the run of non-breaking spaces that PDF
+    // extraction produces, used to make DocumentBySentenceSplitter return nothing, which either
+    // threw IndexOutOfBoundsException or silently dropped the part. See issue #6085.
     @Test
-    void split_should_not_throw_when_sub_splitter_returns_nothing_for_the_first_part() {
-        DocumentByParagraphSplitter splitter = new DocumentByParagraphSplitter(50, 0);
-        String text = NBSP.repeat(200) + "\n\nA normal paragraph that follows the junk.";
+    void split_should_split_a_part_without_any_sentence_into_segments_within_the_limit() {
+        int maxSegmentSize = 50;
+        DocumentByParagraphSplitter splitter = new DocumentByParagraphSplitter(maxSegmentSize, 0);
+        String lastParagraph = "A normal paragraph that follows the junk.";
+        String text = NBSP.repeat(200) + "\n\n" + lastParagraph;
 
         List<TextSegment> segments = splitter.split(Document.from(text));
 
-        assertThat(segments).isNotEmpty();
         assertThat(segments)
                 .extracting(TextSegment::text)
-                .anySatisfy(
-                        segmentText -> assertThat(segmentText).contains("A normal paragraph that follows the junk."));
+                .allSatisfy(segmentText -> assertThat(segmentText).hasSizeLessThanOrEqualTo(maxSegmentSize));
+        assertThat(segments).extracting(TextSegment::text).last().isEqualTo(lastParagraph);
+        for (int i = 0; i < segments.size(); i++) {
+            assertThat(segments.get(i).metadata().getInteger("index")).isEqualTo(i);
+        }
     }
 
     @Test
-    void split_should_keep_a_part_the_sub_splitter_cannot_split() {
+    void split_should_keep_a_part_without_any_sentence_that_sits_between_other_parts() {
         DocumentByParagraphSplitter splitter = new DocumentByParagraphSplitter(50, 0);
         String junk = NBSP.repeat(200);
         String text = "A normal paragraph first.\n\n" + junk + "\n\nAnother normal paragraph.";
 
         List<TextSegment> segments = splitter.split(Document.from(text));
 
-        assertThat(segments).extracting(TextSegment::text).contains(junk);
-        assertThat(String.join("", segments.stream().map(TextSegment::text).toList()))
-                .contains("A normal paragraph first.")
-                .contains("Another normal paragraph.");
+        String joined = segments.stream().map(TextSegment::text).collect(joining());
+        assertThat(joined).contains("A normal paragraph first.").contains(junk).contains("Another normal paragraph.");
     }
 
     @Test
-    void split_should_index_segments_consecutively_when_sub_splitter_returns_nothing() {
-        DocumentByParagraphSplitter splitter = new DocumentByParagraphSplitter(50, 0);
-        String text = NBSP.repeat(200) + "\n\nA normal paragraph that follows the junk.";
+    void split_should_fail_with_a_clear_message_when_sub_splitter_returns_no_segments() {
+        ExampleImpl splitter = new ExampleImpl(50, 0, new EmptyResultSplitter());
+        String text = "a".repeat(100);
 
-        List<TextSegment> segments = splitter.split(Document.from(text));
+        assertThatThrownBy(() -> splitter.split(Document.from(text)))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessageContaining("EmptyResultSplitter")
+                .hasMessageContaining("returned no segments")
+                .hasMessageContaining("100 characters long");
+    }
 
-        for (int i = 0; i < segments.size(); i++) {
-            assertThat(segments.get(i).metadata().getInteger("index")).isEqualTo(i);
+    static class EmptyResultSplitter extends HierarchicalDocumentSplitter {
+
+        EmptyResultSplitter() {
+            super(1, 0);
+        }
+
+        @Override
+        public List<TextSegment> split(Document document) {
+            return List.of();
+        }
+
+        @Override
+        protected String[] split(String text) {
+            return new String[0];
+        }
+
+        @Override
+        protected String joinDelimiter() {
+            return " ";
+        }
+
+        @Override
+        protected DocumentSplitter defaultSubSplitter() {
+            return null;
         }
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitterTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/HierarchicalDocumentSplitterTest.java
@@ -1,12 +1,18 @@
 package dev.langchain4j.data.document.splitter;
 
+import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.ExampleTestTokenCountEstimator;
 import dev.langchain4j.model.TokenCountEstimator;
+import java.util.List;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 class HierarchicalDocumentSplitterTest implements WithAssertions {
+
+    private static final String NBSP = "\u00A0"; // non-breaking space
+
     public static class ExampleImpl extends HierarchicalDocumentSplitter {
         public ExampleImpl(int maxSegmentSizeInChars, int maxOverlapSizeInChars) {
             super(maxSegmentSizeInChars, maxOverlapSizeInChars);
@@ -113,6 +119,50 @@ class HierarchicalDocumentSplitterTest implements WithAssertions {
             assertThat(splitter.estimateSize("\t\n")).isEqualTo(2);
 
             assertThat(splitter.estimateSize("abc def")).isEqualTo(2);
+        }
+    }
+
+    // A run of non-breaking spaces is not blank, so it reaches the sub-splitter, but
+    // DocumentBySentenceSplitter finds no sentence in it and returns nothing. The hierarchy is meant
+    // to bottom out at DocumentByCharacterSplitter, which always produces at least one segment, so
+    // such a part still has to be kept rather than dropped. See issue #6085.
+    @Test
+    void split_should_not_throw_when_sub_splitter_returns_nothing_for_the_first_part() {
+        DocumentByParagraphSplitter splitter = new DocumentByParagraphSplitter(50, 0);
+        String text = NBSP.repeat(200) + "\n\nA normal paragraph that follows the junk.";
+
+        List<TextSegment> segments = splitter.split(Document.from(text));
+
+        assertThat(segments).isNotEmpty();
+        assertThat(segments)
+                .extracting(TextSegment::text)
+                .anySatisfy(
+                        segmentText -> assertThat(segmentText).contains("A normal paragraph that follows the junk."));
+    }
+
+    @Test
+    void split_should_keep_a_part_the_sub_splitter_cannot_split() {
+        DocumentByParagraphSplitter splitter = new DocumentByParagraphSplitter(50, 0);
+        String junk = NBSP.repeat(200);
+        String text = "A normal paragraph first.\n\n" + junk + "\n\nAnother normal paragraph.";
+
+        List<TextSegment> segments = splitter.split(Document.from(text));
+
+        assertThat(segments).extracting(TextSegment::text).contains(junk);
+        assertThat(String.join("", segments.stream().map(TextSegment::text).toList()))
+                .contains("A normal paragraph first.")
+                .contains("Another normal paragraph.");
+    }
+
+    @Test
+    void split_should_index_segments_consecutively_when_sub_splitter_returns_nothing() {
+        DocumentByParagraphSplitter splitter = new DocumentByParagraphSplitter(50, 0);
+        String text = NBSP.repeat(200) + "\n\nA normal paragraph that follows the junk.";
+
+        List<TextSegment> segments = splitter.split(Document.from(text));
+
+        for (int i = 0; i < segments.size(); i++) {
+            assertThat(segments.get(i).metadata().getInteger("index")).isEqualTo(i);
         }
     }
 }


### PR DESCRIPTION
## Issue

  Fixes #6085

  ## Change

  `DocumentBySentenceSplitter` could return no sentence at all for text that is not blank but
  has no recognizable sentence content — a run of non-breaking spaces (U+00A0), which PDF
  extraction and table padding routinely produce, is the practical case. Only the sentence
  splitter does this; `Word` and `Character` both handle the same input:

  | input | Sentence | Word | Character |
  |---|---|---|---|
  | 200 × U+00A0 | **0** | 4 | 4 |
  | plain spaces / tabs / empty | rejected earlier as blank | | |
  | CJK without punctuation, digits, emoji, punctuation only | 4–6 | 4–6 | 4–6 |

  The recursion therefore stopped one level above `DocumentByCharacterSplitter`, the fallback
  meant to catch exactly this. In `HierarchicalDocumentSplitter.split()` the loop over the
  sub-splitter's result then added nothing, and the following line read the last element of the
  accumulated list:

  ```java
  TextSegment lastSegment = segments.get(segments.size() - 1);
  ```

  With no segment flushed yet that is `segments.get(-1)` → `IndexOutOfBoundsException`; with an
  earlier segment present the part is silently dropped and the overlap is taken from unrelated
  text. `EmbeddingStoreIngestor.ingest(documents)` has no per-document guard, so the first case
  takes down a whole batch ingestion.

  **Fix, in two parts:**

  1. `DocumentBySentenceSplitter.split(String)` treats text with no detectable sentence as a
     single sentence. The chain then continues to `Word` → `Character` as designed, so the part
     is split *within* `maxSegmentSize` rather than being lost.

  2. `HierarchicalDocumentSplitter` fails with a clear message — consistent with the existing
     `subSplitter == null` message a few lines above — if a sub-splitter still returns no
     segments. After (1) this is unreachable through the built-in splitters; it only guards a
     user-supplied `subSplitter`, and it never silently emits a segment over `maxSegmentSize`.

Result for `DocumentByParagraphSplitter(50, 0)` on `200×NBSP + "\n\n" + paragraph`:

  | | segments |
  |---|---|
  | before | `IndexOutOfBoundsException` |
  | after | `50, 50, 50, 50, 41` |

  The overlap is now taken from what the sub-split produced rather than from whatever happened
  to be last in the accumulated list. Equivalent on the happy path, but no longer reads an
  unrelated element.

  **Observable behaviour change to be aware of:** `DocumentBySentenceSplitter.split(String)` is
  public, and for text with no detectable sentence it now returns `{text}` instead of an empty
  array. That is the bug being fixed, but a caller invoking it directly will see the difference.

  ## Verification

  - `langchain4j`: 1340 tests, 0 failures.
  - `langchain4j-core`: 1247 tests, 0 failures, 5 skipped.
  - `revapi:check` passes — no API surface change.
  - Two pre-existing notes, both unrelated to these lines:
    - `spotless:check` reports `DocumentBySentenceSplitter.java` and its test. Both files are
      still in the pre-spotless style on `main` (aligned constructor parameters, import order),
      and the ratchet only inspects files that differ from `main` — touching them at all
      surfaces it. Reverting both files and appending a single newline reproduces the identical
      report. Left alone rather than reformatting two whole files inside a bug-fix PR; happy to
      include the reformat if you prefer it.
    - `InMemoryEmbeddingStoreRemovalIT` has 2 errors on this branch's base; fixed upstream by
      #6069, which this branch predates. A rebase clears them.

  Touches the same method as #5743, which changes `overlapFrom()` only. No overlapping lines,
  but the two interact: once this lands, the empty-sub-split path no longer exists, so #5743's
  character-level overlap never sees junk text.

  ## General checklist

  - [X] There are no breaking changes (API, behaviour)
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — Javadoc on `DocumentBySentenceSplitter` updated; no `docs/docs` change needed for a bug fix
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)