### PR TITLE
fix: do not report successful completion after a streaming error

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/StreamingRequestExecutor.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/StreamingRequestExecutor.java
@@ -1,17 +1,16 @@
 package dev.langchain4j.model.openai.internal;
 
+import static dev.langchain4j.http.client.sse.ServerSentEventParsingHandleUtils.toStreamingHandle;
+
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.http.client.sse.ServerSentEventContext;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
-import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
 import dev.langchain4j.model.chat.response.StreamingHandle;
-
 import java.util.function.Consumer;
-
-import static dev.langchain4j.http.client.sse.ServerSentEventParsingHandleUtils.toStreamingHandle;
 
 class StreamingRequestExecutor<Response> {
 
@@ -104,6 +103,7 @@ class StreamingRequestExecutor<Response> {
 
             volatile SuccessfulHttpResponse response;
             volatile StreamingHandle streamingHandle;
+            volatile boolean errorReported;
 
             @Override
             public void onOpen(SuccessfulHttpResponse response) {
@@ -126,6 +126,7 @@ class StreamingRequestExecutor<Response> {
                 }
                 try {
                     if ("error".equals(event.event())) {
+                        errorReported = true;
                         errorHandler.accept(new RuntimeException(event.data()));
                         return;
                     }
@@ -140,19 +141,21 @@ class StreamingRequestExecutor<Response> {
                         partialResponseHandler.accept(parsedAndRawResponse); // do not handle exception, fail-fast
                     }
                 } catch (Exception e) {
+                    errorReported = true;
                     errorHandler.accept(e);
                 }
             }
 
             @Override
             public void onClose() {
-                if (streamingHandle == null || !streamingHandle.isCancelled()) {
+                if (!errorReported && (streamingHandle == null || !streamingHandle.isCancelled())) {
                     streamingCompletionCallback.run();
                 }
             }
 
             @Override
             public void onError(Throwable t) {
+                errorReported = true;
                 errorHandler.accept(t);
             }
         };

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingRequestExecutorTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingRequestExecutorTest.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.model.openai.internal;
 
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
@@ -7,22 +11,17 @@ import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.CompletableFuture;
-
-import static dev.langchain4j.http.client.HttpMethod.GET;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class StreamingRequestExecutorTest {
 
     private static final String ERROR_MESSAGE =
-            "{\"error\":{\"message\":\"Failed to call a function. Please adjust your prompt. " +
-                    "See 'failed_generation' for more details.\",\"type\":\"invalid_request_error\"," +
-                    "\"code\":\"tool_use_failed\"," +
-                    "\"failed_generation\":\"Tool use failed: no tool can be called with name getCarsList\"," +
-                    "\"status_code\":400}}";
+            "{\"error\":{\"message\":\"Failed to call a function. Please adjust your prompt. "
+                    + "See 'failed_generation' for more details.\",\"type\":\"invalid_request_error\","
+                    + "\"code\":\"tool_use_failed\","
+                    + "\"failed_generation\":\"Tool use failed: no tool can be called with name getCarsList\","
+                    + "\"status_code\":400}}";
 
     @Test
     void should_process_streaming_error() throws Exception {
@@ -40,25 +39,168 @@ class StreamingRequestExecutorTest {
             }
         };
 
-        HttpRequest streamingHttpRequest = HttpRequest.builder()
-                .method(GET)
-                .url("http://does.not.matter")
-                .build();
+        HttpRequest streamingHttpRequest =
+                HttpRequest.builder().method(GET).url("http://does.not.matter").build();
 
         StreamingRequestExecutor<ChatCompletionResponse> executor =
                 new StreamingRequestExecutor<>(httpClient, streamingHttpRequest, ChatCompletionResponse.class);
 
         CompletableFuture<Throwable> futureError = new CompletableFuture<>();
 
-        executor.onPartialResponse(ignored -> {
-                })
+        executor.onPartialResponse(ignored -> {}).onError(futureError::complete).execute();
+
+        Throwable error = futureError.get(30, SECONDS);
+
+        assertThat(error).isExactlyInstanceOf(RuntimeException.class).hasMessage(ERROR_MESSAGE);
+    }
+
+    @Test
+    void should_not_call_onComplete_when_error_event_received() throws Exception {
+
+        HttpClient httpClient = new HttpClient() {
+
+            @Override
+            public SuccessfulHttpResponse execute(HttpRequest request) {
+                throw new IllegalStateException("this method should not be called");
+            }
+
+            @Override
+            public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+                listener.onEvent(new ServerSentEvent("error", ERROR_MESSAGE));
+                listener.onClose();
+            }
+        };
+
+        HttpRequest streamingHttpRequest =
+                HttpRequest.builder().method(GET).url("http://does.not.matter").build();
+
+        StreamingRequestExecutor<ChatCompletionResponse> executor =
+                new StreamingRequestExecutor<>(httpClient, streamingHttpRequest, ChatCompletionResponse.class);
+
+        CompletableFuture<Throwable> futureError = new CompletableFuture<>();
+        CompletableFuture<Void> futureComplete = new CompletableFuture<>();
+
+        executor.onPartialResponse(ignored -> {})
+                .onComplete(() -> futureComplete.complete(null))
                 .onError(futureError::complete)
                 .execute();
 
         Throwable error = futureError.get(30, SECONDS);
 
-        assertThat(error)
-                .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessage(ERROR_MESSAGE);
+        assertThat(error).isExactlyInstanceOf(RuntimeException.class).hasMessage(ERROR_MESSAGE);
+
+        assertThat(futureComplete).isNotDone();
+    }
+
+    @Test
+    void should_not_call_onComplete_when_json_parsing_failed() throws Exception {
+
+        HttpClient httpClient = new HttpClient() {
+
+            @Override
+            public SuccessfulHttpResponse execute(HttpRequest request) {
+                throw new IllegalStateException("this method should not be called");
+            }
+
+            @Override
+            public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+                listener.onEvent(new ServerSentEvent(null, "not a valid json"));
+                listener.onClose();
+            }
+        };
+
+        HttpRequest streamingHttpRequest =
+                HttpRequest.builder().method(GET).url("http://does.not.matter").build();
+
+        StreamingRequestExecutor<ChatCompletionResponse> executor =
+                new StreamingRequestExecutor<>(httpClient, streamingHttpRequest, ChatCompletionResponse.class);
+
+        CompletableFuture<Throwable> futureError = new CompletableFuture<>();
+        CompletableFuture<Void> futureComplete = new CompletableFuture<>();
+
+        executor.onPartialResponse(ignored -> {})
+                .onComplete(() -> futureComplete.complete(null))
+                .onError(futureError::complete)
+                .execute();
+
+        Throwable error = futureError.get(30, SECONDS);
+
+        assertThat(error).isNotNull();
+
+        assertThat(futureComplete).isNotDone();
+    }
+
+    @Test
+    void should_not_call_onComplete_when_stream_fails_before_close() throws Exception {
+
+        HttpClient httpClient = new HttpClient() {
+
+            @Override
+            public SuccessfulHttpResponse execute(HttpRequest request) {
+                throw new IllegalStateException("this method should not be called");
+            }
+
+            @Override
+            public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+                listener.onError(new IllegalStateException("connection reset"));
+                listener.onClose();
+            }
+        };
+
+        HttpRequest streamingHttpRequest =
+                HttpRequest.builder().method(GET).url("http://does.not.matter").build();
+
+        StreamingRequestExecutor<ChatCompletionResponse> executor =
+                new StreamingRequestExecutor<>(httpClient, streamingHttpRequest, ChatCompletionResponse.class);
+
+        CompletableFuture<Throwable> futureError = new CompletableFuture<>();
+        CompletableFuture<Void> futureComplete = new CompletableFuture<>();
+
+        executor.onPartialResponse(ignored -> {})
+                .onComplete(() -> futureComplete.complete(null))
+                .onError(futureError::complete)
+                .execute();
+
+        Throwable error = futureError.get(30, SECONDS);
+
+        assertThat(error).isExactlyInstanceOf(IllegalStateException.class).hasMessage("connection reset");
+
+        assertThat(futureComplete).isNotDone();
+    }
+
+    @Test
+    void should_call_onComplete_when_stream_completed_successfully() throws Exception {
+
+        HttpClient httpClient = new HttpClient() {
+
+            @Override
+            public SuccessfulHttpResponse execute(HttpRequest request) {
+                throw new IllegalStateException("this method should not be called");
+            }
+
+            @Override
+            public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+                listener.onEvent(new ServerSentEvent(null, "{\"id\":\"chatcmpl-123\"}"));
+                listener.onClose();
+            }
+        };
+
+        HttpRequest streamingHttpRequest =
+                HttpRequest.builder().method(GET).url("http://does.not.matter").build();
+
+        StreamingRequestExecutor<ChatCompletionResponse> executor =
+                new StreamingRequestExecutor<>(httpClient, streamingHttpRequest, ChatCompletionResponse.class);
+
+        CompletableFuture<Throwable> futureError = new CompletableFuture<>();
+        CompletableFuture<Void> futureComplete = new CompletableFuture<>();
+
+        executor.onPartialResponse(ignored -> {})
+                .onComplete(() -> futureComplete.complete(null))
+                .onError(futureError::complete)
+                .execute();
+
+        futureComplete.get(30, SECONDS);
+
+        assertThat(futureError).isNotDone();
     }
 }


### PR DESCRIPTION
When an in-stream error occurs (an `error` SSE event, a JSON parsing failure, or an SSE-layer `onError`), the user's `onError` callback was invoked, but `onClose` still fired the streaming completion callback, so users received both a failure and a "successful completion". This was inconsistent with the HTTP error path, which only reports `onError`.

Track whether an error has been reported and skip the completion callback in that case.

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
