### PR TITLE
fix: avoid float overflow in cosine similarity

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/CosineSimilarity.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/CosineSimilarity.java
@@ -54,9 +54,11 @@ public class CosineSimilarity {
         double normB = 0.0;
 
         for (int i = 0; i < vectorA.length; i++) {
-            dotProduct += vectorA[i] * vectorB[i];
-            normA += vectorA[i] * vectorA[i];
-            normB += vectorB[i] * vectorB[i];
+            double valueA = vectorA[i];
+            double valueB = vectorB[i];
+            dotProduct += valueA * valueB;
+            normA += valueA * valueA;
+            normB += valueB * valueB;
         }
 
         // Avoid division by zero.

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/CosineSimilarity.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/CosineSimilarity.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.store.embedding;
 
-import dev.langchain4j.data.embedding.Embedding;
-
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.embedding.Embedding;
 
 /**
  * Utility class for calculating cosine similarity between two vectors.
@@ -45,7 +45,8 @@ public class CosineSimilarity {
         float[] vectorB = embeddingB.vector();
 
         if (vectorA.length != vectorB.length) {
-            throw illegalArgument("Length of vector a (%s) must be equal to the length of vector b (%s)",
+            throw illegalArgument(
+                    "Length of vector a (%s) must be equal to the length of vector b (%s)",
                     vectorA.length, vectorB.length);
         }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/CosineSimilarityTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/CosineSimilarityTest.java
@@ -35,6 +35,13 @@ class CosineSimilarityTest implements WithAssertions {
     }
 
     @Test
+    void should_not_overflow_when_vector_components_are_large() {
+        Embedding embedding = Embedding.from(new float[] {Float.MAX_VALUE, Float.MAX_VALUE});
+
+        assertThat(CosineSimilarity.between(embedding, embedding)).isCloseTo(1, withPercentage(1));
+    }
+
+    @Test
     void should_convert_relevance_score_into_cosine_similarity() {
         assertThat(CosineSimilarity.fromRelevanceScore(0)).isEqualTo(-1);
         assertThat(CosineSimilarity.fromRelevanceScore(0.5)).isEqualTo(0);


### PR DESCRIPTION
## Summary

CosineSimilarity accumulates into double variables, but each multiplication is currently evaluated as float multiplication first. Large finite float components therefore overflow to Infinity before promotion to double.

For example, the cosine similarity of [Float.MAX_VALUE, Float.MAX_VALUE] with itself currently returns NaN instead of 1. That violates the documented [-1, 1] result range and can make in-memory embedding search silently drop or misorder matches.

This change promotes each component to double before calculating the dot product and norms, preventing premature float overflow.

## Testing

- added a regression test using large finite float components
- the test returns NaN and fails on current main
- all 5 CosineSimilarityTest tests pass after the fix
- Spotless formatting applied
- git diff --check