### PR TITLE
fix: preserve content metadata during reranking

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
@@ -1,12 +1,17 @@
 package dev.langchain4j.rag.content.aggregator;
 
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.rag.content.ContentMetadata.RERANKED_SCORE;
+import static java.util.Collections.emptyList;
+
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.scoring.ScoringModel;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.rag.query.transformer.ExpandingQueryTransformer;
-
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
@@ -14,12 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static dev.langchain4j.internal.Exceptions.illegalArgument;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.rag.content.ContentMetadata.RERANKED_SCORE;
-import static java.util.Collections.emptyList;
 
 /**
  * A {@link ContentAggregator} that performs re-ranking using a {@link ScoringModel}, such as Cohere.
@@ -52,11 +51,10 @@ public class ReRankingContentAggregator implements ContentAggregator {
             (queryToContents) -> {
                 if (queryToContents.size() > 1) {
                     throw illegalArgument(
-                            "The 'queryToContents' contains %s queries, making the re-ranking ambiguous. " +
-                                    "Because there are multiple queries, it is unclear which one should be " +
-                                    "used for re-ranking. Please provide a 'querySelector' in the constructor/builder.",
-                            queryToContents.size()
-                    );
+                            "The 'queryToContents' contains %s queries, making the re-ranking ambiguous. "
+                                    + "Because there are multiple queries, it is unclear which one should be "
+                                    + "used for re-ranking. Please provide a 'querySelector' in the constructor/builder.",
+                            queryToContents.size());
                 }
                 return queryToContents.keySet().iterator().next();
             };
@@ -70,16 +68,18 @@ public class ReRankingContentAggregator implements ContentAggregator {
         this(scoringModel, DEFAULT_QUERY_SELECTOR, null);
     }
 
-    public ReRankingContentAggregator(ScoringModel scoringModel,
-                                      Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
-                                      Double minScore) {
+    public ReRankingContentAggregator(
+            ScoringModel scoringModel,
+            Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
+            Double minScore) {
         this(scoringModel, querySelector, minScore, null);
     }
 
-    public ReRankingContentAggregator(ScoringModel scoringModel,
-                                      Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
-                                      Double minScore,
-                                      Integer maxResults) {
+    public ReRankingContentAggregator(
+            ScoringModel scoringModel,
+            Function<Map<Query, Collection<List<Content>>>, Query> querySelector,
+            Double minScore,
+            Integer maxResults) {
         this.scoringModel = ensureNotNull(scoringModel, "scoringModel");
         this.querySelector = getOrDefault(querySelector, DEFAULT_QUERY_SELECTOR);
         this.minScore = minScore;
@@ -125,9 +125,7 @@ public class ReRankingContentAggregator implements ContentAggregator {
 
     protected List<Content> reRankAndFilter(List<Content> contents, Query query) {
 
-        List<TextSegment> segments = contents.stream()
-                .map(Content::textSegment)
-                .collect(Collectors.toList());
+        List<TextSegment> segments = contents.stream().map(Content::textSegment).collect(Collectors.toList());
 
         List<Double> scores = scoringModel.scoreAll(segments, query.text()).content();
 
@@ -155,15 +153,15 @@ public class ReRankingContentAggregator implements ContentAggregator {
         private Double minScore;
         private Integer maxResults;
 
-        ReRankingContentAggregatorBuilder() {
-        }
+        ReRankingContentAggregatorBuilder() {}
 
         public ReRankingContentAggregatorBuilder scoringModel(ScoringModel scoringModel) {
             this.scoringModel = scoringModel;
             return this;
         }
 
-        public ReRankingContentAggregatorBuilder querySelector(Function<Map<Query, Collection<List<Content>>>, Query> querySelector) {
+        public ReRankingContentAggregatorBuilder querySelector(
+                Function<Map<Query, Collection<List<Content>>>, Query> querySelector) {
             this.querySelector = querySelector;
             return this;
         }
@@ -179,7 +177,8 @@ public class ReRankingContentAggregator implements ContentAggregator {
         }
 
         public ReRankingContentAggregator build() {
-            return new ReRankingContentAggregator(this.scoringModel, this.querySelector, this.minScore, this.maxResults);
+            return new ReRankingContentAggregator(
+                    this.scoringModel, this.querySelector, this.minScore, this.maxResults);
         }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
@@ -3,11 +3,12 @@ package dev.langchain4j.rag.content.aggregator;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.scoring.ScoringModel;
 import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.rag.query.transformer.ExpandingQueryTransformer;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,15 +131,20 @@ public class ReRankingContentAggregator implements ContentAggregator {
 
         List<Double> scores = scoringModel.scoreAll(segments, query.text()).content();
 
-        Map<TextSegment, Double> segmentToScore = new HashMap<>();
-        for (int i = 0; i < segments.size(); i++) {
-            segmentToScore.put(segments.get(i), scores.get(i));
+        Map<Content, Double> contentToScore = new LinkedHashMap<>();
+        for (int i = 0; i < contents.size(); i++) {
+            contentToScore.put(contents.get(i), scores.get(i));
         }
 
-        return segmentToScore.entrySet().stream()
+        return contentToScore.entrySet().stream()
                 .filter(entry -> minScore == null || entry.getValue() >= minScore)
-                .sorted(Map.Entry.<TextSegment, Double>comparingByValue().reversed())
-                .map(entry ->  Content.from(entry.getKey(), Map.of(RERANKED_SCORE, entry.getValue())))
+                .sorted(Map.Entry.<Content, Double>comparingByValue().reversed())
+                .map(entry -> {
+                    Map<ContentMetadata, Object> metadata = new EnumMap<>(ContentMetadata.class);
+                    metadata.putAll(entry.getKey().metadata());
+                    metadata.put(RERANKED_SCORE, entry.getValue());
+                    return Content.from(entry.getKey().textSegment(), metadata);
+                })
                 .limit(maxResults)
                 .collect(Collectors.toList());
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
@@ -74,10 +74,12 @@ class ReRankingContentAggregatorTest {
 
         List<Content> aggregated = new ReRankingContentAggregator(scoringModel).aggregate(queryToContents);
 
-        assertThat(aggregated).singleElement().satisfies(reranked -> assertThat(reranked.metadata())
-                .containsEntry(ContentMetadata.SCORE, 0.8)
-                .containsEntry(ContentMetadata.EMBEDDING_ID, "embedding-id")
-                .containsEntry(ContentMetadata.RERANKED_SCORE, 0.9));
+        assertThat(aggregated)
+                .singleElement()
+                .satisfies(reranked -> assertThat(reranked.metadata())
+                        .containsEntry(ContentMetadata.SCORE, 0.8)
+                        .containsEntry(ContentMetadata.EMBEDDING_ID, "embedding-id")
+                        .containsEntry(ContentMetadata.RERANKED_SCORE, 0.9));
     }
 
     static Stream<Arguments> should_rerank_when_single_query_and_single_contents() {

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregatorTest.java
@@ -60,6 +60,26 @@ class ReRankingContentAggregatorTest {
         assertReRankedContentScore(aggregated, 0.7, 0.5);
     }
 
+    @Test
+    void should_preserve_content_metadata_when_reranking() {
+        Query query = Query.from("query");
+        Content content = Content.from(
+                TextSegment.from("content"),
+                Map.of(ContentMetadata.SCORE, 0.8, ContentMetadata.EMBEDDING_ID, "embedding-id"));
+        Map<Query, Collection<List<Content>>> queryToContents =
+                singletonMap(query, singletonList(singletonList(content)));
+
+        ScoringModel scoringModel = mock(ScoringModel.class);
+        when(scoringModel.scoreAll(any(), any())).thenReturn(Response.from(singletonList(0.9)));
+
+        List<Content> aggregated = new ReRankingContentAggregator(scoringModel).aggregate(queryToContents);
+
+        assertThat(aggregated).singleElement().satisfies(reranked -> assertThat(reranked.metadata())
+                .containsEntry(ContentMetadata.SCORE, 0.8)
+                .containsEntry(ContentMetadata.EMBEDDING_ID, "embedding-id")
+                .containsEntry(ContentMetadata.RERANKED_SCORE, 0.9));
+    }
+
     static Stream<Arguments> should_rerank_when_single_query_and_single_contents() {
         return Stream.<Arguments>builder()
                 .add(Arguments.of((Function<ScoringModel, ContentAggregator>) ReRankingContentAggregator::new))


### PR DESCRIPTION
## Summary

ReRankingContentAggregator currently rebuilds every reranked Content with only RERANKED_SCORE. This silently drops retriever metadata such as SCORE and EMBEDDING_ID, which breaks traceability and downstream processing after reranking.

This change:

- associates returned scores with the original Content rather than only its TextSegment
- copies the original content metadata before adding/replacing RERANKED_SCORE
- preserves stable encounter order for equal reranking scores
- adds a regression test covering preservation of SCORE and EMBEDDING_ID

## Testing

- ReRankingContentAggregatorTest (11 tests)
- git diff --check

The new regression test fails on current main because the output metadata contains only RERANKED_SCORE, and passes with this fix.