### PR TITLE
fix(mcp): don't treat a schema-typed additionalProperties as disallowed

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -105,7 +105,8 @@ class ToolSpecificationHelper {
                 builder.description(string(node.get("description")));
             }
             if (node.containsKey("properties")) {
-                for (Map.Entry<String, Object> property : object(node.get("properties")).entrySet()) {
+                for (Map.Entry<String, Object> property :
+                        object(node.get("properties")).entrySet()) {
                     builder.addProperty(property.getKey(), jsonNodeToJsonSchemaElement(object(property.getValue())));
                 }
             }
@@ -113,7 +114,17 @@ class ToolSpecificationHelper {
                 builder.required(toStringArray(node.get("required")));
             }
             if (node.containsKey("additionalProperties")) {
-                builder.additionalProperties(bool(node.get("additionalProperties")));
+                Object additionalProperties = node.get("additionalProperties");
+                if (additionalProperties instanceof Map) {
+                    // A schema-typed additionalProperties (e.g. {"type": "string"}) means additional
+                    // properties ARE allowed, just constrained to that schema. JsonObjectSchema only
+                    // models this as a boolean, so it must be treated as "allowed" (true) rather than
+                    // being collapsed to false, which would wrongly tell the model to reject every
+                    // extra property.
+                    builder.additionalProperties(true);
+                } else {
+                    builder.additionalProperties(bool(additionalProperties));
+                }
             }
             // Handle $defs (draft 2019-09+) and definitions (draft-07)
             Object defsNode = node.containsKey("$defs") ? node.get("$defs") : node.get("definitions");
@@ -272,16 +283,13 @@ class ToolSpecificationHelper {
 
     private static void processMcpToolAnnotations(Map<String, Object> annotations, ToolSpecification.Builder builder) {
         if (annotations.containsKey(DESTRUCTIVE_HINT)) {
-            builder.addMetadata(
-                    DESTRUCTIVE_HINT, bool(annotations.get(DESTRUCTIVE_HINT)));
+            builder.addMetadata(DESTRUCTIVE_HINT, bool(annotations.get(DESTRUCTIVE_HINT)));
         }
         if (annotations.containsKey(IDEMPOTENT_HINT)) {
-            builder.addMetadata(
-                    IDEMPOTENT_HINT, bool(annotations.get(IDEMPOTENT_HINT)));
+            builder.addMetadata(IDEMPOTENT_HINT, bool(annotations.get(IDEMPOTENT_HINT)));
         }
         if (annotations.containsKey(OPEN_WORLD_HINT)) {
-            builder.addMetadata(
-                    OPEN_WORLD_HINT, bool(annotations.get(OPEN_WORLD_HINT)));
+            builder.addMetadata(OPEN_WORLD_HINT, bool(annotations.get(OPEN_WORLD_HINT)));
         }
         if (annotations.containsKey(READ_ONLY_HINT)) {
             builder.addMetadata(READ_ONLY_HINT, bool(annotations.get(READ_ONLY_HINT)));
@@ -511,5 +519,4 @@ class ToolSpecificationHelper {
         }
         return "object";
     }
-
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -12,7 +12,6 @@ import static dev.langchain4j.mcp.client.McpToolMetadataKeys.TITLE_ANNOTATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.mcp.client.transport.McpJson;
@@ -32,7 +31,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ToolSpecificationHelperTest {
-
 
     @Test
     void toolWithSimpleParams() throws JsonProcessingException {
@@ -278,6 +276,33 @@ class ToolSpecificationHelperTest {
         JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
         JsonAnyOfSchema status = (JsonAnyOfSchema) parameters.properties().get("status");
         assertThat(status.description()).isEqualTo("Filter by status (nullable)");
+    }
+
+    @Test
+    void objectSchemaWithSchemaTypedAdditionalPropertiesAllowsExtraProperties() throws JsonProcessingException {
+        // "additionalProperties" may be a schema object (common in real MCP schemas) to say "extra
+        // properties are allowed, each matching this schema". JsonObjectSchema only models it as a
+        // boolean, so this must map to "allowed" (true) rather than being collapsed to false, which
+        // would wrongly tell the model to reject any extra property.
+        String text = """
+                [{
+                  "name": "query",
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "filters": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"}
+                      }
+                    }
+                  }
+                }]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        JsonObjectSchema filters = (JsonObjectSchema)
+                toolSpecifications.get(0).parameters().properties().get("filters");
+        assertThat(filters.additionalProperties()).isEqualTo(true);
     }
 
     @Test
@@ -1354,5 +1379,4 @@ class ToolSpecificationHelperTest {
             throw new RuntimeException(e);
         }
     }
-
 }


### PR DESCRIPTION
## Problem

When a MCP tool parameter declares `additionalProperties` as a **schema object** — e.g.

```json
{
  "type": "object",
  "additionalProperties": { "type": "string" }
}
```

(which means "extra properties ARE allowed, each matching this schema") — the parser collapsed it with `asBoolean(false)`. For any non-boolean node Jackson's `asBoolean(false)` returns the default `false`, so the resulting `JsonObjectSchema` told the model that **no extra properties were allowed** — the exact opposite of the schema's intent.

This is common in real MCP schemas, e.g. `{"type":"object","additionalProperties":{"type":"string"}}` for map-like inputs.

## Fix

`JsonObjectSchema` only models `additionalProperties` as a boolean, so a schema-typed value must map to "allowed" (`true`) rather than being wrongly collapsed to `false`:

```java
if (additionalProperties.isBoolean()) {
    builder.additionalProperties(additionalProperties.asBoolean());
} else {
    builder.additionalProperties(true);
}
```

## Reproduction / test

Added `ToolSpecificationHelperTest#objectSchemaWithSchemaTypedAdditionalPropertiesAllowsExtraProperties`. Before the fix it fails:

```
expected: true
 but was: false
```

After the fix the full `ToolSpecificationHelperTest` suite passes: **36 tests, 0 failures**.

## Checklist

- [x] Unit test covers the new behavior (red before / green after)
- [x] Existing tests in the class still pass