### PR TITLE
feat(rag): add fallback content retriever

### DIFF
--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -988,6 +988,22 @@ It supports full-text, vector, and hybrid search.
 It can be found in the `langchain4j-elasticsearch` module.
 Please refer to the `ElasticsearchContentRetriever` Javadoc for more information.
 
+#### Fallback Content Retriever
+
+`FallbackContentRetriever` composes a primary and a fallback retriever. By default, the fallback is used when the
+primary retriever returns no content or throws an exception:
+
+```java
+ContentRetriever contentRetriever = FallbackContentRetriever.builder()
+    .primaryRetriever(sqlContentRetriever)
+    .fallbackRetriever(embeddingStoreContentRetriever)
+    .build();
+```
+
+A custom `fallbackCondition` can detect domain-specific empty responses, such as a structured query result that
+contains column headers but no data rows. Set `fallbackOnException(false)` when primary retrieval failures should be
+propagated instead of triggering fallback.
+
 ### Query Router
 `QueryRouter` is responsible for routing `Query` to the appropriate `ContentRetriever`(s).
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/FallbackContentRetriever.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/FallbackContentRetriever.java
@@ -1,0 +1,108 @@
+package dev.langchain4j.rag.content.retriever;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.query.Query;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * A {@link ContentRetriever} that delegates to a fallback retriever when the primary retrieval does not produce a
+ * usable result.
+ *
+ * <p>By default, fallback is triggered when the primary retriever returns {@code null}, returns an empty list, or
+ * throws a {@link RuntimeException}. A custom predicate can additionally describe domain-specific "empty" results,
+ * for example a structured database response that contains a header but no rows.
+ */
+public class FallbackContentRetriever implements ContentRetriever {
+
+    private final ContentRetriever primaryRetriever;
+    private final ContentRetriever fallbackRetriever;
+    private final Predicate<List<Content>> fallbackCondition;
+    private final boolean fallbackOnException;
+
+    public FallbackContentRetriever(ContentRetriever primaryRetriever, ContentRetriever fallbackRetriever) {
+        this(primaryRetriever, fallbackRetriever, results -> results == null || results.isEmpty(), true);
+    }
+
+    private FallbackContentRetriever(
+            ContentRetriever primaryRetriever,
+            ContentRetriever fallbackRetriever,
+            Predicate<List<Content>> fallbackCondition,
+            boolean fallbackOnException) {
+        this.primaryRetriever = ensureNotNull(primaryRetriever, "primaryRetriever");
+        this.fallbackRetriever = ensureNotNull(fallbackRetriever, "fallbackRetriever");
+        this.fallbackCondition = ensureNotNull(fallbackCondition, "fallbackCondition");
+        this.fallbackOnException = fallbackOnException;
+    }
+
+    @Override
+    public List<Content> retrieve(Query query) {
+        List<Content> contents;
+        try {
+            contents = primaryRetriever.retrieve(query);
+        } catch (RuntimeException e) {
+            if (!fallbackOnException) {
+                throw e;
+            }
+            return retrieveFromFallback(query, e);
+        }
+
+        if (fallbackCondition.test(contents)) {
+            return fallbackRetriever.retrieve(query);
+        }
+        return contents;
+    }
+
+    private List<Content> retrieveFromFallback(Query query, RuntimeException primaryException) {
+        try {
+            return fallbackRetriever.retrieve(query);
+        } catch (RuntimeException fallbackException) {
+            fallbackException.addSuppressed(primaryException);
+            throw fallbackException;
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ContentRetriever primaryRetriever;
+        private ContentRetriever fallbackRetriever;
+        private Predicate<List<Content>> fallbackCondition = results -> results == null || results.isEmpty();
+        private boolean fallbackOnException = true;
+
+        public Builder primaryRetriever(ContentRetriever primaryRetriever) {
+            this.primaryRetriever = primaryRetriever;
+            return this;
+        }
+
+        public Builder fallbackRetriever(ContentRetriever fallbackRetriever) {
+            this.fallbackRetriever = fallbackRetriever;
+            return this;
+        }
+
+        /**
+         * Sets the condition that determines whether the primary result should be replaced by the fallback result.
+         * The default condition matches {@code null} and empty lists.
+         */
+        public Builder fallbackCondition(Predicate<List<Content>> fallbackCondition) {
+            this.fallbackCondition = fallbackCondition;
+            return this;
+        }
+
+        /** Sets whether a {@link RuntimeException} from the primary retriever should trigger fallback. */
+        public Builder fallbackOnException(boolean fallbackOnException) {
+            this.fallbackOnException = fallbackOnException;
+            return this;
+        }
+
+        public FallbackContentRetriever build() {
+            return new FallbackContentRetriever(
+                    primaryRetriever, fallbackRetriever, fallbackCondition, fallbackOnException);
+        }
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/FallbackContentRetrieverTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/FallbackContentRetrieverTest.java
@@ -1,0 +1,107 @@
+package dev.langchain4j.rag.content.retriever;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.query.Query;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class FallbackContentRetrieverTest {
+
+    private static final Query QUERY = Query.from("query");
+
+    @Test
+    void should_return_primary_results_without_calling_fallback() {
+        List<Content> primaryResults = List.of(Content.from("primary"));
+        AtomicInteger fallbackCalls = new AtomicInteger();
+        ContentRetriever fallback = ignored -> {
+            fallbackCalls.incrementAndGet();
+            return List.of(Content.from("fallback"));
+        };
+
+        FallbackContentRetriever retriever = new FallbackContentRetriever(ignored -> primaryResults, fallback);
+
+        assertThat(retriever.retrieve(QUERY)).isSameAs(primaryResults);
+        assertThat(fallbackCalls).hasValue(0);
+    }
+
+    @Test
+    void should_fallback_on_empty_or_null_primary_results() {
+        List<Content> fallbackResults = List.of(Content.from("fallback"));
+        ContentRetriever fallback = ignored -> fallbackResults;
+
+        assertThat(new FallbackContentRetriever(ignored -> List.of(), fallback).retrieve(QUERY))
+                .isSameAs(fallbackResults);
+        assertThat(new FallbackContentRetriever(ignored -> null, fallback).retrieve(QUERY))
+                .isSameAs(fallbackResults);
+    }
+
+    @Test
+    void should_support_a_domain_specific_fallback_condition() {
+        Content noRows = Content.from("Result: header only");
+        List<Content> fallbackResults = List.of(Content.from("fallback"));
+        FallbackContentRetriever retriever = FallbackContentRetriever.builder()
+                .primaryRetriever(ignored -> List.of(noRows))
+                .fallbackRetriever(ignored -> fallbackResults)
+                .fallbackCondition(results -> results.size() == 1
+                        && results.get(0).textSegment().text().endsWith("header only"))
+                .build();
+
+        assertThat(retriever.retrieve(QUERY)).isSameAs(fallbackResults);
+    }
+
+    @Test
+    void should_fallback_on_primary_exception_by_default() {
+        List<Content> fallbackResults = List.of(Content.from("fallback"));
+        ContentRetriever primary = ignored -> {
+            throw new IllegalStateException("primary failed");
+        };
+
+        assertThat(new FallbackContentRetriever(primary, ignored -> fallbackResults).retrieve(QUERY))
+                .isSameAs(fallbackResults);
+    }
+
+    @Test
+    void should_optionally_propagate_primary_exception() {
+        IllegalStateException failure = new IllegalStateException("primary failed");
+        ContentRetriever primary = ignored -> {
+            throw failure;
+        };
+        FallbackContentRetriever retriever = FallbackContentRetriever.builder()
+                .primaryRetriever(primary)
+                .fallbackRetriever(ignored -> List.of(Content.from("fallback")))
+                .fallbackOnException(false)
+                .build();
+
+        assertThatThrownBy(() -> retriever.retrieve(QUERY)).isSameAs(failure);
+    }
+
+    @Test
+    void should_preserve_primary_exception_when_fallback_also_fails() {
+        IllegalStateException primaryFailure = new IllegalStateException("primary failed");
+        IllegalArgumentException fallbackFailure = new IllegalArgumentException("fallback failed");
+        FallbackContentRetriever retriever = new FallbackContentRetriever(
+                ignored -> {
+                    throw primaryFailure;
+                },
+                ignored -> {
+                    throw fallbackFailure;
+                });
+
+        assertThatThrownBy(() -> retriever.retrieve(QUERY))
+                .isSameAs(fallbackFailure)
+                .satisfies(error -> assertThat(error.getSuppressed()).containsExactly(primaryFailure));
+    }
+
+    @Test
+    void should_validate_required_retrievers() {
+        assertThatThrownBy(() -> FallbackContentRetriever.builder()
+                        .fallbackRetriever(ignored -> List.of())
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("primaryRetriever cannot be null");
+    }
+}


### PR DESCRIPTION
## Issue

N/A. New issue creation is currently restricted in this repository for this account.

## Change

Adds a generic `FallbackContentRetriever` decorator that invokes a secondary retriever when the primary retriever returns no usable content or fails.

The default policy falls back for `null`, empty results, and runtime exceptions. A custom predicate supports domain-specific empty results, such as a SQL response containing headers but no rows. Exception fallback can be disabled, and when both retrievers fail the primary exception is preserved as a suppressed exception.

Unit tests cover successful primary retrieval, empty/null results, custom conditions, enabled/disabled exception fallback, dual failures, and validation. Documentation includes a usage example.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run the new unit tests and they are green
- [ ] I have manually run all unit and integration tests in the changed module, core, and main modules
- [x] I have added/updated the documentation
- [ ] I have added an example in the examples repo (not required for this small decorator)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)

## Checklist for adding a new Maven module

- [ ] Not applicable

## Checklist for adding/changing an embedding store integration

- [ ] Not applicable