### PR TITLE
fix: Throw `ContentFilteredException` when the Responses API returns a ref…

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesChatModel.java
@@ -1,5 +1,23 @@
 package dev.langchain4j.model.openaiofficial;
 
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildAiMessage;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildRequestParams;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildResponseMetadata;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractEncryptedReasoning;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractReasoningSummary;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractRefusal;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractText;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractTokenUsage;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractToolExecutionRequests;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.mapStatusToFinishReason;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.validate;
+import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
+import static java.util.Arrays.asList;
+
 import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.client.OpenAIClient;
 import com.openai.credential.Credential;
@@ -12,6 +30,7 @@ import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.internal.ExceptionMapper;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
@@ -23,29 +42,11 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.FinishReason;
-
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildAiMessage;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildRequestParams;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildResponseMetadata;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractEncryptedReasoning;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractReasoningSummary;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractText;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractTokenUsage;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractToolExecutionRequests;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.mapStatusToFinishReason;
-import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.validate;
-import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
-import static java.util.Arrays.asList;
 
 /**
  * ChatModel implementation using the official OpenAI Java client for the Responses API.
@@ -61,19 +62,19 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
         this.client = builder.client != null
                 ? builder.client
                 : setupSyncClient(
-                builder.baseUrl,
-                builder.apiKey,
-                builder.credential,
-                builder.microsoftFoundryDeploymentName,
-                builder.azureOpenAIServiceVersion,
-                builder.organizationId,
-                builder.isMicrosoftFoundry,
-                builder.isGitHubModels,
-                builder.modelName,
-                builder.timeout,
-                builder.maxRetries,
-                builder.proxy,
-                builder.customHeaders);
+                        builder.baseUrl,
+                        builder.apiKey,
+                        builder.credential,
+                        builder.microsoftFoundryDeploymentName,
+                        builder.azureOpenAIServiceVersion,
+                        builder.organizationId,
+                        builder.isMicrosoftFoundry,
+                        builder.isGitHubModels,
+                        builder.modelName,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.proxy,
+                        builder.customHeaders);
 
         ChatRequestParameters commonParameters;
         if (builder.defaultRequestParameters != null) {
@@ -89,7 +90,6 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
                         : OpenAiOfficialResponsesChatRequestParameters.EMPTY;
 
         this.defaultRequestParameters = OpenAiOfficialResponsesChatRequestParameters.builder()
-
                 .modelName(ensureNotNull(getOrDefault(builder.modelName, commonParameters.modelName()), "modelName"))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -97,7 +97,6 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
-
                 .previousResponseId(getOrDefault(builder.previousResponseId, responsesParameters.previousResponseId()))
                 .maxToolCalls(getOrDefault(builder.maxToolCalls, responsesParameters.maxToolCalls()))
                 .parallelToolCalls(getOrDefault(builder.parallelToolCalls, responsesParameters.parallelToolCalls()))
@@ -107,7 +106,8 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
                 .serviceTier(getOrDefault(builder.serviceTier, responsesParameters.serviceTier()))
                 .safetyIdentifier(getOrDefault(builder.safetyIdentifier, responsesParameters.safetyIdentifier()))
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
-                .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
+                .promptCacheRetention(
+                        getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
                 .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
@@ -134,6 +134,11 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
             ResponseCreateParams params = buildRequestParams(chatRequest, parameters);
             Response response = client.responses().create(params);
 
+            String refusal = extractRefusal(response);
+            if (isNotNullOrBlank(refusal)) {
+                throw new ContentFilteredException(refusal);
+            }
+
             String text = extractText(response);
             String thinking = extractReasoningSummary(response);
             String encryptedReasoning = extractEncryptedReasoning(response);
@@ -146,11 +151,7 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
                     .orElse(null);
 
             OpenAiOfficialResponsesChatResponseMetadata metadata = buildResponseMetadata(
-                    response.id(),
-                    parameters.modelName(),
-                    response,
-                    finishReason,
-                    extractTokenUsage(response));
+                    response.id(), parameters.modelName(), response, finishReason, extractTokenUsage(response));
 
             return ChatResponse.builder()
                     .aiMessage(aiMessage)

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -8,6 +8,7 @@ import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
 import static java.util.Arrays.asList;
@@ -70,6 +71,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.internal.ExceptionMapper;
@@ -316,6 +318,20 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             }
         }
         return textBuilder.isEmpty() ? null : textBuilder.toString();
+    }
+
+    static String extractRefusal(com.openai.models.responses.Response response) {
+        StringBuilder refusalBuilder = new StringBuilder();
+        for (ResponseOutputItem item : response.output()) {
+            if (item.isMessage()) {
+                item.asMessage().content().forEach(content -> {
+                    if (content.isRefusal()) {
+                        refusalBuilder.append(content.asRefusal().refusal());
+                    }
+                });
+            }
+        }
+        return refusalBuilder.isEmpty() ? null : refusalBuilder.toString();
     }
 
     static AiMessage buildAiMessage(
@@ -1262,6 +1278,12 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         }
 
         private void extractTokenUsageAndComplete(com.openai.models.responses.Response response) {
+            var refusal = extractRefusal(response);
+            if (isNotNullOrBlank(refusal)) {
+                withLoggingExceptions(() -> handler.onError(new ContentFilteredException(refusal)));
+                return;
+            }
+
             var text = !textBuilder.isEmpty() ? textBuilder.toString() : null;
             var aiMessage = buildAiMessage(
                     text, extractReasoningSummary(response), completedToolCalls, extractEncryptedReasoning(response));

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModelTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModelTest.java
@@ -1,10 +1,19 @@
 package dev.langchain4j.model.openaiofficial;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.openai.client.OpenAIClientImpl;
+import com.openai.core.ClientOptions;
 import com.openai.core.JsonValue;
 import com.openai.core.ObjectMappers;
+import com.openai.core.RequestOptions;
+import com.openai.core.http.Headers;
+import com.openai.core.http.HttpClient;
+import com.openai.core.http.HttpRequest;
+import com.openai.core.http.HttpResponse;
 import com.openai.models.responses.Response;
+import com.openai.models.responses.ResponseCompletedEvent;
 import com.openai.models.responses.ResponseStreamEvent;
 import com.openai.models.responses.ResponseWebSearchCallInProgressEvent;
 import com.openai.models.responses.Tool;
@@ -12,13 +21,19 @@ import com.openai.models.responses.ToolSearchTool;
 import com.openai.models.responses.WebSearchTool;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
@@ -158,6 +173,168 @@ class OpenAiOfficialResponsesStreamingChatModelTest {
                 .type(JsonValue.from("tool_search"))
                 .description("Search tools")
                 .build());
+    }
+
+    private static final String REFUSAL_RESPONSE_JSON = """
+            {
+              "id": "resp_refusal",
+              "created_at": 1745310000,
+              "model": "gpt-5.4",
+              "object": "response",
+              "parallel_tool_calls": true,
+              "tool_choice": "auto",
+              "output": [
+                {
+                  "id": "msg_1",
+                  "type": "message",
+                  "role": "assistant",
+                  "status": "completed",
+                  "content": [{"type": "refusal", "refusal": "I cannot help with that request."}]
+                }
+              ]
+            }
+            """;
+
+    @Test
+    void should_extract_refusal_from_response() {
+        assertThat(OpenAiOfficialResponsesStreamingChatModel.extractRefusal(response(REFUSAL_RESPONSE_JSON)))
+                .isEqualTo("I cannot help with that request.");
+    }
+
+    @Test
+    void should_return_null_refusal_when_response_contains_only_output_text() {
+        Response response = response("""
+                {
+                  "id": "resp_ok",
+                  "created_at": 1745310000,
+                  "model": "gpt-5.4",
+                  "object": "response",
+                  "parallel_tool_calls": true,
+                  "tool_choice": "auto",
+                  "output": [
+                    {
+                      "id": "msg_1",
+                      "type": "message",
+                      "role": "assistant",
+                      "status": "completed",
+                      "content": [{"type": "output_text", "text": "Paris", "annotations": []}]
+                    }
+                  ]
+                }
+                """);
+
+        assertThat(OpenAiOfficialResponsesStreamingChatModel.extractRefusal(response))
+                .isNull();
+    }
+
+    @Test
+    void should_raise_content_filtered_exception_when_stream_completes_with_refusal() {
+        CapturingStreamingHandler handler = new CapturingStreamingHandler();
+        var eventHandler = new OpenAiOfficialResponsesStreamingChatModel.ResponsesEventHandler(
+                handler, new AtomicReference<>(), "gpt-5.4-mini", new ActiveStreamingHandle());
+
+        eventHandler.handleEvent(ResponseStreamEvent.ofCompleted(ResponseCompletedEvent.builder()
+                .response(response(REFUSAL_RESPONSE_JSON))
+                .sequenceNumber(1)
+                .build()));
+
+        assertThat(handler.error).isInstanceOf(ContentFilteredException.class);
+        assertThat(handler.error).hasMessage("I cannot help with that request.");
+        assertThat(handler.completed).isNull();
+    }
+
+    @Test
+    void should_throw_content_filtered_exception_when_response_contains_refusal() {
+        OpenAiOfficialResponsesChatModel model = OpenAiOfficialResponsesChatModel.builder()
+                .client(new OpenAIClientImpl(ClientOptions.builder()
+                        .apiKey("test-key")
+                        .httpClient(new CannedJsonHttpClient(REFUSAL_RESPONSE_JSON))
+                        .build()))
+                .modelName("gpt-5.4-mini")
+                .build();
+
+        assertThatThrownBy(() -> model.chat("Hello"))
+                .isInstanceOf(ContentFilteredException.class)
+                .hasMessage("I cannot help with that request.");
+    }
+
+    private static class CannedJsonHttpClient implements HttpClient {
+
+        private final String body;
+
+        CannedJsonHttpClient(String body) {
+            this.body = body;
+        }
+
+        @Override
+        public HttpResponse execute(HttpRequest request, RequestOptions requestOptions) {
+            return new CannedJsonHttpResponse(body);
+        }
+
+        @Override
+        public CompletableFuture<HttpResponse> executeAsync(HttpRequest request, RequestOptions requestOptions) {
+            return CompletableFuture.completedFuture(execute(request, requestOptions));
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class CannedJsonHttpResponse implements HttpResponse {
+
+        private final String body;
+
+        CannedJsonHttpResponse(String body) {
+            this.body = body;
+        }
+
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public Headers headers() {
+            return Headers.builder().put("Content-Type", "application/json").build();
+        }
+
+        @Override
+        public InputStream body() {
+            return new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class ActiveStreamingHandle implements StreamingHandle {
+
+        @Override
+        public void cancel() {}
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+    }
+
+    private static class CapturingStreamingHandler implements StreamingChatResponseHandler {
+
+        private Throwable error;
+        private ChatResponse completed;
+
+        @Override
+        public void onPartialResponse(String partialResponse) {}
+
+        @Override
+        public void onCompleteResponse(ChatResponse completeResponse) {
+            completed = completeResponse;
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            error = throwable;
+        }
     }
 
     private static Response response(String json) {


### PR DESCRIPTION

## Issue

Closes #6120

## Change

`extractText` collects only `output_text` parts, so a `ResponseOutputRefusal` part matched no branch and was
dropped: `extractText` returned null and the caller got an `AiMessage` with null text and a successful
response. Both Responses models share that extraction, so both were affected.

Add `extractRefusal`, walking the same output items as `extractText` and keeping the other branch:

```java
if (content.isRefusal()) {
    refusalBuilder.append(content.asRefusal().refusal());
}
```

| Path | Before | After |
|---|---|---|
| `OpenAiOfficialResponsesChatModel` | `AiMessage` with null text | throws `ContentFilteredException` |
| `OpenAiOfficialResponsesStreamingChatModel` | `AiMessage` with null text | `handler.onError(ContentFilteredException)` |

This is what #6114 did for the Chat Completions models in this module, and what `OpenAiUtils.aiMessageFrom`
(`OpenAiUtils.java:383-385`) and `WatsonxChatBase` (lines 88 and 107-108) already did.

The streaming side needs no delta accumulation, even though `ResponseStreamEvent` exposes refusal delta
events. Its completion handler already receives the full `Response` and reads streamed content off it:
`extractReasoningSummary(response)` walks `response.output()` for reasoning that also arrives as deltas. The
refusal check sits alongside it and covers both completion paths, `handleCompleted` and `handleIncomplete`.

A blank refusal is treated as no refusal. `ResponseOutputMessage` content has exactly two forms, output text
and refusal, so both are handled now and all four chat models in this module report a refusal the same way.

Most of the diff in `OpenAiOfficialResponsesChatModel` is the formatter reflowing the file, which happens on
any edit to it; the change there is the five lines above the existing `extractText` call.

### Tests

- `OpenAiOfficialResponsesStreamingChatModelTest` (existing class, 4 new tests): `extractRefusal` returns the
  refusal text from a refusal part and null for an ordinary `output_text` response; the synchronous model
  throws `ContentFilteredException`, driven end to end through a stubbed `HttpClient` serving a canned
  Responses payload; the streaming model passes it to `onError` on a completed event and never calls
  `onCompleteResponse`

Two fail on unmodified `main`, one per path, verified by reverting each production file separately. The
null-refusal case passes either way, it pins behaviour that must not change.

```
mvn -pl langchain4j-open-ai-official test
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-open-ai-official verify -DskipITs
revapi: API checks completed without failures

langchain4j-core: Tests run: 1266, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1358, Failures: 0, Errors: 0, Skipped: 0
```

OpenAI integration tests need an API key and were not run.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)