### PR TITLE
Fix typo in Javadoc of LangChain4jManaged

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/invocation/LangChain4jManaged.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/invocation/LangChain4jManaged.java
@@ -7,7 +7,7 @@ import dev.langchain4j.Internal;
  * A marker interface for components that are managed by LangChain4j framework.
  * <p>
  * Implementing this interface indicates that the component is internally managed by LangChain4j,
- * and doesn't require to be instatiated or passed around by the user or LLM.
+ * and doesn't require to be instantiated or passed around by the user or LLM.
  *
  * @since 1.8.0
  */


### PR DESCRIPTION
## What changed

Fixed a typo in the Javadoc of `LangChain4jManaged`:
`instatiated` → `instantiated`.

## Why

The Javadoc comment on line 10 contains a misspelling of "instantiated".
This is part of the public API documentation, so fixing it improves the
enerated Javadoc.

## How verified

Diff inspection of the single affected line. No code logic or API changed —
only a Javadoc comment.