### PR TITLE
fix(voyage-ai): return one score per segment and deprecate topK

### DIFF
--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
@@ -3,15 +3,14 @@ package dev.langchain4j.model.voyageai;
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
-import static dev.langchain4j.internal.ValidationUtils.ensureEq;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.model.voyageai.VoyageAiClient.DEFAULT_BASE_URL;
+import static java.lang.String.format;
 import static java.time.Duration.ofSeconds;
 import static java.util.stream.Collectors.toList;
 
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.InternalServerException;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
@@ -107,21 +106,30 @@ public class VoyageAiScoringModel implements ScoringModel {
 
         RerankResponse response = withRetryMappingExceptions(() -> client.rerank(request), maxRetries);
 
-        List<RerankResponse.RerankData> results = ensureNotNull(response.getData(), "rerank results");
-        ensureEq(
-                results.size(),
-                segments.size(),
-                "Voyage AI returned %s scores for %s segments",
-                results.size(),
-                segments.size());
+        List<RerankResponse.RerankData> results = response.getData();
+        if (results == null || results.size() != segments.size()) {
+            throw new InternalServerException(format(
+                    "Re-ranking failed: expected %s scores, but got %s",
+                    segments.size(), results == null ? 0 : results.size()));
+        }
 
         List<Double> scores = new ArrayList<>(Collections.nCopies(segments.size(), null));
         for (RerankResponse.RerankData result : results) {
-            int index = ensureBetween(result.getIndex(), 0, segments.size() - 1, "rerank result index");
-            if (scores.get(index) != null) {
-                throw illegalArgument("Voyage AI returned duplicate rerank result index: %s", index);
+            Integer index = result.getIndex();
+            if (index == null || index < 0 || index >= segments.size()) {
+                throw new InternalServerException(
+                        format("Re-ranking failed: got an out-of-range document index: %s", index));
             }
-            scores.set(index, ensureNotNull(result.getRelevanceScore(), "relevanceScore"));
+            if (scores.get(index) != null) {
+                throw new InternalServerException(
+                        format("Re-ranking failed: got a duplicate document index: %s", index));
+            }
+            Double relevanceScore = result.getRelevanceScore();
+            if (relevanceScore == null) {
+                throw new InternalServerException(
+                        format("Re-ranking failed: got no relevance score for document index: %s", index));
+            }
+            scores.set(index, relevanceScore);
         }
 
         return Response.from(scores, new TokenUsage(response.getUsage().getTotalTokens()));
@@ -245,16 +253,25 @@ public class VoyageAiScoringModel implements ScoringModel {
         }
 
         /**
-         * The number of most relevant documents to return. If not specified, the reranking results of all documents
-         * will be returned.
-         * <p>
-         * This value must be greater than or equal to the number of segments passed to
-         * {@link VoyageAiScoringModel#scoreAll(List, String)}, because {@link ScoringModel} requires one score per
-         * segment. To limit the final number of re-ranked results, use
-         * {@code ReRankingContentAggregator.builder().maxResults(...)} instead.
+         * The number of most relevant documents Voyage AI should return.
          *
          * @param topK the number of most relevant documents to return.
+         * @deprecated {@code topK} cannot be used together with {@link ScoringModel}, which requires exactly one
+         * score per input segment (see {@link VoyageAiScoringModel#scoreAll(List, String)}). Asking Voyage AI for
+         * fewer documents than were sent makes it impossible to tell which segment each returned score belongs to,
+         * so {@code scoreAll} now throws an {@link IllegalArgumentException} when {@code topK} is smaller than the
+         * number of segments. Any other value has no effect. To limit how many results a RAG pipeline keeps after
+         * re-ranking, use
+         * {@link dev.langchain4j.rag.content.aggregator.ReRankingContentAggregator.ReRankingContentAggregatorBuilder#maxResults(Integer)}
+         * instead:
+         * <pre>{@code
+         * ReRankingContentAggregator.builder()
+         *         .scoringModel(scoringModel)
+         *         .maxResults(3)
+         *         .build();
+         * }</pre>
          */
+        @Deprecated(forRemoval = true, since = "1.20.0")
         public Builder topK(Integer topK) {
             this.topK = topK;
             return this;

--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
@@ -94,8 +94,7 @@ public class VoyageAiScoringModel implements ScoringModel {
                     "'topK' (%s) must be greater than or equal to the number of segments (%s) because "
                             + "ScoringModel must return one score per segment. Use "
                             + "ReRankingContentAggregator.builder().maxResults(...) to limit the final results.",
-                    topK,
-                    segments.size());
+                    topK, segments.size());
         }
 
         RerankRequest request = RerankRequest.builder()

--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
@@ -1,11 +1,14 @@
 package dev.langchain4j.model.voyageai;
 
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
+import static dev.langchain4j.internal.ValidationUtils.ensureEq;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.model.voyageai.VoyageAiClient.DEFAULT_BASE_URL;
 import static java.time.Duration.ofSeconds;
-import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
 
 import dev.langchain4j.data.segment.TextSegment;
@@ -14,6 +17,8 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.model.scoring.ScoringModel;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -84,6 +89,15 @@ public class VoyageAiScoringModel implements ScoringModel {
 
     @Override
     public Response<List<Double>> scoreAll(List<TextSegment> segments, String query) {
+        if (topK != null && topK < segments.size()) {
+            throw illegalArgument(
+                    "'topK' (%s) must be greater than or equal to the number of segments (%s) because "
+                            + "ScoringModel must return one score per segment. Use "
+                            + "ReRankingContentAggregator.builder().maxResults(...) to limit the final results.",
+                    topK,
+                    segments.size());
+        }
+
         RerankRequest request = RerankRequest.builder()
                 .model(modelName)
                 .query(query)
@@ -94,10 +108,22 @@ public class VoyageAiScoringModel implements ScoringModel {
 
         RerankResponse response = withRetryMappingExceptions(() -> client.rerank(request), maxRetries);
 
-        List<Double> scores = response.getData().stream()
-                .sorted(comparingInt(RerankResponse.RerankData::getIndex))
-                .map(RerankResponse.RerankData::getRelevanceScore)
-                .collect(toList());
+        List<RerankResponse.RerankData> results = ensureNotNull(response.getData(), "rerank results");
+        ensureEq(
+                results.size(),
+                segments.size(),
+                "Voyage AI returned %s scores for %s segments",
+                results.size(),
+                segments.size());
+
+        List<Double> scores = new ArrayList<>(Collections.nCopies(segments.size(), null));
+        for (RerankResponse.RerankData result : results) {
+            int index = ensureBetween(result.getIndex(), 0, segments.size() - 1, "rerank result index");
+            if (scores.get(index) != null) {
+                throw illegalArgument("Voyage AI returned duplicate rerank result index: %s", index);
+            }
+            scores.set(index, ensureNotNull(result.getRelevanceScore(), "relevanceScore"));
+        }
 
         return Response.from(scores, new TokenUsage(response.getUsage().getTotalTokens()));
     }
@@ -220,7 +246,13 @@ public class VoyageAiScoringModel implements ScoringModel {
         }
 
         /**
-         * The number of most relevant documents to return. If not specified, the reranking results of all documents will be returned.
+         * The number of most relevant documents to return. If not specified, the reranking results of all documents
+         * will be returned.
+         * <p>
+         * This value must be greater than or equal to the number of segments passed to
+         * {@link VoyageAiScoringModel#scoreAll(List, String)}, because {@link ScoringModel} requires one score per
+         * segment. To limit the final number of re-ranked results, use
+         * {@code ReRankingContentAggregator.builder().maxResults(...)} instead.
          *
          * @param topK the number of most relevant documents to return.
          */

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelIT.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelIT.java
@@ -80,13 +80,13 @@ class VoyageAiScoringModelIT {
     }
 
     @Test
-    void should_respect_top_k() {
+    void should_allow_top_k_when_it_does_not_truncate_scores() {
         // given
         ScoringModel model = VoyageAiScoringModel.builder()
                 .apiKey(System.getenv("VOYAGE_API_KEY"))
                 .modelName(RERANK_LITE_1)
                 .timeout(Duration.ofSeconds(60))
-                .topK(1)
+                .topK(2)
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -102,7 +102,8 @@ class VoyageAiScoringModelIT {
 
         // then
         List<Double> scores = response.content();
-        assertThat(scores).hasSize(1);
+        assertThat(scores).hasSize(2);
+        assertThat(scores.get(0)).isLessThan(scores.get(1));
 
         assertThat(response.tokenUsage().inputTokenCount()).isNotNegative();
         assertThat(response.tokenUsage().outputTokenCount()).isNull();

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelIT.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelIT.java
@@ -1,19 +1,18 @@
 package dev.langchain4j.model.voyageai;
 
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.scoring.ScoringModel;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
-import java.time.Duration;
-import java.util.List;
-
 import static dev.langchain4j.model.voyageai.VoyageAiScoringModelName.RERANK_LITE_1;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Percentage.withPercentage;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.scoring.ScoringModel;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "VOYAGE_API_KEY", matches = ".+")
 class VoyageAiScoringModelIT {
@@ -59,7 +58,8 @@ class VoyageAiScoringModelIT {
                 .build();
 
         TextSegment catSegment = TextSegment.from("The Maine Coon is a large domesticated cat breed.");
-        TextSegment dogSegment = TextSegment.from("The sweet-faced, lovable Labrador Retriever is one of America's most popular dog breeds, year after year.");
+        TextSegment dogSegment = TextSegment.from(
+                "The sweet-faced, lovable Labrador Retriever is one of America's most popular dog breeds, year after year.");
         List<TextSegment> segments = asList(catSegment, dogSegment);
 
         String query = "tell me about dogs";
@@ -92,7 +92,8 @@ class VoyageAiScoringModelIT {
                 .build();
 
         TextSegment catSegment = TextSegment.from("The Maine Coon is a large domesticated cat breed.");
-        TextSegment dogSegment = TextSegment.from("The sweet-faced, lovable Labrador Retriever is one of America's most popular dog breeds, year after year.");
+        TextSegment dogSegment = TextSegment.from(
+                "The sweet-faced, lovable Labrador Retriever is one of America's most popular dog breeds, year after year.");
         List<TextSegment> segments = asList(catSegment, dogSegment);
 
         String query = "tell me about dogs";

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelIT.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelIT.java
@@ -79,40 +79,6 @@ class VoyageAiScoringModelIT {
         assertThat(response.finishReason()).isNull();
     }
 
-    @Test
-    void should_allow_top_k_when_it_does_not_truncate_scores() {
-        // given
-        ScoringModel model = VoyageAiScoringModel.builder()
-                .apiKey(System.getenv("VOYAGE_API_KEY"))
-                .modelName(RERANK_LITE_1)
-                .timeout(Duration.ofSeconds(60))
-                .topK(2)
-                .logRequests(true)
-                .logResponses(true)
-                .build();
-
-        TextSegment catSegment = TextSegment.from("The Maine Coon is a large domesticated cat breed.");
-        TextSegment dogSegment = TextSegment.from(
-                "The sweet-faced, lovable Labrador Retriever is one of America's most popular dog breeds, year after year.");
-        List<TextSegment> segments = asList(catSegment, dogSegment);
-
-        String query = "tell me about dogs";
-
-        // when
-        Response<List<Double>> response = model.scoreAll(segments, query);
-
-        // then
-        List<Double> scores = response.content();
-        assertThat(scores).hasSize(2);
-        assertThat(scores.get(0)).isLessThan(scores.get(1));
-
-        assertThat(response.tokenUsage().inputTokenCount()).isNotNegative();
-        assertThat(response.tokenUsage().outputTokenCount()).isNull();
-        assertThat(response.tokenUsage().totalTokenCount()).isNotNegative();
-
-        assertThat(response.finishReason()).isNull();
-    }
-
     @AfterEach
     void afterEach() throws InterruptedException {
         String ciDelaySeconds = System.getenv("CI_DELAY_SECONDS_VOYAGE_AI");

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelTest.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelTest.java
@@ -103,10 +103,8 @@ class VoyageAiScoringModelTest {
     }
 
     private static MockHttpClient respondingWith(String body) {
-        SuccessfulHttpResponse response = SuccessfulHttpResponse.builder()
-                .statusCode(200)
-                .body(body)
-                .build();
+        SuccessfulHttpResponse response =
+                SuccessfulHttpResponse.builder().statusCode(200).body(body).build();
         return MockHttpClient.thatAlwaysResponds(response);
     }
 }

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelTest.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.InternalServerException;
 import dev.langchain4j.http.client.MockHttpClient;
 import dev.langchain4j.http.client.MockHttpClientBuilder;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
@@ -87,10 +88,75 @@ class VoyageAiScoringModelTest {
 
         // when / then
         assertThatThrownBy(() -> model.scoreAll(SEGMENTS, "query"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Voyage AI returned 1 scores for 2 segments");
+                .isInstanceOf(InternalServerException.class)
+                .hasMessage("Re-ranking failed: expected 2 scores, but got 1");
     }
 
+    @Test
+    void should_fail_when_response_contains_duplicate_index() {
+        // given
+        MockHttpClient mockHttpClient = respondingWith("""
+                {
+                  "object": "list",
+                  "data": [
+                    {
+                      "object": "rerank_result",
+                      "relevance_score": 0.9,
+                      "index": 1
+                    },
+                    {
+                      "object": "rerank_result",
+                      "relevance_score": 0.1,
+                      "index": 1
+                    }
+                  ],
+                  "model": "rerank-2",
+                  "usage": {
+                    "total_tokens": 10
+                  }
+                }
+                """);
+        VoyageAiScoringModel model = model(mockHttpClient, null);
+
+        // when / then
+        assertThatThrownBy(() -> model.scoreAll(SEGMENTS, "query"))
+                .isInstanceOf(InternalServerException.class)
+                .hasMessage("Re-ranking failed: got a duplicate document index: 1");
+    }
+
+    @Test
+    void should_fail_when_response_contains_out_of_range_index() {
+        // given
+        MockHttpClient mockHttpClient = respondingWith("""
+                {
+                  "object": "list",
+                  "data": [
+                    {
+                      "object": "rerank_result",
+                      "relevance_score": 0.9,
+                      "index": 0
+                    },
+                    {
+                      "object": "rerank_result",
+                      "relevance_score": 0.1,
+                      "index": 7
+                    }
+                  ],
+                  "model": "rerank-2",
+                  "usage": {
+                    "total_tokens": 10
+                  }
+                }
+                """);
+        VoyageAiScoringModel model = model(mockHttpClient, null);
+
+        // when / then
+        assertThatThrownBy(() -> model.scoreAll(SEGMENTS, "query"))
+                .isInstanceOf(InternalServerException.class)
+                .hasMessage("Re-ranking failed: got an out-of-range document index: 7");
+    }
+
+    @SuppressWarnings({"deprecation", "removal"}) // 'topK' is deprecated, but its guard still needs to be tested
     private static VoyageAiScoringModel model(MockHttpClient mockHttpClient, Integer topK) {
         return VoyageAiScoringModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelTest.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiScoringModelTest.java
@@ -1,0 +1,112 @@
+package dev.langchain4j.model.voyageai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.model.output.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VoyageAiScoringModelTest {
+
+    private static final List<TextSegment> SEGMENTS =
+            List.of(TextSegment.from("first segment"), TextSegment.from("second segment"));
+
+    @Test
+    void should_return_scores_in_input_segment_order() {
+        // given
+        MockHttpClient mockHttpClient = respondingWith("""
+                {
+                  "object": "list",
+                  "data": [
+                    {
+                      "object": "rerank_result",
+                      "relevance_score": 0.9,
+                      "index": 1
+                    },
+                    {
+                      "object": "rerank_result",
+                      "relevance_score": 0.1,
+                      "index": 0
+                    }
+                  ],
+                  "model": "rerank-2",
+                  "usage": {
+                    "total_tokens": 10
+                  }
+                }
+                """);
+        VoyageAiScoringModel model = model(mockHttpClient, null);
+
+        // when
+        Response<List<Double>> response = model.scoreAll(SEGMENTS, "query");
+
+        // then
+        assertThat(response.content()).containsExactly(0.1, 0.9);
+        assertThat(response.tokenUsage().totalTokenCount()).isEqualTo(10);
+    }
+
+    @Test
+    void should_fail_before_request_when_top_k_would_truncate_scores() {
+        // given
+        MockHttpClient mockHttpClient = new MockHttpClient();
+        VoyageAiScoringModel model = model(mockHttpClient, 1);
+
+        // when / then
+        assertThatThrownBy(() -> model.scoreAll(SEGMENTS, "query"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'topK' (1) must be greater than or equal to the number of segments (2)")
+                .hasMessageContaining("ReRankingContentAggregator.builder().maxResults");
+        assertThat(mockHttpClient.requests()).isEmpty();
+    }
+
+    @Test
+    void should_fail_when_response_does_not_contain_one_score_per_segment() {
+        // given
+        MockHttpClient mockHttpClient = respondingWith("""
+                {
+                  "object": "list",
+                  "data": [
+                    {
+                      "object": "rerank_result",
+                      "relevance_score": 0.9,
+                      "index": 1
+                    }
+                  ],
+                  "model": "rerank-2",
+                  "usage": {
+                    "total_tokens": 10
+                  }
+                }
+                """);
+        VoyageAiScoringModel model = model(mockHttpClient, null);
+
+        // when / then
+        assertThatThrownBy(() -> model.scoreAll(SEGMENTS, "query"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Voyage AI returned 1 scores for 2 segments");
+    }
+
+    private static VoyageAiScoringModel model(MockHttpClient mockHttpClient, Integer topK) {
+        return VoyageAiScoringModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("https://api.voyageai.com/v1")
+                .apiKey("test-api-key")
+                .modelName("rerank-2")
+                .topK(topK)
+                .maxRetries(0)
+                .build();
+    }
+
+    private static MockHttpClient respondingWith(String body) {
+        SuccessfulHttpResponse response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(body)
+                .build();
+        return MockHttpClient.thatAlwaysResponds(response);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6179

## Change

`VoyageAiScoringModel` was the only `ScoringModel` implementation exposing the provider's
`top_k` parameter. When `topK` was smaller than the number of segments, Voyage AI returned
only `topK` rerank results, and `scoreAll` returned fewer scores than segments. Because the
old code sorted the results by their original index and then discarded that index, the caller
received *k* scores belonging to an unidentifiable subset of the input, which broke the
`ScoringModel` contract ("the order of scores corresponds to the order of `TextSegment`s") and
made `ReRankingContentAggregator` fail with `IndexOutOfBoundsException`.

- `scoreAll` now fails fast, before sending the request, when `topK` is smaller than the number
  of segments, and points to `ReRankingContentAggregator.maxResults(...)` as the replacement.
- The score list is rebuilt from the original indexes returned by Voyage AI instead of being
  sorted and stripped, so each score stays attached to its segment.
- A malformed rerank response (wrong number of results, missing/duplicate/out-of-range index,
  missing relevance score) now throws `InternalServerException`, consistent with how
  `langchain4j-open-ai` reports semantically invalid responses.
- `VoyageAiScoringModel.Builder#topK` is deprecated for removal. With the guard in place there is
  no longer any value of `topK` that changes the outcome: a value below the segment count throws,
  and any other value is a no-op. `CohereScoringModel` and `JinaScoringModel` deliberately never
  exposed the equivalent parameter.
- Added unit tests covering the segment order, the `topK` guard (including that no HTTP request is
  sent), and the three malformed-response cases.

## Breaking Changes

**Behaviour:** `VoyageAiScoringModel.scoreAll(...)` now throws `IllegalArgumentException` when the
model was built with a `topK` smaller than the number of segments passed in. Previously it returned
a shorter list of scores.

This only affects configurations that were already broken: the returned scores could not be mapped
back to their segments, and passing such a model to `ReRankingContentAggregator` threw
`IndexOutOfBoundsException`.

If you used `topK` to limit how many results your RAG pipeline keeps, move that limit to the
aggregator, which applies it *after* re-ranking:

```java
// Before - truncates the scores and breaks the ScoringModel contract
ScoringModel scoringModel = VoyageAiScoringModel.builder()
        .apiKey(System.getenv("VOYAGE_API_KEY"))
        .modelName("rerank-2")
        .topK(3)
        .build();

// After - score every segment, then keep the 3 best
ScoringModel scoringModel = VoyageAiScoringModel.builder()
        .apiKey(System.getenv("VOYAGE_API_KEY"))
        .modelName("rerank-2")
        .build();

ContentAggregator contentAggregator = ReRankingContentAggregator.builder()
        .scoringModel(scoringModel)
        .maxResults(3)
        .build();
```

If you called `scoreAll` directly, drop `topK` and take the top *N* yourself from the returned
scores, which are now guaranteed to line up with your segments.

**API:** none. `Builder#topK` is deprecated (`forRemoval = true`) but still present and functional;
`revapi` passes.

## Testing

- `./mvnw -pl langchain4j-voyage-ai clean verify` — 20 unit tests green, integration tests skipped
  (no `VOYAGE_API_KEY`)
- `./mvnw -pl langchain4j-voyage-ai spotless:check` — green
- `revapi:check` — green, no API breakage

## General checklist

- [ ] There are no breaking changes (API, behaviour) — see the **Breaking Changes** section above:
      the behaviour change only affects configurations that were already returning unusable results
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation — `docs/docs/integrations/scoring-reranking-models/voyage-ai.md` does not mention `topK`
- [x] I have added an example in the examples repo — follow-up PR needed: `voyage-ai-examples/src/main/java/VoyageAiScoringModelExample.java#should_respect_top_k` uses `topK(1)` with 2 segments and must be updated
- [x] I have added/updated Spring Boot starter(s) — follow-up: both Voyage AI starters bind a `top-k` property and call the now-deprecated builder method