### PR TITLE
fix: preserve transformed query order in RAG

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
@@ -1,5 +1,14 @@
 package dev.langchain4j.rag;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.rag.content.Content;
@@ -13,7 +22,6 @@ import dev.langchain4j.rag.query.router.DefaultQueryRouter;
 import dev.langchain4j.rag.query.router.QueryRouter;
 import dev.langchain4j.rag.query.transformer.DefaultQueryTransformer;
 import dev.langchain4j.rag.query.transformer.QueryTransformer;
-
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,15 +33,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
-import static java.util.concurrent.CompletableFuture.allOf;
-import static java.util.concurrent.CompletableFuture.supplyAsync;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * The default implementation of {@link RetrievalAugmentor} intended to be suitable for the majority of use cases.
@@ -111,11 +110,12 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
     private final ContentInjector contentInjector;
     private final Executor executor;
 
-    public DefaultRetrievalAugmentor(QueryTransformer queryTransformer,
-                                     QueryRouter queryRouter,
-                                     ContentAggregator contentAggregator,
-                                     ContentInjector contentInjector,
-                                     Executor executor) {
+    public DefaultRetrievalAugmentor(
+            QueryTransformer queryTransformer,
+            QueryRouter queryRouter,
+            ContentAggregator contentAggregator,
+            ContentInjector contentInjector,
+            Executor executor) {
         this.queryTransformer = getOrDefault(queryTransformer, DefaultQueryTransformer::new);
         this.queryRouter = ensureNotNull(queryRouter, "queryRouter");
         this.contentAggregator = getOrDefault(contentAggregator, DefaultContentAggregator::new);
@@ -124,11 +124,7 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
     }
 
     private static ExecutorService createDefaultExecutor() {
-        return new ThreadPoolExecutor(
-            0, Integer.MAX_VALUE,
-            1, SECONDS,
-            new SynchronousQueue<>()
-        );
+        return new ThreadPoolExecutor(0, Integer.MAX_VALUE, 1, SECONDS, new SynchronousQueue<>());
     }
 
     @Override
@@ -152,9 +148,9 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
         ChatMessage augmentedChatMessage = contentInjector.inject(contents, chatMessage);
 
         return AugmentationResult.builder()
-            .chatMessage(augmentedChatMessage)
-            .contents(contents)
-            .build();
+                .chatMessage(augmentedChatMessage)
+                .contents(contents)
+                .build();
     }
 
     private Map<Query, Collection<List<Content>>> process(Collection<Query> queries) {
@@ -166,7 +162,8 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
                 List<Content> contents = contentRetriever.retrieve(query);
                 return singletonMap(query, singletonList(contents));
             } else if (retrievers.size() > 1) {
-                Collection<List<Content>> contents = retrieveFromAll(retrievers, query).join();
+                Collection<List<Content>> contents =
+                        retrieveFromAll(retrievers, query).join();
                 return singletonMap(query, contents);
             } else {
                 return emptyMap();
@@ -174,8 +171,9 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
         } else if (queries.size() > 1) {
             Map<Query, CompletableFuture<Collection<List<Content>>>> queryToFutureContents = new LinkedHashMap<>();
             queries.forEach(query -> {
-                queryToFutureContents.computeIfAbsent(query, ignored ->
-                        supplyAsync(() -> queryRouter.route(query), executor)
+                queryToFutureContents.computeIfAbsent(
+                        query,
+                        ignored -> supplyAsync(() -> queryRouter.route(query), executor)
                                 .thenCompose(retrievers -> retrieveFromAll(retrievers, query)));
             });
             return join(queryToFutureContents);
@@ -184,30 +182,29 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
         }
     }
 
-    private CompletableFuture<Collection<List<Content>>> retrieveFromAll(Collection<ContentRetriever> retrievers,
-                                                                         Query query) {
+    private CompletableFuture<Collection<List<Content>>> retrieveFromAll(
+            Collection<ContentRetriever> retrievers, Query query) {
         List<CompletableFuture<List<Content>>> futureContents = retrievers.stream()
-            .map(retriever -> supplyAsync(() -> retriever.retrieve(query), executor))
-            .collect(Collectors.toList());
+                .map(retriever -> supplyAsync(() -> retriever.retrieve(query), executor))
+                .collect(Collectors.toList());
 
         return allOf(futureContents.toArray(new CompletableFuture[0]))
-            .thenApply(ignored ->
-                futureContents.stream()
-                    .map(CompletableFuture::join)
-                    .collect(Collectors.toList()));
+                .thenApply(ignored ->
+                        futureContents.stream().map(CompletableFuture::join).collect(Collectors.toList()));
     }
 
     private static Map<Query, Collection<List<Content>>> join(
-        Map<Query, CompletableFuture<Collection<List<Content>>>> queryToFutureContents) {
+            Map<Query, CompletableFuture<Collection<List<Content>>>> queryToFutureContents) {
         return allOf(queryToFutureContents.values().toArray(new CompletableFuture[0]))
-            .thenApply(ignored -> {
-                Map<Query, Collection<List<Content>>> queryToContents = new LinkedHashMap<>();
-                for (Map.Entry<Query, CompletableFuture<Collection<List<Content>>>> entry
-                        : queryToFutureContents.entrySet()) {
-                    queryToContents.put(entry.getKey(), entry.getValue().join());
-                }
-                return queryToContents;
-            }).join();
+                .thenApply(ignored -> {
+                    Map<Query, Collection<List<Content>>> queryToContents = new LinkedHashMap<>();
+                    for (Map.Entry<Query, CompletableFuture<Collection<List<Content>>>> entry :
+                            queryToFutureContents.entrySet()) {
+                        queryToContents.put(entry.getKey(), entry.getValue().join());
+                    }
+                    return queryToContents;
+                })
+                .join();
     }
 
     public static DefaultRetrievalAugmentorBuilder builder() {
@@ -222,8 +219,7 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
         private ContentInjector contentInjector;
         private Executor executor;
 
-        DefaultRetrievalAugmentorBuilder() {
-        }
+        DefaultRetrievalAugmentorBuilder() {}
 
         public DefaultRetrievalAugmentorBuilder contentRetriever(ContentRetriever contentRetriever) {
             this.queryRouter = new DefaultQueryRouter(ensureNotNull(contentRetriever, "contentRetriever"));
@@ -256,7 +252,12 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
         }
 
         public DefaultRetrievalAugmentor build() {
-            return new DefaultRetrievalAugmentor(this.queryTransformer, this.queryRouter, this.contentAggregator, this.contentInjector, this.executor);
+            return new DefaultRetrievalAugmentor(
+                    this.queryTransformer,
+                    this.queryRouter,
+                    this.contentAggregator,
+                    this.contentInjector,
+                    this.executor);
         }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
@@ -15,10 +15,10 @@ import dev.langchain4j.rag.query.transformer.DefaultQueryTransformer;
 import dev.langchain4j.rag.query.transformer.QueryTransformer;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,7 +34,6 @@ import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * The default implementation of {@link RetrievalAugmentor} intended to be suitable for the majority of use cases.
@@ -173,12 +172,11 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
                 return emptyMap();
             }
         } else if (queries.size() > 1) {
-            Map<Query, CompletableFuture<Collection<List<Content>>>> queryToFutureContents = new ConcurrentHashMap<>();
+            Map<Query, CompletableFuture<Collection<List<Content>>>> queryToFutureContents = new LinkedHashMap<>();
             queries.forEach(query -> {
-                CompletableFuture<Collection<List<Content>>> futureContents =
+                queryToFutureContents.computeIfAbsent(query, ignored ->
                         supplyAsync(() -> queryRouter.route(query), executor)
-                                .thenCompose(retrievers -> retrieveFromAll(retrievers, query));
-                queryToFutureContents.put(query, futureContents);
+                                .thenCompose(retrievers -> retrieveFromAll(retrievers, query)));
             });
             return join(queryToFutureContents);
         } else {
@@ -202,13 +200,14 @@ public class DefaultRetrievalAugmentor implements RetrievalAugmentor {
     private static Map<Query, Collection<List<Content>>> join(
         Map<Query, CompletableFuture<Collection<List<Content>>>> queryToFutureContents) {
         return allOf(queryToFutureContents.values().toArray(new CompletableFuture[0]))
-            .thenApply(ignored ->
-                queryToFutureContents.entrySet().stream()
-                    .collect(toMap(
-                        Map.Entry::getKey,
-                        entry -> entry.getValue().join()
-                    ))
-            ).join();
+            .thenApply(ignored -> {
+                Map<Query, Collection<List<Content>>> queryToContents = new LinkedHashMap<>();
+                for (Map.Entry<Query, CompletableFuture<Collection<List<Content>>>> entry
+                        : queryToFutureContents.entrySet()) {
+                    queryToContents.put(entry.getKey(), entry.getValue().join());
+                }
+                return queryToContents;
+            }).join();
     }
 
     public static DefaultRetrievalAugmentorBuilder builder() {

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
@@ -103,9 +103,7 @@ class DefaultRetrievalAugmentorTest {
 
         // then
         UserMessage augmented = (UserMessage) result.chatMessage();
-        assertThat(augmented.singleText())
-                .isEqualTo(
-                        """
+        assertThat(augmented.singleText()).isEqualTo("""
                 query
                 content 1
                 content 2
@@ -232,9 +230,7 @@ class DefaultRetrievalAugmentorTest {
 
         // then
         UserMessage augmented = (UserMessage) result.chatMessage();
-        assertThat(augmented.singleText())
-                .isEqualTo(
-                        """
+        assertThat(augmented.singleText()).isEqualTo("""
                 query
                 content 1
                 content 2
@@ -311,8 +307,7 @@ class DefaultRetrievalAugmentorTest {
 
         // then
         UserMessage augmented = (UserMessage) result.chatMessage();
-        assertThat(augmented.singleText())
-                .isEqualTo("""
+        assertThat(augmented.singleText()).isEqualTo("""
                 query
                 content 1
                 content 2""");

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
@@ -151,6 +151,48 @@ class DefaultRetrievalAugmentorTest {
     }
 
     @Test
+    void should_preserve_transformed_query_order() {
+        Query firstQuery = Query.from("z");
+        Query secondQuery = Query.from("a");
+        QueryTransformer queryTransformer = new TestQueryTransformer(firstQuery, secondQuery);
+        ContentRetriever contentRetriever = query -> singletonList(Content.from(query.text()));
+
+        RetrievalAugmentor retrievalAugmentor = DefaultRetrievalAugmentor.builder()
+                .queryTransformer(queryTransformer)
+                .queryRouter(new DefaultQueryRouter(contentRetriever))
+                .executor(Runnable::run)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("query");
+        Metadata metadata = Metadata.from(userMessage, SystemMessage.from("system"), null, null);
+        AugmentationResult result = retrievalAugmentor.augment(new AugmentationRequest(userMessage, metadata));
+
+        assertThat(result.contents())
+                .extracting(content -> content.textSegment().text())
+                .containsExactly(firstQuery.text(), secondQuery.text());
+    }
+
+    @Test
+    void should_retrieve_only_once_for_duplicate_transformed_queries() {
+        Query query = Query.from("duplicate");
+        QueryTransformer queryTransformer = new TestQueryTransformer(query, query);
+        ContentRetriever contentRetriever = mock(ContentRetriever.class);
+        when(contentRetriever.retrieve(query)).thenReturn(emptyList());
+
+        RetrievalAugmentor retrievalAugmentor = DefaultRetrievalAugmentor.builder()
+                .queryTransformer(queryTransformer)
+                .queryRouter(new DefaultQueryRouter(contentRetriever))
+                .executor(Runnable::run)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("query");
+        Metadata metadata = Metadata.from(userMessage, SystemMessage.from("system"), null, null);
+        retrievalAugmentor.augment(new AugmentationRequest(userMessage, metadata));
+
+        verify(contentRetriever).retrieve(query);
+    }
+
+    @Test
     void should_augment_user_message__single_query_multiple_retrievers() {
 
         // given


### PR DESCRIPTION
## Summary

DefaultRetrievalAugmentor receives transformed queries as a Collection, but for multiple queries it stores their futures in a ConcurrentHashMap and later collects the results into a HashMap. This discards encounter order even though no concurrent writes to either map occur.

The order is observable: DefaultContentAggregator performs a second RRF pass over the map values, and stable sorting uses input order to resolve equal RRF scores. Equally ranked contents can therefore be reordered by query hash buckets rather than QueryTransformer output.

There is a second issue on the same path: duplicate transformed Query objects start duplicate asynchronous retrievals, but the map retains only one future. The discarded call adds latency/cost and cannot affect aggregation.

This change:

- uses LinkedHashMap while scheduling and joining query futures
- retains transformed-query order without changing asynchronous execution
- uses computeIfAbsent so an equal Query is retrieved only once
- adds end-to-end ordering and duplicate-call regression tests

## Testing

- DefaultRetrievalAugmentorTest: 18 tests passed
- both new tests fail against current main and pass with this change
- Spotless formatting applied
- git diff --check