### PR TITLE
fix: throw typed exception for null-valued tool search query

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/search/vector/VectorToolSearchStrategy.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/search/vector/VectorToolSearchStrategy.java
@@ -1,5 +1,11 @@
 package dev.langchain4j.service.tool.search.vector;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.Utils.toBase64;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.document.Metadata;
@@ -17,17 +23,10 @@ import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.internal.Utils.toBase64;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * A {@link ToolSearchStrategy} that uses vector similarity search
@@ -77,7 +76,8 @@ public class VectorToolSearchStrategy implements ToolSearchStrategy {
     public VectorToolSearchStrategy(Builder builder) {
         Boolean cacheEmbeddings = getOrDefault(builder.cacheEmbeddings, true);
         if (cacheEmbeddings) {
-            this.embeddingModel = ensureNotNull(new ToolCachingEmbeddingModel(builder.embeddingModel), "embeddingModel");
+            this.embeddingModel =
+                    ensureNotNull(new ToolCachingEmbeddingModel(builder.embeddingModel), "embeddingModel");
         } else {
             this.embeddingModel = ensureNotNull(builder.embeddingModel, "embeddingModel");
         }
@@ -87,7 +87,9 @@ public class VectorToolSearchStrategy implements ToolSearchStrategy {
                 .name(getOrDefault(builder.toolName, DEFAULT_TOOL_NAME))
                 .description(getOrDefault(builder.toolDescription, DEFAULT_TOOL_DESCRIPTION))
                 .parameters(JsonObjectSchema.builder()
-                        .addStringProperty(toolArgumentName, getOrDefault(builder.toolArgumentDescription, DEFAULT_TOOL_ARGUMENT_DESCRIPTION))
+                        .addStringProperty(
+                                toolArgumentName,
+                                getOrDefault(builder.toolArgumentDescription, DEFAULT_TOOL_ARGUMENT_DESCRIPTION))
                         .required(toolArgumentName)
                         .build())
                 .build();
@@ -95,7 +97,8 @@ public class VectorToolSearchStrategy implements ToolSearchStrategy {
         this.maxResults = getOrDefault(builder.maxResults, DEFAULT_MAX_RESULTS);
         this.minScore = getOrDefault(builder.minScore, DEFAULT_MIN_SCORE);
         this.throwToolArgumentsExceptions = getOrDefault(builder.throwToolArgumentsExceptions, false);
-        this.toolResultMessageTextProvider = getOrDefault(builder.toolResultMessageTextProvider, DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER);
+        this.toolResultMessageTextProvider =
+                getOrDefault(builder.toolResultMessageTextProvider, DEFAULT_TOOL_RESULT_MESSAGE_TEXT_PROVIDER);
     }
 
     @Override
@@ -157,7 +160,8 @@ public class VectorToolSearchStrategy implements ToolSearchStrategy {
         try {
             return Json.fromJson(json, Map.class);
         } catch (Exception e) {
-            String message = "Failed to parse tool search arguments: '%s' (base64: '%s')".formatted(json, toBase64(json));
+            String message =
+                    "Failed to parse tool search arguments: '%s' (base64: '%s')".formatted(json, toBase64(json));
             throwException(message, e);
             return null; // unreachable
         }
@@ -173,13 +177,9 @@ public class VectorToolSearchStrategy implements ToolSearchStrategy {
 
     private void throwException(String message, Exception e) {
         if (throwToolArgumentsExceptions) {
-            throw e == null
-                    ? new ToolArgumentsException(message)
-                    : new ToolArgumentsException(message, e);
+            throw e == null ? new ToolArgumentsException(message) : new ToolArgumentsException(message, e);
         } else {
-            throw e == null
-                    ? new ToolExecutionException(message)
-                    : new ToolExecutionException(message, e);
+            throw e == null ? new ToolExecutionException(message) : new ToolExecutionException(message, e);
         }
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/search/vector/VectorToolSearchStrategy.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/search/vector/VectorToolSearchStrategy.java
@@ -148,12 +148,13 @@ public class VectorToolSearchStrategy implements ToolSearchStrategy {
     private String extractQuery(String argumentsJson) {
         Map<String, Object> map = parseMap(argumentsJson);
 
-        if (isNullOrEmpty(map) || !map.containsKey(toolArgumentName)) {
+        Object value = isNullOrEmpty(map) ? null : map.get(toolArgumentName);
+        if (value == null) {
             String message = "Missing required tool argument '%s'".formatted(toolArgumentName);
             throwException(message, null);
         }
 
-        return map.get(toolArgumentName).toString();
+        return value.toString();
     }
 
     private Map<String, Object> parseMap(String json) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/search/vector/VectorToolSearchStrategyTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/search/vector/VectorToolSearchStrategyTest.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.service.tool.search.vector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.search.ToolSearchRequest;
+import dev.langchain4j.service.tool.search.ToolSearchResult;
+import dev.langchain4j.service.tool.search.vector.ToolCachingEmbeddingModelTest.RecordingEmbeddingModel;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VectorToolSearchStrategyTest {
+
+    private final VectorToolSearchStrategy strategy = new VectorToolSearchStrategy(new RecordingEmbeddingModel());
+
+    @Test
+    void should_find_tool_when_query_is_present() {
+        ToolSearchResult result = search(strategy, "{\"query\": \"weather\"}");
+
+        assertThat(result.foundToolNames()).contains("weather");
+    }
+
+    @Test
+    void should_throw_tool_execution_exception_when_query_is_null() {
+        assertThatThrownBy(() -> search(strategy, "{\"query\": null}"))
+                .isExactlyInstanceOf(ToolExecutionException.class)
+                .hasMessage("Missing required tool argument 'query'");
+    }
+
+    @Test
+    void should_throw_tool_execution_exception_when_query_is_missing() {
+        assertThatThrownBy(() -> search(strategy, "{}"))
+                .isExactlyInstanceOf(ToolExecutionException.class)
+                .hasMessage("Missing required tool argument 'query'");
+    }
+
+    @Test
+    void should_throw_tool_arguments_exception_when_query_is_null_and_configured_to() {
+        VectorToolSearchStrategy strategy = VectorToolSearchStrategy.builder()
+                .embeddingModel(new RecordingEmbeddingModel())
+                .throwToolArgumentsExceptions(true)
+                .build();
+
+        assertThatThrownBy(() -> search(strategy, "{\"query\": null}"))
+                .isExactlyInstanceOf(ToolArgumentsException.class)
+                .hasMessage("Missing required tool argument 'query'");
+    }
+
+    private static ToolSearchResult search(VectorToolSearchStrategy strategy, String argumentsJson) {
+        ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                .name("tool_search_tool")
+                .arguments(argumentsJson)
+                .build();
+
+        ToolSearchRequest request = ToolSearchRequest.builder()
+                .toolExecutionRequest(toolExecutionRequest)
+                .searchableTools(List.of(tool("weather", "Returns the weather forecast")))
+                .invocationContext(InvocationContext.builder().build())
+                .build();
+
+        return strategy.search(request);
+    }
+
+    private static ToolSpecification tool(String name, String description) {
+        return ToolSpecification.builder().name(name).description(description).build();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6153

## Change

`VectorToolSearchStrategy.extractQuery(...)` only checked whether the argument key was present, not whether its value was `null`. A query supplied with an explicit `null` value (e.g. `{"query": null}`) passed the `containsKey` check and hit `map.get(name).toString()`, throwing an unhandled `NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke "Object.toString()" because the return value of "java.util.Map.get(Object)" is null
	at ...VectorToolSearchStrategy.extractQuery(VectorToolSearchStrategy.java:153)
```

Since a `NullPointerException` is not a `ToolExecutionException`, it bypassed `throwToolArgumentsExceptions` and the error was never returned to the LLM, so the model could not recover by retrying with a proper query.

The value is now resolved once and a single null check covers both the missing-key and null-value cases:

```java
Object value = isNullOrEmpty(map) ? null : map.get(toolArgumentName);
if (value == null) {
    String message = "Missing required tool argument '%s'".formatted(toolArgumentName);
    throwException(message, null);
}

return value.toString();
```

A null-valued query now throws `ToolExecutionException` (default) or `ToolArgumentsException` (when `throwToolArgumentsExceptions` is enabled), same as a missing query. This mirrors the merged fixes #5456 for the shell executor and #5612 for the skills executor, and aligns the behaviour with the sibling `SimpleToolSearchStrategy`, which already handles a null-valued argument. Behaviour for a valid query and for a missing key is unchanged.

Added `VectorToolSearchStrategyTest` (the class had no unit test, only an IT that requires an embedding model). It reuses the existing `RecordingEmbeddingModel` fake from `ToolCachingEmbeddingModelTest` rather than adding a new one. Verified that the two null-query tests fail with the `NullPointerException` above without the fix, while the valid-query and missing-key tests pass both before and after.

The formatting-only changes to `VectorToolSearchStrategy.java` are isolated in a separate commit (`chore: apply spotless formatting`), so the fix itself is a 3-line diff. They are unavoidable: the file was not spotless-formatted on `main` and the `spotless` profile uses `ratchetFrom origin/main`, so the whole file is reformatted once it is touched.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — bug fix, no behaviour to document -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->