### PR TITLE
feat(rag): add parent and sibling small-to-big retriever

### DIFF
--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -988,6 +988,27 @@ It supports full-text, vector, and hybrid search.
 It can be found in the `langchain4j-elasticsearch` module.
 Please refer to the `ElasticsearchContentRetriever` Javadoc for more information.
 
+#### Small-to-Big Retrieval
+
+`SmallToBigContentRetriever` wraps a retriever that searches small child segments and expands its results with larger
+context. Parent contents and sibling groups are resolved in a single batch, avoiding one lookup per hit.
+
+Use parent expansion when parent segments have a bounded size. When a parent can be too large for the context window,
+use sibling expansion to retrieve only nearby segments:
+
+```java
+ContentRetriever contentRetriever = SmallToBigContentRetriever.<String>builder()
+    .childRetriever(childRetriever)
+    .parentIdProvider(content -> content.textSegment().metadata().getString("parentId"))
+    .expansionMode(SmallToBigContentRetriever.ExpansionMode.SIBLINGS)
+    .siblingContentProvider(parentIds -> loadSiblingsInDocumentOrder(parentIds))
+    .siblingWindow(1, 1)
+    .build();
+```
+
+Overlapping sibling windows and multiple hits from the same parent are deduplicated. The order and retrieval metadata
+of the highest-ranked child are preserved.
+
 ### Query Router
 `QueryRouter` is responsible for routing `Query` to the appropriate `ContentRetriever`(s).
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetriever.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetriever.java
@@ -1,0 +1,262 @@
+package dev.langchain4j.rag.content.retriever;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.query.Query;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+/**
+ * Retrieves small child segments and replaces or expands them with larger context.
+ *
+ * <p>Two expansion strategies are supported:
+ * <ul>
+ *   <li>{@link ExpansionMode#PARENT}: replace child hits with their parent content.</li>
+ *   <li>{@link ExpansionMode#SIBLINGS}: return a configurable window of ordered sibling segments around each hit.
+ *       This avoids injecting an entire parent when it is too large.</li>
+ * </ul>
+ *
+ * <p>Context is resolved in one batch for all unique parent IDs. Multiple child hits belonging to the same parent are
+ * deduplicated while the ranking of the highest-ranked child is preserved.
+ *
+ * @param <K> the type used to identify a parent or sibling group
+ */
+public class SmallToBigContentRetriever<K> implements ContentRetriever {
+
+    public enum ExpansionMode {
+        PARENT,
+        SIBLINGS
+    }
+
+    public enum MissingContextPolicy {
+        KEEP_CHILD,
+        DROP_CHILD,
+        FAIL
+    }
+
+    private final ContentRetriever childRetriever;
+    private final Function<Content, K> parentIdProvider;
+    private final ExpansionMode expansionMode;
+    private final Function<Collection<K>, Map<K, Content>> parentContentProvider;
+    private final Function<Collection<K>, Map<K, List<Content>>> siblingContentProvider;
+    private final int siblingsBefore;
+    private final int siblingsAfter;
+    private final BiPredicate<Content, Content> childMatcher;
+    private final MissingContextPolicy missingContextPolicy;
+
+    private SmallToBigContentRetriever(Builder<K> builder) {
+        this.childRetriever = ensureNotNull(builder.childRetriever, "childRetriever");
+        this.parentIdProvider = ensureNotNull(builder.parentIdProvider, "parentIdProvider");
+        this.expansionMode = ensureNotNull(builder.expansionMode, "expansionMode");
+        this.parentContentProvider = builder.parentContentProvider;
+        this.siblingContentProvider = builder.siblingContentProvider;
+        this.siblingsBefore = ensureNotNegative(builder.siblingsBefore, "siblingsBefore");
+        this.siblingsAfter = ensureNotNegative(builder.siblingsAfter, "siblingsAfter");
+        this.childMatcher = ensureNotNull(builder.childMatcher, "childMatcher");
+        this.missingContextPolicy = ensureNotNull(builder.missingContextPolicy, "missingContextPolicy");
+
+        if (expansionMode == ExpansionMode.PARENT) {
+            ensureNotNull(parentContentProvider, "parentContentProvider");
+        } else {
+            ensureNotNull(siblingContentProvider, "siblingContentProvider");
+        }
+    }
+
+    @Override
+    public List<Content> retrieve(Query query) {
+        List<Content> children = childRetriever.retrieve(query);
+        if (children.isEmpty()) {
+            return children;
+        }
+
+        Map<K, List<RankedContent>> childrenByParent = new LinkedHashMap<>();
+        List<RankedContent> expanded = new ArrayList<>();
+        for (int rank = 0; rank < children.size(); rank++) {
+            Content child = children.get(rank);
+            K parentId = parentIdProvider.apply(child);
+            if (parentId == null) {
+                expanded.add(new RankedContent(rank, 0, child));
+            } else {
+                childrenByParent
+                        .computeIfAbsent(parentId, ignored -> new ArrayList<>())
+                        .add(new RankedContent(rank, 0, child));
+            }
+        }
+
+        if (expansionMode == ExpansionMode.PARENT) {
+            expandParents(childrenByParent, expanded);
+        } else {
+            expandSiblings(childrenByParent, expanded);
+        }
+
+        return expanded.stream()
+                .sorted(Comparator.comparingInt(RankedContent::rank).thenComparingInt(RankedContent::sequence))
+                .map(RankedContent::content)
+                .toList();
+    }
+
+    private void expandParents(Map<K, List<RankedContent>> childrenByParent, List<RankedContent> expanded) {
+        Map<K, Content> parents =
+                ensureNotNull(parentContentProvider.apply(childrenByParent.keySet()), "parentContentProvider result");
+        childrenByParent.forEach((parentId, children) -> {
+            Content parent = parents.get(parentId);
+            if (parent == null) {
+                handleMissing(parentId, children, expanded);
+            } else {
+                RankedContent bestChild = children.get(0);
+                expanded.add(new RankedContent(
+                        bestChild.rank(),
+                        0,
+                        Content.from(parent.textSegment(), bestChild.content().metadata())));
+            }
+        });
+    }
+
+    private void expandSiblings(Map<K, List<RankedContent>> childrenByParent, List<RankedContent> expanded) {
+        Map<K, List<Content>> siblingsByParent =
+                ensureNotNull(siblingContentProvider.apply(childrenByParent.keySet()), "siblingContentProvider result");
+        childrenByParent.forEach((parentId, children) -> {
+            List<Content> siblings = siblingsByParent.get(parentId);
+            if (siblings == null || siblings.isEmpty()) {
+                handleMissing(parentId, children, expanded);
+                return;
+            }
+
+            Set<Integer> selectedIndexes = new LinkedHashSet<>();
+            List<RankedContent> unmatchedChildren = new ArrayList<>();
+            for (RankedContent child : children) {
+                int siblingIndex = findSiblingIndex(siblings, child.content());
+                if (siblingIndex < 0) {
+                    unmatchedChildren.add(child);
+                    continue;
+                }
+                int from = Math.max(0, siblingIndex - siblingsBefore);
+                int to = Math.min(siblings.size() - 1, siblingIndex + siblingsAfter);
+                for (int i = from; i <= to; i++) {
+                    selectedIndexes.add(i);
+                }
+            }
+
+            if (selectedIndexes.isEmpty()) {
+                handleMissing(parentId, children, expanded);
+                return;
+            }
+
+            RankedContent bestChild = children.get(0);
+            int sequence = 0;
+            for (int index : selectedIndexes.stream().sorted().toList()) {
+                Content sibling = siblings.get(index);
+                expanded.add(new RankedContent(
+                        bestChild.rank(),
+                        sequence++,
+                        Content.from(sibling.textSegment(), bestChild.content().metadata())));
+            }
+            expanded.addAll(unmatchedChildren);
+        });
+    }
+
+    private int findSiblingIndex(List<Content> siblings, Content child) {
+        for (int i = 0; i < siblings.size(); i++) {
+            if (childMatcher.test(child, siblings.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void handleMissing(K parentId, List<RankedContent> children, List<RankedContent> expanded) {
+        switch (missingContextPolicy) {
+            case KEEP_CHILD -> expanded.addAll(children);
+            case DROP_CHILD -> {
+                // Intentionally empty.
+            }
+            case FAIL -> throw new IllegalStateException("No larger context found for parent ID: " + parentId);
+        }
+    }
+
+    private static int ensureNotNegative(int value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " cannot be negative");
+        }
+        return value;
+    }
+
+    private record RankedContent(int rank, int sequence, Content content) {}
+
+    public static <K> Builder<K> builder() {
+        return new Builder<>();
+    }
+
+    public static class Builder<K> {
+
+        private ContentRetriever childRetriever;
+        private Function<Content, K> parentIdProvider;
+        private ExpansionMode expansionMode = ExpansionMode.PARENT;
+        private Function<Collection<K>, Map<K, Content>> parentContentProvider;
+        private Function<Collection<K>, Map<K, List<Content>>> siblingContentProvider;
+        private int siblingsBefore = 1;
+        private int siblingsAfter = 1;
+        private BiPredicate<Content, Content> childMatcher = Content::equals;
+        private MissingContextPolicy missingContextPolicy = MissingContextPolicy.KEEP_CHILD;
+
+        public Builder<K> childRetriever(ContentRetriever childRetriever) {
+            this.childRetriever = childRetriever;
+            return this;
+        }
+
+        /** Extracts the parent or sibling-group ID from each retrieved child. Returning {@code null} keeps the child. */
+        public Builder<K> parentIdProvider(Function<Content, K> parentIdProvider) {
+            this.parentIdProvider = parentIdProvider;
+            return this;
+        }
+
+        public Builder<K> expansionMode(ExpansionMode expansionMode) {
+            this.expansionMode = expansionMode;
+            return this;
+        }
+
+        /** Sets a batch provider used by {@link ExpansionMode#PARENT}. */
+        public Builder<K> parentContentProvider(Function<Collection<K>, Map<K, Content>> parentContentProvider) {
+            this.parentContentProvider = parentContentProvider;
+            return this;
+        }
+
+        /** Sets a batch provider of siblings in document order, used by {@link ExpansionMode#SIBLINGS}. */
+        public Builder<K> siblingContentProvider(
+                Function<Collection<K>, Map<K, List<Content>>> siblingContentProvider) {
+            this.siblingContentProvider = siblingContentProvider;
+            return this;
+        }
+
+        /** Sets how many siblings before and after each child hit are returned. */
+        public Builder<K> siblingWindow(int siblingsBefore, int siblingsAfter) {
+            this.siblingsBefore = siblingsBefore;
+            this.siblingsAfter = siblingsAfter;
+            return this;
+        }
+
+        /** Sets how a retrieved child is located in the ordered sibling list. The default uses {@link Content#equals}. */
+        public Builder<K> childMatcher(BiPredicate<Content, Content> childMatcher) {
+            this.childMatcher = childMatcher;
+            return this;
+        }
+
+        public Builder<K> missingContextPolicy(MissingContextPolicy missingContextPolicy) {
+            this.missingContextPolicy = missingContextPolicy;
+            return this;
+        }
+
+        public SmallToBigContentRetriever<K> build() {
+            return new SmallToBigContentRetriever<>(this);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetriever.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetriever.java
@@ -244,7 +244,10 @@ public class SmallToBigContentRetriever<K> implements ContentRetriever {
             return this;
         }
 
-        /** Sets how a retrieved child is located in the ordered sibling list. The default uses {@link Content#equals}. */
+        /**
+         * Sets how a retrieved child is located in the ordered sibling list. The default uses
+         * {@link Object#equals(Object)}.
+         */
         public Builder<K> childMatcher(BiPredicate<Content, Content> childMatcher) {
             this.childMatcher = childMatcher;
             return this;

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetrieverTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetrieverTest.java
@@ -2,7 +2,9 @@ package dev.langchain4j.rag.content.retriever;
 
 import static dev.langchain4j.rag.content.ContentMetadata.SCORE;
 import static dev.langchain4j.rag.content.retriever.SmallToBigContentRetriever.ExpansionMode.SIBLINGS;
+import static dev.langchain4j.rag.content.retriever.SmallToBigContentRetriever.MissingContextPolicy.FAIL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.segment.TextSegment;
@@ -90,6 +92,34 @@ class SmallToBigContentRetrieverTest {
                 .extracting(content -> content.textSegment().text())
                 .containsExactly("parent 1", "child 2");
         assertThat(requestedIds.get()).containsExactly("parent-1", "parent-2");
+    }
+
+    @Test
+    void should_fail_when_larger_context_is_missing_and_policy_is_fail() {
+        Content child = child("child", "missing-parent", 0.9);
+        SmallToBigContentRetriever<String> retriever = SmallToBigContentRetriever.<String>builder()
+                .childRetriever(ignored -> List.of(child))
+                .parentIdProvider(content -> content.textSegment().metadata().getString("parentId"))
+                .parentContentProvider(ignored -> Map.of())
+                .missingContextPolicy(FAIL)
+                .build();
+
+        assertThatThrownBy(() -> retriever.retrieve(QUERY))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("No larger context found for parent ID: missing-parent");
+    }
+
+    @Test
+    void should_reject_a_negative_sibling_window() {
+        assertThatThrownBy(() -> SmallToBigContentRetriever.<String>builder()
+                        .childRetriever(ignored -> List.of())
+                        .parentIdProvider(content -> "parent")
+                        .expansionMode(SIBLINGS)
+                        .siblingContentProvider(ignored -> Map.of())
+                        .siblingWindow(-1, 1)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("siblingsBefore cannot be negative");
     }
 
     private static Content child(String text, String parentId, double score) {

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetrieverTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/SmallToBigContentRetrieverTest.java
@@ -1,0 +1,98 @@
+package dev.langchain4j.rag.content.retriever;
+
+import static dev.langchain4j.rag.content.ContentMetadata.SCORE;
+import static dev.langchain4j.rag.content.retriever.SmallToBigContentRetriever.ExpansionMode.SIBLINGS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.query.Query;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class SmallToBigContentRetrieverTest {
+
+    private static final Query QUERY = Query.from("query");
+
+    @Test
+    void should_replace_children_with_unique_parents_and_preserve_ranking_metadata() {
+        Content firstChild = child("child 1", "parent-1", 0.9);
+        Content secondChildOfSameParent = child("child 2", "parent-1", 0.8);
+        Content childWithoutParent = Content.from("standalone");
+        Content parent = Content.from("parent 1");
+        AtomicReference<Collection<String>> requestedIds = new AtomicReference<>();
+
+        SmallToBigContentRetriever<String> retriever = SmallToBigContentRetriever.<String>builder()
+                .childRetriever(ignored -> List.of(firstChild, secondChildOfSameParent, childWithoutParent))
+                .parentIdProvider(content -> content.textSegment().metadata().getString("parentId"))
+                .parentContentProvider(ids -> {
+                    requestedIds.set(ids);
+                    return Map.of("parent-1", parent);
+                })
+                .build();
+
+        List<Content> result = retriever.retrieve(QUERY);
+
+        assertThat(requestedIds.get()).containsExactly("parent-1");
+        assertThat(result)
+                .extracting(content -> content.textSegment().text())
+                .containsExactly("parent 1", "standalone");
+        assertThat(result.get(0).metadata()).containsEntry(SCORE, 0.9);
+    }
+
+    @Test
+    void should_expand_to_a_deduplicated_sibling_window_in_document_order() {
+        List<Content> siblings = List.of(
+                child("zero", "parent-1", 0),
+                child("one", "parent-1", 0),
+                child("two", "parent-1", 0),
+                child("three", "parent-1", 0),
+                child("four", "parent-1", 0));
+        Content hitTwo = child("two", "parent-1", 0.9);
+        Content hitThree = child("three", "parent-1", 0.8);
+
+        SmallToBigContentRetriever<String> retriever = SmallToBigContentRetriever.<String>builder()
+                .childRetriever(ignored -> List.of(hitTwo, hitThree))
+                .parentIdProvider(content -> content.textSegment().metadata().getString("parentId"))
+                .expansionMode(SIBLINGS)
+                .siblingContentProvider(ids -> Map.of("parent-1", siblings))
+                .siblingWindow(1, 1)
+                .build();
+
+        assertThat(retriever.retrieve(QUERY))
+                .extracting(content -> content.textSegment().text())
+                .containsExactly("one", "two", "three", "four");
+    }
+
+    @Test
+    void should_resolve_all_parent_groups_in_one_batch_and_keep_missing_children() {
+        Content childOne = child("child 1", "parent-1", 0.9);
+        Content childTwo = child("child 2", "parent-2", 0.8);
+        AtomicReference<Collection<String>> requestedIds = new AtomicReference<>();
+
+        SmallToBigContentRetriever<String> retriever = SmallToBigContentRetriever.<String>builder()
+                .childRetriever(ignored -> List.of(childOne, childTwo))
+                .parentIdProvider(content -> content.textSegment().metadata().getString("parentId"))
+                .parentContentProvider(ids -> {
+                    requestedIds.set(ids);
+                    Map<String, Content> result = new LinkedHashMap<>();
+                    result.put("parent-1", Content.from("parent 1"));
+                    return result;
+                })
+                .build();
+
+        assertThat(retriever.retrieve(QUERY))
+                .extracting(content -> content.textSegment().text())
+                .containsExactly("parent 1", "child 2");
+        assertThat(requestedIds.get()).containsExactly("parent-1", "parent-2");
+    }
+
+    private static Content child(String text, String parentId, double score) {
+        return Content.from(TextSegment.from(text, Metadata.from("parentId", parentId)), Map.of(SCORE, score));
+    }
+}


### PR DESCRIPTION
## Issue

Related to #3958 and #1484.

## Change

Adds a storage-agnostic `SmallToBigContentRetriever<K>` that wraps any child retriever and expands small matching chunks into larger context.

It supports two modes:

- `PARENT`: replace child hits with their parent content;
- `SIBLINGS`: return a configurable window of ordered sibling chunks around each hit, avoiding an oversized parent in the LLM context window.

Parent and sibling data providers are batched across unique group IDs to avoid N+1 lookups. Overlapping windows and repeated parents are deduplicated while preserving the best child rank and retrieval metadata. Missing context can keep the child, drop it, or fail.

Unit tests cover parent deduplication and metadata, sibling-window overlap and document order, batched resolution, missing-context fallback, failure policy, and invalid window validation. Documentation includes the sibling strategy.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run the new unit tests and they are green
- [ ] I have manually run all unit and integration tests in the changed module, core, and main modules
- [x] I have added/updated the documentation
- [ ] I have added an example in the examples repo (can follow after API review)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)

## Checklist for adding a new Maven module

- [ ] Not applicable

## Checklist for adding/changing an embedding store integration

- [ ] Not applicable