### PR TITLE
fix: handle UUID-as-string in range metadata filters

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThan.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThan.java
@@ -1,14 +1,14 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.compareAsBigDecimals;
 import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Objects;
+import java.util.UUID;
 
 public class IsGreaterThan implements Filter {
 
@@ -45,6 +45,10 @@ public class IsGreaterThan implements Filter {
             return compareAsBigDecimals(actualValue, comparisonValue) > 0;
         }
 
+        if (comparisonValue instanceof UUID && actualValue instanceof String) {
+            return ((String) actualValue).compareTo(comparisonValue.toString()) > 0;
+        }
+
         return ((Comparable) actualValue).compareTo(comparisonValue) > 0;
     }
 
@@ -52,8 +56,7 @@ public class IsGreaterThan implements Filter {
         if (o == this) return true;
         if (!(o instanceof IsGreaterThan other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThanOrEqualTo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThanOrEqualTo.java
@@ -1,14 +1,14 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.compareAsBigDecimals;
 import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Objects;
+import java.util.UUID;
 
 public class IsGreaterThanOrEqualTo implements Filter {
 
@@ -45,6 +45,10 @@ public class IsGreaterThanOrEqualTo implements Filter {
             return compareAsBigDecimals(actualValue, comparisonValue) >= 0;
         }
 
+        if (comparisonValue instanceof UUID && actualValue instanceof String) {
+            return ((String) actualValue).compareTo(comparisonValue.toString()) >= 0;
+        }
+
         return ((Comparable) actualValue).compareTo(comparisonValue) >= 0;
     }
 
@@ -52,8 +56,7 @@ public class IsGreaterThanOrEqualTo implements Filter {
         if (o == this) return true;
         if (!(o instanceof IsGreaterThanOrEqualTo other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThan.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThan.java
@@ -1,14 +1,14 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.compareAsBigDecimals;
 import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Objects;
+import java.util.UUID;
 
 public class IsLessThan implements Filter {
 
@@ -45,6 +45,10 @@ public class IsLessThan implements Filter {
             return compareAsBigDecimals(actualValue, comparisonValue) < 0;
         }
 
+        if (comparisonValue instanceof UUID && actualValue instanceof String) {
+            return ((String) actualValue).compareTo(comparisonValue.toString()) < 0;
+        }
+
         return ((Comparable) actualValue).compareTo(comparisonValue) < 0;
     }
 
@@ -52,8 +56,7 @@ public class IsLessThan implements Filter {
         if (o == this) return true;
         if (!(o instanceof IsLessThan other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThanOrEqualTo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThanOrEqualTo.java
@@ -1,14 +1,14 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.compareAsBigDecimals;
 import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Objects;
+import java.util.UUID;
 
 public class IsLessThanOrEqualTo implements Filter {
 
@@ -45,16 +45,18 @@ public class IsLessThanOrEqualTo implements Filter {
             return compareAsBigDecimals(actualValue, comparisonValue) <= 0;
         }
 
+        if (comparisonValue instanceof UUID && actualValue instanceof String) {
+            return ((String) actualValue).compareTo(comparisonValue.toString()) <= 0;
+        }
+
         return ((Comparable) actualValue).compareTo(comparisonValue) <= 0;
     }
-
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsLessThanOrEqualTo other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThanOrEqualToTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThanOrEqualToTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.document.Metadata;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -20,5 +22,13 @@ class IsGreaterThanOrEqualToTest extends AbstractComparisonTest<IsGreaterThanOrE
     void comparisonValue(Integer value, boolean expectedResult) {
         Metadata metadata = Metadata.from(Map.of("key", value));
         assertThat(subject.test(metadata)).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void shouldNotThrowWhenActualValueIsUUIDAsStringAndComparisonValueIsUUID() {
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        IsGreaterThanOrEqualTo filter = new IsGreaterThanOrEqualTo("key", uuid);
+        Metadata metadata = Metadata.from(Map.of("key", uuid.toString()));
+        assertThat(filter.test(metadata)).isTrue();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThanTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsGreaterThanTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.document.Metadata;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -20,5 +22,15 @@ class IsGreaterThanTest extends AbstractComparisonTest<IsGreaterThan> {
     void comparisonValue(Integer value, boolean expectedResult) {
         Metadata metadata = Metadata.from(Map.of("key", value));
         assertThat(subject.test(metadata)).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void shouldNotThrowWhenActualValueIsUUIDAsStringAndComparisonValueIsUUID() {
+        UUID uuid1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID uuid2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        // uuid2 > uuid1 lexicographically, so uuid2.toString() isGreaterThan uuid1
+        IsGreaterThan filter = new IsGreaterThan("key", uuid1);
+        Metadata metadata = Metadata.from(Map.of("key", uuid2.toString()));
+        assertThat(filter.test(metadata)).isTrue();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThanOrEqualToTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThanOrEqualToTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.document.Metadata;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -20,5 +22,13 @@ class IsLessThanOrEqualToTest extends AbstractComparisonTest<IsLessThanOrEqualTo
     void comparisonValue(Integer value, boolean expectedResult) {
         Metadata metadata = Metadata.from(Map.of("key", value));
         assertThat(subject.test(metadata)).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void shouldNotThrowWhenActualValueIsUUIDAsStringAndComparisonValueIsUUID() {
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        IsLessThanOrEqualTo filter = new IsLessThanOrEqualTo("key", uuid);
+        Metadata metadata = Metadata.from(Map.of("key", uuid.toString()));
+        assertThat(filter.test(metadata)).isTrue();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThanTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsLessThanTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.document.Metadata;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -20,5 +22,15 @@ class IsLessThanTest extends AbstractComparisonTest<IsLessThan> {
     void comparisonValue(Integer value, boolean expectedResult) {
         Metadata metadata = Metadata.from(Map.of("key", value));
         assertThat(subject.test(metadata)).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void shouldNotThrowWhenActualValueIsUUIDAsStringAndComparisonValueIsUUID() {
+        UUID uuid1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID uuid2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        // uuid1 < uuid2 lexicographically
+        IsLessThan filter = new IsLessThan("key", uuid2);
+        Metadata metadata = Metadata.from(Map.of("key", uuid1.toString()));
+        assertThat(filter.test(metadata)).isTrue();
     }
 }


### PR DESCRIPTION
## Issue

Closes #6081

## Change

`IsGreaterThan`, `IsGreaterThanOrEqualTo`, `IsLessThan`, and `IsLessThanOrEqualTo` threw `ClassCastException` when the stored metadata value was the string representation of a UUID and the comparison value was a `UUID`:

```
java.lang.ClassCastException: class java.util.UUID cannot be cast to class java.lang.String
```

`TypeChecker.ensureTypesAreCompatible` already permits this `(String, UUID)` combination — matching the behaviour of `IsEqualTo`/`IsNotEqualTo`. However the range filters fell through to `((Comparable) actualValue).compareTo(comparisonValue)`, which fails because `String` cannot be compared to `UUID`.

Fix: apply the same pattern `IsEqualTo` already uses. When `comparisonValue` is a `UUID` and `actualValue` is a `String`, delegate to `String.compareTo(comparisonValue.toString())` instead.

## Tests

Each of the four range filter test classes gains one new case:

- `IsGreaterThanTest`: uuid2 string `>` uuid1 → `true`
- `IsGreaterThanOrEqualToTest`: same uuid string `>=` uuid → `true`
- `IsLessThanTest`: uuid1 string `<` uuid2 → `true`
- `IsLessThanOrEqualToTest`: same uuid string `<=` uuid → `true`

All four tests fail before this change with `ClassCastException` and pass after.

## General checklist

- [x] There are no breaking changes
- [x] I have added unit tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all unit tests in the module (`langchain4j-core`): 1251 tests, 0 failures