### PR TITLE
fix(mcp): cancel pending operations and notify server on read/prompt/subscribe timeouts

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -14,8 +14,8 @@ import dev.langchain4j.mcp.client.logging.DefaultMcpLogMessageHandler;
 import dev.langchain4j.mcp.client.logging.McpLogMessageHandler;
 import dev.langchain4j.mcp.client.progress.McpProgressHandler;
 import dev.langchain4j.mcp.client.transport.McpHeaderEncoding;
-import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpCallToolParams;
 import dev.langchain4j.mcp.protocol.McpCallToolRequest;
@@ -183,8 +183,8 @@ public class DefaultMcpClient implements McpClient {
             cachePromptList = getOrDefault(builder.cachePromptList, Boolean.TRUE);
             onResourceUpdated = builder.onResourceUpdated;
             if (builder.toolResultConverter != null && builder.toolResultExtractor != null) {
-                throw new IllegalArgumentException("Set either toolResultConverter or the deprecated "
-                        + "toolResultExtractor, not both");
+                throw new IllegalArgumentException(
+                        "Set either toolResultConverter or the deprecated " + "toolResultExtractor, not both");
             }
             toolResultConverter = builder.toolResultExtractor != null
                     ? new LegacyToolResultConverterAdapter(builder.toolResultExtractor)
@@ -425,8 +425,7 @@ public class DefaultMcpClient implements McpClient {
 
         return new McpInitializeResult(
                 discovered.getId(),
-                new McpInitializeResult.Result(
-                        null, result.getCapabilities(), serverInfo, result.getInstructions()));
+                new McpInitializeResult.Result(null, result.getCapabilities(), serverInfo, result.getInstructions()));
     }
 
     private void initializeModern(String versionToAdvertise, boolean isProbe) {
@@ -458,8 +457,8 @@ public class DefaultMcpClient implements McpClient {
                         error.getData() == null ? null : McpJson.serialize(error.getData()));
             }
             log.debug("MCP server discover result: {}", response.get("result"));
-            McpServerDiscoverResponse.Result discovered =
-                    McpJson.deserialize(response, McpServerDiscoverResponse.class).getResult();
+            McpServerDiscoverResponse.Result discovered = McpJson.deserialize(response, McpServerDiscoverResponse.class)
+                    .getResult();
             initializeResult = toInitializeResultFromDiscover(response, discovered);
             modernProtocol = true;
             McpDiscoverResult discoverResult = toDiscoverResult(discovered);
@@ -492,7 +491,8 @@ public class DefaultMcpClient implements McpClient {
         }
 
         McpServerInfo serverInfo = null;
-        Object serverInfoValue = result.getMeta() == null ? null : result.getMeta().get(MCP_SERVER_INFO_META_KEY);
+        Object serverInfoValue =
+                result.getMeta() == null ? null : result.getMeta().get(MCP_SERVER_INFO_META_KEY);
         if (serverInfoValue != null) {
             McpImplementation implementation = McpJson.convert(serverInfoValue, McpImplementation.class);
             serverInfo =
@@ -739,10 +739,8 @@ public class DefaultMcpClient implements McpClient {
         }
         final JsonNode finalResult = result;
         try {
-            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(
-                    finalResult, false, toolResultConverter);
-            notifyListeners(l -> l.afterExecuteTool(
-                    context, toolResult, McpJsonConversions.toMap(finalResult)));
+            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(finalResult, false, toolResultConverter);
+            notifyListeners(l -> l.afterExecuteTool(context, toolResult, McpJsonConversions.toMap(finalResult)));
             return toolResult;
         } catch (ToolExecutionException e) {
             if (e.errorCode() != null) {
@@ -753,8 +751,7 @@ public class DefaultMcpClient implements McpClient {
                 // -> we notify the listener with afterExecuteTool
                 notifyListeners(l -> l.afterExecuteTool(
                         context,
-                        ToolExecutionHelper.extractResult(
-                                finalResult, true, toolResultConverter),
+                        ToolExecutionHelper.extractResult(finalResult, true, toolResultConverter),
                         McpJsonConversions.toMap(finalResult)));
             }
             throw e;
@@ -809,10 +806,20 @@ public class DefaultMcpClient implements McpClient {
                     "resources/read");
             McpReadResourceResult resourceResult = ResourcesHelper.parseResourceContents(result);
             final JsonNode finalResult = result;
-            notifyListeners(l -> l.afterResourceGet(
-                    context, resourceResult, McpJsonConversions.toMap(finalResult)));
+            notifyListeners(l -> l.afterResourceGet(context, resourceResult, McpJsonConversions.toMap(finalResult)));
             return resourceResult;
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            notifyListeners(l -> l.onResourceGetError(context, timeout));
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            throw new RuntimeException(timeout);
+        } catch (ExecutionException e) {
             notifyListeners(l -> l.onResourceGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
@@ -862,10 +869,20 @@ public class DefaultMcpClient implements McpClient {
                     "prompts/get");
             McpGetPromptResult promptResult = PromptsHelper.parsePromptContents(result);
             final JsonNode finalResult = result;
-            notifyListeners(l -> l.afterPromptGet(
-                    context, promptResult, McpJsonConversions.toMap(finalResult)));
+            notifyListeners(l -> l.afterPromptGet(context, promptResult, McpJsonConversions.toMap(finalResult)));
             return promptResult;
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            notifyListeners(l -> l.onPromptGetError(context, timeout));
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            throw new RuntimeException(timeout);
+        } catch (ExecutionException e) {
             notifyListeners(l -> l.onPromptGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
@@ -963,12 +980,25 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforeResourceSubscribe(context));
         applyMeta(operation, context);
         long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
+        CompletableFuture<JsonNode> resultFuture = null;
         try {
-            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
+            resultFuture = executeViaTransport(context);
             JsonNode result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             McpErrorHelper.checkForErrors(result);
             notifyListeners(l -> l.afterResourceSubscribe(context));
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            RuntimeException re = new RuntimeException(timeout);
+            notifyListeners(l -> l.onResourceSubscribeError(context, re));
+            throw re;
+        } catch (ExecutionException e) {
             RuntimeException re = new RuntimeException(e);
             notifyListeners(l -> l.onResourceSubscribeError(context, re));
             throw re;
@@ -996,12 +1026,25 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforeResourceUnsubscribe(context));
         applyMeta(operation, context);
         long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
+        CompletableFuture<JsonNode> resultFuture = null;
         try {
-            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
+            resultFuture = executeViaTransport(context);
             JsonNode result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             McpErrorHelper.checkForErrors(result);
             notifyListeners(l -> l.afterResourceUnsubscribe(context));
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            RuntimeException re = new RuntimeException(timeout);
+            notifyListeners(l -> l.onResourceUnsubscribeError(context, re));
+            throw re;
+        } catch (ExecutionException e) {
             RuntimeException re = new RuntimeException(e);
             notifyListeners(l -> l.onResourceUnsubscribeError(context, re));
             throw re;
@@ -1131,7 +1174,8 @@ public class DefaultMcpClient implements McpClient {
     private static boolean honoursResourceSubscriptions(Map<String, Object> acknowledgement) {
         Object params = acknowledgement.get("params");
         Object notifications = params instanceof Map ? ((Map<?, ?>) params).get("notifications") : null;
-        Object honoured = notifications instanceof Map ? ((Map<?, ?>) notifications).get("resourceSubscriptions") : null;
+        Object honoured =
+                notifications instanceof Map ? ((Map<?, ?>) notifications).get("resourceSubscriptions") : null;
         return honoured instanceof List<?> list && !list.isEmpty();
     }
 
@@ -1399,7 +1443,9 @@ public class DefaultMcpClient implements McpClient {
     private static String getNextCursor(JsonNode response) {
         McpPaginatedResult.Result result =
                 McpJson.deserialize(response, McpPaginatedResult.class).getResult();
-        if (result == null || result.getNextCursor() == null || result.getNextCursor().isEmpty()) {
+        if (result == null
+                || result.getNextCursor() == null
+                || result.getNextCursor().isEmpty()) {
             return null;
         }
         return result.getNextCursor();
@@ -1594,6 +1640,7 @@ public class DefaultMcpClient implements McpClient {
 
         @Deprecated(since = "1.20.0", forRemoval = true)
         private McpToolResultExtractor toolResultExtractor;
+
         private Integer multiRoundTripMaxRetries;
         private Boolean subscribeToToolListChanges;
         private Boolean subscribeToPromptListChanges;
@@ -1963,5 +2010,4 @@ public class DefaultMcpClient implements McpClient {
     private CompletableFuture<JsonNode> initializeViaTransport(McpInitializeRequest request) {
         return McpJson.map(transport.sendInitializeRequest(request), McpJson::parse);
     }
-
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -1629,6 +1629,92 @@ public class DefaultMcpClientTest {
         verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
     }
 
+    @Test
+    public void resource_read_timeout_cancels_pending_request_and_sends_cancellation_notification() {
+        McpTransport transport = getModernStdioTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        assertThatThrownBy(() -> client.readResource("test://resource")).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
+    public void resource_read_timeout_over_http_cancels_without_cancellation_notification() {
+        McpTransport transport = getModernHttpTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        assertThatThrownBy(() -> client.readResource("test://resource")).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, never()).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
+    public void prompt_get_timeout_cancels_pending_request_and_sends_cancellation_notification() {
+        McpTransport transport = getLegacyHttpTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class))).thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .promptsTimeout(java.time.Duration.ofMillis(100))
+                .build();
+
+        assertThatThrownBy(() -> client.getPrompt("test", Map.of())).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
+    public void resource_subscribe_timeout_cancels_pending_request_and_sends_cancellation_notification() {
+        McpTransport transport = getLegacyHttpTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class))).thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .build();
+
+        assertThatThrownBy(() -> client.subscribeToResource("test://resource")).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
+    }
+
     @SuppressWarnings("unchecked")
     private static Map<Long, ?> getActiveSubscriptions(DefaultMcpClient client) throws Exception {
         java.lang.reflect.Field field = DefaultMcpClient.class.getDeclaredField("activeSubscriptions");


### PR DESCRIPTION
Fixes #6159

## What
DefaultMcpClient cancels the pending operation and sends notifications/cancelled when tools/call times out, but readResource, getPrompt, subscribeToResource and unsubscribeFromResource only removed the operation from pendingOperations. A timed-out read therefore kept the local future alive and the server unaware the client had abandoned the request.

All four methods now, on TimeoutException:
- cancel the local response future (resultFuture.cancel(true))
- send McpCancellationNotification when the transport/protocol requires it
- preserve the previous exception surface (RuntimeException)

## How verified
- 4 new tests in DefaultMcpClientTest covering: modern stdio (notification sent), modern http (no notification), legacy prompt get, legacy resource subscribe - all assert the pending future is cancelled.
- mvn -pl langchain4j-mcp -am test -Dtest=DefaultMcpClientTest: 43 tests, 0 failures, 0 errors.