### PR TITLE
fix: ignore SSE events that arrive after an MCP operation was cancelled

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
@@ -93,6 +93,11 @@ class SseSubscriber implements Flow.Subscriber<String> {
 
     @Override
     public void onNext(String item) {
+        if (future != null && future.isCancelled()) {
+            // the operation was cancelled (e.g. by unsubscribeFromResources), so events that are
+            // still in flight on this stream must not reach the operation handler anymore
+            return;
+        }
         if (logResponses && !item.trim().isEmpty()) {
             logger.info("SSE event received: " + item);
         }


### PR DESCRIPTION
## Issue
  No separate issue. This fixes a flaky failure of the existing integration test `McpResourceSubscriptionStreamableHttpIT.unsubscribeStopsNotifications`, which occasionally fails in CI with:

  ```
  Expecting
    ["file:///status"]
  not to contain
    ["file:///status"]
  ```

  ## Change
  `McpClient.unsubscribeFromResources(long)` is a synchronous method, so once it returns a caller expects the `onResourceUpdated` callback to no longer fire for that subscription. On the streamable HTTP
  transport this was only best-effort:

  * `DefaultMcpClient.unsubscribeFromResources()` cancels the `CompletableFuture` of the `subscriptions/listen` stream, which reaches `Flow.Subscription.cancel()` asynchronously (via
  `SseSubscriber.onSubscribe()`), and the actual stream teardown happens on the HTTP client's threads.
  * The transport sends no `notifications/cancelled` (`StreamableHttpMcpTransport.requiresCancellationNotification()` returns `false`), so the server keeps publishing notifications until it notices that the
  stream is gone.
  * `SseSubscriber.onNext()` dispatched every event to the operation handler unconditionally, so events still in flight during that teardown window were delivered to `onResourceUpdated` after
  `unsubscribeFromResources()` had already returned.

  The window is small and load-dependent, which is why the test only fails occasionally.

  This PR adds the missing client-side gate in `SseSubscriber.onNext()`:

  ```java
  if (future != null && future.isCancelled()) {
      // the operation was cancelled (e.g. by unsubscribeFromResources), so events that are
      // still in flight on this stream must not reach the operation handler anymore
      return;
  }
  ```

  Because `cancel(true)` is called synchronously inside `unsubscribeFromResources()`, `isCancelled()` is already `true` by the time that method returns, so no further notification from that subscription can
  reach the handler. The subsidiary GET SSE channel has no operation future (`future == null`) and is therefore unaffected, as are all non-cancelled operations.

There is no API change (revapi passes) and no behaviour change for anything other than events arriving on an already-cancelled stream, which previously leaked into user callbacks.

  ## Testing
  * The whole `langchain4j-mcp` module (unit tests + all integration tests) is green.
  * `McpResourceSubscription*IT` and `McpSubscriptionDeprecationIT` were additionally run 5 times in a row, all green.

  No new test is added: the behaviour is already covered by `McpResourceSubscriptionTestBase.unsubscribeStopsNotifications` and
  `McpResourceSubscriptionStreamableHttpIT.closingClientStopsSubscriptionNotifications`. Both assert exactly this guarantee; the change makes them deterministic instead of timing-dependent.

  ## General checklist
  - [X] There are no breaking changes (API, behaviour)
  - [ ] I have added unit and/or integration tests for my change (no new test: the existing ITs already cover this, see above)
  - [X] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and
  [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)