### PR TITLE
feat(elasticsearch): add client-side hybrid retriever

### DIFF
--- a/docs/docs/integrations/embedding-stores/elasticsearch.md
+++ b/docs/docs/integrations/embedding-stores/elasticsearch.md
@@ -229,6 +229,27 @@ It comes with the following options:
 >     .build();
 > ```
 
+### Client-side hybrid retrieval
+
+If the Elasticsearch license does not include the server-side RRF retriever, hybrid retrieval can instead be
+performed in the client. `ElasticsearchClientSideHybridContentRetriever` executes kNN and full-text searches
+independently and combines their rankings with Reciprocal Rank Fusion in Java:
+
+```java
+ContentRetriever retriever = ElasticsearchClientSideHybridContentRetriever.builder()
+    .client(client)
+    .indexName("my-index")
+    .embeddingModel(embeddingModel)
+    .filter(filter) // applied to both search branches
+    .vectorMaxResults(20)
+    .fullTextMaxResults(20)
+    .maxResults(10)
+    .build();
+```
+
+This variant does not use Elasticsearch's `retriever.rrf` API. The two searches run concurrently and their
+independently ranked results are fused in the client.
+
 ### Creating Custom Configurations
 
 You can create your own Elasticsearch configuration by implementing the `ElasticsearchConfiguration` interface. For example:

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchClientSideHybridContentRetriever.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchClientSideHybridContentRetriever.java
@@ -1,0 +1,204 @@
+package dev.langchain4j.rag.content.retriever.elasticsearch;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.aggregator.ReciprocalRankFuser;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationFullText;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationKnn;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+
+/**
+ * Performs hybrid retrieval without using Elasticsearch's server-side RRF retriever.
+ *
+ * <p>A kNN search and a full-text search are executed independently and their ranked results are fused in the
+ * client using {@link ReciprocalRankFuser}. This is useful for Elasticsearch installations whose license does not
+ * include the server-side RRF retriever.
+ *
+ * <p>The same {@link Filter} is applied to both searches. Branch-specific result limits and score thresholds can be
+ * configured because vector and full-text scores are not directly comparable.
+ */
+public class ElasticsearchClientSideHybridContentRetriever implements ContentRetriever {
+
+    private static final int DEFAULT_MAX_RESULTS = 3;
+    private static final int DEFAULT_RRF_RANK_CONSTANT = 60;
+
+    private final ContentRetriever vectorRetriever;
+    private final ContentRetriever fullTextRetriever;
+    private final int maxResults;
+    private final int rrfRankConstant;
+    private final Executor executor;
+
+    ElasticsearchClientSideHybridContentRetriever(
+            ContentRetriever vectorRetriever,
+            ContentRetriever fullTextRetriever,
+            int maxResults,
+            int rrfRankConstant,
+            Executor executor) {
+        this.vectorRetriever = ensureNotNull(vectorRetriever, "vectorRetriever");
+        this.fullTextRetriever = ensureNotNull(fullTextRetriever, "fullTextRetriever");
+        this.maxResults = ensureGreaterThanZero(maxResults, "maxResults");
+        this.rrfRankConstant = ensureGreaterThanZero(rrfRankConstant, "rrfRankConstant");
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
+    private ElasticsearchClientSideHybridContentRetriever(Builder builder) {
+        ElasticsearchClient client = ensureNotNull(builder.client, "client");
+        EmbeddingModel embeddingModel = ensureNotNull(builder.embeddingModel, "embeddingModel");
+        int vectorMaxResults = ensureGreaterThanZero(
+                builder.vectorMaxResults == null ? builder.maxResults : builder.vectorMaxResults, "vectorMaxResults");
+        int fullTextMaxResults = ensureGreaterThanZero(
+                builder.fullTextMaxResults == null ? builder.maxResults : builder.fullTextMaxResults,
+                "fullTextMaxResults");
+
+        ElasticsearchConfigurationKnn vectorConfiguration = ElasticsearchConfigurationKnn.builder()
+                .numCandidates(builder.numCandidates)
+                .includeVectorResponse(builder.includeVectorResponse)
+                .build();
+        this.vectorRetriever = ElasticsearchContentRetriever.builder()
+                .client(client)
+                .indexName(builder.indexName)
+                .configuration(vectorConfiguration)
+                .embeddingModel(embeddingModel)
+                .maxResults(vectorMaxResults)
+                .minScore(builder.vectorMinScore)
+                .filter(builder.filter)
+                .build();
+        this.fullTextRetriever = ElasticsearchContentRetriever.builder()
+                .client(client)
+                .indexName(builder.indexName)
+                .configuration(ElasticsearchConfigurationFullText.builder().build())
+                .maxResults(fullTextMaxResults)
+                .minScore(builder.fullTextMinScore)
+                .filter(builder.filter)
+                .build();
+        this.maxResults = ensureGreaterThanZero(builder.maxResults, "maxResults");
+        this.rrfRankConstant = ensureGreaterThanZero(builder.rrfRankConstant, "rrfRankConstant");
+        this.executor = ensureNotNull(builder.executor, "executor");
+    }
+
+    @Override
+    public List<Content> retrieve(Query query) {
+        CompletableFuture<List<Content>> vectorResults =
+                CompletableFuture.supplyAsync(() -> vectorRetriever.retrieve(query), executor);
+        CompletableFuture<List<Content>> fullTextResults =
+                CompletableFuture.supplyAsync(() -> fullTextRetriever.retrieve(query), executor);
+
+        try {
+            return ReciprocalRankFuser.fuse(List.of(vectorResults.join(), fullTextResults.join()), rrfRankConstant)
+                    .stream()
+                    .limit(maxResults)
+                    .toList();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw e;
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ElasticsearchClient client;
+        private String indexName = "default";
+        private EmbeddingModel embeddingModel;
+        private int maxResults = DEFAULT_MAX_RESULTS;
+        private Integer vectorMaxResults;
+        private Integer fullTextMaxResults;
+        private double vectorMinScore;
+        private double fullTextMinScore;
+        private Filter filter;
+        private Integer numCandidates;
+        private boolean includeVectorResponse;
+        private int rrfRankConstant = DEFAULT_RRF_RANK_CONSTANT;
+        private Executor executor = ForkJoinPool.commonPool();
+
+        public Builder client(ElasticsearchClient client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder indexName(String indexName) {
+            this.indexName = indexName;
+            return this;
+        }
+
+        public Builder embeddingModel(EmbeddingModel embeddingModel) {
+            this.embeddingModel = embeddingModel;
+            return this;
+        }
+
+        /** Sets the maximum number of fused results returned to the caller. */
+        public Builder maxResults(int maxResults) {
+            this.maxResults = maxResults;
+            return this;
+        }
+
+        /** Sets the number of candidates retrieved by the vector search before fusion. */
+        public Builder vectorMaxResults(int vectorMaxResults) {
+            this.vectorMaxResults = vectorMaxResults;
+            return this;
+        }
+
+        /** Sets the number of candidates retrieved by the full-text search before fusion. */
+        public Builder fullTextMaxResults(int fullTextMaxResults) {
+            this.fullTextMaxResults = fullTextMaxResults;
+            return this;
+        }
+
+        public Builder vectorMinScore(double vectorMinScore) {
+            this.vectorMinScore = vectorMinScore;
+            return this;
+        }
+
+        public Builder fullTextMinScore(double fullTextMinScore) {
+            this.fullTextMinScore = fullTextMinScore;
+            return this;
+        }
+
+        /** Sets the metadata filter that is applied to both retrieval branches. */
+        public Builder filter(Filter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder numCandidates(Integer numCandidates) {
+            this.numCandidates = numCandidates;
+            return this;
+        }
+
+        public Builder includeVectorResponse(boolean includeVectorResponse) {
+            this.includeVectorResponse = includeVectorResponse;
+            return this;
+        }
+
+        public Builder rrfRankConstant(int rrfRankConstant) {
+            this.rrfRankConstant = rrfRankConstant;
+            return this;
+        }
+
+        /** Sets the executor used to run the two blocking Elasticsearch searches. */
+        public Builder executor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        public ElasticsearchClientSideHybridContentRetriever build() {
+            return new ElasticsearchClientSideHybridContentRetriever(this);
+        }
+    }
+}

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchClientSideHybridContentRetrieverTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/rag/content/retriever/elasticsearch/ElasticsearchClientSideHybridContentRetrieverTest.java
@@ -1,0 +1,63 @@
+package dev.langchain4j.rag.content.retriever.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import java.util.List;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchClientSideHybridContentRetrieverTest {
+
+    private static final Query QUERY = Query.from("query");
+    private static final Executor SAME_THREAD_EXECUTOR = Runnable::run;
+
+    @Test
+    void should_fuse_vector_and_full_text_results_and_remove_duplicates() {
+        Content shared = Content.from("shared");
+        Content vectorOnly = Content.from("vector only");
+        Content fullTextOnly = Content.from("full text only");
+        ContentRetriever vectorRetriever = ignored -> List.of(shared, vectorOnly);
+        ContentRetriever fullTextRetriever = ignored -> List.of(fullTextOnly, shared);
+
+        ElasticsearchClientSideHybridContentRetriever retriever = new ElasticsearchClientSideHybridContentRetriever(
+                vectorRetriever, fullTextRetriever, 3, 60, SAME_THREAD_EXECUTOR);
+
+        assertThat(retriever.retrieve(QUERY)).containsExactly(shared, fullTextOnly, vectorOnly);
+    }
+
+    @Test
+    void should_limit_the_fused_results() {
+        ContentRetriever vectorRetriever = ignored -> List.of(Content.from("one"), Content.from("two"));
+        ContentRetriever fullTextRetriever = ignored -> List.of(Content.from("three"), Content.from("four"));
+
+        ElasticsearchClientSideHybridContentRetriever retriever = new ElasticsearchClientSideHybridContentRetriever(
+                vectorRetriever, fullTextRetriever, 2, 60, SAME_THREAD_EXECUTOR);
+
+        assertThat(retriever.retrieve(QUERY)).hasSize(2);
+    }
+
+    @Test
+    void should_propagate_the_original_retrieval_exception() {
+        IllegalStateException failure = new IllegalStateException("Elasticsearch failed");
+        ContentRetriever vectorRetriever = ignored -> {
+            throw failure;
+        };
+        ContentRetriever fullTextRetriever = ignored -> List.of();
+        ElasticsearchClientSideHybridContentRetriever retriever = new ElasticsearchClientSideHybridContentRetriever(
+                vectorRetriever, fullTextRetriever, 3, 60, SAME_THREAD_EXECUTOR);
+
+        assertThatThrownBy(() -> retriever.retrieve(QUERY)).isSameAs(failure);
+    }
+
+    @Test
+    void should_validate_required_configuration() {
+        assertThatThrownBy(() ->
+                        ElasticsearchClientSideHybridContentRetriever.builder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("client cannot be null");
+    }
+}


### PR DESCRIPTION
## Issue

Related to #4087. That issue added the generic hybrid query path, while this PR fills the Elasticsearch licensing gap where the server-side `retriever.rrf` API is unavailable.

## Change

Adds `ElasticsearchClientSideHybridContentRetriever`, which:

- runs kNN and full-text retrieval concurrently;
- applies the same LangChain4j `Filter` to both branches;
- supports independent candidate limits and score thresholds;
- fuses both ranked lists in Java with `ReciprocalRankFuser`;
- supports a configurable executor and final result limit;
- does not call Elasticsearch's server-side RRF retriever.

This enables hybrid retrieval on Elasticsearch licenses that do not include server-side RRF. Unit tests cover fusion, duplicate removal, result limiting, exception propagation, and required configuration. Documentation includes a client-side usage example.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run the new unit tests and they are green
- [ ] I have manually run all unit and integration tests in the changed module, core, and main modules
- [x] I have added/updated the documentation
- [ ] I have added an example in the examples repo (not required for this isolated integration feature)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)

## Checklist for adding a new Maven module

- [ ] Not applicable

## Checklist for adding/changing an embedding store integration

- [ ] Not applicable; this adds a content retriever without changing persisted data compatibility