### PR TITLE
Avoid duplicate declaration of jsoup version

### DIFF
--- a/document-transformers/langchain4j-document-transformer-jsoup/pom.xml
+++ b/document-transformers/langchain4j-document-transformer-jsoup/pom.xml
@@ -23,14 +23,12 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.23.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/langchain4j-agentic-patterns/pom.xml
+++ b/langchain4j-agentic-patterns/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.langchain4j</groupId>
@@ -13,11 +11,6 @@
     <artifactId>langchain4j-agentic-patterns</artifactId>
     <name>LangChain4j :: Agentic Framework :: Agentic Patterns</name>
 
-    <properties>
-        <jsoup.version>1.23.1</jsoup.version>
-        <pdfbox.version>3.0.7</pdfbox.version>
-    </properties>
-
     <developers>
         <developer>
             <id>mariofusco</id>
@@ -25,6 +18,10 @@
             <url>https://github.com/mariofusco</url>
         </developer>
     </developers>
+
+    <properties>
+        <pdfbox.version>3.0.7</pdfbox.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -49,7 +46,6 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>${jsoup.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/langchain4j-oracle/pom.xml
+++ b/langchain4j-oracle/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.23.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -72,6 +72,7 @@
         <tinylog.version>2.7.0</tinylog.version>
         <wiremock.version>3.13.2</wiremock.version>
         <hibernate.version>7.4.2.Final</hibernate.version>
+        <jsoup.version>1.23.1</jsoup.version>
     </properties>
 
     <dependencyManagement>
@@ -279,6 +280,12 @@
                 <groupId>com.azure</groupId>
                 <artifactId>azure-cosmos</artifactId>
                 <version>4.71.0-beta.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Jsoup is used by 3 distinct modules. Let's centralize its version management into one place.