### PR TITLE
fix(mcp): retain description on union-typed tool parameter schemas

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -222,6 +222,9 @@ class ToolSpecificationHelper {
                     .map(ToolSpecificationHelper::toTypeElement)
                     .toArray(JsonSchemaElement[]::new);
             anyOf.anyOf(types);
+            if (node.has("description")) {
+                anyOf.description(node.get("description").asText());
+            }
             return anyOf.build();
         }
     }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -255,6 +255,33 @@ class ToolSpecificationHelperTest {
     }
 
     @Test
+    void arrayTypePreservesDescription() throws JsonProcessingException {
+        // A property whose "type" is a union array (like ["string", "null"]) goes through the
+        // type-array branch of jsonNodeToJsonSchemaElement, which builds a JsonAnyOfSchema.
+        // The node's own "description" must be carried onto that anyOf schema, just like the
+        // dedicated anyOf branch does. Otherwise LLMs lose the parameter's purpose entirely.
+        String text = """
+                [{
+                  "name": "query",
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": ["string", "null"],
+                        "description": "Filter by status (nullable)"
+                      }
+                    }
+                  }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
+        JsonAnyOfSchema status = (JsonAnyOfSchema) parameters.properties().get("status");
+        assertThat(status.description()).isEqualTo("Filter by status (nullable)");
+    }
+
+    @Test
     void arrayWithAnyOf() throws JsonProcessingException {
         // trimmed version of the tool from @modelcontextprotocol/server-github
         String text =


### PR DESCRIPTION
## Problem

When a MCP tool parameter declares a **union of types** — e.g.

```json
{
  "type": ["string", "null"],
  "description": "Filter by status (nullable)"
}
```

— the `type`-array branch of `ToolSpecificationHelper#jsonNodeToJsonSchemaElement` builds the resulting `JsonAnyOfSchema` **only from the declared type names and drops the node's own `description`**. The LLM therefore sees an anonymous `anyOf(string, null)` and loses the parameter's purpose entirely.

This is inconsistent with the dedicated `anyOf` branch (addressed upstream in #3886), which **does** preserve the `description`. Two equivalent schema shapes behave differently.

## Fix

Carry the node's `description` onto the generated `JsonAnyOfSchema`, mirroring the existing `anyOf` branch:

```java
anyOf.anyOf(types);
if (node.has("description")) {
    anyOf.description(node.get("description").asText());
}
return anyOf.build();
```

## Reproduction / test

Added `ToolSpecificationHelperTest#arrayTypePreservesDescription`. Before the fix it fails:

```
expected: "Filter by status (nullable)"
 but was: null
```

After the fix the full `ToolSpecificationHelperTest` suite passes: **36 tests, 0 failures**.

## Checklist

- [x] Unit test covers the new behavior (red before / green after)
- [x] Existing 35 tests in the class still pass