### PR TITLE
fix: Map an `AiMessage` without text and without tool calls instead of failing

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -96,7 +96,7 @@ class InternalOpenAiOfficialHelper {
 
             if (!aiMessage.hasToolExecutionRequests()) {
                 return ChatCompletionMessageParam.ofAssistant(ChatCompletionAssistantMessageParam.builder()
-                        .content(aiMessage.text())
+                        .content(aiMessage.text() != null ? aiMessage.text() : "")
                         .build());
             }
 

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
@@ -97,6 +97,24 @@ class InternalOpenAiOfficialHelperTest {
     }
 
     @Test
+    void should_map_ai_message_without_text_and_without_tool_execution_requests() {
+        AiMessage message = AiMessage.builder().thinking("reasoning only").build();
+
+        ChatCompletionMessageParam param = InternalOpenAiOfficialHelper.toOpenAiMessage(message);
+
+        assertThat(param.asAssistant().content().orElseThrow().asText()).isEmpty();
+    }
+
+    @Test
+    void should_keep_text_of_ai_message_without_tool_execution_requests() {
+        AiMessage message = AiMessage.from("Paris");
+
+        ChatCompletionMessageParam param = InternalOpenAiOfficialHelper.toOpenAiMessage(message);
+
+        assertThat(param.asAssistant().content().orElseThrow().asText()).isEqualTo("Paris");
+    }
+
+    @Test
     void should_throw_content_filtered_exception_when_chat_completion_contains_refusal() throws Exception {
         ChatCompletion chatCompletion = chatCompletionFrom("""
                 {"role":"assistant","content":null,"refusal":"I cannot help with that request."}""");


### PR DESCRIPTION

## Issue

Closes #6122

## Change

`toOpenAiMessage` has two branches for an `AiMessage`, and only the second one tolerates null text:

```java
if (!aiMessage.hasToolExecutionRequests()) {
    .content(aiMessage.text())                                 // threw on null
}
...
    .content(aiMessage.text() != null ? aiMessage.text() : "") // already guarded
```

`ChatCompletionAssistantMessageParam.Builder.content(String)` is non-null in the SDK, so a message with no
text and no tool calls threw `NullPointerException` before the request was sent. The fix applies the guard the
other branch already uses, so both behave alike.

The message is one this module produces: `OpenAiOfficialStreamingChatModel` builds its result with
`.text(text.isEmpty() ? null : text)`, so a stream returning neither text nor tool calls yields an
`AiMessage` with null text and no tool execution requests. Once that is in the chat memory, the next call in
the conversation fails while mapping it.

The empty string is what the other branch already substitutes for the same value, so both branches now send
the same thing for the same input. The SDK does allow the field to be omitted instead, and some other
integrations skip the text when it is null, but they build a list of content parts where omitting one is
natural; here `content` is a single field, and omitting it in one branch while the other sends `""` would
just move the inconsistency rather than remove it.

### Tests

- `InternalOpenAiOfficialHelperTest` (existing class, 2 new tests): an `AiMessage` with no text and no tool
  calls now maps to empty content instead of throwing; an `AiMessage` that does carry text still maps to that
  text

The first fails on unmodified `main` with the `NullPointerException` above. The second passes either way, it
pins the behaviour that must not change.

```
mvn -pl langchain4j-open-ai-official test
Tests run: 20, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-open-ai-official verify -DskipITs
revapi: API checks completed without failures

langchain4j-core: Tests run: 1266, Failures: 0, Errors: 0, Skipped: 5
langchain4j:      Tests run: 1358, Failures: 0, Errors: 0, Skipped: 0
```

OpenAI integration tests need an API key and were not run.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)