### PR TITLE
[1.11] Avoid duplicate declaration of jsoup version, update to 1.23.1

### DIFF
--- a/document-transformers/langchain4j-document-transformer-jsoup/pom.xml
+++ b/document-transformers/langchain4j-document-transformer-jsoup/pom.xml
@@ -23,14 +23,12 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.18.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 

--- a/langchain4j-agentic-patterns/pom.xml
+++ b/langchain4j-agentic-patterns/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.langchain4j</groupId>
@@ -13,11 +11,6 @@
     <artifactId>langchain4j-agentic-patterns</artifactId>
     <name>LangChain4j :: Agentic Framework :: Agentic Patterns</name>
 
-    <properties>
-        <jsoup.version>1.18.3</jsoup.version>
-        <pdfbox.version>3.0.5</pdfbox.version>
-    </properties>
-
     <developers>
         <developer>
             <id>mariofusco</id>
@@ -25,6 +18,10 @@
             <url>https://github.com/mariofusco</url>
         </developer>
     </developers>
+
+    <properties>
+        <pdfbox.version>3.0.7</pdfbox.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -49,7 +46,6 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>${jsoup.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/langchain4j-oracle/pom.xml
+++ b/langchain4j-oracle/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.18.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -71,6 +71,7 @@
         <testcontainers.version>1.21.4</testcontainers.version>
         <tinylog.version>2.7.0</tinylog.version>
         <wiremock.version>3.13.1</wiremock.version>
+        <jsoup.version>1.23.1</jsoup.version>
     </properties>
 
     <dependencyManagement>
@@ -278,6 +279,12 @@
                 <groupId>com.azure</groupId>
                 <artifactId>azure-cosmos</artifactId>
                 <version>4.71.0-beta.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
             </dependency>
 
         </dependencies>
@@ -766,10 +773,10 @@
                     </execution>
                     <execution>
                         <id>report</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <phase>verify</phase>
                         <configuration>
                             <excludes>
                                 <exclude>**/*Exception.*</exclude>


### PR DESCRIPTION
backport of https://github.com/langchain4j/langchain4j/pull/6092
and update to 1.23.1 to fix https://nvd.nist.gov/vuln/detail/cve-2026-71497