### PR TITLE
docs: fix typos in integration docs

### DIFF
--- a/docs/docs/integrations/embedding-stores/alloydb.md
+++ b/docs/docs/integrations/embedding-stores/alloydb.md
@@ -1,6 +1,6 @@
 # Google AlloyDB for PostgreSQL
 
-[AlloyDB](https://cloud.google.com/alloydb) is a fully managed relational database service that offers high performance, seamless integration, and impressive scalability. AlloyDB is 100% compatible with PostgreSQL. Extend your database application to build AI-powered experiences leveraging AlloyDB's Langchain integrations.
+[AlloyDB](https://cloud.google.com/alloydb) is a fully managed relational database service that offers high performance, seamless integration, and impressive scalability. AlloyDB is 100% compatible with PostgreSQL. Extend your database application to build AI-powered experiences leveraging AlloyDB's LangChain4j integrations.
 
 This module implements `EmbeddingStore` backed by an AlloyDB for PostgreSQL database.
 

--- a/docs/docs/integrations/embedding-stores/cloud-sql.md
+++ b/docs/docs/integrations/embedding-stores/cloud-sql.md
@@ -1,8 +1,8 @@
 # Google Cloud SQL for PostgreSQL
 
-[Cloud SQL](https://cloud.google.com/sql/docs/postgres) is a fully managed relational database service that offers high performance, seamless integration, and impressive scalability. Cloud SQL is 100% compatible with PostgreSQL. Extend your database application to build AI-powered experiences leveraging Cloud SQL's Langchain integrations.
+[Cloud SQL](https://cloud.google.com/sql/docs/postgres) is a fully managed relational database service that offers high performance, seamless integration, and impressive scalability. Cloud SQL is 100% compatible with PostgreSQL. Extend your database application to build AI-powered experiences leveraging Cloud SQL's LangChain4j integrations.
 
-This module implements `EmbeddingStore` backed by an Cloud SQL for PostgreSQL database.
+This module implements `EmbeddingStore` backed by a Cloud SQL for PostgreSQL database.
 
 ## Before You Begin
 

--- a/docs/docs/integrations/frameworks/cdi.md
+++ b/docs/docs/integrations/frameworks/cdi.md
@@ -32,4 +32,4 @@ Full documentation is available at **[langchain4j.github.io/langchain4j-cdi](htt
 | GlassFish | Portable |
 | Liberty | Portable |
 
-For detailed explanation and usage of LangChain4j CDI features, see the [LangChain4J CDI docuemntation](https://langchain4j.github.io/langchain4j-cdi/).
+For detailed explanation and usage of LangChain4j CDI features, see the [LangChain4J CDI documentation](https://langchain4j.github.io/langchain4j-cdi/).

--- a/docs/docs/integrations/language-models/gpullama3-java.md
+++ b/docs/docs/integrations/language-models/gpullama3-java.md
@@ -40,7 +40,7 @@ implementation 'dev.langchain4j:langchain4j-gpu-llama3:1.19.0-beta29'
 ## Model Compatibility
 
 Currently, GPULlama3.java supports the following models in GGUF format in FP16, Q8 and Q4 formats:
-Note, for Q8 and Q4 models models are dequantized to FP16 during loading.
+Note, for Q8 and Q4 models are dequantized to FP16 during loading.
 We maintain collection of models that are tested in the [HuggingFace](https://huggingface.co/beehive-lab/collections) repository.
 
 * Llama3


### PR DESCRIPTION
## What
Fix small typos and grammar in documentation:

- `alloydb.md`, `cloud-sql.md`: `Langchain` -> `LangChain4j`
- `cloud-sql.md`: `an Cloud SQL` -> `a Cloud SQL`
- `cdi.md`: `docuemntation` -> `documentation`
- `gpullama3-java.md`: duplicated word `models models` -> `models`

## Why
Reader-facing docs for LangChain4j integrations; typos and duplicated words hurt clarity.

## How verified
- Reviewed the full diff; all changes are text-only within prose lines.
- No links, code blocks, or filenames touched.