### PR TITLE
fix:Throw `ContentFilteredException` when Chat Completions returns a refusal

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.openaiofficial;
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.chat.request.ResponseFormat.JSON;
 import static dev.langchain4j.model.chat.request.ResponseFormatType.TEXT;
@@ -45,6 +46,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -268,6 +270,12 @@ class InternalOpenAiOfficialHelper {
 
     static AiMessage aiMessageFrom(ChatCompletion chatCompletion) {
         ChatCompletionMessage assistantMessage = chatCompletion.choices().get(0).message();
+
+        String refusal = assistantMessage.refusal().orElse(null);
+        if (isNotNullOrBlank(refusal)) {
+            throw new ContentFilteredException(refusal);
+        }
+
         Optional<String> text = assistantMessage.content();
 
         Optional<List<ChatCompletionMessageToolCall>> toolCalls = assistantMessage.toolCalls();

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModel.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onUnmappedRawEvent;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.finishReasonFrom;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.toOpenAiChatCompletionCreateParams;
@@ -20,6 +21,7 @@ import com.openai.models.chat.completions.ChatCompletionChunk;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionStreamOptions;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.MappingTrackingStreamingChatResponseHandler;
 import dev.langchain4j.internal.ToolCallBuilder;
@@ -110,6 +112,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                     OpenAiOfficialChatResponseMetadata.builder();
 
             StringBuffer textBuilder = new StringBuffer();
+            StringBuffer refusalBuilder = new StringBuffer();
             ToolCallBuilder toolCallBuilder = new ToolCallBuilder();
             AtomicReference<StreamingHandle> streamingHandle = new AtomicReference<>();
 
@@ -131,6 +134,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                                     streamingHandle.get(),
                                     responseMetadataBuilder,
                                     textBuilder,
+                                    refusalBuilder,
                                     toolCallBuilder);
 
                             if (!trackingHandler.wasMapped()) {
@@ -147,6 +151,13 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                             if (error.isPresent()) {
                                 withLoggingExceptions(() -> trackingHandler.onError(error.get()));
                             } else {
+                                String refusal = refusalBuilder.toString();
+                                if (isNotNullOrBlank(refusal)) {
+                                    withLoggingExceptions(
+                                            () -> trackingHandler.onError(new ContentFilteredException(refusal)));
+                                    return;
+                                }
+
                                 if (toolCallBuilder.hasRequests()) {
                                     onCompleteToolCall(trackingHandler, toolCallBuilder.buildAndReset());
                                 }
@@ -180,6 +191,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
             StreamingHandle streamingHandle,
             OpenAiOfficialChatResponseMetadata.Builder responseMetadataBuilder,
             StringBuffer text,
+            StringBuffer refusal,
             ToolCallBuilder toolCallBuilder) {
 
         responseMetadataBuilder.id(chatCompletionChunk.id());
@@ -203,6 +215,9 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                 String partialResponse = choice.delta().content().get();
                 text.append(partialResponse);
                 onPartialResponse(handler, partialResponse, streamingHandle);
+            }
+            if (choice.delta().refusal().isPresent()) {
+                refusal.append(choice.delta().refusal().get());
             }
             if (choice.delta().toolCalls().isPresent()) {
                 for (ChatCompletionChunk.Choice.Delta.ToolCall toolCall :

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
@@ -3,12 +3,16 @@ package dev.langchain4j.model.openaiofficial;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.openai.core.ObjectMappers;
+import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionContentPartImage;
 import com.openai.models.chat.completions.ChatCompletionContentPartInputAudio;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import org.junit.jupiter.api.Test;
 
@@ -90,5 +94,49 @@ class InternalOpenAiOfficialHelperTest {
                 .isInstanceOf(UnsupportedFeatureException.class)
                 .hasMessageContaining("ULTRA_HIGH")
                 .hasMessageContaining("LOW, HIGH, AUTO");
+    }
+
+    @Test
+    void should_throw_content_filtered_exception_when_chat_completion_contains_refusal() throws Exception {
+        ChatCompletion chatCompletion = chatCompletionFrom("""
+                {"role":"assistant","content":null,"refusal":"I cannot help with that request."}""");
+
+        assertThatThrownBy(() -> InternalOpenAiOfficialHelper.aiMessageFrom(chatCompletion))
+                .isInstanceOf(ContentFilteredException.class)
+                .hasMessage("I cannot help with that request.");
+    }
+
+    @Test
+    void should_not_throw_when_chat_completion_has_no_refusal() throws Exception {
+        ChatCompletion chatCompletion = chatCompletionFrom("""
+                {"role":"assistant","content":"Paris"}""");
+
+        AiMessage aiMessage = InternalOpenAiOfficialHelper.aiMessageFrom(chatCompletion);
+
+        assertThat(aiMessage.text()).isEqualTo("Paris");
+    }
+
+    @Test
+    void should_not_throw_when_chat_completion_refusal_is_blank() throws Exception {
+        ChatCompletion chatCompletion = chatCompletionFrom("""
+                {"role":"assistant","content":"Paris","refusal":"  "}""");
+
+        AiMessage aiMessage = InternalOpenAiOfficialHelper.aiMessageFrom(chatCompletion);
+
+        assertThat(aiMessage.text()).isEqualTo("Paris");
+    }
+
+    private static ChatCompletion chatCompletionFrom(String assistantMessageJson) throws Exception {
+        String json = """
+                {
+                  "id": "chatcmpl-test",
+                  "object": "chat.completion",
+                  "created": 1730000000,
+                  "model": "gpt-4o-mini",
+                  "choices": [
+                    {"index": 0, "finish_reason": "stop", "logprobs": null, "message": %s}
+                  ]
+                }""".formatted(assistantMessageJson);
+        return ObjectMappers.jsonMapper().readValue(json, ChatCompletion.class);
     }
 }

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModelTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModelTest.java
@@ -1,0 +1,152 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openai.client.OpenAIClientAsync;
+import com.openai.client.OpenAIClientAsyncImpl;
+import com.openai.core.ClientOptions;
+import com.openai.core.RequestOptions;
+import com.openai.core.http.Headers;
+import com.openai.core.http.HttpClient;
+import com.openai.core.http.HttpRequest;
+import com.openai.core.http.HttpResponse;
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class OpenAiOfficialStreamingChatModelTest {
+
+    @Test
+    void should_raise_content_filtered_exception_when_stream_contains_refusal() throws Exception {
+        String stream = sse(
+                chunk("{\"role\":\"assistant\",\"refusal\":\"I cannot\"}", null),
+                chunk("{\"refusal\":\" help with that.\"}", null),
+                chunk("{}", "\"stop\""));
+
+        RecordingHandler handler = streamWith(stream);
+
+        assertThat(handler.error.get()).isInstanceOf(ContentFilteredException.class);
+        assertThat(handler.error.get()).hasMessage("I cannot help with that.");
+        assertThat(handler.response.get()).isNull();
+    }
+
+    @Test
+    void should_complete_normally_when_stream_contains_no_refusal() throws Exception {
+        String stream = sse(chunk("{\"role\":\"assistant\",\"content\":\"Paris\"}", null), chunk("{}", "\"stop\""));
+
+        RecordingHandler handler = streamWith(stream);
+
+        assertThat(handler.error.get()).isNull();
+        assertThat(handler.response.get().aiMessage().text()).isEqualTo("Paris");
+    }
+
+    private static RecordingHandler streamWith(String sseBody) throws Exception {
+        OpenAIClientAsync client = new OpenAIClientAsyncImpl(ClientOptions.builder()
+                .apiKey("test-key")
+                .httpClient(new CannedHttpClient(sseBody))
+                .build());
+
+        OpenAiOfficialStreamingChatModel model = OpenAiOfficialStreamingChatModel.builder()
+                .openAIClientAsync(client)
+                .modelName("gpt-4o-mini")
+                .build();
+
+        RecordingHandler handler = new RecordingHandler();
+        model.chat("Hello", handler);
+        assertThat(handler.done.await(30, TimeUnit.SECONDS)).isTrue();
+        return handler;
+    }
+
+    private static String chunk(String delta, String finishReason) {
+        return "{\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1730000000,"
+                + "\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":" + delta
+                + ",\"finish_reason\":" + (finishReason == null ? "null" : finishReason) + "}]}";
+    }
+
+    private static String sse(String... chunks) {
+        StringBuilder builder = new StringBuilder();
+        for (String chunk : chunks) {
+            builder.append("data: ").append(chunk).append("\n\n");
+        }
+        return builder.append("data: [DONE]\n\n").toString();
+    }
+
+    private static class RecordingHandler implements StreamingChatResponseHandler {
+
+        private final CountDownLatch done = new CountDownLatch(1);
+        private final AtomicReference<ChatResponse> response = new AtomicReference<>();
+        private final AtomicReference<Throwable> error = new AtomicReference<>();
+
+        @Override
+        public void onPartialResponse(String partialResponse) {}
+
+        @Override
+        public void onCompleteResponse(ChatResponse completeResponse) {
+            response.set(completeResponse);
+            done.countDown();
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            error.set(throwable);
+            done.countDown();
+        }
+    }
+
+    private static class CannedHttpClient implements HttpClient {
+
+        private final String sseBody;
+
+        CannedHttpClient(String sseBody) {
+            this.sseBody = sseBody;
+        }
+
+        @Override
+        public HttpResponse execute(HttpRequest request, RequestOptions requestOptions) {
+            return new CannedHttpResponse(sseBody);
+        }
+
+        @Override
+        public CompletableFuture<HttpResponse> executeAsync(HttpRequest request, RequestOptions requestOptions) {
+            return CompletableFuture.completedFuture(execute(request, requestOptions));
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class CannedHttpResponse implements HttpResponse {
+
+        private final String sseBody;
+
+        CannedHttpResponse(String sseBody) {
+            this.sseBody = sseBody;
+        }
+
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public Headers headers() {
+            return Headers.builder().put("Content-Type", "text/event-stream").build();
+        }
+
+        @Override
+        public InputStream body() {
+            return new ByteArrayInputStream(sseBody.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION

## Issue

Closes #6113 

## Change

`InternalOpenAiOfficialHelper.aiMessageFrom` read only `content()` and `toolCalls()`, so a refusal became an
`AiMessage` with empty text and a successful `ChatResponse`. `OpenAiOfficialStreamingChatModel` ignored
`delta().refusal()`, so the refusal deltas were dropped and the stream completed empty. Either way the caller
could not tell a refusal from an empty answer.

Both paths now raise `ContentFilteredException`:

```java
String refusal = assistantMessage.refusal().orElse(null);
if (isNotNullOrBlank(refusal)) {
    throw new ContentFilteredException(refusal);
}
```

| Path | Before | After |
|---|---|---|
| `OpenAiOfficialChatModel` | empty `AiMessage` | throws `ContentFilteredException` |
| `OpenAiOfficialStreamingChatModel` | empty `AiMessage` | `handler.onError(ContentFilteredException)` |

That is the handling already in the repo: `OpenAiUtils.aiMessageFrom` throws at `OpenAiUtils.java:383-385`,
and `WatsonxChatBase` throws on the synchronous path (line 88) and calls `handler.onError` on the streaming
path (lines 107-108). `ContentFilteredException` is the existing core type for this, added in #3294 together
with the langchain4j-open-ai and Azure OpenAI handling; this module was not covered then.

Streaming accumulates the refusal deltas and raises once the stream completes rather than per chunk, because
OpenAI splits a refusal across deltas the same way it splits content. A blank refusal is treated as no
refusal. There is no answer to compute in this case, the model declined, so the only question is how the
refusal reaches the caller; today it does not reach them at all. If you would rather this module returned the
refusal on the response instead of throwing, that is a small change and I am happy to switch.

Only the Chat Completions models. The Responses models drop `ResponseOutputRefusal` in the same way, but a
Responses refusal arrives as a content block and as typed stream events rather than as a field on the
message, so it needs a different shape and I will send it separately. #5813 and #5814 cover the same field in
`OpenAiStreamingChatModel` (langchain4j-open-ai), a different module that shares none of these classes.

### Tests

- `InternalOpenAiOfficialHelperTest`: a refusal throws `ContentFilteredException` carrying the refusal text,
  a normal response is unaffected, and a blank refusal is ignored. Driven from deserialized Chat Completions
  JSON so the SDK's own parsing of `refusal` is exercised
- `OpenAiOfficialStreamingChatModelTest` (new): a refusal split across two deltas is reassembled and passed
  to `onError`, and `onCompleteResponse` is never called; a stream with no refusal still completes normally.
  Driven through a stubbed `HttpClient` serving a canned SSE stream, so no key or network is needed

Two fail on unmodified `main`, one per path. The no-refusal cases pass either way, they pin behaviour that
must not change.

```
mvn -pl langchain4j-open-ai-official test
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-open-ai-official verify -DskipITs
revapi: API checks completed without failures

langchain4j-core: Tests run: 1247, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1342, Failures: 0, Errors: 0, Skipped: 0
```

OpenAI integration tests need an API key and were not run.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
