### PR TITLE
fix: Normalize Elasticsearch kNN scores to the relevance scale

### DIFF
--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
@@ -3,8 +3,13 @@ package dev.langchain4j.store.embedding.elasticsearch;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.KnnQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.ScriptScoreQuery;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.SourceConfig;
+import co.elastic.clients.json.JsonData;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import java.io.IOException;
 import org.slf4j.Logger;
@@ -14,10 +19,25 @@ import org.slf4j.LoggerFactory;
  * Represents an <a href="https://www.elastic.co/">Elasticsearch</a> index as an embedding store
  * using the approximate kNN query implementation.
  *
+ * <p>The kNN query scores are normalized from the raw similarity scale ([-1;1] for cosine) to a
+ * relevance score in [0;1] via {@code (cosineSimilarity + 1) / 2}, consistently with
+ * {@link ElasticsearchConfigurationScript}. This way {@link EmbeddingSearchRequest#minScore()} is
+ * compared against the same relevance scale used by the other configurations and the returned scores
+ * are always in [0;1].
+ *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-knn-query.html#knn-query-top-level-parameters">kNN query</a>
  */
 public class ElasticsearchConfigurationKnn implements ElasticsearchConfiguration {
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchConfigurationKnn.class);
+
+    /**
+     * Maps the cosine similarity returned by the kNN query (in [-1;1]) to a relevance score in
+     * [0;1], so that it matches the semantics of {@link EmbeddingSearchRequest#minScore()}.
+     */
+    private static final String NORMALIZED_COSINE_SIMILARITY_SCRIPT =
+            "(cosineSimilarity(params.query_vector, 'vector') + 1.0) / 2";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private final Integer numCandidates;
     private final boolean includeVectorResponse;
 
@@ -72,6 +92,26 @@ public class ElasticsearchConfigurationKnn implements ElasticsearchConfiguration
     public SearchResponse<Document> vectorSearch(
             ElasticsearchClient client, String indexName, EmbeddingSearchRequest embeddingSearchRequest)
             throws ElasticsearchException, IOException {
+        KnnQuery knn = buildKnnQuery(embeddingSearchRequest);
+
+        ScriptScoreQuery scriptScoreQuery = buildScriptScoreQuery(knn, embeddingSearchRequest);
+
+        log.trace("Searching for embeddings in index [{}] with query [{}].", indexName, scriptScoreQuery);
+
+        return client.search(
+                s -> s.source(sr -> {
+                            if (includeVectorResponse) {
+                                return sr.filter(f -> f.excludeVectors(false));
+                            }
+                            return new SourceConfig.Builder().filter(f -> f);
+                        })
+                        .index(indexName)
+                        .size(embeddingSearchRequest.maxResults())
+                        .query(q -> q.scriptScore(scriptScoreQuery)),
+                Document.class);
+    }
+
+    private KnnQuery buildKnnQuery(EmbeddingSearchRequest embeddingSearchRequest) {
         KnnQuery.Builder krb = new KnnQuery.Builder()
                 .field(VECTOR_FIELD)
                 .queryVector(embeddingSearchRequest.queryEmbedding().vectorAsList());
@@ -84,21 +124,22 @@ public class ElasticsearchConfigurationKnn implements ElasticsearchConfiguration
             krb.numCandidates(numCandidates);
         }
 
-        KnnQuery knn = krb.build();
+        return krb.build();
+    }
 
-        log.trace("Searching for embeddings in index [{}] with query [{}].", indexName, knn);
+    private ScriptScoreQuery buildScriptScoreQuery(KnnQuery knn, EmbeddingSearchRequest embeddingSearchRequest)
+            throws JsonProcessingException {
+        JsonData queryVector =
+                toJsonData(embeddingSearchRequest.queryEmbedding().vector());
+        return ScriptScoreQuery.of(q -> q.query(Query.of(query -> query.knn(knn)))
+                // minScore() is a relevance score in [0;1], so it must be compared against the cosine
+                // similarity normalized to the same range instead of the raw kNN score in [-1;1]
+                .minScore((float) embeddingSearchRequest.minScore())
+                .script(s -> s.source(source -> source.scriptString(NORMALIZED_COSINE_SIMILARITY_SCRIPT))
+                        .params("query_vector", queryVector)));
+    }
 
-        return client.search(
-                s -> s.source(sr -> {
-                            if (includeVectorResponse) {
-                                return sr.filter(f -> f.excludeVectors(false));
-                            }
-                            return new SourceConfig.Builder().filter(f -> f);
-                        })
-                        .index(indexName)
-                        .size(embeddingSearchRequest.maxResults())
-                        .query(q -> q.knn(knn))
-                        .minScore(embeddingSearchRequest.minScore()),
-                Document.class);
+    private <T> JsonData toJsonData(T rawData) throws JsonProcessingException {
+        return JsonData.fromJson(objectMapper.writeValueAsString(rawData));
     }
 }

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnnTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnnTest.java
@@ -1,0 +1,171 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import static co.elastic.clients.elasticsearch.core.search.TotalHitsRelation.Eq;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.KnnQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ScriptScoreQuery;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.DefaultTransportOptions;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchConfigurationKnnTest {
+
+    @Test
+    void should_apply_min_score_on_the_normalized_cosine_scale() throws IOException {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchClient client = new ElasticsearchClient(transport);
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(Embedding.from(new float[] {0.1f, 0.2f}))
+                .maxResults(3)
+                .minScore(0.5)
+                .build();
+
+        ElasticsearchConfigurationKnn.builder().build().vectorSearch(client, "movies", searchRequest);
+
+        SearchRequest request = transport.capturedRequest;
+        assertThat(request).isNotNull();
+        // minScore must not be compared against the raw kNN score, which is in the [-1;1] cosine scale
+        assertThat(request.minScore()).isNull();
+
+        ScriptScoreQuery scriptScoreQuery = request.query().scriptScore();
+        assertThat(scriptScoreQuery).isNotNull();
+        assertThat(scriptScoreQuery.query().knn()).isNotNull();
+        assertThat(scriptScoreQuery.query().knn().field()).isEqualTo(ElasticsearchConfiguration.VECTOR_FIELD);
+        // minScore is a relevance score in [0;1], so it is compared against the normalized cosine score
+        assertThat(scriptScoreQuery.minScore()).isEqualTo(0.5f);
+        assertThat(scriptScoreQuery.script().source().scriptString())
+                .isEqualTo("(cosineSimilarity(params.query_vector, 'vector') + 1.0) / 2");
+
+        JsonData queryVector = scriptScoreQuery.script().params().get("query_vector");
+        assertThat(queryVector.to(Float[].class, transport.jsonpMapper())).containsExactly(0.1f, 0.2f);
+    }
+
+    @Test
+    void should_apply_filter_and_num_candidates_to_knn_query() throws IOException {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchClient client = new ElasticsearchClient(transport);
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(Embedding.from(new float[] {0.1f, 0.2f}))
+                .maxResults(3)
+                .filter(new IsEqualTo("year", 2023))
+                .build();
+
+        ElasticsearchConfigurationKnn.builder().numCandidates(7).build().vectorSearch(client, "movies", searchRequest);
+
+        SearchRequest request = transport.capturedRequest;
+        assertThat(request).isNotNull();
+
+        KnnQuery knnQuery = request.query().scriptScore().query().knn();
+        assertThat(knnQuery).isNotNull();
+        assertThat(knnQuery.numCandidates()).isEqualTo(7);
+        assertThat(knnQuery.filter()).hasSize(1);
+    }
+
+    @Test
+    void should_return_scores_as_they_are_scored_by_the_script_score_query() throws IOException {
+        // Simulates the Elasticsearch response of the script_score query, whose score is the
+        // cosine similarity normalized to a relevance score in [0;1].
+        SearchResponse<Document> response = SearchResponse.of(sr -> sr.took(1)
+                .timedOut(false)
+                .shards(sh -> sh.total(1).successful(1).failed(0))
+                .hits(h -> h.total(t -> t.value(2).relation(TotalHitsRelation.Eq))
+                        .hits(List.of(
+                                Hit.of(hit -> hit.index("movies")
+                                        .id("1")
+                                        .score(0.95)
+                                        .source(Document.builder()
+                                                .vector(new float[] {0.1f, 0.2f})
+                                                .text("hello")
+                                                .metadata(Map.of("year", 2023))
+                                                .build())),
+                                Hit.of(hit -> hit.index("movies")
+                                        .id("2")
+                                        .score(0.6)
+                                        .source(Document.builder()
+                                                .vector(new float[] {0.1f, 0.2f})
+                                                .text("world")
+                                                .metadata(Map.of("year", 2023))
+                                                .build()))))));
+
+        CapturingTransport transport = new CapturingTransport(response);
+        ElasticsearchClient client = new ElasticsearchClient(transport);
+        ElasticsearchEmbeddingStore store = new ElasticsearchEmbeddingStore(
+                ElasticsearchConfigurationKnn.builder().build(), client, "movies");
+
+        EmbeddingSearchResult<TextSegment> result = store.search(EmbeddingSearchRequest.builder()
+                .queryEmbedding(Embedding.from(new float[] {0.1f, 0.2f}))
+                .maxResults(10)
+                .build());
+
+        assertThat(result.matches()).hasSize(2);
+        assertThat(result.matches().get(0).score()).isEqualTo(0.95);
+        assertThat(result.matches().get(0).embeddingId()).isEqualTo("1");
+        assertThat(result.matches().get(1).score()).isEqualTo(0.6);
+        assertThat(result.matches().get(1).embeddingId()).isEqualTo("2");
+    }
+
+    private static class CapturingTransport implements ElasticsearchTransport {
+
+        private final JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+        private final SearchResponse<Document> response;
+        private SearchRequest capturedRequest;
+
+        CapturingTransport() {
+            this(SearchResponse.of(sr -> sr.took(0)
+                    .timedOut(false)
+                    .shards(s -> s.total(1).successful(1).failed(0))
+                    .hits(h -> h.total(t -> t.value(0).relation(Eq)).hits(List.of()))));
+        }
+
+        CapturingTransport(SearchResponse<Document> response) {
+            this.response = response;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            capturedRequest = (SearchRequest) request;
+            return (ResponseT) response;
+        }
+
+        @Override
+        public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            return CompletableFuture.completedFuture(performRequest(request, endpoint, options));
+        }
+
+        @Override
+        public JsonpMapper jsonpMapper() {
+            return jsonpMapper;
+        }
+
+        @Override
+        public TransportOptions options() {
+            return DefaultTransportOptions.EMPTY;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
The ElasticsearchConfigurationKnn passed minScore (a relevance score in [0;1]) directly to the search request's minScore, which is compared against the raw kNN score in the cosine scale ([-1;1]), and returned that raw score (which can be negative) to the caller. This made minScore filtering and the returned scores inconsistent with ElasticsearchConfigurationScript, which already maps cosine similarity with (cos+1)/2.

Wrap the kNN query in a script_score query that normalizes the cosine similarity to [0;1] with (cosineSimilarity + 1) / 2 and compare minScore against it, so both filtering and the returned scores use the same relevance scale across configurations.

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
