### PR TITLE
fix: preserve Content.metadata when ReRankingContentAggregator re-ranks

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
@@ -1,24 +1,26 @@
 package dev.langchain4j.rag.content.aggregator;
 
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.rag.content.ContentMetadata.RERANKED_SCORE;
+import static java.util.Collections.emptyList;
+
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.scoring.ScoringModel;
 import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.rag.query.transformer.ExpandingQueryTransformer;
-
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static dev.langchain4j.internal.Exceptions.illegalArgument;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.rag.content.ContentMetadata.RERANKED_SCORE;
-import static java.util.Collections.emptyList;
 
 /**
  * A {@link ContentAggregator} that performs re-ranking using a {@link ScoringModel}, such as Cohere.
@@ -51,11 +53,10 @@ public class ReRankingContentAggregator implements ContentAggregator {
             (queryToContents) -> {
                 if (queryToContents.size() > 1) {
                     throw illegalArgument(
-                            "The 'queryToContents' contains %s queries, making the re-ranking ambiguous. " +
-                                    "Because there are multiple queries, it is unclear which one should be " +
-                                    "used for re-ranking. Please provide a 'querySelector' in the constructor/builder.",
-                            queryToContents.size()
-                    );
+                            "The 'queryToContents' contains %s queries, making the re-ranking ambiguous. "
+                                    + "Because there are multiple queries, it is unclear which one should be "
+                                    + "used for re-ranking. Please provide a 'querySelector' in the constructor/builder.",
+                            queryToContents.size());
                 }
                 return queryToContents.keySet().iterator().next();
             };
@@ -69,16 +70,18 @@ public class ReRankingContentAggregator implements ContentAggregator {
         this(scoringModel, DEFAULT_QUERY_SELECTOR, null);
     }
 
-    public ReRankingContentAggregator(ScoringModel scoringModel,
-                                      Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
-                                      Double minScore) {
+    public ReRankingContentAggregator(
+            ScoringModel scoringModel,
+            Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
+            Double minScore) {
         this(scoringModel, querySelector, minScore, null);
     }
 
-    public ReRankingContentAggregator(ScoringModel scoringModel,
-                                      Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
-                                      Double minScore,
-                                      Integer maxResults) {
+    public ReRankingContentAggregator(
+            ScoringModel scoringModel,
+            Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
+            Double minScore,
+            Integer maxResults) {
         this.scoringModel = ensureNotNull(scoringModel, "scoringModel");
         this.querySelector = getOrDefault(querySelector, DEFAULT_QUERY_SELECTOR);
         this.minScore = minScore;
@@ -124,21 +127,26 @@ public class ReRankingContentAggregator implements ContentAggregator {
 
     protected List<Content> reRankAndFilter(List<Content> contents, Query query) {
 
-        List<TextSegment> segments = contents.stream()
-                .map(Content::textSegment)
-                .collect(Collectors.toList());
+        List<TextSegment> segments = contents.stream().map(Content::textSegment).collect(Collectors.toList());
 
         List<Double> scores = scoringModel.scoreAll(segments, query.text()).content();
 
-        Map<TextSegment, Double> segmentToScore = new HashMap<>();
-        for (int i = 0; i < segments.size(); i++) {
-            segmentToScore.put(segments.get(i), scores.get(i));
+        List<Content> reranked = new ArrayList<>();
+        for (int i = 0; i < contents.size(); i++) {
+            Double score = scores.get(i);
+            if (minScore != null && score < minScore) {
+                continue;
+            }
+            Content original = contents.get(i);
+            Map<ContentMetadata, Object> metadata = new HashMap<>(original.metadata());
+            metadata.put(RERANKED_SCORE, score);
+            reranked.add(Content.from(original.textSegment(), metadata));
         }
 
-        return segmentToScore.entrySet().stream()
-                .filter(entry -> minScore == null || entry.getValue() >= minScore)
-                .sorted(Map.Entry.<TextSegment, Double>comparingByValue().reversed())
-                .map(entry ->  Content.from(entry.getKey(), Map.of(RERANKED_SCORE, entry.getValue())))
+        return reranked.stream()
+                .sorted(Comparator.comparing(
+                        (Content content) -> (Double) content.metadata().get(RERANKED_SCORE),
+                        Comparator.reverseOrder()))
                 .limit(maxResults)
                 .collect(Collectors.toList());
     }
@@ -149,15 +157,15 @@ public class ReRankingContentAggregator implements ContentAggregator {
         private Double minScore;
         private Integer maxResults;
 
-        ReRankingContentAggregatorBuilder() {
-        }
+        ReRankingContentAggregatorBuilder() {}
 
         public ReRankingContentAggregatorBuilder scoringModel(ScoringModel scoringModel) {
             this.scoringModel = scoringModel;
             return this;
         }
 
-        public ReRankingContentAggregatorBuilder querySelector(Function<Map<Query, Collection<List<Content>>>, Query> querySelector) {
+        public ReRankingContentAggregatorBuilder querySelector(
+                Function<Map<Query, Collection<List<Content>>>, Query> querySelector) {
             this.querySelector = querySelector;
             return this;
         }
@@ -173,7 +181,8 @@ public class ReRankingContentAggregator implements ContentAggregator {
         }
 
         public ReRankingContentAggregator build() {
-            return new ReRankingContentAggregator(this.scoringModel, this.querySelector, this.minScore, this.maxResults);
+            return new ReRankingContentAggregator(
+                    this.scoringModel, this.querySelector, this.minScore, this.maxResults);
         }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
@@ -12,10 +12,7 @@ import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.rag.query.transformer.ExpandingQueryTransformer;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -131,24 +128,23 @@ public class ReRankingContentAggregator implements ContentAggregator {
 
         List<Double> scores = scoringModel.scoreAll(segments, query.text()).content();
 
-        List<Content> reranked = new ArrayList<>();
+        Map<Content, Double> contentToScore = new LinkedHashMap<>();
         for (int i = 0; i < contents.size(); i++) {
-            Double score = scores.get(i);
-            if (minScore != null && score < minScore) {
-                continue;
-            }
-            Content original = contents.get(i);
-            Map<ContentMetadata, Object> metadata = new HashMap<>(original.metadata());
-            metadata.put(RERANKED_SCORE, score);
-            reranked.add(Content.from(original.textSegment(), metadata));
+            contentToScore.put(contents.get(i), scores.get(i));
         }
 
-        return reranked.stream()
-                .sorted(Comparator.comparing(
-                        (Content content) -> (Double) content.metadata().get(RERANKED_SCORE),
-                        Comparator.reverseOrder()))
+        return contentToScore.entrySet().stream()
+                .filter(entry -> minScore == null || entry.getValue() >= minScore)
+                .sorted(Map.Entry.<Content, Double>comparingByValue().reversed())
+                .map(entry -> withReRankedScore(entry.getKey(), entry.getValue()))
                 .limit(maxResults)
                 .collect(Collectors.toList());
+    }
+
+    private static Content withReRankedScore(Content content, Double score) {
+        Map<ContentMetadata, Object> metadata = new LinkedHashMap<>(content.metadata());
+        metadata.put(RERANKED_SCORE, score);
+        return Content.from(content.textSegment(), metadata);
     }
 
     public static class ReRankingContentAggregatorBuilder {

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -324,6 +325,27 @@ class ReRankingContentAggregatorTest {
         assertThat(aggregated.get(0).metadata())
                 .containsEntry(ContentMetadata.SCORE, 0.41)
                 .containsEntry(ContentMetadata.EMBEDDING_ID, "doc-2");
+    }
+
+    @Test
+    void should_keep_fused_order_when_reranked_scores_are_equal() {
+
+        Query query = Query.from("query");
+
+        List<Content> contents = IntStream.range(0, 20)
+                .mapToObj(i -> Content.from("content " + i))
+                .toList();
+        List<Double> equalScores = contents.stream().map(content -> 0.5).toList();
+
+        Map<Query, Collection<List<Content>>> queryToContents = singletonMap(query, singletonList(contents));
+
+        ScoringModel scoringModel = mock(ScoringModel.class);
+        when(scoringModel.scoreAll(any(), any())).thenReturn(Response.from(equalScores));
+        ContentAggregator aggregator = new ReRankingContentAggregator(scoringModel);
+
+        List<Content> aggregated = aggregator.aggregate(queryToContents);
+
+        assertReRankedContentOrder(aggregated, contents.toArray(new Content[0]));
     }
 
     private void assertReRankedContentOrder(List<Content> actual, Content... expectedContents) {

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
@@ -265,6 +265,67 @@ class ReRankingContentAggregatorTest {
                 .build();
     }
 
+    @Test
+    void should_preserve_original_content_metadata_when_reranking() {
+
+        Query query = Query.from("query");
+
+        Content content1 = Content.from(
+                TextSegment.from("content 1"),
+                Map.of(ContentMetadata.SCORE, 0.82, ContentMetadata.EMBEDDING_ID, "doc-1"));
+        Content content2 = Content.from(
+                TextSegment.from("content 2"),
+                Map.of(ContentMetadata.SCORE, 0.41, ContentMetadata.EMBEDDING_ID, "doc-2"));
+
+        Map<Query, Collection<List<Content>>> queryToContents =
+                singletonMap(query, singletonList(asList(content1, content2)));
+
+        ScoringModel scoringModel = mock(ScoringModel.class);
+        when(scoringModel.scoreAll(any(), any())).thenReturn(Response.from(asList(0.5, 0.7)));
+        ContentAggregator aggregator = new ReRankingContentAggregator(scoringModel);
+
+        List<Content> aggregated = aggregator.aggregate(queryToContents);
+
+        assertThat(aggregated).hasSize(2);
+        assertReRankedContentOrder(aggregated, content2, content1);
+        assertReRankedContentScore(aggregated, 0.7, 0.5);
+        assertThat(aggregated.get(0).metadata())
+                .containsEntry(ContentMetadata.SCORE, 0.41)
+                .containsEntry(ContentMetadata.EMBEDDING_ID, "doc-2");
+        assertThat(aggregated.get(1).metadata())
+                .containsEntry(ContentMetadata.SCORE, 0.82)
+                .containsEntry(ContentMetadata.EMBEDDING_ID, "doc-1");
+    }
+
+    @Test
+    void should_preserve_original_content_metadata_after_min_score_filter() {
+
+        Query query = Query.from("query");
+
+        Content content1 = Content.from(
+                TextSegment.from("content 1"),
+                Map.of(ContentMetadata.SCORE, 0.82, ContentMetadata.EMBEDDING_ID, "doc-1"));
+        Content content2 = Content.from(
+                TextSegment.from("content 2"),
+                Map.of(ContentMetadata.SCORE, 0.41, ContentMetadata.EMBEDDING_ID, "doc-2"));
+
+        Map<Query, Collection<List<Content>>> queryToContents =
+                singletonMap(query, singletonList(asList(content1, content2)));
+
+        ScoringModel scoringModel = mock(ScoringModel.class);
+        when(scoringModel.scoreAll(any(), any())).thenReturn(Response.from(asList(0.3, 0.7)));
+        ContentAggregator aggregator = new ReRankingContentAggregator(scoringModel, null, 0.4);
+
+        List<Content> aggregated = aggregator.aggregate(queryToContents);
+
+        assertThat(aggregated).hasSize(1);
+        assertReRankedContentOrder(aggregated, content2);
+        assertReRankedContentScore(aggregated, 0.7);
+        assertThat(aggregated.get(0).metadata())
+                .containsEntry(ContentMetadata.SCORE, 0.41)
+                .containsEntry(ContentMetadata.EMBEDDING_ID, "doc-2");
+    }
+
     private void assertReRankedContentOrder(List<Content> actual, Content... expectedContents) {
         List<TextSegment> expectedTextSegments =
                 Arrays.stream(expectedContents).map(Content::textSegment).toList();


### PR DESCRIPTION
## Issue

Fixes #6128

## Change

`ReRankingContentAggregator.reRankAndFilter` currently:

1. Puts scores in a `HashMap<TextSegment, Double>`.
2. Rebuilds each result with `Content.from(segment, Map.of(RERANKED_SCORE, score))`.

That drops `ContentMetadata.SCORE` and `ContentMetadata.EMBEDDING_ID` that retrievers attach in #2222. After hybrid retrieval + rerank, only the reranker score survives.

This change pairs each fused `Content` with its score by index, copies the original metadata map, writes `RERANKED_SCORE`, then sorts by that score descending (Java's stable sort keeps fused order on ties). Ranking, `minScore`, and `maxResults` are unchanged.

## Breaking Changes

None. Existing tests already assert text order and `RERANKED_SCORE`. This only keeps extra metadata keys that were previously discarded. `TextSegment` identity used by RRF is unchanged.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)