### PR TITLE
docs: fix RequestCategory typed key example

### DIFF
--- a/docs/docs/tutorials/agents.md
+++ b/docs/docs/tutorials/agents.md
@@ -1180,8 +1180,8 @@ public static class ExpertResponse implements TypedKey<String> { }
 
 public static class Category implements TypedKey<RequestCategory> {
     @Override
-    public Category defaultValue() {
-        return Category.UNKNOWN;
+    public RequestCategory defaultValue() {
+        return RequestCategory.UNKNOWN;
     }
 }
 ```
@@ -1238,9 +1238,9 @@ TechnicalExpert technicalExpert = AgenticServices.agentBuilder(TechnicalExpert.c
         .build();
 
 UntypedAgent expertsAgent = AgenticServices.conditionalBuilder()
-        .subAgents(scope -> scope.readState(Category.class) == Category.MEDICAL, medicalExpert)
-        .subAgents(scope -> scope.readState(Category.class) == Category.LEGAL, legalExpert)
-        .subAgents(scope -> scope.readState(Category.class) == Category.TECHNICAL, technicalExpert)
+        .subAgents(scope -> scope.readState(Category.class) == RequestCategory.MEDICAL, medicalExpert)
+        .subAgents(scope -> scope.readState(Category.class) == RequestCategory.LEGAL, legalExpert)
+        .subAgents(scope -> scope.readState(Category.class) == RequestCategory.TECHNICAL, technicalExpert)
         .build();
 
 ExpertChatbot expertChatbot = AgenticServices.sequenceBuilder(ExpertChatbot.class)


### PR DESCRIPTION
## Issue

Fixes #6167

## Change

Correct five `RequestCategory` references in the strongly typed keys example:

- Change `Category.defaultValue()` from the typed-key class return type to the stored `RequestCategory` value type.
- Return `RequestCategory.UNKNOWN` instead of referencing `UNKNOWN` on the typed-key class.
- Compare the value read with `Category.class` against `RequestCategory.MEDICAL`, `RequestCategory.LEGAL`, and `RequestCategory.TECHNICAL`.

`typedOutputKey = Category.class` remains unchanged because `Category` is the class implementing `TypedKey<RequestCategory>`.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change (not applicable: documentation-only fix)
- [ ] The tests cover both positive and negative cases (not applicable: documentation-only fix)
- [x] I have manually run the relevant documentation build and it is green (`npm run build` in `docs`)
- [ ] I have manually run all unit and integration tests in the core and main modules (not applicable: documentation-only fix)
- [x] I have updated the documentation
- [ ] I have added an example in the examples repo (not applicable)
- [ ] I have updated Spring Boot starters (not applicable)

## Checklist for adding new maven module

Not applicable.

## Checklist for adding new embedding store integration

Not applicable.

## Checklist for changing existing embedding store integration

Not applicable.
