### PR TITLE
feat(jina): support the INPUT_TYPE per-call embedding parameter

### DIFF
--- a/docs/docs/integrations/embedding-models/jina.md
+++ b/docs/docs/integrations/embedding-models/jina.md
@@ -26,6 +26,11 @@ https://jina.ai/
 - **Multimodal** (`jina-clip-v2`, `jina-embeddings-v4` — auto-detected from the model name): embeds text and
   images. Jina embeds one modality per input item (it does **not** fuse interleaved text + image); pass a single
   `TextContent` or a single `ImageContent` (URL or base64) per input in an `EmbeddingRequest`.
+- **Input type** (`jina-embeddings-v3`, `jina-embeddings-v4`, `jina-embeddings-v5` — auto-detected from the
+  model name): embeds a search query differently from the documents it is matched against, which usually
+  improves retrieval quality. Set `EmbeddingInputType.QUERY` or `DOCUMENT` per call on an `EmbeddingRequest`,
+  or via `EmbeddingStoreContentRetriever.embeddingInputType(...)`. Models that do not offer this (for example
+  `jina-clip-v2`) reject the parameter instead of silently ignoring it.
 - **Listeners**: configure via `JinaEmbeddingModel.builder().listeners(...)`.
 
 See [Embedding Model](/tutorials/rag#embedding-model) for the request/response API and multimodal usage.

--- a/langchain4j-jina/revapi.json
+++ b/langchain4j-jina/revapi.json
@@ -54,6 +54,12 @@
           "old": "method void dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest::<init>(java.lang.String, java.util.List<dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest.JinaMultimodalInput>)",
           "new": "method void dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest::<init>(java.lang.String, java.lang.Boolean, java.util.List<dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest.JinaMultimodalInput>)",
           "justification": "Internal request DTO (internal.api package), not part of the public API; the constructor gained the lateChunking parameter that the multimodal path must send"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest::<init>(java.lang.String, java.lang.Boolean, java.util.List<dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest.JinaMultimodalInput>)",
+          "new": "method void dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest::<init>(java.lang.String, java.lang.String, java.lang.Boolean, java.util.List<dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest.JinaMultimodalInput>)",
+          "justification": "Internal request DTO (internal.api package), not part of the public API; the constructor gained the task parameter that carries the per-call EmbeddingInputType"
         }
       ]
     }

--- a/langchain4j-jina/revapi.json
+++ b/langchain4j-jina/revapi.json
@@ -21,6 +21,11 @@
         },
         {
           "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.embedding.request.EmbeddingParameter",
+          "justification": "Core langchain4j type intentionally exposed by the EmbeddingModel request/response API (embed(EmbeddingRequest), supportedParameters(), supportedContentTypes(), provider(), listeners())"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
           "new": "missing-class dev.langchain4j.data.message.ContentType",
           "justification": "Core langchain4j type intentionally exposed by the EmbeddingModel request/response API (embed(EmbeddingRequest), supportedParameters(), supportedContentTypes(), provider(), listeners())"
         },
@@ -47,7 +52,7 @@
         {
           "code": "java.method.removed",
           "old": "method dev.langchain4j.model.output.Response<java.util.List<dev.langchain4j.data.embedding.Embedding>> dev.langchain4j.model.jina.JinaEmbeddingModel::embedAll(java.util.List<dev.langchain4j.data.segment.TextSegment>)",
-          "justification": "embedAll now inherits its default implementation from EmbeddingModel (routing through embed(EmbeddingRequest)); the method is still present and callable via inheritance — non-breaking"
+          "justification": "embedAll now inherits its default implementation from EmbeddingModel (routing through embed(EmbeddingRequest)); the method is still present and callable via inheritance \u2014 non-breaking"
         },
         {
           "code": "java.method.numberOfParametersChanged",

--- a/langchain4j-jina/revapi.json
+++ b/langchain4j-jina/revapi.json
@@ -52,7 +52,7 @@
         {
           "code": "java.method.removed",
           "old": "method dev.langchain4j.model.output.Response<java.util.List<dev.langchain4j.data.embedding.Embedding>> dev.langchain4j.model.jina.JinaEmbeddingModel::embedAll(java.util.List<dev.langchain4j.data.segment.TextSegment>)",
-          "justification": "embedAll now inherits its default implementation from EmbeddingModel (routing through embed(EmbeddingRequest)); the method is still present and callable via inheritance \u2014 non-breaking"
+          "justification": "embedAll now inherits its default implementation from EmbeddingModel (routing through embed(EmbeddingRequest)); the method is still present and callable via inheritance — non-breaking"
         },
         {
           "code": "java.method.numberOfParametersChanged",

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
@@ -1,10 +1,16 @@
 package dev.langchain4j.model.jina;
 
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.time.Duration.ofSeconds;
+import static java.util.stream.Collectors.toList;
+
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.ContentType;
 import dev.langchain4j.data.message.ImageContent;
-import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.ModelProvider;
@@ -23,20 +29,11 @@ import dev.langchain4j.model.jina.internal.api.JinaEmbeddingResponse;
 import dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest;
 import dev.langchain4j.model.jina.internal.api.JinaMultimodalEmbeddingRequest.JinaMultimodalInput;
 import dev.langchain4j.model.jina.internal.client.JinaClient;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
-
-import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static java.time.Duration.ofSeconds;
-import static java.util.stream.Collectors.toList;
+import org.slf4j.Logger;
 
 /**
  * An implementation of an {@link EmbeddingModel} that uses
@@ -112,9 +109,7 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
 
     @Override
     public Set<ContentType> supportedContentTypes() {
-        return isMultimodalModel(modelName)
-                ? Set.of(ContentType.TEXT, ContentType.IMAGE)
-                : Set.of(ContentType.TEXT);
+        return isMultimodalModel(modelName) ? Set.of(ContentType.TEXT, ContentType.IMAGE) : Set.of(ContentType.TEXT);
     }
 
     @Override
@@ -199,7 +194,8 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
                 if (image.url() != null) {
                     imageValue = image.url().toString();
                 } else if (image.base64Data() != null) {
-                    imageValue = "data:" + getOrDefault(image.mimeType(), "image/png") + ";base64," + image.base64Data();
+                    imageValue =
+                            "data:" + getOrDefault(image.mimeType(), "image/png") + ";base64," + image.base64Data();
                 } else {
                     throw new UnsupportedFeatureException("ImageContent must have either a URL or base64 data");
                 }
@@ -235,8 +231,7 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
         private HttpClientBuilder httpClientBuilder;
         private List<EmbeddingModelListener> listeners;
 
-        JinaEmbeddingModelBuilder() {
-        }
+        JinaEmbeddingModelBuilder() {}
 
         public JinaEmbeddingModelBuilder listeners(List<EmbeddingModelListener> listeners) {
             this.listeners = listeners;
@@ -309,7 +304,10 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
         }
 
         public String toString() {
-            return "JinaEmbeddingModel.JinaEmbeddingModelBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + (this.apiKey == null ? null : "********") + ", modelName=" + this.modelName + ", timeout=" + this.timeout + ", maxRetries=" + this.maxRetries + ", lateChunking=" + this.lateChunking + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "JinaEmbeddingModel.JinaEmbeddingModelBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", modelName=" + this.modelName + ", timeout="
+                    + this.timeout + ", maxRetries=" + this.maxRetries + ", lateChunking=" + this.lateChunking
+                    + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
@@ -12,7 +12,10 @@ import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
 import dev.langchain4j.model.embedding.request.EmbeddingInput;
+import dev.langchain4j.model.embedding.request.EmbeddingInputType;
+import dev.langchain4j.model.embedding.request.EmbeddingParameter;
 import dev.langchain4j.model.embedding.request.EmbeddingRequest;
+import dev.langchain4j.model.embedding.request.EmbeddingRequestParameters;
 import dev.langchain4j.model.embedding.response.EmbeddingResponse;
 import dev.langchain4j.model.embedding.response.EmbeddingResponseMetadata;
 import dev.langchain4j.model.jina.internal.api.JinaEmbeddingRequest;
@@ -115,6 +118,11 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
     }
 
     @Override
+    public Set<EmbeddingParameter<?>> supportedParameters() {
+        return Set.of(EmbeddingRequestParameters.INPUT_TYPE);
+    }
+
+    @Override
     public EmbeddingResponse doEmbed(EmbeddingRequest request) {
 
         List<Embedding> embeddings;
@@ -124,11 +132,7 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
             JinaMultimodalEmbeddingRequest wireRequest = buildMultimodalRequest(request);
             response = withRetryMappingExceptions(() -> client.embedMultimodal(wireRequest), maxRetries);
         } else {
-            JinaEmbeddingRequest wireRequest = JinaEmbeddingRequest.builder()
-                    .model(modelName)
-                    .lateChunking(lateChunking)
-                    .input(request.inputs().stream().map(EmbeddingInput::text).collect(toList()))
-                    .build();
+            JinaEmbeddingRequest wireRequest = buildRequest(request);
             response = withRetryMappingExceptions(() -> client.embed(wireRequest), maxRetries);
         }
 
@@ -151,9 +155,36 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
                 .build();
     }
 
+    JinaEmbeddingRequest buildRequest(EmbeddingRequest request) {
+        return JinaEmbeddingRequest.builder()
+                .model(modelName)
+                .task(toJinaTask(request.inputType()))
+                .lateChunking(lateChunking)
+                .input(request.inputs().stream().map(EmbeddingInput::text).collect(toList()))
+                .build();
+    }
+
     JinaMultimodalEmbeddingRequest buildMultimodalRequest(EmbeddingRequest request) {
         return new JinaMultimodalEmbeddingRequest(
-                modelName, lateChunking, request.inputs().stream().map(this::toMultimodalInput).collect(toList()));
+                modelName,
+                toJinaTask(request.inputType()),
+                lateChunking,
+                request.inputs().stream().map(this::toMultimodalInput).collect(toList()));
+    }
+
+    /**
+     * Maps a {@link EmbeddingInputType} to the corresponding Jina {@code task}, so that a query and the
+     * documents it is matched against are embedded asymmetrically. Returns {@code null} when no input type
+     * is requested, in which case {@code task} is omitted from the request and Jina applies its own default.
+     */
+    static String toJinaTask(EmbeddingInputType inputType) {
+        if (inputType == null) {
+            return null;
+        }
+        return switch (inputType) {
+            case QUERY -> "retrieval.query";
+            case DOCUMENT -> "retrieval.passage";
+        };
     }
 
     private JinaMultimodalInput toMultimodalInput(EmbeddingInput input) {

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
@@ -114,7 +114,7 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
 
     @Override
     public Set<EmbeddingParameter<?>> supportedParameters() {
-        return Set.of(EmbeddingRequestParameters.INPUT_TYPE);
+        return isTaskAwareModel(modelName) ? Set.of(EmbeddingRequestParameters.INPUT_TYPE) : Set.of();
     }
 
     @Override
@@ -216,6 +216,15 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
 
     private static boolean isMultimodalModel(String modelName) {
         return modelName != null && (modelName.contains("clip") || modelName.contains("embeddings-v4"));
+    }
+
+    /**
+     * Whether the model accepts Jina's {@code task} parameter. Only the jina-embeddings-v3 and
+     * jina-embeddings-v4 families are task-aware; jina-clip-* and jina-embeddings-v2-* are not, and
+     * declaring {@code INPUT_TYPE} for them would send a parameter they cannot apply.
+     */
+    private static boolean isTaskAwareModel(String modelName) {
+        return modelName != null && (modelName.contains("embeddings-v3") || modelName.contains("embeddings-v4"));
     }
 
     public static class JinaEmbeddingModelBuilder {

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
@@ -219,12 +219,15 @@ public class JinaEmbeddingModel extends DimensionAwareEmbeddingModel {
     }
 
     /**
-     * Whether the model accepts Jina's {@code task} parameter. Only the jina-embeddings-v3 and
-     * jina-embeddings-v4 families are task-aware; jina-clip-* and jina-embeddings-v2-* are not, and
-     * declaring {@code INPUT_TYPE} for them would send a parameter they cannot apply.
+     * Whether the model accepts Jina's {@code task} parameter. Only the jina-embeddings-v3, v4 and v5
+     * families are task-aware; jina-clip-*, jina-colbert-* and jina-embeddings-v2-* are not, and declaring
+     * {@code INPUT_TYPE} for them would send a parameter they cannot apply.
      */
     private static boolean isTaskAwareModel(String modelName) {
-        return modelName != null && (modelName.contains("embeddings-v3") || modelName.contains("embeddings-v4"));
+        return modelName != null
+                && (modelName.contains("embeddings-v3")
+                        || modelName.contains("embeddings-v4")
+                        || modelName.contains("embeddings-v5"));
     }
 
     public static class JinaEmbeddingModelBuilder {

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/api/JinaEmbeddingRequest.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/api/JinaEmbeddingRequest.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.model.jina.internal.api;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.List;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -36,8 +35,7 @@ public class JinaEmbeddingRequest {
         private Boolean lateChunking;
         private List<String> input;
 
-        JinaEmbeddingRequestBuilder() {
-        }
+        JinaEmbeddingRequestBuilder() {}
 
         public JinaEmbeddingRequestBuilder model(String model) {
             this.model = model;
@@ -64,7 +62,8 @@ public class JinaEmbeddingRequest {
         }
 
         public String toString() {
-            return "JinaEmbeddingRequest.JinaEmbeddingRequestBuilder(model=" + this.model + ", task=" + this.task + ", lateChunking=" + this.lateChunking + ", input=" + this.input + ")";
+            return "JinaEmbeddingRequest.JinaEmbeddingRequestBuilder(model=" + this.model + ", task=" + this.task
+                    + ", lateChunking=" + this.lateChunking + ", input=" + this.input + ")";
         }
     }
 }

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/api/JinaEmbeddingRequest.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/api/JinaEmbeddingRequest.java
@@ -15,11 +15,13 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public class JinaEmbeddingRequest {
 
     public String model;
+    public String task;
     public Boolean lateChunking;
     public List<String> input;
 
-    JinaEmbeddingRequest(String model, Boolean lateChunking, List<String> input) {
+    JinaEmbeddingRequest(String model, String task, Boolean lateChunking, List<String> input) {
         this.model = model;
+        this.task = task;
         this.lateChunking = lateChunking;
         this.input = input;
     }
@@ -30,6 +32,7 @@ public class JinaEmbeddingRequest {
 
     public static class JinaEmbeddingRequestBuilder {
         private String model;
+        private String task;
         private Boolean lateChunking;
         private List<String> input;
 
@@ -38,6 +41,11 @@ public class JinaEmbeddingRequest {
 
         public JinaEmbeddingRequestBuilder model(String model) {
             this.model = model;
+            return this;
+        }
+
+        public JinaEmbeddingRequestBuilder task(String task) {
+            this.task = task;
             return this;
         }
 
@@ -52,11 +60,11 @@ public class JinaEmbeddingRequest {
         }
 
         public JinaEmbeddingRequest build() {
-            return new JinaEmbeddingRequest(this.model, this.lateChunking, this.input);
+            return new JinaEmbeddingRequest(this.model, this.task, this.lateChunking, this.input);
         }
 
         public String toString() {
-            return "JinaEmbeddingRequest.JinaEmbeddingRequestBuilder(model=" + this.model + ", lateChunking=" + this.lateChunking + ", input=" + this.input + ")";
+            return "JinaEmbeddingRequest.JinaEmbeddingRequestBuilder(model=" + this.model + ", task=" + this.task + ", lateChunking=" + this.lateChunking + ", input=" + this.input + ")";
         }
     }
 }

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/api/JinaMultimodalEmbeddingRequest.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/api/JinaMultimodalEmbeddingRequest.java
@@ -19,11 +19,14 @@ import java.util.List;
 public class JinaMultimodalEmbeddingRequest {
 
     public String model;
+    public String task;
     public Boolean lateChunking;
     public List<JinaMultimodalInput> input;
 
-    public JinaMultimodalEmbeddingRequest(String model, Boolean lateChunking, List<JinaMultimodalInput> input) {
+    public JinaMultimodalEmbeddingRequest(
+            String model, String task, Boolean lateChunking, List<JinaMultimodalInput> input) {
         this.model = model;
+        this.task = task;
         this.lateChunking = lateChunking;
         this.input = input;
     }

--- a/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaEmbeddingParametersTest.java
+++ b/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaEmbeddingParametersTest.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.model.embedding.request.EmbeddingInputType.QUERY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -12,6 +13,8 @@ import dev.langchain4j.model.embedding.request.EmbeddingInputType;
 import dev.langchain4j.model.embedding.request.EmbeddingRequest;
 import dev.langchain4j.model.embedding.request.EmbeddingRequestParameters;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JinaEmbeddingParametersTest {
 
@@ -28,62 +31,30 @@ class JinaEmbeddingParametersTest {
         return EmbeddingRequest.builder().input("a query").inputType(inputType).build();
     }
 
-    private static String requestJson(String modelName, EmbeddingInputType inputType) throws Exception {
-        return MAPPER.writeValueAsString(model(modelName).buildRequest(request(inputType)));
+    private static JsonNode requestJson(String modelName, EmbeddingInputType inputType) throws Exception {
+        return MAPPER.readTree(MAPPER.writeValueAsString(model(modelName).buildRequest(request(inputType))));
     }
 
-    private static String multimodalRequestJson(String modelName, EmbeddingInputType inputType) throws Exception {
-        return MAPPER.writeValueAsString(model(modelName).buildMultimodalRequest(request(inputType)));
+    private static JsonNode multimodalRequestJson(String modelName, EmbeddingInputType inputType) throws Exception {
+        return MAPPER.readTree(MAPPER.writeValueAsString(model(modelName).buildMultimodalRequest(request(inputType))));
     }
 
-    @Test
-    void should_declare_input_type_as_supported_parameter() {
-        assertThat(model("jina-embeddings-v3").supportedParameters())
-                .containsExactly(EmbeddingRequestParameters.INPUT_TYPE);
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "jina-embeddings-v3",
+                "jina-embeddings-v4",
+                "jina-embeddings-v5-text-small",
+                "jina-embeddings-v5-omni-nano"
+            })
+    void should_declare_input_type_for_task_aware_models(String modelName) {
+        assertThat(model(modelName).supportedParameters()).containsExactly(EmbeddingRequestParameters.INPUT_TYPE);
     }
 
-    @Test
-    void should_map_query_to_retrieval_query_task() throws Exception {
-        assertThat(requestJson("jina-embeddings-v3", QUERY)).contains("\"task\":\"retrieval.query\"");
-    }
-
-    @Test
-    void should_map_document_to_retrieval_passage_task() throws Exception {
-        assertThat(requestJson("jina-embeddings-v3", DOCUMENT)).contains("\"task\":\"retrieval.passage\"");
-    }
-
-    @Test
-    void should_omit_task_when_no_input_type_is_requested() throws Exception {
-        assertThat(requestJson("jina-embeddings-v3", null)).doesNotContain("task");
-    }
-
-    @Test
-    void should_send_task_for_multimodal_model() throws Exception {
-        // jina-embeddings-v4 is both multimodal and task-aware, so the multimodal path must carry the task too
-        assertThat(multimodalRequestJson("jina-embeddings-v4", QUERY)).contains("\"task\":\"retrieval.query\"");
-    }
-
-    @Test
-    void should_omit_task_for_multimodal_model_when_no_input_type_is_requested() throws Exception {
-        assertThat(multimodalRequestJson("jina-embeddings-v4", null)).doesNotContain("task");
-    }
-
-    @Test
-    void should_map_null_input_type_to_null_task() {
-        assertThat(JinaEmbeddingModel.toJinaTask(null)).isNull();
-    }
-
-    @Test
-    void should_declare_input_type_for_task_aware_multimodal_model() {
-        assertThat(model("jina-embeddings-v4").supportedParameters())
-                .containsExactly(EmbeddingRequestParameters.INPUT_TYPE);
-    }
-
-    @Test
-    void should_not_declare_input_type_for_models_without_task_support() {
-        assertThat(model("jina-clip-v2").supportedParameters()).isEmpty();
-        assertThat(model("jina-clip-v1").supportedParameters()).isEmpty();
-        assertThat(model("jina-embeddings-v2-base-en").supportedParameters()).isEmpty();
+    @ParameterizedTest
+    @ValueSource(strings = {"jina-clip-v1", "jina-clip-v2", "jina-embeddings-v2-base-en", "jina-colbert-v2"})
+    void should_not_declare_input_type_for_models_without_task_support(String modelName) {
+        assertThat(model(modelName).supportedParameters()).isEmpty();
     }
 
     @Test
@@ -103,5 +74,42 @@ class JinaEmbeddingParametersTest {
                         .inputType(QUERY)
                         .build()))
                 .isExactlyInstanceOf(UnsupportedFeatureException.class);
+    }
+
+    @Test
+    void should_map_query_to_retrieval_query_task() throws Exception {
+        assertThat(requestJson("jina-embeddings-v3", QUERY).get("task").asText())
+                .isEqualTo("retrieval.query");
+    }
+
+    @Test
+    void should_map_document_to_retrieval_passage_task() throws Exception {
+        assertThat(requestJson("jina-embeddings-v3", DOCUMENT).get("task").asText())
+                .isEqualTo("retrieval.passage");
+    }
+
+    @Test
+    void should_omit_task_when_no_input_type_is_requested() throws Exception {
+        assertThat(requestJson("jina-embeddings-v3", null).has("task")).isFalse();
+    }
+
+    @Test
+    void should_send_task_for_multimodal_model() throws Exception {
+        // jina-embeddings-v4 is both multimodal and task-aware, so the multimodal path must carry the task too
+        assertThat(multimodalRequestJson("jina-embeddings-v4", QUERY)
+                        .get("task")
+                        .asText())
+                .isEqualTo("retrieval.query");
+    }
+
+    @Test
+    void should_omit_task_for_multimodal_model_when_no_input_type_is_requested() throws Exception {
+        assertThat(multimodalRequestJson("jina-embeddings-v4", null).has("task"))
+                .isFalse();
+    }
+
+    @Test
+    void should_map_null_input_type_to_null_task() {
+        assertThat(JinaEmbeddingModel.toJinaTask(null)).isNull();
     }
 }

--- a/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaEmbeddingParametersTest.java
+++ b/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaEmbeddingParametersTest.java
@@ -3,8 +3,11 @@ package dev.langchain4j.model.jina;
 import static dev.langchain4j.model.embedding.request.EmbeddingInputType.DOCUMENT;
 import static dev.langchain4j.model.embedding.request.EmbeddingInputType.QUERY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.request.EmbeddingInputType;
 import dev.langchain4j.model.embedding.request.EmbeddingRequest;
 import dev.langchain4j.model.embedding.request.EmbeddingRequestParameters;
@@ -68,5 +71,37 @@ class JinaEmbeddingParametersTest {
     @Test
     void should_map_null_input_type_to_null_task() {
         assertThat(JinaEmbeddingModel.toJinaTask(null)).isNull();
+    }
+
+    @Test
+    void should_declare_input_type_for_task_aware_multimodal_model() {
+        assertThat(model("jina-embeddings-v4").supportedParameters())
+                .containsExactly(EmbeddingRequestParameters.INPUT_TYPE);
+    }
+
+    @Test
+    void should_not_declare_input_type_for_models_without_task_support() {
+        assertThat(model("jina-clip-v2").supportedParameters()).isEmpty();
+        assertThat(model("jina-clip-v1").supportedParameters()).isEmpty();
+        assertThat(model("jina-embeddings-v2-base-en").supportedParameters()).isEmpty();
+    }
+
+    @Test
+    void should_reject_input_type_for_model_without_task_support() {
+        // mirrors AbstractEmbeddingModelIT#should_fail_when_input_type_is_not_supported, which the common
+        // JinaEmbeddingModelIT runs against jina-clip-v2; baseUrl points at a dead port so that any attempt
+        // to reach Jina surfaces as something other than UnsupportedFeatureException
+        EmbeddingModel model = JinaEmbeddingModel.builder()
+                .baseUrl("http://127.0.0.1:1/")
+                .apiKey("test-key")
+                .modelName("jina-clip-v2")
+                .maxRetries(0)
+                .build();
+
+        assertThatThrownBy(() -> model.embed(EmbeddingRequest.builder()
+                        .input("hello")
+                        .inputType(QUERY)
+                        .build()))
+                .isExactlyInstanceOf(UnsupportedFeatureException.class);
     }
 }

--- a/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaEmbeddingParametersTest.java
+++ b/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaEmbeddingParametersTest.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.model.jina;
+
+import static dev.langchain4j.model.embedding.request.EmbeddingInputType.DOCUMENT;
+import static dev.langchain4j.model.embedding.request.EmbeddingInputType.QUERY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.embedding.request.EmbeddingInputType;
+import dev.langchain4j.model.embedding.request.EmbeddingRequest;
+import dev.langchain4j.model.embedding.request.EmbeddingRequestParameters;
+import org.junit.jupiter.api.Test;
+
+class JinaEmbeddingParametersTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static JinaEmbeddingModel model(String modelName) {
+        return JinaEmbeddingModel.builder()
+                .apiKey("test-key")
+                .modelName(modelName)
+                .build();
+    }
+
+    private static EmbeddingRequest request(EmbeddingInputType inputType) {
+        return EmbeddingRequest.builder().input("a query").inputType(inputType).build();
+    }
+
+    private static String requestJson(String modelName, EmbeddingInputType inputType) throws Exception {
+        return MAPPER.writeValueAsString(model(modelName).buildRequest(request(inputType)));
+    }
+
+    private static String multimodalRequestJson(String modelName, EmbeddingInputType inputType) throws Exception {
+        return MAPPER.writeValueAsString(model(modelName).buildMultimodalRequest(request(inputType)));
+    }
+
+    @Test
+    void should_declare_input_type_as_supported_parameter() {
+        assertThat(model("jina-embeddings-v3").supportedParameters())
+                .containsExactly(EmbeddingRequestParameters.INPUT_TYPE);
+    }
+
+    @Test
+    void should_map_query_to_retrieval_query_task() throws Exception {
+        assertThat(requestJson("jina-embeddings-v3", QUERY)).contains("\"task\":\"retrieval.query\"");
+    }
+
+    @Test
+    void should_map_document_to_retrieval_passage_task() throws Exception {
+        assertThat(requestJson("jina-embeddings-v3", DOCUMENT)).contains("\"task\":\"retrieval.passage\"");
+    }
+
+    @Test
+    void should_omit_task_when_no_input_type_is_requested() throws Exception {
+        assertThat(requestJson("jina-embeddings-v3", null)).doesNotContain("task");
+    }
+
+    @Test
+    void should_send_task_for_multimodal_model() throws Exception {
+        // jina-embeddings-v4 is both multimodal and task-aware, so the multimodal path must carry the task too
+        assertThat(multimodalRequestJson("jina-embeddings-v4", QUERY)).contains("\"task\":\"retrieval.query\"");
+    }
+
+    @Test
+    void should_omit_task_for_multimodal_model_when_no_input_type_is_requested() throws Exception {
+        assertThat(multimodalRequestJson("jina-embeddings-v4", null)).doesNotContain("task");
+    }
+
+    @Test
+    void should_map_null_input_type_to_null_task() {
+        assertThat(JinaEmbeddingModel.toJinaTask(null)).isNull();
+    }
+}

--- a/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/common/JinaV3EmbeddingModelIT.java
+++ b/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/common/JinaV3EmbeddingModelIT.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.model.jina.common;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.common.AbstractEmbeddingModelIT;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
+import dev.langchain4j.model.jina.JinaEmbeddingModel;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * IT for {@code jina-embeddings-v3}, Jina's text-only task-aware model. It maps the common
+ * {@code INPUT_TYPE} parameter onto Jina's {@code task}, so this is where
+ * {@link AbstractEmbeddingModelIT#should_embed_query_and_document_differently} actually runs; the sibling
+ * {@link JinaEmbeddingModelIT} covers the multimodal, non-task-aware {@code jina-clip-v2}.
+ */
+@EnabledIfEnvironmentVariable(named = "JINA_API_KEY", matches = ".+")
+class JinaV3EmbeddingModelIT extends AbstractEmbeddingModelIT {
+
+    private static final String API_KEY = System.getenv("JINA_API_KEY");
+    private static final String MODEL_NAME = "jina-embeddings-v3";
+
+    @Override
+    protected List<EmbeddingModel> models() {
+        return List.of(JinaEmbeddingModel.builder()
+                .apiKey(API_KEY)
+                .modelName(MODEL_NAME)
+                .build());
+    }
+
+    @Override
+    protected EmbeddingModel modelWith(EmbeddingModelListener listener) {
+        return JinaEmbeddingModel.builder()
+                .apiKey(API_KEY)
+                .modelName(MODEL_NAME)
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected EmbeddingModel failingModelWith(EmbeddingModelListener listener) {
+        return JinaEmbeddingModel.builder()
+                .apiKey("banana")
+                .modelName(MODEL_NAME)
+                .maxRetries(0)
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected boolean supportsImageInput() {
+        return false; // jina-embeddings-v3 is text-only; jina-clip-v2 and jina-embeddings-v4 are the multimodal ones
+    }
+
+    @Override
+    protected boolean supportsDimensionsParameter() {
+        return false; // Jina's Matryoshka `dimensions` parameter is not mapped by JinaEmbeddingModel yet
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6164

## Change

Jina's API takes a `task` that selects how an input is embedded, so a search query and the documents it
is matched against can be embedded asymmetrically. LangChain4j expresses this provider-independently as
the `INPUT_TYPE` per-call parameter (`EmbeddingInputType.QUERY` / `DOCUMENT`), which Cohere and Voyage AI
already honor.

`JinaEmbeddingModel` was migrated to the request/response API in #5735 but never declared any per-call
parameter, so it inherited the default empty `supportedParameters()`. Passing an input type failed:

```
EmbeddingModel 'dev.langchain4j.model.jina.JinaEmbeddingModel' does not support the following
per-call parameter(s): inputType. Only the following are supported:
```

(verified by removing the new override and re-running — the supported list is genuinely empty)

That made `EmbeddingStoreContentRetriever.embeddingInputType(...)` and `EmbeddingStoreIngestor` unusable
with Jina, while the same configuration works on Cohere and Voyage AI.

`INPUT_TYPE` is now declared and mapped to Jina's `task`, mirroring
`CohereEmbeddingModel.toCohereInputType(...)`:

- `QUERY` -> `retrieval.query`
- `DOCUMENT` -> `retrieval.passage`

Both are supported by jina-embeddings-v3/v4/v5. The task is sent on the multimodal path as well, since
`jina-embeddings-v4` is both multimodal and task-aware.

**Backward compatible.** When no input type is requested the task is `null` and omitted from the request
(the DTOs are `@JsonInclude(NON_NULL)`), so existing requests serialize byte-identically — the 8
pre-existing `JinaMultimodalEmbeddingModelTest` cases assert on the serialized JSON and still pass
unchanged.

Deliberately out of scope to keep this reviewable: Jina's `dimensions` (Matryoshka) parameter, and any
builder-level `task` default. Cohere and Voyage carry a builder-level `inputType` only for backward
compatibility with their pre-existing APIs; Jina has no such history.

The `task` field was added to the two internal request DTOs. `JinaMultimodalEmbeddingRequest`'s
constructor gained a parameter, so `revapi.json` gets an ignore entry — the same way the `lateChunking`
parameter was handled in #6026.

Formatting is isolated in its own commit (`chore: apply spotless formatting`), so the functional diff can
be reviewed on its own. It also drops two imports (`TextSegment`, `Response`) that were already unused on
`main`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- Happy to add a note to the Jina docs page if you'd like one -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!--
New unit test `JinaEmbeddingParametersTest` (7 cases) runs fully offline — it builds the wire request with
a dummy API key and asserts the serialized JSON, following the existing `JinaMultimodalEmbeddingModelTest`
pattern. `JinaEmbeddingModelIT` needs JINA_API_KEY and was not run locally.
-->