### PR TITLE
fix: fail closed when legacy Elasticsearch config cannot apply filters

### DIFF
--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfiguration.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfiguration.java
@@ -69,10 +69,15 @@ public interface ElasticsearchConfiguration {
             ElasticsearchClient client, String indexName, FullTextSearchRequest request)
             throws ElasticsearchException, IOException {
         if (request.filter() != null) {
+            throw new UnsupportedOperationException(this.getClass().getName()
+                    + " does not implement fullTextSearch(ElasticsearchClient, String, FullTextSearchRequest), "
+                    + "so it cannot apply the requested filter. Refusing to execute an unfiltered search.");
+        }
+        if (request.maxResults() != 3 || request.minScore() != 0.0) {
             LoggerFactory.getLogger(ElasticsearchConfiguration.class)
                     .warn(
                             "[{}] does not implement fullTextSearch(ElasticsearchClient, String, FullTextSearchRequest), "
-                                    + "so the filter, maxResults and minScore are ignored and documents which do not match the filter can be returned.",
+                                    + "so maxResults and minScore are ignored.",
                             this.getClass().getName());
         }
         return fullTextSearch(client, indexName, request.textQuery());

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationTest.java
@@ -13,24 +13,30 @@ import org.junit.jupiter.api.Test;
 
 class ElasticsearchConfigurationTest {
 
-    private static final FullTextSearchRequest REQUEST = FullTextSearchRequest.builder()
+    private static final FullTextSearchRequest FILTERED_REQUEST = FullTextSearchRequest.builder()
             .textQuery("search text")
             .maxResults(7)
             .minScore(0.5)
             .filter(new IsEqualTo("tenant", "acme"))
             .build();
 
+    private static final FullTextSearchRequest UNFILTERED_REQUEST = FullTextSearchRequest.builder()
+            .textQuery("search text")
+            .maxResults(7)
+            .minScore(0.5)
+            .build();
+
     /**
      * Configurations written before {@link FullTextSearchRequest} existed only implement the deprecated
-     * {@link ElasticsearchConfiguration#fullTextSearch(ElasticsearchClient, String, String)}. They must keep working,
-     * even though the constraints of the request cannot be applied.
+     * {@link ElasticsearchConfiguration#fullTextSearch(ElasticsearchClient, String, String)}. They must keep working
+     * for unfiltered requests, even though non-security constraints cannot be applied.
      */
     @Test
     @SuppressWarnings("removal")
     void should_fall_back_to_the_deprecated_full_text_search() throws IOException {
         LegacyConfiguration configuration = new LegacyConfiguration();
 
-        SearchResponse<Document> response = configuration.fullTextSearch(null, "articles", REQUEST);
+        SearchResponse<Document> response = configuration.fullTextSearch(null, "articles", UNFILTERED_REQUEST);
 
         assertThat(configuration.capturedIndexName).isEqualTo("articles");
         assertThat(configuration.capturedTextQuery).isEqualTo("search text");
@@ -38,10 +44,20 @@ class ElasticsearchConfigurationTest {
     }
 
     @Test
+    void should_fail_closed_when_legacy_configuration_cannot_apply_filter() {
+        LegacyConfiguration configuration = new LegacyConfiguration();
+
+        assertThatThrownBy(() -> configuration.fullTextSearch(null, "articles", FILTERED_REQUEST))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("cannot apply the requested filter")
+                .hasMessageContaining("Refusing to execute an unfiltered search");
+    }
+
+    @Test
     void should_fail_when_the_configuration_does_not_support_full_text_search() {
         ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {};
 
-        assertThatThrownBy(() -> configuration.fullTextSearch(null, "articles", REQUEST))
+        assertThatThrownBy(() -> configuration.fullTextSearch(null, "articles", UNFILTERED_REQUEST))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("does not support fulltext search");
     }


### PR DESCRIPTION
## Problem

`ElasticsearchConfiguration.fullTextSearch(..., FullTextSearchRequest)` preserves compatibility with configurations that only override the deprecated string-based overload. When such a legacy configuration receives a request with a `Filter`, the current fallback only logs a warning and then executes the unfiltered search. For authorization filters, this is a fail-open path that can return documents outside the caller's access scope.

## Changes

- fail closed with `UnsupportedOperationException` when a legacy configuration cannot apply a requested filter
- preserve the deprecated fallback for unfiltered requests
- keep warning that non-security constraints (`maxResults` and `minScore`) are ignored by the legacy overload
- add regression coverage for both filtered and unfiltered legacy requests

## Testing

`mvn -o -Dmaven.repo.local=... -f langchain4j-elasticsearch/pom.xml -DskipITs -Dtest=ElasticsearchConfigurationTest test`

Result: 3 tests, 0 failures, 0 errors.