### PR TITLE
Fix typos in Milvus embedding stores Javadoc

### DIFF
--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStore.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStore.java
@@ -393,7 +393,7 @@ public class MilvusV2EmbeddingStore implements EmbeddingStore<TextSegment> {
      *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
      *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
      *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
+     *     <li>Before deleting entities by complex boolean expressions, make sure the collection has been loaded.</li>
      *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
      *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
      * </ul>
@@ -419,7 +419,7 @@ public class MilvusV2EmbeddingStore implements EmbeddingStore<TextSegment> {
      *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
      *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
      *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
+     *     <li>Before deleting entities by complex boolean expressions, make sure the collection has been loaded.</li>
      *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
      *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
      * </ul>
@@ -443,7 +443,7 @@ public class MilvusV2EmbeddingStore implements EmbeddingStore<TextSegment> {
      *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
      *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
      *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
+     *     <li>Before deleting entities by complex boolean expressions, make sure the collection has been loaded.</li>
      *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
      *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
      * </ul>
@@ -709,7 +709,7 @@ public class MilvusV2EmbeddingStore implements EmbeddingStore<TextSegment> {
          *
          * @param sparseMetricType The type of the metric used for sparse vector similarity search.
          *                         Default value: IP.
-         * @return builer
+         * @return builder
          */
         public Builder sparseMetricType(IndexParam.MetricType sparseMetricType) {
             this.sparseMetricType = sparseMetricType;

--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStore.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStore.java
@@ -313,7 +313,7 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
      *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
      *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
      *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
+     *     <li>Before deleting entities by complex boolean expressions, make sure the collection has been loaded.</li>
      *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
      *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
      * </ul>
@@ -339,7 +339,7 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
      *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
      *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
      *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
+     *     <li>Before deleting entities by complex boolean expressions, make sure the collection has been loaded.</li>
      *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
      *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
      * </ul>
@@ -363,7 +363,7 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
      *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
      *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
      *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
+     *     <li>Before deleting entities by complex boolean expressions, make sure the collection has been loaded.</li>
      *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
      *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
      * </ul>


### PR DESCRIPTION
## What changed

Fixed two spelling typos in the Javadoc of the Milvus embedding stores:

- `comlpex` → `complex` (6 occurrences: 3 in `MilvusEmbeddingStore`, 3 in `MilvusV2EmbeddingStore`)
- `builer` → `builder` (1 occurrence in `MilvusV2EmbeddingStore`)

## Why

These typos appear in the public API Javadoc of both Milvus modules.
The same sentences spell "complex" correctly in adjacent bullets,
confirming these are unintentional misspellings.

## How verified

Diff inspection — comments only, no code changes.