### PR TITLE
fix: Apply the configured maxRetries when embedding a batch

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModel.java
@@ -121,20 +121,20 @@ public class GoogleAiEmbeddingModel extends DimensionAwareEmbeddingModel {
         TaskType taskType = embedding2 ? null : toTaskType(inputType);
 
         List<GeminiEmbeddingRequest> embeddingRequests = request.inputs().stream()
-                .map(input -> buildEmbeddingRequest(embedding2 ? withTaskInstruction(input, inputType) : input, taskType))
+                .map(input ->
+                        buildEmbeddingRequest(embedding2 ? withTaskInstruction(input, inputType) : input, taskType))
                 .collect(Collectors.toList());
 
         return EmbeddingResponse.builder()
                 .embeddings(batchEmbed(embeddingRequests))
-                .metadata(EmbeddingResponseMetadata.builder().modelName(modelName).build())
+                .metadata(
+                        EmbeddingResponseMetadata.builder().modelName(modelName).build())
                 .build();
     }
 
     @Override
     public Set<ContentType> supportedContentTypes() {
-        return isMultimodalModel(modelName)
-                ? Set.of(ContentType.TEXT, ContentType.IMAGE)
-                : Set.of(ContentType.TEXT);
+        return isMultimodalModel(modelName) ? Set.of(ContentType.TEXT, ContentType.IMAGE) : Set.of(ContentType.TEXT);
     }
 
     private static boolean isMultimodalModel(String modelName) {
@@ -197,8 +197,8 @@ public class GoogleAiEmbeddingModel extends DimensionAwareEmbeddingModel {
             GeminiBatchEmbeddingRequest batchEmbeddingRequest =
                     new GeminiBatchEmbeddingRequest(embeddingRequests.subList(startIndex, lastIndex));
 
-            GeminiBatchEmbeddingResponse geminiResponse =
-                    withRetryMappingExceptions(() -> geminiService.batchEmbed(modelName, batchEmbeddingRequest));
+            GeminiBatchEmbeddingResponse geminiResponse = withRetryMappingExceptions(
+                    () -> geminiService.batchEmbed(modelName, batchEmbeddingRequest), maxRetries);
 
             allEmbeddings.addAll(geminiResponse.embeddings().stream()
                     .map(values -> Embedding.from(values.values()))

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModelRetryTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModelRetryTest.java
@@ -1,0 +1,121 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.exception.InternalServerException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import dev.langchain4j.model.embedding.request.EmbeddingRequest;
+import dev.langchain4j.model.output.Response;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class GoogleAiEmbeddingModelRetryTest {
+
+    private static final String BATCH_EMBED_RESPONSE = "{\"embeddings\":[{\"values\":[0.1,0.2,0.3]}]}";
+
+    private static class FailingHttpClient implements HttpClient {
+
+        private final AtomicInteger attempts = new AtomicInteger();
+        private final int failuresBeforeSuccess;
+
+        private FailingHttpClient(int failuresBeforeSuccess) {
+            this.failuresBeforeSuccess = failuresBeforeSuccess;
+        }
+
+        static FailingHttpClient alwaysFailing() {
+            return new FailingHttpClient(Integer.MAX_VALUE);
+        }
+
+        static FailingHttpClient failingOnce() {
+            return new FailingHttpClient(1);
+        }
+
+        @Override
+        public SuccessfulHttpResponse execute(HttpRequest request) {
+            if (attempts.incrementAndGet() > failuresBeforeSuccess) {
+                return SuccessfulHttpResponse.builder()
+                        .statusCode(200)
+                        .body(BATCH_EMBED_RESPONSE)
+                        .build();
+            }
+            throw new HttpException(500, "server error");
+        }
+
+        @Override
+        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static GoogleAiEmbeddingModel model(FailingHttpClient httpClient, int maxRetries) {
+        return GoogleAiEmbeddingModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(httpClient))
+                .baseUrl("http://localhost")
+                .apiKey("dummy")
+                .modelName("gemini-embedding-001")
+                .maxRetries(maxRetries)
+                .build();
+    }
+
+    @Test
+    void should_not_retry_embedding_when_max_retries_is_zero() {
+        FailingHttpClient httpClient = FailingHttpClient.alwaysFailing();
+
+        assertThatThrownBy(() -> model(httpClient, 0).embed("hello")).isInstanceOf(InternalServerException.class);
+
+        assertThat(httpClient.attempts).hasValue(1);
+    }
+
+    @Test
+    void should_not_retry_batch_embedding_when_max_retries_is_zero() {
+        FailingHttpClient httpClient = FailingHttpClient.alwaysFailing();
+
+        assertThatThrownBy(() -> model(httpClient, 0).embedAll(List.of(TextSegment.from("hello"))))
+                .isInstanceOf(InternalServerException.class);
+
+        assertThat(httpClient.attempts).hasValue(1);
+    }
+
+    @Test
+    void should_not_retry_embedding_request_when_max_retries_is_zero() {
+        FailingHttpClient httpClient = FailingHttpClient.alwaysFailing();
+        EmbeddingRequest request = EmbeddingRequest.builder()
+                .textSegment(TextSegment.from("hello"))
+                .build();
+
+        assertThatThrownBy(() -> model(httpClient, 0).embed(request)).isInstanceOf(InternalServerException.class);
+
+        assertThat(httpClient.attempts).hasValue(1);
+    }
+
+    @Test
+    void should_return_embeddings_when_a_retry_succeeds() {
+        FailingHttpClient httpClient = FailingHttpClient.failingOnce();
+
+        Response<List<Embedding>> response = model(httpClient, 1).embedAll(List.of(TextSegment.from("hello")));
+
+        assertThat(httpClient.attempts).hasValue(2);
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).vector()).containsExactly(0.1f, 0.2f, 0.3f);
+    }
+
+    @Test
+    void should_retry_batch_embedding() {
+        FailingHttpClient httpClient = FailingHttpClient.alwaysFailing();
+
+        assertThatThrownBy(() -> model(httpClient, 1).embedAll(List.of(TextSegment.from("hello"))))
+                .isInstanceOf(InternalServerException.class);
+
+        assertThat(httpClient.attempts).hasValue(2);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6173 

## Change

`GoogleAiEmbeddingModel` passes `maxRetries` to `withRetryMappingExceptions` in `embed()`, but the
private `batchEmbed()` called the no-arg overload, which falls back to
`RetryUtils.DEFAULT_RETRY_POLICY` and its two retries. Against a server returning 500,
`maxRetries(0)` made three attempts instead of one, and `maxRetries(5)` gave up after three.

```java
withRetryMappingExceptions(() -> geminiService.batchEmbed(modelName, batchEmbeddingRequest), maxRetries);
```

`batchEmbed()` backs both `embedAll(List<TextSegment>)` and `embed(EmbeddingRequest)`, so one
argument corrects both batch entry points. It is the only retry call in the repository that omits
the count while its class holds a retries field.

The default configuration is unchanged: the builder default is also 2, so both paths made three
attempts before and after, and only an explicitly configured value was ignored.

The file is reformatted by spotless because it does not currently conform, so the first hunk of the
diff is formatting I did not write; the semantic change is the `maxRetries` argument alone.

### Tests

- `GoogleAiEmbeddingModelRetryTest` (new), 5 tests driving a canned `HttpClient` that throws
  `HttpException(500)` and counts attempts, so the real `GeminiService` and retry policy run: that
  both affected entry points make one attempt at `maxRetries(0)` and that `embedAll` makes two at
  `maxRetries(1)`, that a batch failing once still returns its embeddings, and that the unaffected
  `embed(String)` already honoured the setting. Each failure case asserts the mapped
  `InternalServerException`.

3 of the 5 fail on unmodified `main`: `should_not_retry_batch_embedding_when_max_retries_is_zero`,
`should_not_retry_embedding_request_when_max_retries_is_zero` and `should_retry_batch_embedding`.
The other 2 pass either way and cover the unaffected `embed(String)` path and the success path.

```
$ mvn -pl langchain4j-google-ai-gemini test
Tests run: 396, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-google-ai-gemini test -Dtest=GoogleAiEmbeddingModelRetryTest   # fix reverted
Tests run: 5, Failures: 3, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-core test
Tests run: 1282, Failures: 0, Errors: 0, Skipped: 5

$ mvn -pl langchain4j test
Tests run: 1365, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-google-ai-gemini verify
[INFO] API checks completed without failures.
```

No integration test was added or run: the change needs no Gemini credentials to exercise.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)