### PR TITLE
Support customHeaders in OpenAI Responses API models

### DIFF
--- a/docs/docs/integrations/language-models/open-ai.md
+++ b/docs/docs/integrations/language-models/open-ai.md
@@ -479,6 +479,33 @@ StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
         .build();
 ```
 
+### Custom HTTP headers
+
+If the OpenAI API is reached through an authenticated proxy or a gateway that expects additional HTTP headers,
+these headers can be set on the builder. They are sent with every request:
+```java
+ChatModel model = OpenAiResponsesChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-4o-mini")
+        .customHeaders(Map.of("Proxy-Authorization", "Basic dXNlcjpwYXNz"))
+        .build();
+```
+
+If the header value is not constant (for example, an OAuth2 token that expires and has to be refreshed),
+a `Supplier` can be provided instead. It is called before each request:
+```java
+ChatModel model = OpenAiResponsesChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-4o-mini")
+        .customHeaders(() -> Map.of("Authorization", "Bearer " + tokenProvider.currentToken()))
+        .build();
+```
+
+Custom headers are applied last, so they can also be used to override the headers
+LangChain4j sets by default (for example, `Authorization`).
+
+The same applies to `OpenAiResponsesStreamingChatModel`.
+
 ### `OpenAiResponsesChatRequestParameters`
 
 `OpenAiResponsesChatRequestParameters` extends `DefaultChatRequestParameters` with Responses API-specific fields:

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatModel.java
@@ -22,6 +22,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 @Experimental
 public class OpenAiResponsesChatModel implements ChatModel {
@@ -38,6 +39,7 @@ public class OpenAiResponsesChatModel implements ChatModel {
                 .organizationId(builder.organizationId)
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
 
         ChatRequestParameters commonParameters;
@@ -167,6 +169,7 @@ public class OpenAiResponsesChatModel implements ChatModel {
         private Boolean logResponses;
         private List<ChatModelListener> listeners;
         private ChatRequestParameters defaultRequestParameters;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -329,6 +332,30 @@ public class OpenAiResponsesChatModel implements ChatModel {
 
         public Builder listeners(ChatModelListener... listeners) {
             return listeners(asList(listeners));
+        }
+
+        /**
+         * Sets custom HTTP headers to be added to each HTTP request.
+         *
+         * @param customHeaders a map of headers
+         * @return {@code this}
+         */
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers to be added to each HTTP request.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         *
+         * @param customHeadersSupplier a supplier that provides a map of headers
+         * @return {@code this}
+         */
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
         }
 
         public Builder defaultRequestParameters(ChatRequestParameters parameters) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -35,8 +35,8 @@ import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.http.client.sse.ServerSentEventContext;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.internal.ExceptionMapper;
-import dev.langchain4j.internal.MappingTrackingStreamingChatResponseHandler;
 import dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils;
+import dev.langchain4j.internal.MappingTrackingStreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
@@ -56,6 +56,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 class OpenAiResponsesClient {
 
@@ -170,6 +171,7 @@ class OpenAiResponsesClient {
     private final String baseUrl;
     private final String apiKey;
     private final String organizationId;
+    private final Supplier<Map<String, String>> customHeadersSupplier;
 
     OpenAiResponsesClient(Builder builder) {
         HttpClientBuilder httpClientBuilder =
@@ -183,6 +185,7 @@ class OpenAiResponsesClient {
         this.baseUrl = getOrDefault(builder.baseUrl, DEFAULT_BASE_URL);
         this.apiKey = builder.apiKey;
         this.organizationId = builder.organizationId;
+        this.customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, () -> Map::of);
     }
 
     static Builder builder() {
@@ -374,6 +377,8 @@ class OpenAiResponsesClient {
         if (organizationId != null) {
             requestBuilder.addHeader(OPENAI_ORGANIZATION_HEADER, organizationId);
         }
+
+        requestBuilder.addHeaders(customHeadersSupplier.get());
 
         return requestBuilder.body(requestBody).build();
     }
@@ -778,6 +783,7 @@ class OpenAiResponsesClient {
         private String organizationId;
         private boolean logRequests;
         private boolean logResponses;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -810,6 +816,11 @@ class OpenAiResponsesClient {
             if (logResponses != null) {
                 this.logResponses = logResponses;
             }
+            return this;
+        }
+
+        Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModel.java
@@ -22,6 +22,7 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 @Experimental
 public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
@@ -38,6 +39,7 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
                 .organizationId(builder.organizationId)
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
 
         ChatRequestParameters commonParameters;
@@ -170,6 +172,7 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
         private Boolean logResponses;
         private List<ChatModelListener> listeners;
         private ChatRequestParameters defaultRequestParameters;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -347,6 +350,30 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
 
         public Builder listeners(ChatModelListener... listeners) {
             return listeners(asList(listeners));
+        }
+
+        /**
+         * Sets custom HTTP headers to be added to each HTTP request.
+         *
+         * @param customHeaders a map of headers
+         * @return {@code this}
+         */
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers to be added to each HTTP request.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         *
+         * @param customHeadersSupplier a supplier that provides a map of headers
+         * @return {@code this}
+         */
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
         }
 
         public Builder defaultRequestParameters(ChatRequestParameters parameters) {

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesCustomHeadersTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesCustomHeadersTest.java
@@ -1,0 +1,220 @@
+package dev.langchain4j.model.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class OpenAiResponsesCustomHeadersTest {
+
+    private static final String RESPONSE_BODY = """
+            {
+              "id": "resp_1",
+              "model": "gpt-4o-mini",
+              "status": "completed",
+              "output": [
+                {
+                  "type": "message",
+                  "role": "assistant",
+                  "content": [
+                    {
+                      "type": "output_text",
+                      "text": "Hi"
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+    /**
+     * Captures the outgoing request, so that its headers can be inspected.
+     */
+    private static class CapturingHttpClient implements HttpClient {
+
+        private HttpRequest request;
+
+        @Override
+        public SuccessfulHttpResponse execute(HttpRequest request) {
+            this.request = request;
+            return SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .headers(Map.of("Content-Type", List.of("application/json")))
+                    .body(RESPONSE_BODY)
+                    .build();
+        }
+
+        @Override
+        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+            this.request = request;
+        }
+    }
+
+    private static class CapturingHttpClientBuilder implements HttpClientBuilder {
+
+        private final CapturingHttpClient httpClient = new CapturingHttpClient();
+
+        @Override
+        public Duration connectTimeout() {
+            return null;
+        }
+
+        @Override
+        public HttpClientBuilder connectTimeout(Duration connectTimeout) {
+            return this;
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return null;
+        }
+
+        @Override
+        public HttpClientBuilder readTimeout(Duration readTimeout) {
+            return this;
+        }
+
+        @Override
+        public HttpClient build() {
+            return httpClient;
+        }
+    }
+
+    @Test
+    void should_send_custom_headers_with_chat_model() {
+
+        CapturingHttpClientBuilder httpClientBuilder = new CapturingHttpClientBuilder();
+
+        OpenAiResponsesChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(httpClientBuilder)
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .customHeaders(Map.of("Proxy-Authorization", "Basic dXNlcjpwYXNz"))
+                .build();
+
+        model.chat("Hello");
+
+        assertThat(httpClientBuilder.httpClient.request.headers())
+                .containsEntry("Proxy-Authorization", List.of("Basic dXNlcjpwYXNz"))
+                .containsEntry("Authorization", List.of("Bearer test-key"));
+    }
+
+    @Test
+    void should_send_custom_headers_with_streaming_chat_model() {
+
+        CapturingHttpClientBuilder httpClientBuilder = new CapturingHttpClientBuilder();
+
+        OpenAiResponsesStreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .httpClientBuilder(httpClientBuilder)
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .customHeaders(Map.of("Proxy-Authorization", "Basic dXNlcjpwYXNz"))
+                .build();
+
+        model.chat("Hello", new StreamingChatResponseHandler() {
+
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {}
+
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        assertThat(httpClientBuilder.httpClient.request.headers())
+                .containsEntry("Proxy-Authorization", List.of("Basic dXNlcjpwYXNz"))
+                .containsEntry("Authorization", List.of("Bearer test-key"));
+    }
+
+    @Test
+    void should_call_custom_headers_supplier_before_each_request() {
+
+        CapturingHttpClientBuilder httpClientBuilder = new CapturingHttpClientBuilder();
+        AtomicInteger callCount = new AtomicInteger();
+
+        Supplier<Map<String, String>> customHeadersSupplier =
+                () -> Map.of("X-Custom-Token", "token-" + callCount.incrementAndGet());
+
+        OpenAiResponsesChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(httpClientBuilder)
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .customHeaders(customHeadersSupplier)
+                .build();
+
+        model.chat("first");
+        assertThat(httpClientBuilder.httpClient.request.headers()).containsEntry("X-Custom-Token", List.of("token-1"));
+
+        model.chat("second");
+        assertThat(httpClientBuilder.httpClient.request.headers()).containsEntry("X-Custom-Token", List.of("token-2"));
+
+        assertThat(callCount).hasValue(2);
+    }
+
+    @Test
+    void should_allow_custom_headers_to_override_default_headers() {
+
+        CapturingHttpClientBuilder httpClientBuilder = new CapturingHttpClientBuilder();
+
+        OpenAiResponsesChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(httpClientBuilder)
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .customHeaders(Map.of("Authorization", "Bearer overridden"))
+                .build();
+
+        model.chat("Hello");
+
+        assertThat(httpClientBuilder.httpClient.request.headers())
+                .containsEntry("Authorization", List.of("Bearer overridden"));
+    }
+
+    @Test
+    void should_work_without_custom_headers() {
+
+        CapturingHttpClientBuilder httpClientBuilder = new CapturingHttpClientBuilder();
+
+        OpenAiResponsesChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(httpClientBuilder)
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .build();
+
+        model.chat("Hello");
+
+        assertThat(httpClientBuilder.httpClient.request.headers())
+                .containsEntry("Authorization", List.of("Bearer test-key"));
+    }
+
+    @Test
+    void should_handle_null_returned_by_custom_headers_supplier() {
+
+        CapturingHttpClientBuilder httpClientBuilder = new CapturingHttpClientBuilder();
+
+        OpenAiResponsesChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(httpClientBuilder)
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .customHeaders(() -> null)
+                .build();
+
+        model.chat("Hello");
+
+        assertThat(httpClientBuilder.httpClient.request.headers())
+                .containsEntry("Authorization", List.of("Bearer test-key"));
+    }
+}


### PR DESCRIPTION
## Issue
  Closes #6100

  ## Change
  `OpenAiResponsesChatModel` and `OpenAiResponsesStreamingChatModel` had no way to set custom HTTP headers, so they could not be used behind an authenticated proxy or a gateway that requires extra headers.

  This PR adds the two overloads that `OpenAiChatModel` and `OpenAiStreamingChatModel` already have, bringing the Responses API models to parity:

  ```java
  ChatModel model = OpenAiResponsesChatModel.builder()
          .apiKey(System.getenv("OPENAI_API_KEY"))
          .modelName("gpt-4o-mini")
          .customHeaders(Map.of("Proxy-Authorization", "Basic dXNlcjpwYXNz"))
          .build();
  ```

  ```java
  ChatModel model = OpenAiResponsesChatModel.builder()
          .apiKey(System.getenv("OPENAI_API_KEY"))
          .modelName("gpt-4o-mini")
          .customHeaders(() -> Map.of("Authorization", "Bearer " + tokenProvider.currentToken()))
          .build();
  ```

  Details:
  - `customHeaders(Map<String, String>)` and `customHeaders(Supplier<Map<String, String>>)` were added to both builders. The `Supplier` is invoked before every request, so dynamic values such as expiring OAuth2
  tokens are supported.
  - The headers are plumbed through `OpenAiResponsesClient`, which builds its requests itself rather than going through `DefaultOpenAiClient`. The default is `Map::of`, following the same pattern as
  `DefaultOpenAiClient`.
  - Custom headers are applied after the built-in ones (`Authorization`, `OpenAI-Organization`, `Content-Type`, `Accept`), so they can deliberately override them. This matches the precedence in
  `DefaultOpenAiClient#buildRequestHeaders` and is what the authenticated-proxy use case needs.
  - A `null` or empty map returned by the supplier is a no-op.
  - No masking work was needed: `HttpRequestLogger` masks by header-name keyword, so credential-carrying custom headers are already masked when `logRequests` is enabled.

  Tests: `OpenAiResponsesCustomHeadersTest` captures the outgoing `HttpRequest` through a stub `HttpClient` and asserts the headers that are actually sent, covering the static map, the supplier being called
  before each request, overriding a default header, the streaming model, and the negative cases (no custom headers configured, supplier returning `null`).

  Documentation: a "Custom HTTP headers" section was added to `docs/docs/integrations/language-models/open-ai.md`, under the OpenAI Responses API section.

  ## General checklist
  - [X] There are no breaking changes (API, behaviour)
  - [X] I have added unit and/or integration tests for my change
  - [X] The tests cover both positive and negative cases
  - [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)