### PR TITLE
fix: address several low-severity correctness bugs

### DIFF
--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapper.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapper.java
@@ -112,7 +112,9 @@ public class DefaultAzureAiSearchFilterMapper implements AzureAiSearchFilterMapp
     }
 
     private String mapSearchInValues(Collection<?> comparisonValues) {
-        return comparisonValues.stream().map(Object::toString).sorted().collect(Collectors.joining(", "));
+        // search.in() splits the list on the delimiter without trimming whitespace, so joining with
+        // ", " would produce leading-space tokens that never match. Join with a plain comma instead.
+        return comparisonValues.stream().map(Object::toString).sorted().collect(Collectors.joining(","));
     }
 
     private String formatComparisonFilter(String key, String value, String format) {

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapperTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/DefaultAzureAiSearchFilterMapperTest.java
@@ -53,7 +53,7 @@ class DefaultAzureAiSearchFilterMapperTest {
         IsIn isInFilter = new IsIn("key1", Arrays.asList("value1", "value2"));
         String result = mapper.map(isInFilter);
         assertThat(result)
-                .isEqualTo("metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1, value2')))");
+                .isEqualTo("metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1,value2')))");
     }
 
     @Test
@@ -62,7 +62,7 @@ class DefaultAzureAiSearchFilterMapperTest {
         String result = mapper.map(isNotInFilter);
         assertThat(result)
                 .isEqualTo(
-                        "(not metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1, value2'))))");
+                        "(not metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('value1,value2'))))");
     }
 
     @Test
@@ -85,7 +85,7 @@ class DefaultAzureAiSearchFilterMapperTest {
         String result = mapper.map(isInFilter);
         assertThat(result)
                 .isEqualTo(
-                        "metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('D''Angelo, O''Brien')))");
+                        "metadata/attributes/any(k: k/key eq 'key1' and search.in(k/value, ('D''Angelo,O''Brien')))");
     }
 
     @Test
@@ -96,7 +96,7 @@ class DefaultAzureAiSearchFilterMapperTest {
         String result = mapper.map(filter);
         assertThat(result)
                 .isEqualTo(
-                        "(metadata/attributes/any(k: k/key eq 'key1' and k/value eq 'value1') and ((not metadata/attributes/any(k: k/key eq 'key2' and search.in(k/value, ('value2, value3')))) or metadata/attributes/any(k: k/key eq 'key3' and k/value gt '100')))");
+                        "(metadata/attributes/any(k: k/key eq 'key1' and k/value eq 'value1') and ((not metadata/attributes/any(k: k/key eq 'key2' and search.in(k/value, ('value2,value3')))) or metadata/attributes/any(k: k/key eq 'key3' and k/value gt '100')))");
     }
 
     @Test

--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/Mapper.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/Mapper.java
@@ -81,7 +81,8 @@ class Mapper {
             String collectionName,
             FieldDefinition fieldDefinition,
             ConsistencyLevel consistencyLevel,
-            boolean queryForVectorOnSearch) {
+            boolean queryForVectorOnSearch,
+            boolean hybridSearch) {
         List<EmbeddingMatch<TextSegment>> matches = new ArrayList<>();
 
         Map<String, Embedding> idToEmbedding = new HashMap<>();
@@ -126,11 +127,20 @@ class Mapper {
             TextSegment textSegment =
                     toTextSegment(searchResp.getSearchResults().get(0).get(i), fieldDefinition);
             EmbeddingMatch<TextSegment> embeddingMatch =
-                    new EmbeddingMatch<>(RelevanceScore.fromCosineSimilarity(score), rowId, embedding, textSegment);
+                    new EmbeddingMatch<>(toRelevanceScore(score, hybridSearch), rowId, embedding, textSegment);
             matches.add(embeddingMatch);
         }
 
         return matches;
+    }
+
+    static double toRelevanceScore(double score, boolean hybridSearch) {
+        if (hybridSearch) {
+            // Milvus returns a Reciprocal Rank Fusion (RRF) score for hybrid search, which is rank-based
+            // and already on a relevance-like scale. It must not be mapped as a cosine similarity.
+            return score;
+        }
+        return RelevanceScore.fromCosineSimilarity(score);
     }
 
     private static TextSegment toTextSegment(SearchResp.SearchResult searchResult, FieldDefinition fieldDefinition) {

--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStore.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2EmbeddingStore.java
@@ -260,7 +260,8 @@ public class MilvusV2EmbeddingStore implements EmbeddingStore<TextSegment> {
                 collectionName,
                 fieldDefinition,
                 consistencyLevel,
-                retrieveEmbeddingsOnSearch);
+                retrieveEmbeddingsOnSearch,
+                this.searchMode == SearchMode.HYBRID);
 
         List<EmbeddingMatch<TextSegment>> result = matches.stream()
                 .filter(match -> match.score() >= embeddingSearchRequest.minScore())

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MapperTest.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MapperTest.java
@@ -1,9 +1,11 @@
 package dev.langchain4j.store.embedding.milvus.v2;
 
+import static dev.langchain4j.store.embedding.milvus.v2.Mapper.toRelevanceScore;
 import static dev.langchain4j.store.embedding.milvus.v2.Mapper.toSparseVectors;
 import static dev.langchain4j.store.embedding.milvus.v2.Mapper.toVectors;
 
 import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.store.embedding.RelevanceScore;
 import java.util.Arrays;
 import java.util.List;
 import java.util.SortedMap;
@@ -11,6 +13,25 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 class MapperTest implements WithAssertions {
+
+    @Test
+    void should_use_hybrid_score_as_is_for_hybrid_search() {
+        // given - an RRF (rank-based) score returned by Milvus hybrid search
+        double rrfScore = 0.0328;
+
+        // when
+        double relevanceScore = toRelevanceScore(rrfScore, true);
+
+        // then - the RRF score must not be mapped as if it were a cosine similarity
+        assertThat(relevanceScore).isEqualTo(rrfScore);
+    }
+
+    @Test
+    void should_convert_cosine_score_to_relevance_score_for_vector_search() {
+        assertThat(toRelevanceScore(0.6, false)).isEqualTo(RelevanceScore.fromCosineSimilarity(0.6));
+        assertThat(toRelevanceScore(-1.0, false)).isEqualTo(0.0);
+        assertThat(toRelevanceScore(1.0, false)).isEqualTo(1.0);
+    }
 
     @Test
     void should_convert_embeddings_to_vectors() {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiTokenCountEstimator.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiTokenCountEstimator.java
@@ -165,7 +165,14 @@ public class OpenAiTokenCountEstimator implements TokenCountEstimator {
     }
 
     private int estimateTokenCountIn(ToolExecutionResultMessage toolExecutionResultMessage) {
-        return estimateTokenCountInText(toolExecutionResultMessage.text());
+        int tokenCount = 0;
+        for (Content content : toolExecutionResultMessage.contents()) {
+            if (content instanceof TextContent textContent) {
+                tokenCount += estimateTokenCountInText(textContent.text());
+            }
+            // Non-text content (e.g. ImageContent) has no text to count.
+        }
+        return tokenCount;
     }
 
     @Override

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiTokenCountEstimatorTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiTokenCountEstimatorTest.java
@@ -2,6 +2,9 @@ package dev.langchain4j.model.openai;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.model.TokenCountEstimator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -95,6 +98,26 @@ class OpenAiTokenCountEstimatorTest {
 
         // then
         assertThat(tokenCount).isPositive();
+    }
+
+    @Test
+    void should_count_tokens_in_tool_execution_result_message_with_non_text_contents() {
+
+        // given - a tool result containing both text and an image; calling text() on it would throw,
+        // so the estimator must iterate over contents() instead.
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .toolName("tool")
+                .contents(TextContent.from("hello"), ImageContent.from("http://example.com/image.png"))
+                .build();
+
+        // when
+        int tokenCount = tokenCountEstimator.estimateTokenCountInMessage(message);
+
+        // then - non-text contents are ignored, so the count matches a plain text result
+        int textOnlyTokenCount = tokenCountEstimator.estimateTokenCountInMessage(
+                ToolExecutionResultMessage.from("id", "tool", "hello"));
+        assertThat(tokenCount).isPositive();
+        assertThat(tokenCount).isEqualTo(textOnlyTokenCount);
     }
 
     @Test

--- a/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
+++ b/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
@@ -18,10 +18,12 @@ import static java.util.stream.Collectors.toMap;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.CosineSimilarity;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.RelevanceScore;
 import dev.langchain4j.store.embedding.filter.Filter;
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateAuthClient;
@@ -263,7 +265,8 @@ public class WeaviateEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     /**
      * {@inheritDoc}
-     * The score inside {@link EmbeddingMatch} is Weaviate's certainty.
+     * The score inside {@link EmbeddingMatch} is a relevance score derived from Weaviate's certainty
+     * (a raw cosine similarity) via {@link RelevanceScore#fromCosineSimilarity(double)}.
      */
     @Override
     public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
@@ -297,7 +300,7 @@ public class WeaviateEmbeddingStore implements EmbeddingStore<TextSegment> {
                 .withFields(fields.toArray(new Field[0]))
                 .withNearVector(NearVectorArgument.builder()
                         .vector(request.queryEmbedding().vectorAsList().toArray(new Float[0]))
-                        .certainty((float) request.minScore())
+                        .certainty((float) CosineSimilarity.fromRelevanceScore(request.minScore()))
                         .build())
                 .withLimit(request.maxResults())
                 .run();
@@ -401,10 +404,11 @@ public class WeaviateEmbeddingStore implements EmbeddingStore<TextSegment> {
         return metadata;
     }
 
-    private EmbeddingMatch<TextSegment> toEmbeddingMatch(Map<String, ?> item) {
+    EmbeddingMatch<TextSegment> toEmbeddingMatch(Map<String, ?> item) {
 
         Map<String, ?> additional = (Map<String, ?>) item.get(ADDITIONALS);
-        Double score = (Double) additional.get("certainty");
+        double certainty = ((Number) additional.get("certainty")).doubleValue();
+        Double score = RelevanceScore.fromCosineSimilarity(certainty);
         String embeddingId = (String) additional.get("id");
         Embedding embedding = toEmbedding(additional);
 

--- a/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStoreTest.java
+++ b/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStoreTest.java
@@ -3,9 +3,13 @@ package dev.langchain4j.store.embedding.weaviate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.RelevanceScore;
 import dev.langchain4j.store.embedding.filter.Filter;
 import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -83,6 +87,31 @@ class WeaviateEmbeddingStoreTest {
         boolean matched = WeaviateEmbeddingStore.matchesFilter(properties, METADATA_FIELD, TEXT_FIELD, filter);
 
         assertThat(matched).isFalse();
+    }
+
+    @Test
+    void should_convert_certainty_to_relevance_score_in_embedding_match() {
+        // given - a Weaviate search result item with certainty (a raw cosine similarity)
+        WeaviateEmbeddingStore store = WeaviateEmbeddingStore.builder()
+                .scheme("http")
+                .host("localhost")
+                .build();
+
+        Map<String, Object> additional = new HashMap<>();
+        additional.put("certainty", 0.6);
+        additional.put("id", "id1");
+        additional.put("vector", List.of(1.0, 2.0, 3.0));
+        Map<String, Object> item = new HashMap<>();
+        item.put("_additional", additional);
+        item.put(TEXT_FIELD, "hello");
+
+        // when
+        EmbeddingMatch<TextSegment> match = store.toEmbeddingMatch(item);
+
+        // then - certainty is mapped into a relevance score in [0..1]
+        assertThat(match.score()).isEqualTo(RelevanceScore.fromCosineSimilarity(0.6));
+        assertThat(match.embeddingId()).isEqualTo("id1");
+        assertThat(match.embedded().text()).isEqualTo("hello");
     }
 
     @Test

--- a/langchain4j/src/main/java/dev/langchain4j/service/memory/ChatMemoryService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/memory/ChatMemoryService.java
@@ -35,7 +35,12 @@ public class ChatMemoryService {
     }
 
     public ChatMemory getChatMemory(Object memoryId) {
-        return chatMemoryProvider != null ? chatMemories.get(memoryId) : memoryId == DEFAULT ? defaultChatMemory : null;
+        if (chatMemoryProvider != null) {
+            return chatMemories.get(memoryId);
+        }
+        // Single-chat-memory mode: there is only one (default) ChatMemory, and
+        // getOrCreateChatMemory() returns it for any memoryId, so do the same here.
+        return defaultChatMemory;
     }
 
     public ChatMemory evictChatMemory(Object memoryId) {
@@ -43,8 +48,12 @@ public class ChatMemoryService {
     }
 
     public void clearAll() {
-        chatMemories.values().forEach(ChatMemory::clear);
-        chatMemories.clear();
+        if (chatMemoryProvider != null) {
+            chatMemories.values().forEach(ChatMemory::clear);
+            chatMemories.clear();
+        } else {
+            defaultChatMemory.clear();
+        }
     }
 
     public Collection<Object> getChatMemoryIDs() {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -349,6 +349,14 @@ public class DefaultToolExecutor implements ToolExecutor {
             if (argument instanceof Boolean) {
                 return argument;
             }
+            if (argument instanceof String stringArgument) {
+                if ("true".equalsIgnoreCase(stringArgument)) {
+                    return true;
+                }
+                if ("false".equalsIgnoreCase(stringArgument)) {
+                    return false;
+                }
+            }
             throw new IllegalArgumentException(String.format(
                     "Argument \"%s\" is not convertable to %s, got %s: <%s>",
                     parameterName, parameterClass.getName(), argument.getClass().getName(), argument));

--- a/langchain4j/src/test/java/dev/langchain4j/service/memory/ChatMemoryServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/memory/ChatMemoryServiceTest.java
@@ -1,0 +1,115 @@
+package dev.langchain4j.service.memory;
+
+import static dev.langchain4j.service.memory.ChatMemoryService.DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChatMemoryServiceTest {
+
+    @Test
+    void single_memory_mode_getChatMemory_returns_the_default_memory_for_any_memoryId() {
+        // given
+        ChatMemory defaultChatMemory = MessageWindowChatMemory.builder().maxMessages(10).build();
+        ChatMemoryService service = new ChatMemoryService(defaultChatMemory);
+
+        // when-then
+        // The memory is returned not only for the DEFAULT literal, but also for an equal-but-distinct
+        // String (the bug was a reference comparison) and for any other id, consistently with
+        // getOrCreateChatMemory().
+        assertThat(service.getChatMemory(DEFAULT)).isSameAs(defaultChatMemory);
+        assertThat(service.getChatMemory(new String(DEFAULT))).isSameAs(defaultChatMemory);
+        assertThat(service.getChatMemory("any-other-id")).isSameAs(defaultChatMemory);
+        assertThat(service.getChatMemory(42L)).isSameAs(defaultChatMemory);
+        assertThat(service.getOrCreateChatMemory(new String(DEFAULT))).isSameAs(defaultChatMemory);
+        assertThat(service.getOrCreateChatMemory("any-other-id")).isSameAs(defaultChatMemory);
+    }
+
+    @Test
+    void single_memory_mode_clearAll_clears_the_default_memory_without_NPE() {
+        // given
+        ChatMemory defaultChatMemory = MessageWindowChatMemory.builder().maxMessages(10).build();
+        defaultChatMemory.add(UserMessage.from("hello"));
+        assertThat(defaultChatMemory.messages()).hasSize(1);
+        ChatMemoryService service = new ChatMemoryService(defaultChatMemory);
+
+        // when
+        service.clearAll();
+
+        // then
+        assertThat(defaultChatMemory.messages()).isEmpty();
+    }
+
+    @Test
+    void provider_mode_getChatMemory_returns_memory_only_after_it_was_created() {
+        // given
+        ChatMemoryProvider provider = memoryId -> MessageWindowChatMemory.builder().maxMessages(10).build();
+        ChatMemoryService service = new ChatMemoryService(provider);
+
+        // when-then
+        assertThat(service.getChatMemory("id1")).isNull();
+        service.getOrCreateChatMemory("id1");
+        assertThat(service.getChatMemory("id1")).isNotNull();
+        assertThat(service.getChatMemory("id2")).isNull();
+    }
+
+    @Test
+    void provider_mode_clearAll_clears_all_created_memories() {
+        // given
+        ChatMemoryProvider provider = memoryId -> MessageWindowChatMemory.builder().maxMessages(10).build();
+        ChatMemoryService service = new ChatMemoryService(provider);
+
+        ChatMemory memory1 = service.getOrCreateChatMemory("id1");
+        ChatMemory memory2 = service.getOrCreateChatMemory("id2");
+        memory1.add(UserMessage.from("hello"));
+        memory2.add(UserMessage.from("hi"));
+        assertThat(memory1.messages()).hasSize(1);
+        assertThat(memory2.messages()).hasSize(1);
+
+        // when
+        service.clearAll();
+
+        // then
+        assertThat(memory1.messages()).isEmpty();
+        assertThat(memory2.messages()).isEmpty();
+        assertThat(service.getChatMemoryIDs()).isEmpty();
+        assertThat(service.getChatMemories()).isEmpty();
+    }
+
+    @Test
+    void provider_mode_evictChatMemory_removes_only_the_requested_memory() {
+        // given
+        ChatMemoryProvider provider = memoryId -> MessageWindowChatMemory.builder().maxMessages(10).build();
+        ChatMemoryService service = new ChatMemoryService(provider);
+
+        ChatMemory memory1 = service.getOrCreateChatMemory("id1");
+        service.getOrCreateChatMemory("id2");
+
+        // when
+        ChatMemory evicted = service.evictChatMemory("id1");
+
+        // then
+        assertThat(evicted).isSameAs(memory1);
+        assertThat(service.getChatMemory("id1")).isNull();
+        assertThat(service.getChatMemory("id2")).isNotNull();
+    }
+
+    @Test
+    void single_memory_mode_and_provider_mode_are_mutually_exclusive() {
+        // ChatMemoryService can only be configured with either a single ChatMemory or a provider.
+        ChatMemoryService single = new ChatMemoryService(MessageWindowChatMemory.builder().maxMessages(10).build());
+        assertThat(single.getChatMemory(DEFAULT)).isNotNull();
+
+        ChatMemoryService provider = new ChatMemoryService(memoryId -> MessageWindowChatMemory.builder().maxMessages(10).build());
+        assertThat(provider.getChatMemory(DEFAULT)).isNull();
+
+        List<ChatMessage> messages = provider.getOrCreateChatMemory(DEFAULT).messages();
+        assertThat(messages).isEmpty();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -170,9 +170,13 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         assertThat(coerceArgument(true, "arg", boolean.class, null)).isEqualTo(true);
         assertThat(coerceArgument(Boolean.FALSE, "arg", boolean.class, null)).isEqualTo(false);
+        // String values must be accepted, consistently with the numeric/enum/UUID branches.
+        assertThat(coerceArgument("true", "arg", boolean.class, null)).isEqualTo(true);
+        assertThat(coerceArgument("false", "arg", Boolean.class, null)).isEqualTo(false);
+        assertThat(coerceArgument("TRUE", "arg", boolean.class, null)).isEqualTo(true);
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> coerceArgument("true", "arg", boolean.class, null))
-                .withMessageContaining("Argument \"arg\" is not convertable to boolean, got java.lang.String: <true>");
+                .isThrownBy(() -> coerceArgument("not-a-boolean", "arg", boolean.class, null))
+                .withMessageContaining("Argument \"arg\" is not convertable to boolean, got java.lang.String: <not-a-boolean>");
 
         assertThat(coerceArgument(1.5, "arg", double.class, null)).isEqualTo(1.5);
         assertThat(coerceArgument(1.5, "arg", Double.class, null)).isEqualTo(1.5);


### PR DESCRIPTION
- ChatMemoryService: in single-memory mode, getChatMemory() used a String reference comparison (memoryId == DEFAULT), so an equal-but-distinct String returned null while getOrCreateChatMemory() returned the default memory for any id. Return the default memory for any id, and make clearAll() clear the default memory instead of NPE-ing on the null chatMemories map.
- DefaultToolExecutor: accept "true"/"false" strings for Boolean/boolean tool parameters, consistent with the numeric, enum and UUID branches.
- OpenAiTokenCountEstimator: count TextContent inside tool execution result messages instead of calling text(), which threw IllegalStateException for multi-content/image results.
- Weaviate: convert minScore (relevance 0..1) to certainty (cosine -1..1) for the server-side filter and map returned certainty to a relevance score.
- Milvus V2: use hybrid-search RRF scores as-is instead of mapping them as cosine similarity.
- Azure AI Search: join search.in() values with a plain comma; ", " produced leading-space tokens that never matched.

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
