### PR TITLE
Add `OpenAiOfficialBatchChatModel` for the OpenAI Batch API

### DIFF
--- a/docs/docs/integrations/language-models/open-ai-official.md
+++ b/docs/docs/integrations/language-models/open-ai-official.md
@@ -418,3 +418,65 @@ metadata.createdAt();        // Timestamp when the response was created
 metadata.completedAt();      // Timestamp when the response was completed
 metadata.serviceTier();      // Service tier used for the request
 ```
+
+## Batch Processing
+
+`OpenAiOfficialBatchChatModel` implements the core `BatchChatModel` interface to process many chat requests
+asynchronously via the [OpenAI Batch API](https://platform.openai.com/docs/guides/batch), at 50% of the
+standard per-token price. See [Batch Processing](/tutorials/batch-processing) for how batching works in
+LangChain4j.
+
+Requests are written to a JSONL file, uploaded through the Files API with the `batch` purpose, and run
+against the `/v1/chat/completions` endpoint. All requests in a batch must resolve to the same model. Results
+preserve submission order, so the i-th result always corresponds to the i-th request, whether it succeeded
+or failed.
+
+```java
+OpenAiOfficialBatchChatModel batchModel = OpenAiOfficialBatchChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-4o-mini")
+        .build();
+
+BatchResponse<ChatResponse> submitted = batchModel.submit(new BatchRequest<>(List.of(
+        ChatRequest.builder().messages(UserMessage.from("What is the capital of France?")).build(),
+        ChatRequest.builder().messages(UserMessage.from("What is the capital of Germany?")).build())));
+
+String batchId = submitted.batchId();
+
+// Poll until the batch reaches a terminal state (SUCCEEDED, FAILED, CANCELLED, EXPIRED).
+BatchResponse<ChatResponse> batch = batchModel.retrieve(batchId);
+while (!batch.state().isTerminal()) {
+    Thread.sleep(Duration.ofSeconds(30).toMillis());
+    batch = batchModel.retrieve(batchId);
+}
+
+for (BatchItemResult<ChatResponse> result : batch.results()) {
+    if (result.isSuccess()) {
+        System.out.println(result.response().aiMessage().text());
+    } else {
+        System.out.println("Failed: " + result.error().message());
+    }
+}
+```
+
+A running batch can be cancelled, and existing batches can be listed with pagination:
+```java
+batchModel.cancel(batchId);
+
+BatchPage<ChatResponse> page = batchModel.list(new BatchPagination(20, null));
+```
+
+Azure OpenAI is supported as well, where the model is identified by its batch deployment name, as is any
+OpenAI-compatible endpoint that implements the Files and Batch APIs.
+
+Batch-specific options can be set on the builder:
+```java
+OpenAiOfficialBatchChatModel batchModel = OpenAiOfficialBatchChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-4o-mini")
+        .completionWindow("24h")                          // defaults to 24h
+        .batchMetadata(Map.of("owner", "nightly-job"))    // attached to the batch itself
+        .inputFileExpiresAfterSeconds(Duration.ofDays(14).toSeconds())
+        .outputExpiresAfterSeconds(Duration.ofDays(7).toSeconds())
+        .build();
+```

--- a/docs/docs/integrations/language-models/open-ai-official.md
+++ b/docs/docs/integrations/language-models/open-ai-official.md
@@ -428,7 +428,7 @@ LangChain4j.
 
 Requests are written to a JSONL file, uploaded through the Files API with the `batch` purpose, and run
 against the `/v1/chat/completions` endpoint. All requests in a batch must resolve to the same model. Results
-preserve submission order, so the i-th result always corresponds to the i-th request, whether it succeeded
+preserve submission order, so the i-th result corresponds to the i-th request, whether it succeeded
 or failed.
 
 ```java
@@ -476,7 +476,7 @@ OpenAiOfficialBatchChatModel batchModel = OpenAiOfficialBatchChatModel.builder()
         .modelName("gpt-4o-mini")
         .completionWindow("24h")                          // defaults to 24h
         .batchMetadata(Map.of("owner", "nightly-job"))    // attached to the batch itself
-        .inputFileExpiresAfterSeconds(Duration.ofDays(14).toSeconds())
-        .outputExpiresAfterSeconds(Duration.ofDays(7).toSeconds())
+        .inputFileExpiresAfter(Duration.ofDays(14))
+        .outputExpiresAfter(Duration.ofDays(7))
         .build();
 ```

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialBatchHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialBatchHelper.java
@@ -1,0 +1,183 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.openai.core.ObjectMappers;
+import com.openai.models.batches.Batch;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import dev.langchain4j.model.batch.BatchError;
+import dev.langchain4j.model.batch.BatchState;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+class InternalOpenAiOfficialBatchHelper {
+
+    static final String CUSTOM_ID_PREFIX = "request-";
+
+    private static final String CHAT_COMPLETIONS_URL = "/v1/chat/completions";
+    private static final String POST_METHOD = "POST";
+    private static final String UNKNOWN_ERROR_MESSAGE = "unknown";
+    private static final int HTTP_OK = 200;
+    private static final int NO_STATUS_CODE = 0;
+
+    private static final JsonMapper JSON_MAPPER = ObjectMappers.jsonMapper();
+
+    private InternalOpenAiOfficialBatchHelper() {}
+
+    static String toCustomId(int requestIndex) {
+        return CUSTOM_ID_PREFIX + requestIndex;
+    }
+
+    private static int toRequestIndex(@Nullable String customId) {
+        if (customId == null || !customId.startsWith(CUSTOM_ID_PREFIX)) {
+            throw invalidCustomId(customId, null);
+        }
+        try {
+            int requestIndex = Integer.parseInt(customId.substring(CUSTOM_ID_PREFIX.length()));
+            if (requestIndex < 0) {
+                throw invalidCustomId(customId, null);
+            }
+            return requestIndex;
+        } catch (NumberFormatException e) {
+            throw invalidCustomId(customId, e);
+        }
+    }
+
+    private static IllegalStateException invalidCustomId(@Nullable String customId, @Nullable Throwable cause) {
+        return new IllegalStateException("Unexpected custom_id in batch result: " + customId, cause);
+    }
+
+    static byte[] toJsonl(List<ChatCompletionCreateParams> requests) {
+        StringBuilder jsonl = new StringBuilder();
+        for (int i = 0; i < requests.size(); i++) {
+            ObjectNode line = JSON_MAPPER.createObjectNode();
+            line.put("custom_id", toCustomId(i));
+            line.put("method", POST_METHOD);
+            line.put("url", CHAT_COMPLETIONS_URL);
+            line.set("body", JSON_MAPPER.valueToTree(requests.get(i)._body()));
+            jsonl.append(line).append('\n');
+        }
+        return jsonl.toString().getBytes(UTF_8);
+    }
+
+    static BatchState toBatchState(Batch.Status status) {
+        return switch (status.value()) {
+            case VALIDATING -> BatchState.PENDING;
+            case IN_PROGRESS, FINALIZING, CANCELLING -> BatchState.RUNNING;
+            case COMPLETED -> BatchState.SUCCEEDED;
+            case FAILED -> BatchState.FAILED;
+            case CANCELLED -> BatchState.CANCELLED;
+            case EXPIRED -> BatchState.EXPIRED;
+            case _UNKNOWN -> BatchState.UNSPECIFIED;
+        };
+    }
+
+    static List<ResultLine> toResultLines(InputStream content) {
+        List<ResultLine> resultLines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(content, UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.isBlank()) {
+                    resultLines.add(toResultLine(JSON_MAPPER.readTree(line)));
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read batch results", e);
+        }
+        return resultLines;
+    }
+
+    static BatchError toBatchError(com.openai.models.batches.BatchError error) {
+        Map<String, Object> details = new LinkedHashMap<>();
+        error.code().ifPresent(code -> details.put("code", code));
+        error.param().ifPresent(param -> details.put("param", param));
+        error.line().ifPresent(line -> details.put("line", line));
+        return new BatchError(NO_STATUS_CODE, error.message().orElse(UNKNOWN_ERROR_MESSAGE), toDetails(details));
+    }
+
+    private static ResultLine toResultLine(JsonNode node) throws JsonProcessingException {
+        int requestIndex = toRequestIndex(text(node, "custom_id"));
+
+        JsonNode error = node.get("error");
+        if (isPresent(error)) {
+            return ResultLine.failure(requestIndex, toBatchError(NO_STATUS_CODE, error));
+        }
+
+        JsonNode response = node.get("response");
+        if (!isPresent(response)) {
+            return ResultLine.failure(requestIndex, unknownError(NO_STATUS_CODE));
+        }
+
+        int statusCode = response.path("status_code").asInt();
+        JsonNode body = response.get("body");
+        if (statusCode == HTTP_OK && isPresent(body)) {
+            return ResultLine.success(requestIndex, JSON_MAPPER.treeToValue(body, ChatCompletion.class));
+        }
+
+        return ResultLine.failure(requestIndex, toResponseError(statusCode, body));
+    }
+
+    private static BatchError toResponseError(int statusCode, @Nullable JsonNode body) {
+        JsonNode bodyError = isPresent(body) ? body.get("error") : null;
+        return isPresent(bodyError) ? toBatchError(statusCode, bodyError) : unknownError(statusCode);
+    }
+
+    private static BatchError unknownError(int statusCode) {
+        return new BatchError(statusCode, UNKNOWN_ERROR_MESSAGE, null);
+    }
+
+    private static BatchError toBatchError(int code, JsonNode error) {
+        Map<String, Object> details = new LinkedHashMap<>();
+        putIfPresent(details, "type", text(error, "type"));
+        putIfPresent(details, "code", text(error, "code"));
+        putIfPresent(details, "param", text(error, "param"));
+        String message = text(error, "message");
+        return new BatchError(code, message != null ? message : UNKNOWN_ERROR_MESSAGE, toDetails(details));
+    }
+
+    private static @Nullable List<Map<String, Object>> toDetails(Map<String, Object> details) {
+        return details.isEmpty() ? null : List.of(details);
+    }
+
+    private static void putIfPresent(Map<String, Object> details, String key, @Nullable String value) {
+        if (value != null) {
+            details.put(key, value);
+        }
+    }
+
+    private static @Nullable String text(JsonNode node, String fieldName) {
+        JsonNode value = node.get(fieldName);
+        return isPresent(value) && value.isValueNode() ? value.asText() : null;
+    }
+
+    private static boolean isPresent(@Nullable JsonNode node) {
+        return node != null && !node.isNull();
+    }
+
+    record ResultLine(
+            int requestIndex,
+            @Nullable ChatCompletion completion,
+            @Nullable BatchError error) {
+
+        static ResultLine success(int requestIndex, ChatCompletion completion) {
+            return new ResultLine(requestIndex, completion, null);
+        }
+
+        static ResultLine failure(int requestIndex, BatchError error) {
+            return new ResultLine(requestIndex, null, error);
+        }
+    }
+}

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialBatchHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialBatchHelper.java
@@ -25,39 +25,49 @@ import org.jspecify.annotations.Nullable;
 
 class InternalOpenAiOfficialBatchHelper {
 
-    static final String CUSTOM_ID_PREFIX = "request-";
+    static final int NO_STATUS_CODE = 0;
+    static final String UNKNOWN_ERROR_MESSAGE = "unknown";
 
+    private static final String CUSTOM_ID_PREFIX = "request-";
     private static final String CHAT_COMPLETIONS_URL = "/v1/chat/completions";
     private static final String POST_METHOD = "POST";
-    private static final String UNKNOWN_ERROR_MESSAGE = "unknown";
     private static final int HTTP_OK = 200;
-    private static final int NO_STATUS_CODE = 0;
 
     private static final JsonMapper JSON_MAPPER = ObjectMappers.jsonMapper();
 
     private InternalOpenAiOfficialBatchHelper() {}
 
-    static String toCustomId(int requestIndex) {
+    private static String toCustomId(int requestIndex) {
         return CUSTOM_ID_PREFIX + requestIndex;
     }
 
-    private static int toRequestIndex(@Nullable String customId) {
+    private static @Nullable Integer toRequestIndex(@Nullable String customId) {
         if (customId == null || !customId.startsWith(CUSTOM_ID_PREFIX)) {
-            throw invalidCustomId(customId, null);
+            return null;
         }
         try {
             int requestIndex = Integer.parseInt(customId.substring(CUSTOM_ID_PREFIX.length()));
-            if (requestIndex < 0) {
-                throw invalidCustomId(customId, null);
-            }
-            return requestIndex;
+            return requestIndex < 0 ? null : requestIndex;
         } catch (NumberFormatException e) {
-            throw invalidCustomId(customId, e);
+            return null;
         }
     }
 
-    private static IllegalStateException invalidCustomId(@Nullable String customId, @Nullable Throwable cause) {
-        return new IllegalStateException("Unexpected custom_id in batch result: " + customId, cause);
+    /**
+     * Mirrors the base URL resolution that {@code OpenAiOfficialSetup} applies when it builds the client, so
+     * that the provider this integration detects matches the endpoint the client actually talks to. The
+     * shared resolution is not visible from this package, and the batch request shape differs per provider,
+     * so an environment-configured endpoint has to be taken into account here too.
+     */
+    static @Nullable String resolveBaseUrl(@Nullable String baseUrl) {
+        if (baseUrl != null) {
+            return baseUrl;
+        }
+        String azureOpenAiBaseUrl = System.getenv("AZURE_OPENAI_BASE_URL");
+        if (azureOpenAiBaseUrl != null) {
+            return azureOpenAiBaseUrl;
+        }
+        return System.getenv("OPENAI_BASE_URL");
     }
 
     static byte[] toJsonl(List<ChatCompletionCreateParams> requests) {
@@ -109,7 +119,7 @@ class InternalOpenAiOfficialBatchHelper {
     }
 
     private static ResultLine toResultLine(JsonNode node) throws JsonProcessingException {
-        int requestIndex = toRequestIndex(text(node, "custom_id"));
+        Integer requestIndex = toRequestIndex(text(node, "custom_id"));
 
         JsonNode error = node.get("error");
         if (isPresent(error)) {
@@ -167,16 +177,21 @@ class InternalOpenAiOfficialBatchHelper {
         return node != null && !node.isNull();
     }
 
+    /**
+     * One line of a batch result file. {@code requestIndex} is the zero-based position of the request this
+     * line belongs to, decoded from its {@code custom_id}, or {@code null} when that {@code custom_id} was
+     * not produced by {@link #toJsonl(List)} and therefore cannot be correlated.
+     */
     record ResultLine(
-            int requestIndex,
+            @Nullable Integer requestIndex,
             @Nullable ChatCompletion completion,
             @Nullable BatchError error) {
 
-        static ResultLine success(int requestIndex, ChatCompletion completion) {
+        static ResultLine success(@Nullable Integer requestIndex, ChatCompletion completion) {
             return new ResultLine(requestIndex, completion, null);
         }
 
-        static ResultLine failure(int requestIndex, BatchError error) {
+        static ResultLine failure(@Nullable Integer requestIndex, BatchError error) {
             return new ResultLine(requestIndex, null, error);
         }
     }

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModel.java
@@ -1,0 +1,697 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.toBatchState;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.toJsonl;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.toResultLines;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.aiMessageFrom;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.finishReasonFrom;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.toOpenAiChatCompletionCreateParams;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.tokenUsageFrom;
+
+import com.openai.azure.AzureOpenAIServiceVersion;
+import com.openai.client.OpenAIClient;
+import com.openai.core.JsonValue;
+import com.openai.core.MultipartField;
+import com.openai.core.http.HttpResponse;
+import com.openai.credential.Credential;
+import com.openai.models.batches.Batch;
+import com.openai.models.batches.BatchCreateParams;
+import com.openai.models.batches.BatchListPage;
+import com.openai.models.batches.BatchListParams;
+import com.openai.models.batches.BatchRequestCounts;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.models.files.FileCreateParams;
+import com.openai.models.files.FileObject;
+import com.openai.models.files.FilePurpose;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.batch.BatchError;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.chat.BatchChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup;
+import dev.langchain4j.model.output.FinishReason;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Submits chat requests to the
+ * <a href="https://platform.openai.com/docs/guides/batch">OpenAI Batch API</a>, which processes them
+ * asynchronously at a reduced cost compared to real-time requests.
+ *
+ * <p>Requests are serialized to a JSONL file, uploaded through the Files API with the {@code batch} purpose,
+ * and submitted against the chat completions endpoint. Results are correlated back to the submitted requests
+ * by {@code custom_id}, so {@link BatchResponse#results()} is always in submission order even though OpenAI
+ * does not guarantee the order of the output file.</p>
+ *
+ * <p>Every request in a batch must use the same model, so submitting requests that resolve to different
+ * models fails fast with an {@link IllegalArgumentException}.</p>
+ *
+ * <p>Azure OpenAI is supported. Its batch and file operations are scoped to the resource rather than to a
+ * deployment, it expects {@code /chat/completions} as the batch endpoint, and it identifies the model by
+ * deployment name, all of which are handled here. GitHub Models has no Batch API and is rejected with an
+ * {@link UnsupportedFeatureException}.</p>
+ *
+ * @see BatchChatModel
+ * @see BatchResponse
+ */
+@Experimental
+public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatModel implements BatchChatModel {
+
+    private static final String DEFAULT_COMPLETION_WINDOW = "24h";
+    private static final String MICROSOFT_FOUNDRY_CHAT_COMPLETIONS_ENDPOINT = "/chat/completions";
+    private static final String INPUT_FILE_NAME = "batch.jsonl";
+    private static final String INPUT_FILE_CONTENT_TYPE = "application/jsonl";
+    private static final String EXPIRES_AFTER_ANCHOR = "created_at";
+    private static final String UNKNOWN_ERROR_MESSAGE = "unknown";
+    private static final String MISSING_RESULT_MESSAGE = "No result was returned for this request";
+
+    private final BatchCreateParams.CompletionWindow completionWindow;
+    private final BatchCreateParams.Endpoint endpoint;
+    private final Map<String, String> batchMetadata;
+
+    @Nullable
+    private final String microsoftFoundryDeploymentName;
+
+    @Nullable
+    private final Long inputFileExpiresAfterSeconds;
+
+    @Nullable
+    private final Long outputExpiresAfterSeconds;
+
+    public OpenAiOfficialBatchChatModel(Builder builder) {
+        ModelProvider detectedProvider = OpenAiOfficialSetup.detectModelProvider(
+                builder.isMicrosoftFoundry,
+                builder.isGitHubModels,
+                builder.baseUrl,
+                builder.microsoftFoundryDeploymentName,
+                builder.azureOpenAIServiceVersion);
+        if (ModelProvider.GITHUB_MODELS.equals(detectedProvider)) {
+            throw new UnsupportedFeatureException("The Batch API is not supported by GitHub Models");
+        }
+
+        this.client = builder.openAIClient != null
+                ? builder.openAIClient
+                : OpenAiOfficialSetup.setupSyncClient(
+                        builder.baseUrl,
+                        builder.apiKey,
+                        builder.credential,
+                        null,
+                        builder.azureOpenAIServiceVersion,
+                        builder.organizationId,
+                        ModelProvider.MICROSOFT_FOUNDRY.equals(detectedProvider),
+                        false,
+                        builder.modelName,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.proxy,
+                        builder.customHeaders);
+        init(
+                builder.baseUrl,
+                builder.apiKey,
+                builder.credential,
+                builder.microsoftFoundryDeploymentName,
+                builder.azureOpenAIServiceVersion,
+                builder.organizationId,
+                builder.isMicrosoftFoundry,
+                builder.isGitHubModels,
+                builder.defaultRequestParameters,
+                builder.modelName,
+                builder.temperature,
+                builder.topP,
+                builder.stop,
+                builder.maxCompletionTokens,
+                builder.presencePenalty,
+                builder.frequencyPenalty,
+                builder.logitBias,
+                builder.responseFormat,
+                builder.strictJsonSchema,
+                builder.seed,
+                builder.user,
+                builder.strictTools,
+                builder.parallelToolCalls,
+                builder.store,
+                builder.metadata,
+                builder.serviceTier,
+                builder.timeout,
+                builder.maxRetries,
+                builder.proxy,
+                null,
+                builder.customHeaders,
+                null,
+                null,
+                false);
+        this.modelName = defaultRequestParameters.modelName();
+        this.completionWindow = BatchCreateParams.CompletionWindow.of(
+                getOrDefault(builder.completionWindow, DEFAULT_COMPLETION_WINDOW));
+        boolean isMicrosoftFoundry = ModelProvider.MICROSOFT_FOUNDRY.equals(this.modelProvider);
+        this.endpoint = isMicrosoftFoundry
+                ? BatchCreateParams.Endpoint.of(MICROSOFT_FOUNDRY_CHAT_COMPLETIONS_ENDPOINT)
+                : BatchCreateParams.Endpoint.V1_CHAT_COMPLETIONS;
+        this.microsoftFoundryDeploymentName =
+                isMicrosoftFoundry ? getOrDefault(builder.microsoftFoundryDeploymentName, modelName) : null;
+        this.batchMetadata = copy(builder.batchMetadata);
+        this.inputFileExpiresAfterSeconds = builder.inputFileExpiresAfterSeconds;
+        this.outputExpiresAfterSeconds = builder.outputExpiresAfterSeconds;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Submitting a batch uploads a JSONL input file through the provider's Files API before creating the
+     * batch, so that API's storage, retention and quota limits apply in addition to the batch limits, and may
+     * change independently of them. Uploaded input files are retained until they expire or are deleted, which
+     * {@link Builder#inputFileExpiresAfterSeconds(Long)} controls.</p>
+     *
+     * <p>OpenAI currently limits a batch to 50,000 requests and its input file to 200 MB; exceeding either is
+     * rejected by the API.</p>
+     *
+     * @throws IllegalArgumentException if the batch is empty, or if the requests do not all resolve to the
+     *                                  same model.
+     */
+    @Override
+    public BatchResponse<ChatResponse> submit(BatchRequest<ChatRequest> request) {
+        List<ChatRequest> chatRequests = ensureNotEmpty(request.requests(), "requests");
+
+        Set<String> modelNames = new LinkedHashSet<>();
+        List<ChatCompletionCreateParams> createParams = new ArrayList<>();
+        for (ChatRequest chatRequest : chatRequests) {
+            OpenAiOfficialChatRequestParameters parameters =
+                    defaultRequestParameters.overrideWith(chatRequest.parameters());
+            InternalOpenAiOfficialHelper.validate(parameters);
+
+            String effectiveModelName = resolveModelName(parameters);
+            modelNames.add(effectiveModelName);
+            createParams.add(toOpenAiChatCompletionCreateParams(chatRequest, parameters, strictTools, strictJsonSchema)
+                    .model(effectiveModelName)
+                    .build());
+        }
+        if (modelNames.size() > 1) {
+            throw new IllegalArgumentException("Batch requests cannot use different models; "
+                    + "all requests must use the same model: " + modelNames);
+        }
+
+        FileCreateParams.Builder fileCreateParams = FileCreateParams.builder()
+                .file(MultipartField.<InputStream>builder()
+                        .value(new ByteArrayInputStream(toJsonl(createParams)))
+                        .filename(INPUT_FILE_NAME)
+                        .contentType(INPUT_FILE_CONTENT_TYPE)
+                        .build())
+                .purpose(FilePurpose.BATCH);
+        if (inputFileExpiresAfterSeconds != null) {
+            fileCreateParams.expiresAfter(FileCreateParams.ExpiresAfter.builder()
+                    .anchor(JsonValue.from(EXPIRES_AFTER_ANCHOR))
+                    .seconds(inputFileExpiresAfterSeconds)
+                    .build());
+        }
+        FileObject inputFile = client.files().create(fileCreateParams.build());
+
+        BatchCreateParams.Builder batchCreateParams = BatchCreateParams.builder()
+                .inputFileId(inputFile.id())
+                .endpoint(endpoint)
+                .completionWindow(completionWindow);
+
+        if (!batchMetadata.isEmpty()) {
+            BatchCreateParams.Metadata.Builder metadataBuilder = BatchCreateParams.Metadata.builder();
+            batchMetadata.forEach((key, value) -> metadataBuilder.putAdditionalProperty(key, JsonValue.from(value)));
+            batchCreateParams.metadata(metadataBuilder.build());
+        }
+        if (outputExpiresAfterSeconds != null) {
+            batchCreateParams.outputExpiresAfter(BatchCreateParams.OutputExpiresAfter.builder()
+                    .anchor(JsonValue.from(EXPIRES_AFTER_ANCHOR))
+                    .seconds(outputExpiresAfterSeconds)
+                    .build());
+        }
+
+        return toBatchResponse(client.batches().create(batchCreateParams.build()), List.of());
+    }
+
+    private String resolveModelName(OpenAiOfficialChatRequestParameters parameters) {
+        if (microsoftFoundryDeploymentName == null) {
+            return ensureNotBlank(parameters.modelName(), "modelName");
+        }
+        if (parameters.modelName() != null && !parameters.modelName().equals(modelName)) {
+            throw new UnsupportedFeatureException("Microsoft Foundry batch requests do not support overriding "
+                    + "modelName per request; configure the batch deployment when building the model");
+        }
+        return microsoftFoundryDeploymentName;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Both the output file and the error file are streamed, but every parsed result is held in memory, so
+     * a batch close to OpenAI's 200 MB limit requires a correspondingly large heap. Results are returned as soon as OpenAI has
+     * produced them, which includes the partial results of an expired or cancelled batch.</p>
+     *
+     * <p>Results are correlated by {@code custom_id}. Because those identifiers are generated by
+     * {@link #submit(BatchRequest)}, a returned identifier that is malformed, duplicated, or outside the
+     * submitted range is an invariant violation rather than a normal outcome, and fails with an
+     * {@link IllegalStateException} instead of being reported as an extra result.</p>
+     *
+     * <p>{@link BatchError#code()} holds the HTTP status code for a request that OpenAI attempted and
+     * rejected, and {@code 0} for a request that never ran (for example an expired one) or for a
+     * batch-level failure, because OpenAI reports those with a string code instead. That string code is
+     * available under the {@code "code"} key of {@link BatchError#details()}.</p>
+     */
+    @Override
+    public BatchResponse<ChatResponse> retrieve(String batchId) {
+        Batch batch = client.batches().retrieve(batchId);
+        return toBatchResponse(batch, readResults(batch));
+    }
+
+    @Override
+    public void cancel(String batchId) {
+        client.batches().cancel(batchId);
+    }
+
+    @Override
+    public BatchPage<ChatResponse> list(@Nullable BatchPagination pagination) {
+        BatchListParams.Builder listParams = BatchListParams.builder();
+        if (pagination != null) {
+            if (pagination.pageSize() != null) {
+                listParams.limit(pagination.pageSize().longValue());
+            }
+            if (pagination.pageToken() != null) {
+                listParams.after(pagination.pageToken());
+            }
+        }
+
+        BatchListPage page = client.batches().list(listParams.build());
+        List<Batch> batches = page.data();
+
+        List<BatchResponse<ChatResponse>> batchResponses = new ArrayList<>();
+        for (Batch batch : batches) {
+            batchResponses.add(toBatchResponse(batch, List.of()));
+        }
+
+        String nextPageToken = page.hasMore().orElse(false) && !batches.isEmpty()
+                ? batches.get(batches.size() - 1).id()
+                : null;
+        return new BatchPage<>(batchResponses, nextPageToken);
+    }
+
+    /**
+     * @return a new {@link Builder} for {@link OpenAiOfficialBatchChatModel}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private List<BatchItemResult<ChatResponse>> readResults(Batch batch) {
+        List<InternalOpenAiOfficialBatchHelper.ResultLine> resultLines = new ArrayList<>();
+        Optional<String> outputFileId = batch.outputFileId();
+        if (outputFileId.isPresent()) {
+            resultLines.addAll(readResultFile(outputFileId.get()));
+        }
+        Optional<String> errorFileId = batch.errorFileId();
+        if (errorFileId.isPresent()) {
+            resultLines.addAll(readResultFile(errorFileId.get()));
+        }
+
+        if (resultLines.isEmpty()) {
+            return toBatchLevelFailures(batch);
+        }
+
+        int requestCount = requestCount(batch, resultLines);
+        List<BatchItemResult<ChatResponse>> results = new ArrayList<>(Collections.nCopies(requestCount, null));
+        for (InternalOpenAiOfficialBatchHelper.ResultLine resultLine : resultLines) {
+            int requestIndex = resultLine.requestIndex();
+            if (requestIndex >= requestCount) {
+                throw new IllegalStateException("Batch result refers to request " + requestIndex + ", but only "
+                        + requestCount + " request(s) were submitted");
+            }
+            if (results.get(requestIndex) != null) {
+                throw new IllegalStateException("Duplicate custom_id in batch result: "
+                        + InternalOpenAiOfficialBatchHelper.toCustomId(requestIndex));
+            }
+            results.set(requestIndex, toBatchItemResult(resultLine));
+        }
+        for (int i = 0; i < results.size(); i++) {
+            if (results.get(i) == null) {
+                results.set(i, BatchItemResult.failure(new BatchError(0, MISSING_RESULT_MESSAGE, null)));
+            }
+        }
+        return results;
+    }
+
+    private static int requestCount(Batch batch, List<InternalOpenAiOfficialBatchHelper.ResultLine> resultLines) {
+        Optional<BatchRequestCounts> requestCounts = batch.requestCounts();
+        if (requestCounts.isPresent()) {
+            return (int) requestCounts.get().total();
+        }
+        int highestIndex = -1;
+        for (InternalOpenAiOfficialBatchHelper.ResultLine resultLine : resultLines) {
+            highestIndex = Math.max(highestIndex, resultLine.requestIndex());
+        }
+        return highestIndex + 1;
+    }
+
+    private List<InternalOpenAiOfficialBatchHelper.ResultLine> readResultFile(String fileId) {
+        try (HttpResponse content = client.files().content(fileId)) {
+            return toResultLines(content.body());
+        }
+    }
+
+    private static List<BatchItemResult<ChatResponse>> toBatchLevelFailures(Batch batch) {
+        List<com.openai.models.batches.BatchError> errors =
+                batch.errors().flatMap(Batch.Errors::data).orElse(List.of());
+
+        List<BatchItemResult<ChatResponse>> failures = new ArrayList<>();
+        for (com.openai.models.batches.BatchError error : errors) {
+            failures.add(BatchItemResult.failure(InternalOpenAiOfficialBatchHelper.toBatchError(error)));
+        }
+        return failures;
+    }
+
+    private BatchItemResult<ChatResponse> toBatchItemResult(InternalOpenAiOfficialBatchHelper.ResultLine resultLine) {
+        ChatCompletion completion = resultLine.completion();
+        if (completion != null) {
+            return BatchItemResult.success(toChatResponse(completion));
+        }
+        BatchError error = resultLine.error();
+        return BatchItemResult.failure(error != null ? error : new BatchError(0, UNKNOWN_ERROR_MESSAGE, null));
+    }
+
+    private ChatResponse toChatResponse(ChatCompletion chatCompletion) {
+        OpenAiOfficialChatResponseMetadata.Builder responseMetadataBuilder =
+                OpenAiOfficialChatResponseMetadata.builder()
+                        .id(chatCompletion.id())
+                        .modelName(chatCompletion.model())
+                        .created(chatCompletion.created());
+
+        if (!chatCompletion.choices().isEmpty()) {
+            ChatCompletion.Choice choice = chatCompletion.choices().get(0);
+            responseMetadataBuilder.finishReason(finishReasonFrom(choice.finishReason()));
+
+            if (choice.message().toolCalls().isPresent()
+                    && choice.finishReason().equals(ChatCompletion.Choice.FinishReason.STOP)) {
+                responseMetadataBuilder.finishReason(FinishReason.TOOL_EXECUTION);
+            }
+        }
+        if (chatCompletion.usage().isPresent()) {
+            responseMetadataBuilder.tokenUsage(
+                    tokenUsageFrom(chatCompletion.usage().get()));
+        }
+        if (chatCompletion.serviceTier().isPresent()) {
+            responseMetadataBuilder.serviceTier(
+                    chatCompletion.serviceTier().get().toString());
+        }
+        if (chatCompletion.systemFingerprint().isPresent()) {
+            responseMetadataBuilder.systemFingerprint(
+                    chatCompletion.systemFingerprint().get());
+        }
+
+        return ChatResponse.builder()
+                .aiMessage(aiMessageFrom(chatCompletion))
+                .metadata(responseMetadataBuilder.build())
+                .build();
+    }
+
+    private static BatchResponse<ChatResponse> toBatchResponse(
+            Batch batch, List<BatchItemResult<ChatResponse>> results) {
+        return BatchResponse.<ChatResponse>builder()
+                .batchId(batch.id())
+                .state(toBatchState(batch.status()))
+                .results(results)
+                .build();
+    }
+
+    public static class Builder {
+
+        private String baseUrl;
+        private String apiKey;
+        private Credential credential;
+        private String microsoftFoundryDeploymentName;
+        private AzureOpenAIServiceVersion azureOpenAIServiceVersion;
+        private String organizationId;
+        private boolean isMicrosoftFoundry;
+        private boolean isGitHubModels;
+        private OpenAIClient openAIClient;
+
+        private ChatRequestParameters defaultRequestParameters;
+        private String modelName;
+        private Double temperature;
+        private Double topP;
+        private List<String> stop;
+        private Integer maxCompletionTokens;
+        private Double presencePenalty;
+        private Double frequencyPenalty;
+        private Map<String, Integer> logitBias;
+        private String responseFormat;
+        private Boolean strictJsonSchema;
+        private Integer seed;
+        private String user;
+        private Boolean strictTools;
+        private Boolean parallelToolCalls;
+        private Boolean store;
+        private Map<String, String> metadata;
+        private String serviceTier;
+
+        private String completionWindow;
+        private Map<String, String> batchMetadata;
+        private Long inputFileExpiresAfterSeconds;
+        private Long outputExpiresAfterSeconds;
+
+        private Duration timeout;
+        private Integer maxRetries;
+        private Proxy proxy;
+        private Map<String, String> customHeaders;
+
+        /**
+         * Sets default common {@link ChatRequestParameters} or OpenAI-specific {@link OpenAiOfficialChatRequestParameters}.
+         * <br>
+         * When a parameter is set via an individual builder method (e.g., {@link #modelName(String)}),
+         * its value takes precedence over the same parameter set via {@link ChatRequestParameters}.
+         */
+        public Builder defaultRequestParameters(ChatRequestParameters parameters) {
+            this.defaultRequestParameters = parameters;
+            return this;
+        }
+
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public Builder modelName(com.openai.models.ChatModel modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder credential(Credential credential) {
+            this.credential = credential;
+            return this;
+        }
+
+        public Builder microsoftFoundryDeploymentName(String microsoftFoundryDeploymentName) {
+            this.microsoftFoundryDeploymentName = microsoftFoundryDeploymentName;
+            return this;
+        }
+
+        public Builder azureOpenAIServiceVersion(AzureOpenAIServiceVersion azureOpenAIServiceVersion) {
+            this.azureOpenAIServiceVersion = azureOpenAIServiceVersion;
+            return this;
+        }
+
+        public Builder organizationId(String organizationId) {
+            this.organizationId = organizationId;
+            return this;
+        }
+
+        public Builder isGitHubModels(boolean isGitHubModels) {
+            this.isGitHubModels = isGitHubModels;
+            return this;
+        }
+
+        public Builder isMicrosoftFoundry(boolean isMicrosoftFoundry) {
+            this.isMicrosoftFoundry = isMicrosoftFoundry;
+            return this;
+        }
+
+        public Builder openAIClient(OpenAIClient openAIClient) {
+            this.openAIClient = openAIClient;
+            return this;
+        }
+
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public Builder stop(List<String> stop) {
+            this.stop = stop;
+            return this;
+        }
+
+        public Builder maxCompletionTokens(Integer maxCompletionTokens) {
+            this.maxCompletionTokens = maxCompletionTokens;
+            return this;
+        }
+
+        public Builder presencePenalty(Double presencePenalty) {
+            this.presencePenalty = presencePenalty;
+            return this;
+        }
+
+        public Builder frequencyPenalty(Double frequencyPenalty) {
+            this.frequencyPenalty = frequencyPenalty;
+            return this;
+        }
+
+        public Builder logitBias(Map<String, Integer> logitBias) {
+            this.logitBias = logitBias;
+            return this;
+        }
+
+        public Builder responseFormat(String responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        public Builder strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        public Builder seed(Integer seed) {
+            this.seed = seed;
+            return this;
+        }
+
+        public Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public Builder strictTools(Boolean strictTools) {
+            this.strictTools = strictTools;
+            return this;
+        }
+
+        public Builder parallelToolCalls(Boolean parallelToolCalls) {
+            this.parallelToolCalls = parallelToolCalls;
+            return this;
+        }
+
+        public Builder store(Boolean store) {
+            this.store = store;
+            return this;
+        }
+
+        /**
+         * Sets the metadata sent with every chat request in the batch.
+         *
+         * @see #batchMetadata(Map)
+         */
+        public Builder metadata(Map<String, String> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public Builder serviceTier(String serviceTier) {
+            this.serviceTier = serviceTier;
+            return this;
+        }
+
+        /**
+         * Sets the time frame within which the batch should be processed. Defaults to {@code 24h},
+         * which is currently the only value accepted by OpenAI.
+         */
+        public Builder completionWindow(String completionWindow) {
+            this.completionWindow = completionWindow;
+            return this;
+        }
+
+        /**
+         * Sets the metadata attached to the batch itself, which OpenAI returns when the batch is retrieved
+         * or listed. This is distinct from {@link #metadata(Map)}, which is sent with every chat request
+         * inside the batch.
+         */
+        public Builder batchMetadata(Map<String, String> batchMetadata) {
+            this.batchMetadata = batchMetadata;
+            return this;
+        }
+
+        /**
+         * Sets the number of seconds after upload at which the JSONL input file expires. Not set by default,
+         * in which case the provider's own retention for batch input files applies. The accepted range is
+         * defined by the provider and differs between OpenAI and Azure OpenAI.
+         */
+        public Builder inputFileExpiresAfterSeconds(Long inputFileExpiresAfterSeconds) {
+            this.inputFileExpiresAfterSeconds = inputFileExpiresAfterSeconds;
+            return this;
+        }
+
+        /**
+         * Sets the number of seconds after the output file is created at which it, and the error file,
+         * expire. Not set by default, in which case the provider's own retention applies. The accepted
+         * range is defined by the provider and differs between OpenAI and Azure OpenAI.
+         */
+        public Builder outputExpiresAfterSeconds(Long outputExpiresAfterSeconds) {
+            this.outputExpiresAfterSeconds = outputExpiresAfterSeconds;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder proxy(Proxy proxy) {
+            this.proxy = proxy;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public OpenAiOfficialBatchChatModel build() {
+            return new OpenAiOfficialBatchChatModel(this);
+        }
+    }
+}

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModel.java
@@ -4,6 +4,8 @@ import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.NO_STATUS_CODE;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.UNKNOWN_ERROR_MESSAGE;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.toBatchState;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.toJsonl;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialBatchHelper.toResultLines;
@@ -55,6 +57,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Submits chat requests to the
@@ -63,8 +67,9 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Requests are serialized to a JSONL file, uploaded through the Files API with the {@code batch} purpose,
  * and submitted against the chat completions endpoint. Results are correlated back to the submitted requests
- * by {@code custom_id}, so {@link BatchResponse#results()} is always in submission order even though OpenAI
- * does not guarantee the order of the output file.</p>
+ * by {@code custom_id}, so {@link BatchResponse#results()} is in submission order even though OpenAI does
+ * not guarantee the order of the output file. See {@link #retrieve(String)} for the one case in which that
+ * correlation is not possible.</p>
  *
  * <p>Every request in a batch must use the same model, so submitting requests that resolve to different
  * models fails fast with an {@link IllegalArgumentException}.</p>
@@ -85,8 +90,9 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
     private static final String INPUT_FILE_NAME = "batch.jsonl";
     private static final String INPUT_FILE_CONTENT_TYPE = "application/jsonl";
     private static final String EXPIRES_AFTER_ANCHOR = "created_at";
-    private static final String UNKNOWN_ERROR_MESSAGE = "unknown";
     private static final String MISSING_RESULT_MESSAGE = "No result was returned for this request";
+
+    private static final Logger log = LoggerFactory.getLogger(OpenAiOfficialBatchChatModel.class);
 
     private final BatchCreateParams.CompletionWindow completionWindow;
     private final BatchCreateParams.Endpoint endpoint;
@@ -96,16 +102,21 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
     private final String microsoftFoundryDeploymentName;
 
     @Nullable
-    private final Long inputFileExpiresAfterSeconds;
+    private final Duration inputFileExpiresAfter;
 
     @Nullable
-    private final Long outputExpiresAfterSeconds;
+    private final Duration outputExpiresAfter;
 
     public OpenAiOfficialBatchChatModel(Builder builder) {
+        // The environment only decides the endpoint when this model builds the client from it; an injected
+        // client carries a base URL of its own, which the environment must not contradict.
+        String resolvedBaseUrl = builder.openAIClient == null
+                ? InternalOpenAiOfficialBatchHelper.resolveBaseUrl(builder.baseUrl)
+                : builder.baseUrl;
         ModelProvider detectedProvider = OpenAiOfficialSetup.detectModelProvider(
                 builder.isMicrosoftFoundry,
                 builder.isGitHubModels,
-                builder.baseUrl,
+                resolvedBaseUrl,
                 builder.microsoftFoundryDeploymentName,
                 builder.azureOpenAIServiceVersion);
         if (ModelProvider.GITHUB_MODELS.equals(detectedProvider)) {
@@ -163,18 +174,21 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
                 null,
                 null,
                 false);
+        // init() detects the provider from the configured base URL only, while the batch request shape has
+        // to follow the endpoint the client was actually built against, which may come from the environment.
+        this.modelProvider = detectedProvider;
         this.modelName = defaultRequestParameters.modelName();
         this.completionWindow = BatchCreateParams.CompletionWindow.of(
                 getOrDefault(builder.completionWindow, DEFAULT_COMPLETION_WINDOW));
-        boolean isMicrosoftFoundry = ModelProvider.MICROSOFT_FOUNDRY.equals(this.modelProvider);
+        boolean isMicrosoftFoundry = ModelProvider.MICROSOFT_FOUNDRY.equals(detectedProvider);
         this.endpoint = isMicrosoftFoundry
                 ? BatchCreateParams.Endpoint.of(MICROSOFT_FOUNDRY_CHAT_COMPLETIONS_ENDPOINT)
                 : BatchCreateParams.Endpoint.V1_CHAT_COMPLETIONS;
         this.microsoftFoundryDeploymentName =
                 isMicrosoftFoundry ? getOrDefault(builder.microsoftFoundryDeploymentName, modelName) : null;
         this.batchMetadata = copy(builder.batchMetadata);
-        this.inputFileExpiresAfterSeconds = builder.inputFileExpiresAfterSeconds;
-        this.outputExpiresAfterSeconds = builder.outputExpiresAfterSeconds;
+        this.inputFileExpiresAfter = builder.inputFileExpiresAfter;
+        this.outputExpiresAfter = builder.outputExpiresAfter;
     }
 
     /**
@@ -183,7 +197,7 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
      * <p>Submitting a batch uploads a JSONL input file through the provider's Files API before creating the
      * batch, so that API's storage, retention and quota limits apply in addition to the batch limits, and may
      * change independently of them. Uploaded input files are retained until they expire or are deleted, which
-     * {@link Builder#inputFileExpiresAfterSeconds(Long)} controls.</p>
+     * {@link Builder#inputFileExpiresAfter(Duration)} controls.</p>
      *
      * <p>OpenAI currently limits a batch to 50,000 requests and its input file to 200 MB; exceeding either is
      * rejected by the API.</p>
@@ -220,10 +234,10 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
                         .contentType(INPUT_FILE_CONTENT_TYPE)
                         .build())
                 .purpose(FilePurpose.BATCH);
-        if (inputFileExpiresAfterSeconds != null) {
+        if (inputFileExpiresAfter != null) {
             fileCreateParams.expiresAfter(FileCreateParams.ExpiresAfter.builder()
                     .anchor(JsonValue.from(EXPIRES_AFTER_ANCHOR))
-                    .seconds(inputFileExpiresAfterSeconds)
+                    .seconds(inputFileExpiresAfter.toSeconds())
                     .build());
         }
         FileObject inputFile = client.files().create(fileCreateParams.build());
@@ -238,10 +252,10 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
             batchMetadata.forEach((key, value) -> metadataBuilder.putAdditionalProperty(key, JsonValue.from(value)));
             batchCreateParams.metadata(metadataBuilder.build());
         }
-        if (outputExpiresAfterSeconds != null) {
+        if (outputExpiresAfter != null) {
             batchCreateParams.outputExpiresAfter(BatchCreateParams.OutputExpiresAfter.builder()
                     .anchor(JsonValue.from(EXPIRES_AFTER_ANCHOR))
-                    .seconds(outputExpiresAfterSeconds)
+                    .seconds(outputExpiresAfter.toSeconds())
                     .build());
         }
 
@@ -266,10 +280,13 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
      * a batch close to OpenAI's 200 MB limit requires a correspondingly large heap. Results are returned as soon as OpenAI has
      * produced them, which includes the partial results of an expired or cancelled batch.</p>
      *
-     * <p>Results are correlated by {@code custom_id}. Because those identifiers are generated by
-     * {@link #submit(BatchRequest)}, a returned identifier that is malformed, duplicated, or outside the
-     * submitted range is an invariant violation rather than a normal outcome, and fails with an
-     * {@link IllegalStateException} instead of being reported as an extra result.</p>
+     * <p>Results are correlated by {@code custom_id}, using the identifiers that
+     * {@link #submit(BatchRequest)} generates. If any of them is missing, malformed, duplicated or outside
+     * the submitted range - which happens for a batch that was not submitted through this model, for example
+     * one created from the OpenAI dashboard - correlation is abandoned for the whole batch and the results
+     * are returned in the order the result files list them, with a warning logged. Results are never
+     * discarded, so a batch that was paid for is always readable; only their correspondence to the submitted
+     * requests is lost.</p>
      *
      * <p>{@link BatchError#code()} holds the HTTP status code for a request that OpenAI attempted and
      * rejected, and {@code 0} for a request that never ran (for example an expired one) or for a
@@ -336,22 +353,39 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
         }
 
         int requestCount = requestCount(batch, resultLines);
+        List<BatchItemResult<ChatResponse>> correlated = correlateByRequestIndex(resultLines, requestCount);
+        if (correlated != null) {
+            return correlated;
+        }
+
+        log.warn(
+                "Batch {} returned custom_id values that this model did not generate, so its {} result(s) "
+                        + "cannot be matched to the submitted requests and are returned in result file order",
+                batch.id(),
+                resultLines.size());
+        return resultLines.stream().map(this::toBatchItemResult).toList();
+    }
+
+    /**
+     * @return the results at the position of the request each belongs to, with a failure standing in for
+     * every request that produced no result, or {@code null} if the {@code custom_id} values cannot be
+     * mapped onto the submitted requests one-to-one.
+     */
+    @Nullable
+    private List<BatchItemResult<ChatResponse>> correlateByRequestIndex(
+            List<InternalOpenAiOfficialBatchHelper.ResultLine> resultLines, int requestCount) {
+
         List<BatchItemResult<ChatResponse>> results = new ArrayList<>(Collections.nCopies(requestCount, null));
         for (InternalOpenAiOfficialBatchHelper.ResultLine resultLine : resultLines) {
-            int requestIndex = resultLine.requestIndex();
-            if (requestIndex >= requestCount) {
-                throw new IllegalStateException("Batch result refers to request " + requestIndex + ", but only "
-                        + requestCount + " request(s) were submitted");
-            }
-            if (results.get(requestIndex) != null) {
-                throw new IllegalStateException("Duplicate custom_id in batch result: "
-                        + InternalOpenAiOfficialBatchHelper.toCustomId(requestIndex));
+            Integer requestIndex = resultLine.requestIndex();
+            if (requestIndex == null || requestIndex >= requestCount || results.get(requestIndex) != null) {
+                return null;
             }
             results.set(requestIndex, toBatchItemResult(resultLine));
         }
         for (int i = 0; i < results.size(); i++) {
             if (results.get(i) == null) {
-                results.set(i, BatchItemResult.failure(new BatchError(0, MISSING_RESULT_MESSAGE, null)));
+                results.set(i, BatchItemResult.failure(new BatchError(NO_STATUS_CODE, MISSING_RESULT_MESSAGE, null)));
             }
         }
         return results;
@@ -364,7 +398,10 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
         }
         int highestIndex = -1;
         for (InternalOpenAiOfficialBatchHelper.ResultLine resultLine : resultLines) {
-            highestIndex = Math.max(highestIndex, resultLine.requestIndex());
+            Integer requestIndex = resultLine.requestIndex();
+            if (requestIndex != null) {
+                highestIndex = Math.max(highestIndex, requestIndex);
+            }
         }
         return highestIndex + 1;
     }
@@ -392,7 +429,8 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
             return BatchItemResult.success(toChatResponse(completion));
         }
         BatchError error = resultLine.error();
-        return BatchItemResult.failure(error != null ? error : new BatchError(0, UNKNOWN_ERROR_MESSAGE, null));
+        return BatchItemResult.failure(
+                error != null ? error : new BatchError(NO_STATUS_CODE, UNKNOWN_ERROR_MESSAGE, null));
     }
 
     private ChatResponse toChatResponse(ChatCompletion chatCompletion) {
@@ -472,8 +510,8 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
 
         private String completionWindow;
         private Map<String, String> batchMetadata;
-        private Long inputFileExpiresAfterSeconds;
-        private Long outputExpiresAfterSeconds;
+        private Duration inputFileExpiresAfter;
+        private Duration outputExpiresAfter;
 
         private Duration timeout;
         private Integer maxRetries;
@@ -651,22 +689,23 @@ public final class OpenAiOfficialBatchChatModel extends OpenAiOfficialBaseChatMo
         }
 
         /**
-         * Sets the number of seconds after upload at which the JSONL input file expires. Not set by default,
-         * in which case the provider's own retention for batch input files applies. The accepted range is
-         * defined by the provider and differs between OpenAI and Azure OpenAI.
+         * Sets how long after upload the JSONL input file expires. Not set by default, in which case the
+         * provider's own retention for batch input files applies and the file is kept until it is deleted.
+         * The accepted range is defined by the provider and differs between OpenAI and Azure OpenAI. Values
+         * are sent with a whole-second resolution.
          */
-        public Builder inputFileExpiresAfterSeconds(Long inputFileExpiresAfterSeconds) {
-            this.inputFileExpiresAfterSeconds = inputFileExpiresAfterSeconds;
+        public Builder inputFileExpiresAfter(Duration inputFileExpiresAfter) {
+            this.inputFileExpiresAfter = inputFileExpiresAfter;
             return this;
         }
 
         /**
-         * Sets the number of seconds after the output file is created at which it, and the error file,
-         * expire. Not set by default, in which case the provider's own retention applies. The accepted
-         * range is defined by the provider and differs between OpenAI and Azure OpenAI.
+         * Sets how long after the output file is created it, and the error file, expire. Not set by default,
+         * in which case the provider's own retention applies. The accepted range is defined by the provider
+         * and differs between OpenAI and Azure OpenAI. Values are sent with a whole-second resolution.
          */
-        public Builder outputExpiresAfterSeconds(Long outputExpiresAfterSeconds) {
-            this.outputExpiresAfterSeconds = outputExpiresAfterSeconds;
+        public Builder outputExpiresAfter(Duration outputExpiresAfter) {
+            this.outputExpiresAfter = outputExpiresAfter;
             return this;
         }
 

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/setup/OpenAiOfficialSetup.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/setup/OpenAiOfficialSetup.java
@@ -193,21 +193,23 @@ public class OpenAiOfficialSetup {
             String microsoftFoundryDeploymentName,
             AzureOpenAIServiceVersion azureOpenAIServiceVersion) {
 
+        String resolvedBaseUrl = detectBaseUrlFromEnv(baseUrl);
+
         if (isMicrosoftFoundry) {
             return ModelProvider.MICROSOFT_FOUNDRY; // Forced by the user
         }
         if (isGitHubModels) {
             return ModelProvider.GITHUB_MODELS; // Forced by the user
         }
-        if (baseUrl != null) {
-            if (baseUrl.endsWith("openai.azure.com")
-                    || baseUrl.endsWith("openai.azure.com/")
-                    || baseUrl.endsWith("cognitiveservices.azure.com")
-                    || baseUrl.endsWith("cognitiveservices.azure.com/")
-                    || baseUrl.endsWith("ai.azure.com")
-                    || baseUrl.endsWith("ai.azure.com/")) {
+        if (resolvedBaseUrl != null) {
+            if (resolvedBaseUrl.endsWith("openai.azure.com")
+                    || resolvedBaseUrl.endsWith("openai.azure.com/")
+                    || resolvedBaseUrl.endsWith("cognitiveservices.azure.com")
+                    || resolvedBaseUrl.endsWith("cognitiveservices.azure.com/")
+                    || resolvedBaseUrl.endsWith("ai.azure.com")
+                    || resolvedBaseUrl.endsWith("ai.azure.com/")) {
                 return ModelProvider.MICROSOFT_FOUNDRY;
-            } else if (baseUrl.startsWith(GITHUB_MODELS_URL)) {
+            } else if (resolvedBaseUrl.startsWith(GITHUB_MODELS_URL)) {
                 return ModelProvider.GITHUB_MODELS;
             }
         }

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/setup/OpenAiOfficialSetup.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/setup/OpenAiOfficialSetup.java
@@ -193,23 +193,21 @@ public class OpenAiOfficialSetup {
             String microsoftFoundryDeploymentName,
             AzureOpenAIServiceVersion azureOpenAIServiceVersion) {
 
-        String resolvedBaseUrl = detectBaseUrlFromEnv(baseUrl);
-
         if (isMicrosoftFoundry) {
             return ModelProvider.MICROSOFT_FOUNDRY; // Forced by the user
         }
         if (isGitHubModels) {
             return ModelProvider.GITHUB_MODELS; // Forced by the user
         }
-        if (resolvedBaseUrl != null) {
-            if (resolvedBaseUrl.endsWith("openai.azure.com")
-                    || resolvedBaseUrl.endsWith("openai.azure.com/")
-                    || resolvedBaseUrl.endsWith("cognitiveservices.azure.com")
-                    || resolvedBaseUrl.endsWith("cognitiveservices.azure.com/")
-                    || resolvedBaseUrl.endsWith("ai.azure.com")
-                    || resolvedBaseUrl.endsWith("ai.azure.com/")) {
+        if (baseUrl != null) {
+            if (baseUrl.endsWith("openai.azure.com")
+                    || baseUrl.endsWith("openai.azure.com/")
+                    || baseUrl.endsWith("cognitiveservices.azure.com")
+                    || baseUrl.endsWith("cognitiveservices.azure.com/")
+                    || baseUrl.endsWith("ai.azure.com")
+                    || baseUrl.endsWith("ai.azure.com/")) {
                 return ModelProvider.MICROSOFT_FOUNDRY;
-            } else if (resolvedBaseUrl.startsWith(GITHUB_MODELS_URL)) {
+            } else if (baseUrl.startsWith(GITHUB_MODELS_URL)) {
                 return ModelProvider.GITHUB_MODELS;
             }
         }

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModelTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModelTest.java
@@ -1,0 +1,657 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.openai.client.OpenAIClientImpl;
+import com.openai.core.ClientOptions;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class OpenAiOfficialBatchChatModelTest {
+
+    private static final String MODEL_NAME = "gpt-4o-mini";
+    private static final String FILES_PATH = "files";
+    private static final String BATCHES_PATH = "batches";
+    private static final String BATCH_ID = "batch_abc";
+    private static final String OUTPUT_FILE_CONTENT_PATH = "files/file-out/content";
+    private static final String ERROR_FILE_CONTENT_PATH = "files/file-err/content";
+
+    private OpenAiOfficialStubHttpClient httpClient;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = new OpenAiOfficialStubHttpClient();
+    }
+
+    private OpenAiOfficialBatchChatModel model() {
+        return modelBuilder().build();
+    }
+
+    private OpenAiOfficialBatchChatModel.Builder modelBuilder() {
+        return OpenAiOfficialBatchChatModel.builder()
+                .openAIClient(new OpenAIClientImpl(ClientOptions.builder()
+                        .apiKey("test-key")
+                        .httpClient(httpClient)
+                        .build()))
+                .modelName(MODEL_NAME);
+    }
+
+    private static String fileJson(String id) {
+        return "{\"id\":\"" + id + "\",\"object\":\"file\",\"bytes\":123,\"created_at\":1700000000,"
+                + "\"filename\":\"batch.jsonl\",\"purpose\":\"batch\",\"status\":\"processed\"}";
+    }
+
+    private static String batchJson(String status, String outputFileId, String errorFileId) {
+        return "{\"id\":\"" + BATCH_ID + "\",\"object\":\"batch\",\"endpoint\":\"/v1/chat/completions\","
+                + "\"input_file_id\":\"file-in\",\"completion_window\":\"24h\",\"created_at\":1700000000,"
+                + "\"status\":\"" + status + "\""
+                + (outputFileId == null ? "" : ",\"output_file_id\":\"" + outputFileId + "\"")
+                + (errorFileId == null ? "" : ",\"error_file_id\":\"" + errorFileId + "\"")
+                + "}";
+    }
+
+    private static String completionJson(String content) {
+        return "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"created\":1700000000,"
+                + "\"model\":\"" + MODEL_NAME + "\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\","
+                + "\"message\":{\"role\":\"assistant\",\"content\":\"" + content + "\"}}],"
+                + "\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":2,\"total_tokens\":11}}";
+    }
+
+    private static String successLine(int index, String content) {
+        return "{\"id\":\"batch_req_" + index + "\",\"custom_id\":\"request-" + index + "\","
+                + "\"response\":{\"status_code\":200,\"request_id\":\"r" + index + "\",\"body\":"
+                + completionJson(content) + "},\"error\":null}";
+    }
+
+    private static BatchRequest<ChatRequest> batchOf(String... prompts) {
+        List<ChatRequest> requests = java.util.Arrays.stream(prompts)
+                .map(prompt ->
+                        ChatRequest.builder().messages(UserMessage.from(prompt)).build())
+                .toList();
+        return new BatchRequest<>(requests);
+    }
+
+    private void stubSubmit() {
+        httpClient.enqueue(FILES_PATH, fileJson("file-in"));
+        httpClient.enqueue(BATCHES_PATH, batchJson("validating", null, null));
+    }
+
+    @Test
+    void should_upload_jsonl_with_batch_purpose_and_one_line_per_request() {
+        stubSubmit();
+
+        model().submit(batchOf("What is 1+1?", "What is 2+2?"));
+
+        String uploadBody = httpClient.requestTo(FILES_PATH).body();
+        assertThat(uploadBody).contains("name=\"purpose\"").contains("batch");
+        assertThat(uploadBody).contains("filename=\"batch.jsonl\"");
+
+        assertThat(jsonlLineOf(uploadBody, "request-0"))
+                .contains("\"method\":\"POST\"")
+                .contains("\"url\":\"/v1/chat/completions\"")
+                .contains("What is 1+1?")
+                .contains("\"model\":\"" + MODEL_NAME + "\"")
+                .doesNotContain("What is 2+2?");
+        assertThat(jsonlLineOf(uploadBody, "request-1"))
+                .contains("What is 2+2?")
+                .doesNotContain("What is 1+1?");
+    }
+
+    private static String jsonlLineOf(String uploadBody, String customId) {
+        return uploadBody
+                .lines()
+                .filter(line -> line.startsWith("{\"custom_id\":\"" + customId + "\""))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No uploaded JSONL line for custom_id '" + customId + "' in:\n" + uploadBody));
+    }
+
+    @Test
+    void should_return_batch_id_and_pending_state_on_submit() {
+        stubSubmit();
+
+        BatchResponse<ChatResponse> response = model().submit(batchOf("hi"));
+
+        assertThat(response.batchId()).isEqualTo(BATCH_ID);
+        assertThat(response.state()).isEqualTo(BatchState.PENDING);
+        assertThat(response.results()).isEmpty();
+    }
+
+    @Test
+    void should_send_completion_window_batch_metadata_and_output_expiry() {
+        stubSubmit();
+
+        modelBuilder()
+                .batchMetadata(Map.of("owner", "nightly-job"))
+                .outputExpiresAfterSeconds(3600L)
+                .build()
+                .submit(batchOf("hi"));
+
+        String createBody = httpClient.requestTo(BATCHES_PATH).body();
+        assertThat(createBody)
+                .contains("\"input_file_id\":\"file-in\"")
+                .contains("\"endpoint\":\"/v1/chat/completions\"")
+                .contains("\"completion_window\":\"24h\"")
+                .contains("\"owner\":\"nightly-job\"")
+                .contains("\"seconds\":3600")
+                .contains("\"anchor\":\"created_at\"");
+    }
+
+    @Test
+    void should_apply_per_request_parameters_over_builder_defaults() {
+        stubSubmit();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .temperature(0.1)
+                .build();
+        modelBuilder().temperature(0.9).build().submit(new BatchRequest<>(List.of(request)));
+
+        assertThat(httpClient.requestTo(FILES_PATH).body()).contains("\"temperature\":0.1");
+    }
+
+    @Test
+    void should_apply_openai_specific_default_request_parameters() {
+        stubSubmit();
+
+        modelBuilder()
+                .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                        .maxCompletionTokens(7)
+                        .seed(42)
+                        .user("user-1")
+                        .store(true)
+                        .serviceTier("flex")
+                        .parallelToolCalls(false)
+                        .logitBias(Map.of("50256", -100))
+                        .build())
+                .build()
+                .submit(batchOf("hi"));
+
+        assertThat(jsonlLineOf(httpClient.requestTo(FILES_PATH).body(), "request-0"))
+                .contains("\"max_completion_tokens\":7")
+                .contains("\"seed\":42")
+                .contains("\"user\":\"user-1\"")
+                .contains("\"store\":true")
+                .contains("\"service_tier\":\"flex\"")
+                .contains("\"parallel_tool_calls\":false")
+                .contains("\"50256\":-100");
+    }
+
+    @Test
+    void should_fail_when_model_name_is_not_set() {
+        OpenAiOfficialBatchChatModel model = OpenAiOfficialBatchChatModel.builder()
+                .openAIClient(new OpenAIClientImpl(ClientOptions.builder()
+                        .apiKey("test-key")
+                        .httpClient(httpClient)
+                        .build()))
+                .build();
+
+        assertThatThrownBy(() -> model.submit(batchOf("hi")))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("modelName cannot be null or blank");
+    }
+
+    @Test
+    void should_return_results_in_submission_order_when_output_lines_are_out_of_order() {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson("completed", "file-out", null));
+        httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, successLine(1, "second") + "\n" + successLine(0, "first"));
+
+        BatchResponse<ChatResponse> response = model().retrieve(BATCH_ID);
+
+        assertThat(response.state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(response.results()).hasSize(2);
+        assertThat(response.results().get(0).response().aiMessage().text()).isEqualTo("first");
+        assertThat(response.results().get(1).response().aiMessage().text()).isEqualTo("second");
+    }
+
+    @Test
+    void should_map_response_metadata_from_the_completion() {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson("completed", "file-out", null));
+        httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, successLine(0, "hello"));
+
+        ChatResponse response = model().retrieve(BATCH_ID).results().get(0).response();
+
+        assertThat(response.metadata().id()).isEqualTo("chatcmpl-1");
+        assertThat(response.metadata().modelName()).isEqualTo(MODEL_NAME);
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.STOP);
+        assertThat(response.metadata().tokenUsage().totalTokenCount()).isEqualTo(11);
+    }
+
+    @Test
+    void should_merge_error_file_entries_with_output_file_entries_in_submission_order() {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson("completed", "file-out", "file-err"));
+        httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, successLine(0, "ok"));
+        httpClient.enqueue(
+                ERROR_FILE_CONTENT_PATH,
+                "{\"id\":\"batch_req_1\",\"custom_id\":\"request-1\",\"response\":null,"
+                        + "\"error\":{\"code\":\"batch_expired\",\"message\":\"This request expired\"}}");
+
+        List<BatchItemResult<ChatResponse>> results = model().retrieve(BATCH_ID).results();
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).isSuccess()).isTrue();
+        assertThat(results.get(1).isSuccess()).isFalse();
+        assertThat(results.get(1).error().message()).isEqualTo("This request expired");
+        assertThat(results.get(1).error().details()).containsExactly(Map.of("code", "batch_expired"));
+    }
+
+    @Test
+    void should_map_http_error_line_in_output_file_to_failure_with_status_code() {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson("completed", "file-out", null));
+        httpClient.enqueue(
+                OUTPUT_FILE_CONTENT_PATH,
+                "{\"id\":\"batch_req_0\",\"custom_id\":\"request-0\",\"response\":{\"status_code\":400,"
+                        + "\"body\":{\"error\":{\"message\":\"Invalid request\",\"type\":\"invalid_request_error\","
+                        + "\"code\":\"context_length_exceeded\"}}},\"error\":null}");
+
+        List<BatchItemResult<ChatResponse>> results = model().retrieve(BATCH_ID).results();
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).isSuccess()).isFalse();
+        assertThat(results.get(0).error().code()).isEqualTo(400);
+        assertThat(results.get(0).error().message()).isEqualTo("Invalid request");
+        assertThat(results.get(0).error().details())
+                .containsExactly(Map.of(
+                        "type", "invalid_request_error",
+                        "code", "context_length_exceeded"));
+    }
+
+    private void stubCompletedBatchWithOutput(int total, String outputContent) {
+        httpClient.enqueue(
+                BATCHES_PATH + "/" + BATCH_ID,
+                "{\"id\":\"" + BATCH_ID + "\",\"object\":\"batch\",\"endpoint\":\"/v1/chat/completions\","
+                        + "\"input_file_id\":\"file-in\",\"completion_window\":\"24h\",\"created_at\":1700000000,"
+                        + "\"status\":\"completed\",\"output_file_id\":\"file-out\","
+                        + "\"request_counts\":{\"total\":" + total + ",\"completed\":" + total + ",\"failed\":0}}");
+        httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, outputContent);
+    }
+
+    @Test
+    void should_fail_when_a_result_has_a_malformed_custom_id() {
+        stubCompletedBatchWithOutput(
+                1, successLine(0, "ok").replace("\"custom_id\":\"request-0\"", "\"custom_id\":\"request-foo\""));
+
+        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Unexpected custom_id in batch result: request-foo");
+    }
+
+    @Test
+    void should_fail_when_a_result_has_no_custom_id() {
+        stubCompletedBatchWithOutput(1, successLine(0, "ok").replace("\"custom_id\":\"request-0\",", ""));
+
+        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Unexpected custom_id in batch result: null");
+    }
+
+    @Test
+    void should_fail_when_a_result_has_a_negative_custom_id() {
+        stubCompletedBatchWithOutput(
+                1, successLine(0, "ok").replace("\"custom_id\":\"request-0\"", "\"custom_id\":\"request--1\""));
+
+        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Unexpected custom_id in batch result: request--1");
+    }
+
+    @Test
+    void should_fail_when_a_result_is_outside_the_submitted_range() {
+        stubCompletedBatchWithOutput(2, successLine(5, "stray"));
+
+        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Batch result refers to request 5, but only 2 request(s) were submitted");
+    }
+
+    @Test
+    void should_fail_when_a_custom_id_is_duplicated() {
+        stubCompletedBatchWithOutput(2, successLine(0, "first") + "\n" + successLine(0, "again"));
+
+        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Duplicate custom_id in batch result: request-0");
+    }
+
+    @Test
+    void should_return_batch_level_errors_when_batch_failed() {
+        httpClient.enqueue(
+                BATCHES_PATH + "/" + BATCH_ID,
+                "{\"id\":\"" + BATCH_ID + "\",\"object\":\"batch\",\"endpoint\":\"/v1/chat/completions\","
+                        + "\"input_file_id\":\"file-in\",\"completion_window\":\"24h\",\"created_at\":1700000000,"
+                        + "\"status\":\"failed\",\"errors\":{\"object\":\"list\",\"data\":[{\"code\":\"invalid_json_line\","
+                        + "\"message\":\"Line 1 is not valid JSON\",\"line\":1,\"param\":null}]}}");
+
+        BatchResponse<ChatResponse> response = model().retrieve(BATCH_ID);
+
+        assertThat(response.state()).isEqualTo(BatchState.FAILED);
+        assertThat(response.results()).hasSize(1);
+        assertThat(response.results().get(0).error().message()).isEqualTo("Line 1 is not valid JSON");
+        assertThat(response.results().get(0).error().details())
+                .containsExactly(Map.of("code", "invalid_json_line", "line", 1L));
+    }
+
+    @Test
+    void should_return_partial_results_when_batch_expired() {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson("expired", "file-out", "file-err"));
+        httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, successLine(0, "done in time"));
+        httpClient.enqueue(
+                ERROR_FILE_CONTENT_PATH,
+                "{\"custom_id\":\"request-1\",\"response\":null,"
+                        + "\"error\":{\"code\":\"batch_expired\",\"message\":\"expired\"}}");
+
+        BatchResponse<ChatResponse> response = model().retrieve(BATCH_ID);
+
+        assertThat(response.state()).isEqualTo(BatchState.EXPIRED);
+        assertThat(response.results()).hasSize(2);
+        assertThat(response.results().get(0).isSuccess()).isTrue();
+        assertThat(response.results().get(1).isSuccess()).isFalse();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "validating,PENDING",
+        "in_progress,RUNNING",
+        "finalizing,RUNNING",
+        "cancelling,RUNNING",
+        "completed,SUCCEEDED",
+        "failed,FAILED",
+        "cancelled,CANCELLED",
+        "expired,EXPIRED",
+        "some_future_status,UNSPECIFIED"
+    })
+    void should_map_every_openai_status_to_a_batch_state(String openAiStatus, BatchState expectedState) {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson(openAiStatus, null, null));
+
+        assertThat(model().retrieve(BATCH_ID).state()).isEqualTo(expectedState);
+    }
+
+    @Test
+    void should_cancel_batch() {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID + "/cancel", batchJson("cancelling", null, null));
+
+        model().cancel(BATCH_ID);
+
+        assertThat(httpClient
+                        .requestTo(BATCHES_PATH + "/" + BATCH_ID + "/cancel")
+                        .method())
+                .isEqualTo("POST");
+    }
+
+    @Test
+    void should_list_batches_and_return_last_id_as_next_page_token_when_more_are_available() {
+        httpClient.enqueue(
+                BATCHES_PATH,
+                "{\"object\":\"list\",\"data\":[" + batchJson("completed", "file-out", null) + "],\"has_more\":true}");
+
+        BatchPage<ChatResponse> page = model().list(new BatchPagination(10, "batch_previous"));
+
+        assertThat(page.batches()).hasSize(1);
+        assertThat(page.batches().get(0).batchId()).isEqualTo(BATCH_ID);
+        assertThat(page.nextPageToken()).isEqualTo(BATCH_ID);
+        assertThat(httpClient.requestTo(BATCHES_PATH).path()).isEqualTo(BATCHES_PATH);
+    }
+
+    @Test
+    void should_return_null_next_page_token_when_no_more_batches_are_available() {
+        httpClient.enqueue(
+                BATCHES_PATH,
+                "{\"object\":\"list\",\"data\":[" + batchJson("completed", "file-out", null) + "],\"has_more\":false}");
+
+        assertThat(model().list(null).nextPageToken()).isNull();
+    }
+
+    @Test
+    void should_fail_when_requests_use_different_models() {
+        ChatRequest other = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .modelName("gpt-4o")
+                .build();
+        ChatRequest defaulted =
+                ChatRequest.builder().messages(UserMessage.from("hi")).build();
+
+        assertThatThrownBy(() -> model().submit(new BatchRequest<>(List.of(defaulted, other))))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Batch requests cannot use different models; " + "all requests must use the same model: ["
+                        + MODEL_NAME + ", gpt-4o]");
+    }
+
+    @Test
+    void should_use_microsoft_foundry_endpoint_and_deployment_name_as_model() {
+        stubSubmit();
+
+        OpenAiOfficialBatchChatModel.builder()
+                .openAIClient(new OpenAIClientImpl(ClientOptions.builder()
+                        .apiKey("test-key")
+                        .httpClient(httpClient)
+                        .build()))
+                .isMicrosoftFoundry(true)
+                .modelName(MODEL_NAME)
+                .microsoftFoundryDeploymentName("my-deployment")
+                .build()
+                .submit(batchOf("hi"));
+
+        assertThat(httpClient.requestTo(BATCHES_PATH).body())
+                .contains("\"endpoint\":\"/chat/completions\"")
+                .doesNotContain("/v1/chat/completions");
+        assertThat(jsonlLineOf(httpClient.requestTo(FILES_PATH).body(), "request-0"))
+                .contains("\"model\":\"my-deployment\"")
+                .contains("\"url\":\"/v1/chat/completions\"");
+    }
+
+    @Test
+    void should_fail_when_used_with_github_models() {
+        assertThatThrownBy(() -> OpenAiOfficialBatchChatModel.builder()
+                        .apiKey("test-key")
+                        .isGitHubModels(true)
+                        .modelName(MODEL_NAME)
+                        .build())
+                .isExactlyInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage("The Batch API is not supported by GitHub Models");
+    }
+
+    @Test
+    void should_place_sparse_results_at_their_own_request_index() {
+        httpClient.enqueue(
+                BATCHES_PATH + "/" + BATCH_ID,
+                "{\"id\":\"" + BATCH_ID + "\",\"object\":\"batch\",\"endpoint\":\"/v1/chat/completions\","
+                        + "\"input_file_id\":\"file-in\",\"completion_window\":\"24h\",\"created_at\":1700000000,"
+                        + "\"status\":\"expired\",\"output_file_id\":\"file-out\","
+                        + "\"request_counts\":{\"total\":3,\"completed\":2,\"failed\":0}}");
+        httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, successLine(2, "third") + "\n" + successLine(0, "first"));
+
+        List<BatchItemResult<ChatResponse>> results = model().retrieve(BATCH_ID).results();
+
+        assertThat(results).hasSize(3);
+        assertThat(results.get(0).response().aiMessage().text()).isEqualTo("first");
+        assertThat(results.get(1).isSuccess()).isFalse();
+        assertThat(results.get(1).error().message()).isEqualTo("No result was returned for this request");
+        assertThat(results.get(2).response().aiMessage().text()).isEqualTo("third");
+    }
+
+    @Test
+    void should_reject_topK_which_openai_does_not_support() {
+        ChatRequest request =
+                ChatRequest.builder().messages(UserMessage.from("hi")).topK(5).build();
+
+        assertThatThrownBy(() -> model().submit(new BatchRequest<>(List.of(request))))
+                .isExactlyInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage("'topK' parameter is not supported by OpenAI");
+    }
+
+    @Test
+    void should_reject_per_request_model_override_on_microsoft_foundry() {
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .modelName("another-deployment")
+                .build();
+
+        OpenAiOfficialBatchChatModel model = OpenAiOfficialBatchChatModel.builder()
+                .openAIClient(new OpenAIClientImpl(ClientOptions.builder()
+                        .apiKey("test-key")
+                        .httpClient(httpClient)
+                        .build()))
+                .isMicrosoftFoundry(true)
+                .modelName(MODEL_NAME)
+                .microsoftFoundryDeploymentName("my-deployment")
+                .build();
+
+        assertThatThrownBy(() -> model.submit(new BatchRequest<>(List.of(request))))
+                .isExactlyInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage("Microsoft Foundry batch requests do not support overriding modelName per request; "
+                        + "configure the batch deployment when building the model");
+    }
+
+    @Test
+    void should_fail_when_github_models_is_detected_from_the_base_url() {
+        assertThatThrownBy(() -> OpenAiOfficialBatchChatModel.builder()
+                        .apiKey("test-key")
+                        .baseUrl("https://models.github.ai/inference")
+                        .modelName(MODEL_NAME)
+                        .build())
+                .isExactlyInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage("The Batch API is not supported by GitHub Models");
+    }
+
+    @Test
+    void should_send_input_file_expiry_when_configured() {
+        stubSubmit();
+
+        modelBuilder().inputFileExpiresAfterSeconds(1209600L).build().submit(batchOf("hi"));
+
+        assertThat(httpClient.requestTo(FILES_PATH).body())
+                .contains("name=\"expires_after[anchor]\"")
+                .contains("created_at")
+                .contains("name=\"expires_after[seconds]\"")
+                .contains("1209600");
+    }
+
+    @Test
+    void should_serialize_tools_and_map_returned_tool_calls() {
+        stubSubmit();
+        ToolSpecification tool = ToolSpecification.builder()
+                .name("get_weather")
+                .description("Get the weather")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+
+        model().submit(new BatchRequest<>(List.of(ChatRequest.builder()
+                .messages(UserMessage.from("weather in Paris?"))
+                .toolSpecifications(tool)
+                .build())));
+
+        assertThat(jsonlLineOf(httpClient.requestTo(FILES_PATH).body(), "request-0"))
+                .contains("\"tools\":[")
+                .contains("\"name\":\"get_weather\"")
+                .contains("\"city\"");
+
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson("completed", "file-out", null));
+        httpClient.enqueue(
+                OUTPUT_FILE_CONTENT_PATH,
+                "{\"custom_id\":\"request-0\",\"response\":{\"status_code\":200,\"body\":"
+                        + "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"created\":1700000000,"
+                        + "\"model\":\"" + MODEL_NAME + "\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\","
+                        + "\"message\":{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"call_1\","
+                        + "\"type\":\"function\",\"function\":{\"name\":\"get_weather\","
+                        + "\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\"}}]}}]}},\"error\":null}");
+
+        ChatResponse response = model().retrieve(BATCH_ID).results().get(0).response();
+        assertThat(response.aiMessage().hasToolExecutionRequests()).isTrue();
+        assertThat(response.aiMessage().toolExecutionRequests().get(0).name()).isEqualTo("get_weather");
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
+    }
+
+    @Test
+    void should_serialize_json_schema_response_format() {
+        stubSubmit();
+
+        model().submit(new BatchRequest<>(List.of(ChatRequest.builder()
+                .messages(UserMessage.from("extract"))
+                .responseFormat(ResponseFormat.builder()
+                        .type(ResponseFormatType.JSON)
+                        .jsonSchema(JsonSchema.builder()
+                                .name("Person")
+                                .rootElement(JsonObjectSchema.builder()
+                                        .addStringProperty("name")
+                                        .required("name")
+                                        .build())
+                                .build())
+                        .build())
+                .build())));
+
+        assertThat(jsonlLineOf(httpClient.requestTo(FILES_PATH).body(), "request-0"))
+                .contains("\"response_format\"")
+                .contains("json_schema")
+                .contains("\"name\":\"Person\"");
+    }
+
+    @Test
+    void should_serialize_image_content() {
+        stubSubmit();
+
+        model().submit(new BatchRequest<>(List.of(ChatRequest.builder()
+                .messages(UserMessage.from(
+                        TextContent.from("what is this?"), ImageContent.from("https://example.com/cat.png")))
+                .build())));
+
+        assertThat(jsonlLineOf(httpClient.requestTo(FILES_PATH).body(), "request-0"))
+                .contains("image_url")
+                .contains("https://example.com/cat.png");
+    }
+
+    @Test
+    void should_send_limit_and_after_on_the_wire_when_listing() {
+        httpClient.enqueue(BATCHES_PATH, "{\"object\":\"list\",\"data\":[],\"has_more\":false}");
+
+        model().list(new BatchPagination(25, "batch_previous"));
+
+        assertThat(httpClient.requestTo(BATCHES_PATH).query())
+                .contains("limit=25")
+                .contains("after=batch_previous");
+    }
+
+    @Test
+    void should_return_partial_results_when_batch_was_cancelled() {
+        httpClient.enqueue(BATCHES_PATH + "/" + BATCH_ID, batchJson("cancelled", "file-out", null));
+        httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, successLine(0, "finished before cancel"));
+
+        BatchResponse<ChatResponse> response = model().retrieve(BATCH_ID);
+
+        assertThat(response.state()).isEqualTo(BatchState.CANCELLED);
+        assertThat(response.results()).hasSize(1);
+        assertThat(response.results().get(0).response().aiMessage().text()).isEqualTo("finished before cancel");
+    }
+
+    @Test
+    void should_fail_when_batch_is_empty() {
+        assertThatThrownBy(() -> model().submit(new BatchRequest<>(List.of())))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("requests cannot be null or empty");
+    }
+}

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModelTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModelTest.java
@@ -23,6 +23,7 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.FinishReason;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -146,7 +147,7 @@ class OpenAiOfficialBatchChatModelTest {
 
         modelBuilder()
                 .batchMetadata(Map.of("owner", "nightly-job"))
-                .outputExpiresAfterSeconds(3600L)
+                .outputExpiresAfter(Duration.ofHours(1))
                 .build()
                 .submit(batchOf("hi"));
 
@@ -289,51 +290,59 @@ class OpenAiOfficialBatchChatModelTest {
         httpClient.enqueue(OUTPUT_FILE_CONTENT_PATH, outputContent);
     }
 
-    @Test
-    void should_fail_when_a_result_has_a_malformed_custom_id() {
-        stubCompletedBatchWithOutput(
-                1, successLine(0, "ok").replace("\"custom_id\":\"request-0\"", "\"custom_id\":\"request-foo\""));
+    @ParameterizedTest
+    @CsvSource({
+        "\"custom_id\":\"request-0\", \"custom_id\":\"request-foo\", malformed",
+        "'\"custom_id\":\"request-0\",', '', absent",
+        "\"custom_id\":\"request-0\", \"custom_id\":\"request--1\", negative",
+        "\"custom_id\":\"request-0\", \"custom_id\":\"task-0\", 'foreign prefix'"
+    })
+    void should_return_results_in_file_order_when_a_custom_id_cannot_be_correlated(
+            String original, String replacement, String scenario) {
+        stubCompletedBatchWithOutput(1, successLine(0, "ok").replace(original, replacement));
 
-        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessage("Unexpected custom_id in batch result: request-foo");
+        List<BatchItemResult<ChatResponse>> results = model().retrieve(BATCH_ID).results();
+
+        assertThat(results).as(scenario).hasSize(1);
+        assertThat(results.get(0).isSuccess()).as(scenario).isTrue();
+        assertThat(results.get(0).response().aiMessage().text()).as(scenario).isEqualTo("ok");
     }
 
     @Test
-    void should_fail_when_a_result_has_no_custom_id() {
-        stubCompletedBatchWithOutput(1, successLine(0, "ok").replace("\"custom_id\":\"request-0\",", ""));
+    void should_return_results_in_file_order_when_a_result_is_outside_the_submitted_range() {
+        stubCompletedBatchWithOutput(2, successLine(1, "second") + "\n" + successLine(5, "stray"));
 
-        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessage("Unexpected custom_id in batch result: null");
+        List<BatchItemResult<ChatResponse>> results = model().retrieve(BATCH_ID).results();
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).response().aiMessage().text()).isEqualTo("second");
+        assertThat(results.get(1).response().aiMessage().text()).isEqualTo("stray");
     }
 
     @Test
-    void should_fail_when_a_result_has_a_negative_custom_id() {
-        stubCompletedBatchWithOutput(
-                1, successLine(0, "ok").replace("\"custom_id\":\"request-0\"", "\"custom_id\":\"request--1\""));
-
-        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessage("Unexpected custom_id in batch result: request--1");
-    }
-
-    @Test
-    void should_fail_when_a_result_is_outside_the_submitted_range() {
-        stubCompletedBatchWithOutput(2, successLine(5, "stray"));
-
-        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessage("Batch result refers to request 5, but only 2 request(s) were submitted");
-    }
-
-    @Test
-    void should_fail_when_a_custom_id_is_duplicated() {
+    void should_return_both_results_in_file_order_when_a_custom_id_is_duplicated() {
         stubCompletedBatchWithOutput(2, successLine(0, "first") + "\n" + successLine(0, "again"));
 
-        assertThatThrownBy(() -> model().retrieve(BATCH_ID))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessage("Duplicate custom_id in batch result: request-0");
+        List<BatchItemResult<ChatResponse>> results = model().retrieve(BATCH_ID).results();
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).response().aiMessage().text()).isEqualTo("first");
+        assertThat(results.get(1).response().aiMessage().text()).isEqualTo("again");
+    }
+
+    @Test
+    void should_return_every_result_of_a_batch_submitted_elsewhere() {
+        stubCompletedBatchWithOutput(
+                2,
+                successLine(0, "alpha").replace("\"custom_id\":\"request-0\"", "\"custom_id\":\"task-a\"") + "\n"
+                        + successLine(1, "beta").replace("\"custom_id\":\"request-1\"", "\"custom_id\":\"task-b\""));
+
+        List<BatchItemResult<ChatResponse>> results = model().retrieve(BATCH_ID).results();
+
+        assertThat(results).hasSize(2);
+        assertThat(results).allMatch(BatchItemResult::isSuccess);
+        assertThat(results.get(0).response().aiMessage().text()).isEqualTo("alpha");
+        assertThat(results.get(1).response().aiMessage().text()).isEqualTo("beta");
     }
 
     @Test
@@ -463,6 +472,19 @@ class OpenAiOfficialBatchChatModelTest {
     }
 
     @Test
+    void should_use_microsoft_foundry_endpoint_when_it_is_detected_from_the_base_url() {
+        stubSubmit();
+
+        modelBuilder()
+                .baseUrl("https://example.openai.azure.com")
+                .microsoftFoundryDeploymentName("my-deployment")
+                .build()
+                .submit(batchOf("hi"));
+
+        assertThat(httpClient.requestTo(BATCHES_PATH).body()).contains("\"endpoint\":\"/chat/completions\"");
+    }
+
+    @Test
     void should_fail_when_used_with_github_models() {
         assertThatThrownBy(() -> OpenAiOfficialBatchChatModel.builder()
                         .apiKey("test-key")
@@ -540,7 +562,7 @@ class OpenAiOfficialBatchChatModelTest {
     void should_send_input_file_expiry_when_configured() {
         stubSubmit();
 
-        modelBuilder().inputFileExpiresAfterSeconds(1209600L).build().submit(batchOf("hi"));
+        modelBuilder().inputFileExpiresAfter(Duration.ofDays(14)).build().submit(batchOf("hi"));
 
         assertThat(httpClient.requestTo(FILES_PATH).body())
                 .contains("name=\"expires_after[anchor]\"")

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModelTransportTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBatchChatModelTransportTest.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import com.openai.azure.AzureOpenAIServiceVersion;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Verifies the URLs that a client built by this integration actually sends to, rather than by an injected
+ * one. The Azure {@code /openai} prefix and {@code api-version} are applied by the SDK based on the
+ * hostname, so they cannot be reproduced against a local server; what is covered here is that batch and
+ * file operations are never scoped to a deployment.
+ */
+class OpenAiOfficialBatchChatModelTransportTest {
+
+    private static final String BATCH_JSON = """
+            {"id":"batch_abc","object":"batch","endpoint":"/chat/completions","input_file_id":"file-in",\
+            "completion_window":"24h","created_at":1700000000,"status":"validating"}""";
+    private static final String FILE_JSON = """
+            {"id":"file-in","object":"file","bytes":1,"created_at":1700000000,"filename":"batch.jsonl",\
+            "purpose":"batch","status":"processed"}""";
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void beforeEach() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        wireMockServer.stubFor(
+                WireMock.post(WireMock.urlPathMatching(".*/files")).willReturn(WireMock.okJson(FILE_JSON)));
+        wireMockServer.stubFor(
+                WireMock.post(WireMock.urlPathMatching(".*/batches")).willReturn(WireMock.okJson(BATCH_JSON)));
+        wireMockServer.stubFor(
+                WireMock.get(WireMock.urlPathMatching(".*/batches/batch_abc")).willReturn(WireMock.okJson(BATCH_JSON)));
+        wireMockServer.stubFor(WireMock.post(WireMock.urlPathMatching(".*/batches/batch_abc/cancel"))
+                .willReturn(WireMock.okJson(BATCH_JSON)));
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathMatching(".*/batches"))
+                .willReturn(WireMock.okJson("{\"object\":\"list\",\"data\":[],\"has_more\":false}")));
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    private OpenAiOfficialBatchChatModel foundryModel(String baseUrl) {
+        return OpenAiOfficialBatchChatModel.builder()
+                .baseUrl(baseUrl)
+                .apiKey("test-key")
+                .isMicrosoftFoundry(true)
+                .azureOpenAIServiceVersion(AzureOpenAIServiceVersion.getV2024_10_21())
+                .modelName("gpt-4o-mini")
+                .microsoftFoundryDeploymentName("my-deployment")
+                .build();
+    }
+
+    private List<String> sentUrls() {
+        return wireMockServer.findAll(WireMock.anyRequestedFor(WireMock.anyUrl())).stream()
+                .map(LoggedRequest::getUrl)
+                .toList();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    void should_not_scope_microsoft_foundry_batch_and_file_urls_to_a_deployment(String baseUrlSuffix) {
+        OpenAiOfficialBatchChatModel model = foundryModel(wireMockServer.baseUrl() + baseUrlSuffix);
+
+        model.submit(new BatchRequest<>(
+                List.of(ChatRequest.builder().messages(UserMessage.from("hi")).build())));
+
+        assertThat(sentUrls()).isNotEmpty().noneMatch(url -> url.contains("deployments"));
+        assertThat(sentUrls()).anyMatch(url -> url.endsWith("/files"));
+        assertThat(sentUrls()).anyMatch(url -> url.endsWith("/batches"));
+    }
+
+    @Test
+    void should_not_scope_microsoft_foundry_retrieve_cancel_and_list_to_a_deployment() {
+        OpenAiOfficialBatchChatModel model = foundryModel(wireMockServer.baseUrl());
+
+        model.retrieve("batch_abc");
+        model.cancel("batch_abc");
+        model.list(new BatchPagination(10, "batch_previous"));
+
+        assertThat(sentUrls())
+                .isNotEmpty()
+                .noneMatch(url -> url.contains("deployments"))
+                .anyMatch(url -> url.startsWith("/batches/batch_abc"))
+                .anyMatch(url -> url.startsWith("/batches/batch_abc/cancel"))
+                .anyMatch(url -> url.contains("limit=10") && url.contains("after=batch_previous"));
+    }
+
+    @Test
+    void should_use_plain_paths_when_not_microsoft_foundry() {
+        OpenAiOfficialBatchChatModel model = OpenAiOfficialBatchChatModel.builder()
+                .baseUrl(wireMockServer.baseUrl())
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .build();
+
+        model.retrieve("batch_abc");
+
+        assertThat(sentUrls()).containsExactly("/batches/batch_abc");
+    }
+}

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStubHttpClient.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStubHttpClient.java
@@ -1,0 +1,113 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.openai.core.RequestOptions;
+import com.openai.core.http.Headers;
+import com.openai.core.http.HttpClient;
+import com.openai.core.http.HttpRequest;
+import com.openai.core.http.HttpRequestBody;
+import com.openai.core.http.HttpResponse;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Test helper: an {@link HttpClient} that replays canned response bodies keyed by request path and records
+ * every outgoing request, so the real OpenAI SDK performs the real serialization and parsing without a
+ * network call or an API key.
+ */
+class OpenAiOfficialStubHttpClient implements HttpClient {
+
+    private final Map<String, Deque<String>> responseBodiesByPath = new LinkedHashMap<>();
+    private final List<RecordedRequest> recordedRequests = new ArrayList<>();
+
+    void enqueue(String path, String responseBody) {
+        responseBodiesByPath.computeIfAbsent(path, key -> new ArrayDeque<>()).add(responseBody);
+    }
+
+    List<RecordedRequest> recordedRequests() {
+        return recordedRequests;
+    }
+
+    RecordedRequest requestTo(String path) {
+        return recordedRequests.stream()
+                .filter(recordedRequest -> recordedRequest.path().equals(path))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No request was sent to '" + path + "'. Sent: "
+                        + recordedRequests.stream().map(RecordedRequest::path).toList()));
+    }
+
+    @Override
+    public HttpResponse execute(HttpRequest request, RequestOptions requestOptions) {
+        String path = String.join("/", request.pathSegments());
+        recordedRequests.add(new RecordedRequest(request.method().toString(), path, request.url(), readBody(request)));
+
+        Deque<String> responseBodies = responseBodiesByPath.get(path);
+        if (responseBodies == null || responseBodies.isEmpty()) {
+            throw new AssertionError("No stubbed response for " + request.method() + " '" + path + "'");
+        }
+        return toResponse(responseBodies.poll());
+    }
+
+    @Override
+    public CompletableFuture<HttpResponse> executeAsync(HttpRequest request, RequestOptions requestOptions) {
+        return CompletableFuture.completedFuture(execute(request, requestOptions));
+    }
+
+    @Override
+    public void close() {}
+
+    private static String readBody(HttpRequest request) {
+        HttpRequestBody body = request.body();
+        if (body == null) {
+            return "";
+        }
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        try {
+            body.writeTo(buffer);
+        } catch (Exception e) {
+            throw new AssertionError("Failed to read the request body", e);
+        }
+        return buffer.toString(UTF_8);
+    }
+
+    private static HttpResponse toResponse(String responseBody) {
+        byte[] bytes = responseBody.getBytes(UTF_8);
+        return new HttpResponse() {
+
+            @Override
+            public int statusCode() {
+                return 200;
+            }
+
+            @Override
+            public Headers headers() {
+                return Headers.builder().put("Content-Type", "application/json").build();
+            }
+
+            @Override
+            public InputStream body() {
+                return new ByteArrayInputStream(bytes);
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    record RecordedRequest(String method, String path, String url, String body) {
+
+        String query() {
+            int separator = url.indexOf('?');
+            return separator < 0 ? "" : url.substring(separator + 1);
+        }
+    }
+}

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialBatchChatModelIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialBatchChatModelIT.java
@@ -1,0 +1,99 @@
+package dev.langchain4j.model.openaiofficial.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialBatchChatModel;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiOfficialBatchChatModelIT {
+
+    private static final Duration COMPLETION_TIMEOUT = Duration.ofMinutes(15);
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(15);
+
+    private final OpenAiOfficialBatchChatModel model = OpenAiOfficialBatchChatModel.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .modelName(InternalOpenAiOfficialTestHelper.CHAT_MODEL_NAME)
+            .maxCompletionTokens(20)
+            .temperature(0.0)
+            .batchMetadata(Map.of("source", "langchain4j-integration-test"))
+            .build();
+
+    private static BatchRequest<ChatRequest> batchOf(String... prompts) {
+        List<ChatRequest> requests = java.util.Arrays.stream(prompts)
+                .map(prompt ->
+                        ChatRequest.builder().messages(UserMessage.from(prompt)).build())
+                .toList();
+        return new BatchRequest<>(requests);
+    }
+
+    @Test
+    void should_submit_and_retrieve_results_in_submission_order() {
+        BatchResponse<ChatResponse> submitted = model.submit(batchOf(
+                "What is the capital of France? Answer with the city name only.",
+                "What is 2+2? Answer with the number only."));
+
+        assertThat(submitted.batchId()).isNotBlank();
+        assertThat(submitted.state().isTerminal()).isFalse();
+
+        BatchResponse<ChatResponse> completed = awaitTerminalState(submitted.batchId());
+
+        assertThat(completed.state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(completed.results()).hasSize(2);
+        assertThat(completed.results()).allMatch(BatchItemResult::isSuccess);
+        assertThat(completed.responses().get(0).aiMessage().text()).containsIgnoringCase("Paris");
+        assertThat(completed.responses().get(1).aiMessage().text()).contains("4");
+        assertThat(completed.responses().get(0).metadata().tokenUsage().totalTokenCount())
+                .isPositive();
+    }
+
+    @Test
+    void should_cancel_batch() {
+        BatchResponse<ChatResponse> submitted = model.submit(batchOf("Reply with exactly one word: GAMMA"));
+
+        model.cancel(submitted.batchId());
+
+        BatchResponse<ChatResponse> cancelled = model.retrieve(submitted.batchId());
+        assertThat(cancelled.state()).isIn(BatchState.RUNNING, BatchState.CANCELLED);
+    }
+
+    @Test
+    void should_list_batches() {
+        model.submit(batchOf("Reply with exactly one word: DELTA"));
+
+        BatchPage<ChatResponse> page = model.list(new BatchPagination(1, null));
+
+        assertThat(page.batches()).hasSize(1);
+        assertThat(page.batches().get(0).batchId()).isNotBlank();
+    }
+
+    private BatchResponse<ChatResponse> awaitTerminalState(String batchId) {
+        try {
+            return await().atMost(COMPLETION_TIMEOUT)
+                    .pollInterval(POLL_INTERVAL)
+                    .until(
+                            () -> model.retrieve(batchId),
+                            response -> response.state().isTerminal());
+        } catch (ConditionTimeoutException e) {
+            model.cancel(batchId);
+            return Assumptions.abort("Batch " + batchId + " did not reach a terminal state within " + COMPLETION_TIMEOUT
+                    + "; OpenAI allows up to 24h, so this run is inconclusive rather than failed");
+        }
+    }
+}

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialBatchChatModelIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialBatchChatModelIT.java
@@ -27,12 +27,17 @@ class OpenAiOfficialBatchChatModelIT {
     private static final Duration COMPLETION_TIMEOUT = Duration.ofMinutes(15);
     private static final Duration POLL_INTERVAL = Duration.ofSeconds(15);
 
+    // Every submit uploads an input file that the Batch API never removes on its own, so each run of this
+    // test would otherwise leave one behind for good. Two days outlives the 24h completion window.
+    private static final Duration INPUT_FILE_RETENTION = Duration.ofDays(2);
+
     private final OpenAiOfficialBatchChatModel model = OpenAiOfficialBatchChatModel.builder()
             .apiKey(System.getenv("OPENAI_API_KEY"))
             .modelName(InternalOpenAiOfficialTestHelper.CHAT_MODEL_NAME)
             .maxCompletionTokens(20)
             .temperature(0.0)
             .batchMetadata(Map.of("source", "langchain4j-integration-test"))
+            .inputFileExpiresAfter(INPUT_FILE_RETENTION)
             .build();
 
     private static BatchRequest<ChatRequest> batchOf(String... prompts) {
@@ -75,12 +80,15 @@ class OpenAiOfficialBatchChatModelIT {
 
     @Test
     void should_list_batches() {
-        model.submit(batchOf("Reply with exactly one word: DELTA"));
+        BatchResponse<ChatResponse> submitted = model.submit(batchOf("Reply with exactly one word: DELTA"));
+        try {
+            BatchPage<ChatResponse> page = model.list(new BatchPagination(1, null));
 
-        BatchPage<ChatResponse> page = model.list(new BatchPagination(1, null));
-
-        assertThat(page.batches()).hasSize(1);
-        assertThat(page.batches().get(0).batchId()).isNotBlank();
+            assertThat(page.batches()).hasSize(1);
+            assertThat(page.batches().get(0).batchId()).isNotBlank();
+        } finally {
+            model.cancel(submitted.batchId()); // this batch only had to exist, not to be processed and billed
+        }
     }
 
     private BatchResponse<ChatResponse> awaitTerminalState(String batchId) {


### PR DESCRIPTION

## Issue
Progresses #3916

## Change
`langchain4j-open-ai-official` had no batch support, so the OpenAI Batch API, which runs at 50% of the
standard per-token price, was not reachable through LangChain4j. This adds `OpenAiOfficialBatchChatModel`
on the core `BatchChatModel` interface.

```java
OpenAiOfficialBatchChatModel batchModel = OpenAiOfficialBatchChatModel.builder()
        .apiKey(System.getenv("OPENAI_API_KEY"))
        .modelName("gpt-4o-mini")
        .build();

BatchResponse<ChatResponse> submitted = batchModel.submit(new BatchRequest<>(List.of(
        ChatRequest.builder()
                .messages(UserMessage.from("What are some famous places to visit in San Francisco?"))
                .build(),
        ChatRequest.builder()
                .messages(UserMessage.from("Why is San Jose considered the heart of Silicon Valley?"))
                .build())));
```

OpenAI does not accept batch requests inline. They are written to JSONL, uploaded through the Files API
with the `batch` purpose, and the batch is created against that file, so `submit` performs two calls and
`retrieve` downloads the results.

Three details of that API shape the implementation. Results come back in two separate files, so `retrieve`
reads both; reading only the output file silently drops every failed request. Output order is not
guaranteed, so results are correlated by `custom_id` rather than by position, which also means a partial
batch reports an explicit failure for a request that produced no result instead of shifting later results
into a position they do not own. And one input file may only target one model, so mixed models are
rejected before the upload rather than by the API.

Correlation is best effort rather than an invariant. A `custom_id` that is missing, malformed, duplicated
or outside the submitted range means the batch was not submitted through this model — one created from the
OpenAI dashboard, for example — so `retrieve` abandons correlation for that batch, logs a warning and
returns the results in the order the result files list them. Results are never discarded, so a batch that
was paid for stays readable; only the correspondence to submitted requests is lost.

Azure OpenAI runs through the same class. Its batch and file operations are scoped to the resource, so
that client is built without the deployment path `calculateBaseUrl` adds for chat; the batch endpoint is
`/chat/completions` rather than `/v1/chat/completions`; and the model is identified by deployment name in
each JSONL line. Because the batch request shape depends on the provider, an endpoint configured through
`AZURE_OPENAI_BASE_URL`/`OPENAI_BASE_URL` has to be taken into account when detecting it, which this
integration does for itself rather than by changing the detection shared with the other chat models. The
environment is only consulted when this model builds the client; an injected client carries its own base
URL. GitHub Models has no Batch API and is rejected at construction.

Extending `OpenAiOfficialBaseChatModel` reuses the existing defaults-to-per-request merge and carries the
same non-deprecated parameter surface as `OpenAiOfficialChatModel`. `listeners`, `supportedCapabilities`
and `tokenCountEstimator` are omitted. The batch-specific options are `completionWindow`, `batchMetadata`,
`inputFileExpiresAfter` and `outputExpiresAfter`, the last two taking a `Duration` like the other
durations on the builder.

Embeddings and images are separate core interfaces and follow as their own PRs. No existing production
file is modified.

The documentation links the batch tutorial added by #6224, so that page only resolves once #6224 is in.

### Tests
- `OpenAiOfficialBatchChatModelTest` (new): 46 offline tests over a stubbed transport, so the real SDK does
  the real multipart upload, serialization and parsing without a key. They cover `custom_id`
  correlation including sparse ids, the fallback to result file order for ids this model did not generate,
  both result files, every batch status, pagination, the Azure request shape, tool calls, JSON-schema
  response format, image content, and the fail-fast paths.
- `OpenAiOfficialBatchChatModelTransportTest` (new): builds the client through this integration rather than
  injecting one, and asserts batch and file operations are never scoped to a deployment.
- `OpenAiOfficialStubHttpClient` (new): the canned `HttpClient` the above runs on.
- `OpenAiOfficialBatchChatModelIT` (new): key-gated live test, and I ran it green against the real Batch API
  on `gpt-4o-mini`. It uploads the JSONL, creates the batch, polls to a terminal state, asserts each answer
  came back on its own request, and then exercises `cancel` and `list`. It cancels every batch it does not
  need processed and sets an input file expiry, because the Batch API never removes uploaded input files on
  its own.

Because this is new API, reverting a production file does not compile, so fail-without was proven by
mutation instead. Every single-branch mutation of the JSONL serialization, the result file reads, the
`custom_id` correlation and its fallback, the endpoint selection and the same-model check turns at least
one test red. Two paths are not covered: selecting Microsoft Foundry passwordless authentication, which
behaves identically when an API key is set and needs an Azure identity to observe, and reading the base
URL from the environment, which cannot be exercised in process.

```
mvn -pl langchain4j-open-ai-official verify -Dit.test=OpenAiOfficialBatchChatModelIT
  Tests run: 63, Failures: 0, Errors: 0, Skipped: 0          (unit)
  Tests run: 3,  Failures: 0, Errors: 0, Skipped: 0          (OpenAiOfficialBatchChatModelIT)
  revapi: API checks completed without failures.
  BUILD SUCCESS

mvn -pl langchain4j-core test    Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
mvn -pl langchain4j test         Tests run: 1337, Failures: 0, Errors: 0, Skipped: 0
```

The live IT was run against OpenAI only. The Azure paths are covered by offline tests asserting the request
they produce, but I have no Azure resource to exercise them end to end.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
