### PR TITLE
fix(experimental-sql): escape CSV special characters in SqlDatabaseContentRetriever results

### DIFF
--- a/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
+++ b/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
@@ -339,21 +339,28 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
             while (resultSet.next()) {
                 List<String> columnValues = new ArrayList<>();
                 for (int i = 1; i <= columnCount; i++) {
-
-                    String columnValue = resultSet.getObject(i) == null
-                            ? ""
-                            : resultSet.getObject(i).toString();
-
-                    if (columnValue.contains(",")) {
-                        columnValue = "\"" + columnValue + "\"";
-                    }
-                    columnValues.add(columnValue);
+                    columnValues.add(toCsvValue(resultSet.getObject(i)));
                 }
                 resultRows.add(String.join(",", columnValues));
             }
         }
 
         return String.join("\n", resultRows);
+    }
+
+    /**
+     * Formats a value as a CSV field, escaping it as per RFC 4180 when it contains
+     * a comma, a double quote, or a line break.
+     */
+    static String toCsvValue(Object value) {
+        String stringValue = value == null ? "" : value.toString();
+        if (stringValue.contains(",")
+                || stringValue.contains("\"")
+                || stringValue.contains("\n")
+                || stringValue.contains("\r")) {
+            return '"' + stringValue.replace("\"", "\"\"") + '"';
+        }
+        return stringValue;
     }
 
     private static Content format(String result, String sqlQuery) {

--- a/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
+++ b/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
@@ -19,6 +19,7 @@ import dev.langchain4j.rag.query.Query;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -326,12 +327,13 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
         List<String> resultRows = new ArrayList<>();
 
         try (ResultSet resultSet = statement.executeQuery(sqlQuery)) {
-            int columnCount = resultSet.getMetaData().getColumnCount();
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            int columnCount = metaData.getColumnCount();
 
             // header
             List<String> columnNames = new ArrayList<>();
             for (int i = 1; i <= columnCount; i++) {
-                columnNames.add(resultSet.getMetaData().getColumnName(i));
+                columnNames.add(toCsvValue(metaData.getColumnName(i)));
             }
             resultRows.add(String.join(",", columnNames));
 
@@ -352,7 +354,7 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
      * Formats a value as a CSV field, escaping it as per RFC 4180 when it contains
      * a comma, a double quote, or a line break.
      */
-    static String toCsvValue(Object value) {
+    private static String toCsvValue(Object value) {
         String stringValue = value == null ? "" : value.toString();
         if (stringValue.contains(",")
                 || stringValue.contains("\"")

--- a/experimental/langchain4j-experimental-sql/src/test/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetrieverTest.java
+++ b/experimental/langchain4j-experimental-sql/src/test/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetrieverTest.java
@@ -11,9 +11,11 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.List;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.OngoingStubbing;
 
 class SqlDatabaseContentRetrieverTest {
 
@@ -88,7 +90,43 @@ class SqlDatabaseContentRetrieverTest {
         assertThat(result).isEqualTo("id,name\n42,");
     }
 
+    @Test
+    void execute_should_escape_column_names_with_comma_and_quotes() throws SQLException {
+        Statement statement = mockStatementReturningSingleRow(
+                List.of("concat(first_name, ' ', last_name)", "total \"count\""), "Alice Jones", 3);
+
+        String result =
+                retriever.execute("SELECT concat(first_name, ' ', last_name), count(*) FROM customers", statement);
+
+        assertThat(result).isEqualTo("\"concat(first_name, ' ', last_name)\",\"total \"\"count\"\"\"\nAlice Jones,3");
+    }
+
+    @Test
+    void execute_should_quote_values_with_carriage_return() throws SQLException {
+        Statement statement = mockStatementReturningSingleRow(List.of("name", "notes"), "Alice", "line1\r\nline2");
+
+        String result = retriever.execute("SELECT name, notes FROM customers", statement);
+
+        assertThat(result).isEqualTo("name,notes\nAlice,\"line1\r\nline2\"");
+    }
+
+    @Test
+    void execute_should_render_multiple_rows() throws SQLException {
+        Statement statement = mockStatementReturningRows(
+                List.of("id", "name"),
+                List.of(Arrays.asList(1, "Alice"), Arrays.asList(2, "Bob, Jr."), Arrays.asList(3, null)));
+
+        String result = retriever.execute("SELECT id, name FROM customers", statement);
+
+        assertThat(result).isEqualTo("id,name\n1,Alice\n2,\"Bob, Jr.\"\n3,");
+    }
+
     private static Statement mockStatementReturningSingleRow(List<String> columnNames, Object... rowValues)
+            throws SQLException {
+        return mockStatementReturningRows(columnNames, List.of(Arrays.asList(rowValues)));
+    }
+
+    private static Statement mockStatementReturningRows(List<String> columnNames, List<List<Object>> rows)
             throws SQLException {
         ResultSetMetaData metaData = mock(ResultSetMetaData.class);
         when(metaData.getColumnCount()).thenReturn(columnNames.size());
@@ -98,9 +136,18 @@ class SqlDatabaseContentRetrieverTest {
 
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getMetaData()).thenReturn(metaData);
-        when(resultSet.next()).thenReturn(true, false);
-        for (int i = 1; i <= rowValues.length; i++) {
-            when(resultSet.getObject(i)).thenReturn(rowValues[i - 1]);
+
+        OngoingStubbing<Boolean> next = when(resultSet.next());
+        for (int row = 0; row < rows.size(); row++) {
+            next = next.thenReturn(true);
+        }
+        next.thenReturn(false);
+
+        for (int i = 1; i <= columnNames.size(); i++) {
+            OngoingStubbing<Object> value = when(resultSet.getObject(i));
+            for (List<Object> row : rows) {
+                value = value.thenReturn(row.get(i - 1));
+            }
         }
 
         Statement statement = mock(Statement.class);

--- a/experimental/langchain4j-experimental-sql/src/test/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetrieverTest.java
+++ b/experimental/langchain4j-experimental-sql/src/test/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetrieverTest.java
@@ -2,9 +2,16 @@ package dev.langchain4j.experimental.rag.content.retriever.sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.model.chat.ChatModel;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
@@ -42,5 +49,62 @@ class SqlDatabaseContentRetrieverTest {
     @Test
     void clean_should_return_plain_text_unchanged() {
         assertThat(retriever.clean("SELECT * FROM customer")).isEqualTo("SELECT * FROM customer");
+    }
+
+    @Test
+    void execute_should_escape_values_with_comma_and_quotes() throws SQLException {
+        Statement statement =
+                mockStatementReturningSingleRow(List.of("name", "address"), "Alice \"AJ\" Jones", "1 Main St, Apt 2");
+
+        String result = retriever.execute("SELECT name, address FROM customers", statement);
+
+        assertThat(result).isEqualTo("name,address\n\"Alice \"\"AJ\"\" Jones\",\"1 Main St, Apt 2\"");
+    }
+
+    @Test
+    void execute_should_quote_values_with_line_break() throws SQLException {
+        Statement statement = mockStatementReturningSingleRow(List.of("name", "notes"), "Alice", "line1\nline2");
+
+        String result = retriever.execute("SELECT name, notes FROM customers", statement);
+
+        assertThat(result).isEqualTo("name,notes\nAlice,\"line1\nline2\"");
+    }
+
+    @Test
+    void execute_should_quote_values_with_double_quotes_only() throws SQLException {
+        Statement statement = mockStatementReturningSingleRow(List.of("name"), "5\" monitor");
+
+        String result = retriever.execute("SELECT name FROM products", statement);
+
+        assertThat(result).isEqualTo("name\n\"5\"\" monitor\"");
+    }
+
+    @Test
+    void execute_should_not_quote_plain_values_and_should_handle_null() throws SQLException {
+        Statement statement = mockStatementReturningSingleRow(List.of("id", "name"), 42, null);
+
+        String result = retriever.execute("SELECT id, name FROM customers", statement);
+
+        assertThat(result).isEqualTo("id,name\n42,");
+    }
+
+    private static Statement mockStatementReturningSingleRow(List<String> columnNames, Object... rowValues)
+            throws SQLException {
+        ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+        when(metaData.getColumnCount()).thenReturn(columnNames.size());
+        for (int i = 1; i <= columnNames.size(); i++) {
+            when(metaData.getColumnName(i)).thenReturn(columnNames.get(i - 1));
+        }
+
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getMetaData()).thenReturn(metaData);
+        when(resultSet.next()).thenReturn(true, false);
+        for (int i = 1; i <= rowValues.length; i++) {
+            when(resultSet.getObject(i)).thenReturn(rowValues[i - 1]);
+        }
+
+        Statement statement = mock(Statement.class);
+        when(statement.executeQuery(anyString())).thenReturn(resultSet);
+        return statement;
     }
 }


### PR DESCRIPTION
## Issue

Fixes #6155

## Change

`SqlDatabaseContentRetriever.execute()` renders query results as CSV-like text that is
injected into the LLM prompt, but the escaping is incomplete: values are only wrapped in
double quotes when they contain a comma, embedded double quotes are never escaped, and line
breaks are not handled at all.

Consequences:

- A value like `Alice "AJ" Jones` (with a comma elsewhere in the row) is rendered as
  `"Alice "AJ" Jones"` — embedded quotes are not escaped per RFC 4180, so the row is not
  valid CSV and the column boundaries become ambiguous.
- A value containing `\n`/`\r` is emitted as-is, injecting fake rows and corrupting the
  table structure that the LLM sees.
- A value containing only a double quote (no comma) is not quoted at all.

This change escapes values per RFC 4180: a value is wrapped in double quotes, with embedded
double quotes doubled, when it contains a comma, a double quote, a line feed, or a carriage
return. Plain values (including `null`, rendered as an empty field) are emitted unchanged,
so existing behavior for simple values is preserved.

Unit tests cover: comma + quotes, line break, double quote only, plain values and `null`.

## General checklist

- [x] There are no other requests for the same feature/bug (checked open issues/PRs:
      #2314 / #5928 cover `Content` equality and RRF dedup, #6129 covers `ReRankingContentAggregator`
      metadata — different classes, no overlap with this fix)
- [x] Implementation: minimal, confined to `SqlDatabaseContentRetriever.execute()` + a new
      package-private `toCsvValue` helper
- [x] Unit tests added (mocked `Statement`/`ResultSet`, no database required)
- [x] Formatting: `./mvnw spotless:apply -pl experimental/langchain4j-experimental-sql`
- [x] Public API not changed (`toCsvValue` is package-private; `execute` signature unchanged)

## Commit message

```
fix(experimental-sql): escape CSV special characters in SqlDatabaseContentRetriever results
```
