### PR TITLE
fix: Override toBuilder, equals, hashCode and toString in WatsonxChatResponseMetadata

### DIFF
--- a/langchain4j-watsonx/revapi.json
+++ b/langchain4j-watsonx/revapi.json
@@ -68,6 +68,12 @@
           "code": "java\\.method\\.finalMethodAddedToNonFinalClass",
           "new": "method .* dev\\.langchain4j\\.model\\.watsonx\\.WatsonxChatBase<R extends com\\.ibm\\.watsonx\\.ai\\.chat\\.BaseChatRequest>::.*",
           "justification": "executeChat, executeChatStreaming and applyCommonParameters are inherited from the @Internal WatsonxChatBase and are not part of the public API."
+        },
+        {
+          "code": "java.method.returnTypeChangedCovariantly",
+          "old": "method dev.langchain4j.model.chat.response.ChatResponseMetadata dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata.Builder::build()",
+          "new": "method dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata.Builder::build()",
+          "justification": "Covariant override: javac emits a bridge method retaining the original ()Ldev/langchain4j/model/chat/response/ChatResponseMetadata; descriptor (ACC_BRIDGE, ACC_SYNTHETIC), so callers compiled against the previous signature still link and run. Source-compatible as well, and consistent with the other nine ChatResponseMetadata subclasses."
         }
       ]
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadata.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadata.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.watsonx;
 
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import java.util.Objects;
 
 public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
 
@@ -37,6 +38,48 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
 
     public Boolean getCached() {
         return cached;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return ((Builder) super.toBuilder(builder()))
+                .created(created)
+                .modelVersion(modelVersion)
+                .serviceTier(serviceTier)
+                .systemFingerprint(systemFingerprint)
+                .cached(cached);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        WatsonxChatResponseMetadata that = (WatsonxChatResponseMetadata) o;
+        return Objects.equals(created, that.created)
+                && Objects.equals(modelVersion, that.modelVersion)
+                && Objects.equals(serviceTier, that.serviceTier)
+                && Objects.equals(systemFingerprint, that.systemFingerprint)
+                && Objects.equals(cached, that.cached);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), created, modelVersion, serviceTier, systemFingerprint, cached);
+    }
+
+    @Override
+    public String toString() {
+        return "WatsonxChatResponseMetadata{" + "id='"
+                + id() + '\'' + ", modelName='"
+                + modelName() + '\'' + ", tokenUsage="
+                + tokenUsage() + ", finishReason="
+                + finishReason() + ", created="
+                + created + ", modelVersion='"
+                + modelVersion + '\'' + ", serviceTier='"
+                + serviceTier + '\'' + ", systemFingerprint='"
+                + systemFingerprint + '\'' + ", cached="
+                + cached + '}';
     }
 
     public static Builder builder() {
@@ -76,7 +119,7 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
         }
 
         @Override
-        public ChatResponseMetadata build() {
+        public WatsonxChatResponseMetadata build() {
             return new WatsonxChatResponseMetadata(this);
         }
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadataTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadataTest.java
@@ -1,0 +1,142 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import org.junit.jupiter.api.Test;
+
+class WatsonxChatResponseMetadataTest {
+
+    private static WatsonxChatResponseMetadata.Builder fullyPopulated() {
+        return WatsonxChatResponseMetadata.builder()
+                .id("chat-id")
+                .modelName("ibm/granite-3-8b-instruct")
+                .tokenUsage(new TokenUsage(1, 2, 3))
+                .finishReason(FinishReason.STOP)
+                .created(1754000000L)
+                .modelVersion("2.0.0")
+                .serviceTier("premium")
+                .systemFingerprint("fp-1")
+                .cached(true);
+    }
+
+    @Test
+    void toBuilder_should_preserve_type_and_watsonx_fields() {
+        ChatResponseMetadata rebuilt = fullyPopulated().build().toBuilder().build();
+
+        assertThat(rebuilt).isInstanceOf(WatsonxChatResponseMetadata.class);
+
+        WatsonxChatResponseMetadata watsonxMetadata = (WatsonxChatResponseMetadata) rebuilt;
+        assertThat(watsonxMetadata.getCreated()).isEqualTo(1754000000L);
+        assertThat(watsonxMetadata.getModelVersion()).isEqualTo("2.0.0");
+        assertThat(watsonxMetadata.getServiceTier()).isEqualTo("premium");
+        assertThat(watsonxMetadata.getSystemFingerprint()).isEqualTo("fp-1");
+        assertThat(watsonxMetadata.getCached()).isTrue();
+    }
+
+    @Test
+    void toBuilder_should_preserve_inherited_fields() {
+        ChatResponseMetadata rebuilt = fullyPopulated().build().toBuilder().build();
+
+        assertThat(rebuilt.id()).isEqualTo("chat-id");
+        assertThat(rebuilt.modelName()).isEqualTo("ibm/granite-3-8b-instruct");
+        assertThat(rebuilt.tokenUsage()).isEqualTo(new TokenUsage(1, 2, 3));
+        assertThat(rebuilt.finishReason()).isEqualTo(FinishReason.STOP);
+    }
+
+    @Test
+    void toBuilder_should_keep_type_when_the_service_layer_replaces_token_usage() {
+        ChatResponseMetadata rebuilt = fullyPopulated().build().toBuilder()
+                .tokenUsage(new TokenUsage(10, 20, 30))
+                .build();
+
+        assertThat(rebuilt).isInstanceOf(WatsonxChatResponseMetadata.class);
+        assertThat(rebuilt.tokenUsage()).isEqualTo(new TokenUsage(10, 20, 30));
+        assertThat(((WatsonxChatResponseMetadata) rebuilt).getModelVersion()).isEqualTo("2.0.0");
+    }
+
+    @Test
+    void toBuilder_should_preserve_a_metadata_without_the_gateway_fields() {
+        ChatResponseMetadata rebuilt =
+                WatsonxChatResponseMetadata.builder()
+                        .id("chat-id")
+                        .created(1754000000L)
+                        .modelVersion("2.0.0")
+                        .build()
+                        .toBuilder()
+                        .build();
+
+        assertThat(rebuilt).isInstanceOf(WatsonxChatResponseMetadata.class);
+
+        WatsonxChatResponseMetadata watsonxMetadata = (WatsonxChatResponseMetadata) rebuilt;
+        assertThat(watsonxMetadata.getCreated()).isEqualTo(1754000000L);
+        assertThat(watsonxMetadata.getModelVersion()).isEqualTo("2.0.0");
+        assertThat(watsonxMetadata.getServiceTier()).isNull();
+        assertThat(watsonxMetadata.getSystemFingerprint()).isNull();
+        assertThat(watsonxMetadata.getCached()).isNull();
+    }
+
+    @Test
+    void equals_and_hashCode_should_handle_null_watsonx_fields() {
+        ChatResponseMetadata metadata1 =
+                WatsonxChatResponseMetadata.builder().id("chat-id").build();
+        ChatResponseMetadata metadata2 =
+                WatsonxChatResponseMetadata.builder().id("chat-id").build();
+
+        assertThat(metadata1).isEqualTo(metadata2);
+        assertThat(metadata1).hasSameHashCodeAs(metadata2);
+        assertThat(metadata1).isNotEqualTo(fullyPopulated().build());
+    }
+
+    @Test
+    void equals_and_hashCode_should_include_watsonx_fields() {
+        ChatResponseMetadata metadata1 = fullyPopulated().build();
+        ChatResponseMetadata metadata2 = fullyPopulated().build();
+
+        assertThat(metadata1).isEqualTo(metadata2);
+        assertThat(metadata1).hasSameHashCodeAs(metadata2);
+    }
+
+    @Test
+    void equals_should_distinguish_each_watsonx_field() {
+        ChatResponseMetadata base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(fullyPopulated().created(1L).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().modelVersion("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().serviceTier("other").build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().systemFingerprint("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().cached(false).build());
+    }
+
+    @Test
+    void equals_should_still_honor_inherited_fields() {
+        ChatResponseMetadata base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(fullyPopulated().id("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().modelName("other").build());
+    }
+
+    @Test
+    void equals_should_reject_null_and_other_types() {
+        ChatResponseMetadata base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(null);
+        assertThat(base).isNotEqualTo("not a metadata object");
+    }
+
+    @Test
+    void toString_should_include_watsonx_fields() {
+        String text = fullyPopulated().build().toString();
+
+        assertThat(text)
+                .contains("WatsonxChatResponseMetadata{")
+                .contains("created=1754000000")
+                .contains("modelVersion='2.0.0'")
+                .contains("serviceTier='premium'")
+                .contains("systemFingerprint='fp-1'")
+                .contains("cached=true");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6139

## Change

`WatsonxChatResponseMetadata` adds five fields on top of `ChatResponseMetadata` but did not override
`toBuilder()`, so the inherited implementation returned a plain `ChatResponseMetadata.Builder`: rebuilding
the metadata produced a plain `ChatResponseMetadata` and dropped `created`, `modelVersion`, `serviceTier`,
`systemFingerprint` and `cached`.

Users cannot avoid that rebuild. `AiServiceStreamingResponseHandler.java:487` and `ToolServiceResult.java:65`
both call `metadata().toBuilder()` to replace the token usage, so every streaming AiServices response and
every tool-execution result over watsonx came back downgraded, throwing `ClassCastException` on a cast and
silently skipping an `instanceof` branch. `equals()`, `hashCode()` and `toString()` had the same gap, seeing
only the four common fields.

```java
@Override
public Builder toBuilder() {
    return ((Builder) super.toBuilder(builder()))
            .created(created)
            .modelVersion(modelVersion)
            .serviceTier(serviceTier)
            .systemFingerprint(systemFingerprint)
            .cached(cached);
}
```

Watsonx was the only one of the ten `ChatResponseMetadata` subclasses missing these; the shape is
`MistralAiChatResponseMetadata.java:30-33`, and `toString` follows #5636 in this module. `Builder.build()`
now returns the covariant `WatsonxChatResponseMetadata` like the other nine, recorded in `revapi.json`:
javac emits a bridge method keeping the original `()Ldev/.../ChatResponseMetadata;` descriptor
(`ACC_BRIDGE, ACC_SYNTHETIC`), so callers compiled against the old signature still link.

Two instances differing only in a watsonx field now compare unequal, which is the defect being fixed rather
than a contract change.

### Tests

- `WatsonxChatResponseMetadataTest` (new), 10 tests: the rebuilt metadata is still a
  `WatsonxChatResponseMetadata` and keeps all five fields, for the gateway shape and the plain shape where
  three are null (`Converter.java:130-135`); the rebuild survives the token-usage replacement above; `equals`
  distinguishes each field from an independently built instance; `toString` carries the class name and all five.

5 of the 10 fail on unmodified `main`; the other 5 cover the inherited common fields and pass either way.

```
$ mvn -pl langchain4j-watsonx test
Tests run: 175, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-watsonx test          # production change reverted
Tests run: 10, Failures: 5, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-core test
Tests run: 1266, Failures: 0, Errors: 0, Skipped: 5

$ mvn -pl langchain4j test
Tests run: 1358, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-watsonx verify
[INFO] API checks completed without failures.
```

No integration test was added or run: the change is confined to the metadata value type.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)