### PR TITLE
fix(mcp): use UTF-8 for stdio and Docker transport streams

### DIFF
--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.mcp.client.transport.docker;
 
-import dev.langchain4j.mcp.client.transport.McpJson;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
@@ -17,6 +16,7 @@ import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
@@ -528,5 +528,4 @@ public class DockerMcpTransport implements McpTransport {
     public void executeOperationWithoutResponse(McpCallContext context) {
         sendMessage(context);
     }
-
 }

--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -255,7 +256,7 @@ public class DockerMcpTransport implements McpTransport {
                     .exec(new DockerResultCallback(logEvents, logger, messageHandler));
             callback.awaitStarted(attachTimeout.toMillis(), TimeUnit.MILLISECONDS);
 
-            out.write((request + "\n").getBytes());
+            out.write((request + "\n").getBytes(StandardCharsets.UTF_8));
             out.flush();
 
             if (id != null) {

--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -36,7 +37,7 @@ class DockerResultCallback extends ResultCallback.Adapter<Frame> {
 
     @Override
     public void onNext(Frame frame) {
-        String frameStr = new String(frame.getPayload());
+        String frameStr = new String(frame.getPayload(), StandardCharsets.UTF_8);
         if (frame.getStreamType() == StreamType.STDERR) {
             LOG.debug("[STDERR] {}", frameStr);
         } else if (frame.getStreamType() == StreamType.STDOUT) {

--- a/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallbackTest.java
+++ b/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallbackTest.java
@@ -34,4 +34,15 @@ class DockerResultCallbackTest {
             verifyNoInteractions(messageHandler);
         }
     }
+
+    @Test
+    void shouldDecodeDockerFramesAsUtf8() {
+        McpOperationHandler messageHandler = mock(McpOperationHandler.class);
+        DockerResultCallback callback = new DockerResultCallback(false, messageHandler);
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"caf\u00e9 \ud55c\uae00 \ud83d\ude80\"}";
+
+        callback.onNext(new Frame(StreamType.STDOUT, (message + "\n").getBytes(UTF_8)));
+
+        verify(messageHandler).onMessage(message + "\n");
+    }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +24,8 @@ class ProcessStderrHandler implements Runnable, Closeable {
 
     @Override
     public void run() {
-        try (InputStreamReader inputStreamReader = new InputStreamReader(process.getErrorStream())) {
+        try (InputStreamReader inputStreamReader =
+                new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8)) {
             try (BufferedReader reader = new BufferedReader(inputStreamReader)) {
                 String line;
                 while ((line = reader.readLine()) != null) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
@@ -33,11 +33,7 @@ public class JsonRpcIoHandler implements Runnable, Closeable {
     }
 
     public JsonRpcIoHandler(
-            InputStream input,
-            OutputStream output,
-            Consumer<String> messageHandler,
-            boolean logEvents,
-            Logger logger) {
+            InputStream input, OutputStream output, Consumer<String> messageHandler, boolean logEvents, Logger logger) {
         this.input = input;
         this.logEvents = logEvents;
         this.messageHandler = messageHandler;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,13 +38,13 @@ public class JsonRpcIoHandler implements Runnable, Closeable {
         this.input = input;
         this.logEvents = logEvents;
         this.messageHandler = messageHandler;
-        this.out = new PrintStream(output, true);
+        this.out = new PrintStream(output, true, StandardCharsets.UTF_8);
         this.trafficLog = getOrDefault(logger, McpLoggers.traffic());
     }
 
     @Override
     public void run() {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (logEvents) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandlerTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.mcp.client.transport.stdio;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -31,6 +32,26 @@ class ProcessStderrHandlerTest {
 
             verify(logger).debug("[STDERR] {}", "server log");
             verify(logger, never()).debug("[ERROR] {}", "server log");
+        }
+    }
+
+    @Test
+    void shouldDecodeProcessStderrOutputAsUtf8() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            Logger logger = mock(Logger.class);
+            loggerFactory
+                    .when(() -> LoggerFactory.getLogger(ProcessStderrHandler.class))
+                    .thenReturn(logger);
+
+            Process process = mock(Process.class);
+            when(process.getErrorStream())
+                    .thenReturn(new ByteArrayInputStream(
+                            ("caf\u00e9 \ud55c\uae00 \ud83d\ude80" + System.lineSeparator()).getBytes(UTF_8)));
+            when(process.pid()).thenReturn(123L);
+
+            new ProcessStderrHandler(process).run();
+
+            verify(logger).debug("[STDERR] {}", "caf\u00e9 \ud55c\uae00 \ud83d\ude80");
         }
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandlerTest.java
@@ -73,6 +73,38 @@ class JsonRpcIoHandlerTest {
     }
 
     @Test
+    void should_read_multibyte_messages_as_utf8() {
+        // given
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"caf\u00e9 \ud55c\uae00 \ud83d\ude80\"}";
+        ByteArrayInputStream in = new ByteArrayInputStream((message + "\n").getBytes(UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        List<String> received = new ArrayList<>();
+
+        JsonRpcIoHandler handler = new JsonRpcIoHandler(in, out, received::add, false);
+
+        // when
+        handler.run();
+
+        // then
+        assertThat(received).containsExactly(message);
+    }
+
+    @Test
+    void should_write_multibyte_messages_as_utf8() throws Exception {
+        // given
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":1,\"params\":\"caf\u00e9 \ud55c\uae00 \ud83d\ude80\"}";
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonRpcIoHandler handler = new JsonRpcIoHandler(in, out, ignored -> {}, false);
+
+        // when
+        handler.submit(message);
+
+        // then
+        assertThat(out.toByteArray()).isEqualTo((message + System.lineSeparator()).getBytes(UTF_8));
+    }
+
+    @Test
     void should_stop_reading_after_close() throws Exception {
         // given
         BlockingInputStream in = new BlockingInputStream();


### PR DESCRIPTION
## Issue

Closes #6177

## Change

The stdio and Docker MCP transports converted between bytes and text without an explicit charset in four places, so they used `Charset.defaultCharset()`. `JsonRpcIoHandler` read incoming messages through `new InputStreamReader(input)` and wrote outgoing ones through `new PrintStream(output, true)`; `ProcessStderrHandler` decoded the subprocess stderr the same way; `DockerResultCallback` decoded frames with `new String(frame.getPayload())` and `DockerMcpTransport#execute` encoded requests with `(request + "\n").getBytes()`. MCP messages are JSON-RPC 2.0, and RFC 8259 section 8.1 requires UTF-8 for JSON exchanged between systems. The default charset is only guaranteed to be UTF-8 from Java 18 (JEP 400), and this project targets Java 17, where it is platform-dependent.

All four now pass `StandardCharsets.UTF_8` explicitly. This is byte-identical on a UTF-8-default JVM, so nothing changes for the majority of users; it only makes the behaviour the same everywhere else. Pure ASCII sessions were never affected, and the HTTP and WebSocket transports were not affected either — they contain no charset-less conversion, and `McpHeaderEncoding` already used `StandardCharsets.UTF_8`. After this change the two modules have none left.

I did not assume which of the four call sites actually misbehave — I measured. Running the four new tests against the unmodified `main` with `_JAVA_OPTIONS=-Dfile.encoding=ISO-8859-1` fails all four:

```
[ERROR] JsonRpcIoHandlerTest.should_read_multibyte_messages_as_utf8:89
[ERROR] JsonRpcIoHandlerTest.should_write_multibyte_messages_as_utf8:104
[ERROR] ProcessStderrHandlerTest.shouldDecodeProcessStderrOutputAsUtf8:54
[ERROR] DockerResultCallbackTest.shouldDecodeDockerFramesAsUtf8:46
```

With the fix they pass under `ISO-8859-1` and under the default UTF-8 alike. The tests use `café 한글 🚀` written as `\uXXXX` escapes so that the source file encoding cannot influence the result. The negative side is covered by that charset-forced run rather than by a separate test method, since the defect is only observable through the JVM default charset, which is fixed at startup; the positive side is covered on every CI JVM.

`DockerMcpTransport#execute` is the one line without its own test. It writes into a `PipedOutputStream` inside a private method that needs a live container attachment, so there is no unit seam for it. I fixed it anyway because it is the sending half of the pair whose receiving half (`DockerResultCallback`) is tested here, and leaving it would fix only one direction of the same transport.

The first commit is the reformatting spotless applies to `JsonRpcIoHandler` and `DockerMcpTransport` once those files are touched, kept separate from the fix so it can be reviewed as a no-op.

## General checklist
- [X] There are no breaking changes (API, behaviour)
    - No API change. The only behaviour change is the fix itself, and it is a no-op wherever the default charset is already UTF-8.
- [X] I have added unit and/or integration tests for my change
    - `JsonRpcIoHandlerTest` (2 new), `ProcessStderrHandlerTest` (1 new), `DockerResultCallbackTest` (1 new).
- [X] The tests cover both positive and negative cases
    - Positive: multibyte round-trip on read and write. Negative: the same tests fail on unmodified `main` under `-Dfile.encoding=ISO-8859-1`, as shown above.
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
    - `langchain4j-mcp` 187, `langchain4j-mcp-docker` 6, BUILD SUCCESS (JDK 17). `mvn -Pspotless spotless:check` clean on both modules.
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
    - `langchain4j-core` 1282 (5 skipped) + `langchain4j` 1365, BUILD SUCCESS (JDK 17).
- [X] I have added/updated the documentation
    - N/A. No user-facing API or configuration changes.
- [X] I have added an example in the examples repo (only for "big" features)
    - N/A. Bug fix.
- [X] I have added/updated Spring Boot starter(s) (if applicable)
    - N/A. No starter is affected.

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
