### PR TITLE
Fix ClassCastException when injecting content into a non-UserMessage

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/DefaultContentInjector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/DefaultContentInjector.java
@@ -7,7 +7,9 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.segment.TextSegment;
@@ -92,9 +94,22 @@ public class DefaultContentInjector implements ContentInjector {
 
     protected Prompt createPrompt(ChatMessage chatMessage, List<Content> contents) {
         Map<String, Object> variables = new HashMap<>();
-        variables.put("userMessage", ((UserMessage) chatMessage).singleText());
+        variables.put("userMessage", userMessageText(chatMessage));
         variables.put("contents", format(contents));
         return promptTemplate.apply(variables);
+    }
+
+    private String userMessageText(ChatMessage chatMessage) {
+        if (chatMessage instanceof UserMessage userMessage) {
+            return userMessage.singleText();
+        }
+        if (chatMessage instanceof AiMessage aiMessage) {
+            return aiMessage.text();
+        }
+        if (chatMessage instanceof SystemMessage systemMessage) {
+            return systemMessage.text();
+        }
+        throw new IllegalArgumentException("Unsupported message type: " + chatMessage.type());
     }
 
     protected String format(List<Content> contents) {

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/DefaultContentInjectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/DefaultContentInjectorTest.java
@@ -6,6 +6,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.input.PromptTemplate;
@@ -20,6 +21,27 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class DefaultContentInjectorTest {
+
+    @Test
+    void should_inject_into_system_message() {
+
+        // given
+        SystemMessage systemMessage = SystemMessage.from("You are a helpful assistant.");
+
+        List<Content> contents = singletonList(Content.from("Bananas are awesome!"));
+
+        ContentInjector injector = new DefaultContentInjector();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, systemMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+                You are a helpful assistant.
+
+                Answer using the following information:
+                Bananas are awesome!""".stripIndent());
+    }
 
     @Test
     void should_not_inject_when_no_content() {


### PR DESCRIPTION
## Problem

`DefaultContentInjector.inject()` unconditionally casts the incoming `ChatMessage` to `UserMessage` inside `createPrompt()`, which runs **before** the `instanceof UserMessage` check in `inject()`:

```java
Prompt prompt = createPrompt(chatMessage, contents);   // casts to UserMessage -> CCE
if (chatMessage instanceof UserMessage userMessage) {
    return userMessage.toBuilder()...;
} else {
    return prompt.toUserMessage();                      // unreachable
}
```

Passing any non-`UserMessage` (e.g. a `SystemMessage` carrying retrieved context) therefore throws `ClassCastException`, making the intended `else` branch (`prompt.toUserMessage()`) dead code.

## Change

- Replaced the blanket cast with a type-safe `userMessageText()` helper that resolves the message text per type:
  - `UserMessage` → `singleText()`
  - `AiMessage` / `SystemMessage` → `text()`
  - other types → clear `IllegalArgumentException`
- The protected `createPrompt()` signature is unchanged, so subclasses are unaffected.
- Added a regression test injecting into a `SystemMessage`.

## Validation

- New test fails with `ClassCastException` before the change, passes after.
- Full `dev.langchain4j.rag` test suite: **169 tests, 0 failures, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)