### PR TITLE
fix: Map a content-filtered incomplete Responses API response to CONTENT_FILTER

### DIFF
--- a/docs/docs/integrations/language-models/open-ai-official.md
+++ b/docs/docs/integrations/language-models/open-ai-official.md
@@ -412,7 +412,7 @@ OpenAiOfficialResponsesChatResponseMetadata metadata =
 
 metadata.id();               // Response ID (can be used as previousResponseId)
 metadata.modelName();        // Model name used for the request
-metadata.finishReason();     // Finish reason (STOP, LENGTH, TOOL_EXECUTION, OTHER)
+metadata.finishReason();     // Finish reason (STOP, LENGTH, TOOL_EXECUTION, CONTENT_FILTER, OTHER)
 metadata.tokenUsage();       // Returns OpenAiOfficialTokenUsage with detailed token counts
 metadata.createdAt();        // Timestamp when the response was created
 metadata.completedAt();      // Timestamp when the response was completed

--- a/docs/docs/integrations/language-models/open-ai.md
+++ b/docs/docs/integrations/language-models/open-ai.md
@@ -676,7 +676,7 @@ OpenAiResponsesChatResponseMetadata metadata =
 
 metadata.id();               // Response ID (can be used as previousResponseId)
 metadata.modelName();        // Model name used for the request
-metadata.finishReason();     // Finish reason (STOP, LENGTH, TOOL_EXECUTION, OTHER)
+metadata.finishReason();     // Finish reason (STOP, LENGTH, TOOL_EXECUTION, CONTENT_FILTER, OTHER)
 metadata.tokenUsage();       // Returns OpenAiTokenUsage with detailed token counts
 metadata.createdAt();        // Timestamp when the response was created
 metadata.completedAt();      // Timestamp when the response was completed

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesChatModel.java
@@ -8,6 +8,7 @@ import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStream
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildRequestParams;
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.buildResponseMetadata;
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractEncryptedReasoning;
+import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractIncompleteReason;
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractReasoningSummary;
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractRefusal;
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractText;
@@ -147,7 +148,8 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
             AiMessage aiMessage = buildAiMessage(text, thinking, toolExecutionRequests, encryptedReasoning);
 
             String finishReason = response.status()
-                    .map(status -> mapStatusToFinishReason(status.asString(), !toolExecutionRequests.isEmpty()))
+                    .map(status -> mapStatusToFinishReason(
+                            status.asString(), extractIncompleteReason(response), !toolExecutionRequests.isEmpty()))
                     .orElse(null);
 
             OpenAiOfficialResponsesChatResponseMetadata metadata = buildResponseMetadata(

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -366,16 +366,23 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         return builder.build();
     }
 
-    static String mapStatusToFinishReason(String status, boolean hasToolCalls) {
+    static String mapStatusToFinishReason(String status, String incompleteReason, boolean hasToolCalls) {
         if (status == null) {
             return null;
         }
         return switch (status) {
             case "completed" -> hasToolCalls ? "TOOL_EXECUTION" : "STOP";
-            case "incomplete" -> "LENGTH";
+            case "incomplete" -> "content_filter".equals(incompleteReason) ? "CONTENT_FILTER" : "LENGTH";
             case "failed" -> "OTHER";
             default -> "OTHER";
         };
+    }
+
+    static String extractIncompleteReason(com.openai.models.responses.Response response) {
+        return response.incompleteDetails()
+                .flatMap(com.openai.models.responses.Response.IncompleteDetails::reason)
+                .map(com.openai.models.responses.Response.IncompleteDetails.Reason::asString)
+                .orElse(null);
     }
 
     static OpenAiOfficialTokenUsage extractTokenUsage(com.openai.models.responses.Response response) {
@@ -1242,7 +1249,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
 
             // Extract status and map to finish reason
             response.status().ifPresent(status -> {
-                this.finishReason = mapStatusToFinishReason(status.asString(), !completedToolCalls.isEmpty());
+                this.finishReason = mapStatusToFinishReason(
+                        status.asString(), extractIncompleteReason(response), !completedToolCalls.isEmpty());
             });
 
             // Extract token usage and complete
@@ -1269,12 +1277,10 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         }
 
         private void handleIncomplete(ResponseIncompleteEvent event) {
-            // Incomplete is not an error - it just means the response was cut off due to token limits
-            // Treat it as a normal completion with finish reason LENGTH
-            finishReason = "LENGTH";
+            var response = event.response();
+            finishReason = mapStatusToFinishReason("incomplete", extractIncompleteReason(response), false);
 
-            // Complete the response normally
-            extractTokenUsageAndComplete(event.response());
+            extractTokenUsageAndComplete(response);
         }
 
         private void extractTokenUsageAndComplete(com.openai.models.responses.Response response) {

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModelTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModelTest.java
@@ -14,6 +14,7 @@ import com.openai.core.http.HttpRequest;
 import com.openai.core.http.HttpResponse;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCompletedEvent;
+import com.openai.models.responses.ResponseIncompleteEvent;
 import com.openai.models.responses.ResponseStreamEvent;
 import com.openai.models.responses.ResponseWebSearchCallInProgressEvent;
 import com.openai.models.responses.Tool;
@@ -28,6 +29,7 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
+import dev.langchain4j.model.output.FinishReason;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -225,6 +227,80 @@ class OpenAiOfficialResponsesStreamingChatModelTest {
 
         assertThat(OpenAiOfficialResponsesStreamingChatModel.extractRefusal(response))
                 .isNull();
+    }
+
+    private static String incompleteResponseJson(String incompleteDetails) {
+        return """
+                {
+                  "id": "resp_incomplete",
+                  "created_at": 1745310000,
+                  "model": "gpt-5.4",
+                  "object": "response",
+                  "parallel_tool_calls": true,
+                  "tool_choice": "auto",
+                  "status": "incomplete",
+                  %s
+                  "output": [
+                    {
+                      "id": "msg_1",
+                      "type": "message",
+                      "role": "assistant",
+                      "status": "incomplete",
+                      "content": [{"type": "output_text", "text": "Partial", "annotations": []}]
+                    }
+                  ]
+                }
+                """.formatted(incompleteDetails);
+    }
+
+    private static ChatResponse chatWith(String responseJson) {
+        OpenAiOfficialResponsesChatModel model = OpenAiOfficialResponsesChatModel.builder()
+                .client(new OpenAIClientImpl(ClientOptions.builder()
+                        .apiKey("test-key")
+                        .httpClient(new CannedJsonHttpClient(responseJson))
+                        .build()))
+                .modelName("gpt-5.4-mini")
+                .build();
+
+        return model.chat(
+                ChatRequest.builder().messages(UserMessage.from("Hello")).build());
+    }
+
+    @Test
+    void should_report_content_filter_when_response_is_incomplete_because_of_the_content_filter() {
+        ChatResponse response =
+                chatWith(incompleteResponseJson("\"incomplete_details\": {\"reason\": \"content_filter\"},"));
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.CONTENT_FILTER);
+    }
+
+    @Test
+    void should_report_length_when_response_is_incomplete_because_of_the_token_limit() {
+        ChatResponse response =
+                chatWith(incompleteResponseJson("\"incomplete_details\": {\"reason\": \"max_output_tokens\"},"));
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+
+    @Test
+    void should_report_length_when_response_is_incomplete_without_details() {
+        ChatResponse response = chatWith(incompleteResponseJson(""));
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+
+    @Test
+    void should_report_content_filter_when_stream_ends_incomplete_because_of_the_content_filter() {
+        CapturingStreamingHandler handler = new CapturingStreamingHandler();
+        var eventHandler = new OpenAiOfficialResponsesStreamingChatModel.ResponsesEventHandler(
+                handler, new AtomicReference<>(), "gpt-5.4-mini", new ActiveStreamingHandle());
+
+        eventHandler.handleEvent(ResponseStreamEvent.ofIncomplete(ResponseIncompleteEvent.builder()
+                .response(response(incompleteResponseJson("\"incomplete_details\": {\"reason\": \"content_filter\"},")))
+                .sequenceNumber(1)
+                .build()));
+
+        assertThat(handler.completed.metadata().finishReason()).isEqualTo(FinishReason.CONTENT_FILTER);
     }
 
     @Test

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -142,6 +142,8 @@ class OpenAiResponsesClient {
     private static final String FIELD_SCHEMA = "schema";
     private static final String FIELD_ADDITIONAL_PROPERTIES = "additionalProperties";
     private static final String FIELD_STATUS = "status";
+    private static final String FIELD_INCOMPLETE_DETAILS = "incomplete_details";
+    private static final String FIELD_REASON = "reason";
     private static final String FIELD_CREATED_AT = "created_at";
     private static final String FIELD_COMPLETED_AT = "completed_at";
     private static final String DEFAULT_IMAGE_MIME_TYPE = "image/jpeg";
@@ -496,16 +498,21 @@ class OpenAiResponsesClient {
         return usageBuilder.build();
     }
 
-    private static FinishReason finishReasonFromStatus(String status, boolean hasToolCalls) {
+    private static FinishReason finishReasonFromStatus(String status, String incompleteReason, boolean hasToolCalls) {
         if (status == null || status.isBlank()) {
             return null;
         }
         return switch (status) {
             case "completed" -> hasToolCalls ? FinishReason.TOOL_EXECUTION : FinishReason.STOP;
-            case "incomplete" -> FinishReason.LENGTH;
+            case "incomplete" ->
+                "content_filter".equals(incompleteReason) ? FinishReason.CONTENT_FILTER : FinishReason.LENGTH;
             case "failed" -> FinishReason.OTHER;
             default -> FinishReason.OTHER;
         };
+    }
+
+    private static String incompleteReasonFrom(JsonNode responseNode) {
+        return responseNode.path(FIELD_INCOMPLETE_DETAILS).path(FIELD_REASON).asText(null);
     }
 
     private ChatResponse parseChatResponse(SuccessfulHttpResponse rawHttpResponse) throws Exception {
@@ -533,8 +540,10 @@ class OpenAiResponsesClient {
             metadataBuilder.tokenUsage(tokenUsage);
         }
 
-        FinishReason finishReason =
-                finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !toolExecutionRequests.isEmpty());
+        FinishReason finishReason = finishReasonFromStatus(
+                responseNode.path(FIELD_STATUS).asText(null),
+                incompleteReasonFrom(responseNode),
+                !toolExecutionRequests.isEmpty());
         if (finishReason != null) {
             metadataBuilder.finishReason(finishReason);
         }
@@ -1014,8 +1023,10 @@ class OpenAiResponsesClient {
                 metadataBuilder.tokenUsage(tokenUsage);
             }
 
-            FinishReason finishReason =
-                    finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
+            FinishReason finishReason = finishReasonFromStatus(
+                    responseNode.path(FIELD_STATUS).asText(null),
+                    incompleteReasonFrom(responseNode),
+                    !completedToolCalls.isEmpty());
             if (finishReason != null) {
                 metadataBuilder.finishReason(finishReason);
             }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesFinishReasonTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesFinishReasonTest.java
@@ -1,0 +1,107 @@
+package dev.langchain4j.model.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenAiResponsesFinishReasonTest {
+
+    private static String incompleteResponseJson(String incompleteDetails) {
+        return """
+                {
+                  "id": "resp_incomplete",
+                  "model": "gpt-5.4-mini",
+                  "object": "response",
+                  "status": "incomplete",
+                  %s
+                  "output": [
+                    {
+                      "id": "msg_1",
+                      "type": "message",
+                      "role": "assistant",
+                      "content": [{"type": "output_text", "text": "Partial"}]
+                    }
+                  ]
+                }
+                """.formatted(incompleteDetails);
+    }
+
+    private static ChatResponse chatWith(String responseJson) {
+        MockHttpClient mockHttpClient = new MockHttpClient(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(responseJson)
+                .build());
+
+        OpenAiResponsesChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost")
+                .apiKey("dummy")
+                .modelName("gpt-5.4-mini")
+                .build();
+
+        return model.chat(
+                ChatRequest.builder().messages(UserMessage.from("Hello")).build());
+    }
+
+    @Test
+    void should_report_content_filter_when_response_is_incomplete_because_of_the_content_filter() {
+        ChatResponse response =
+                chatWith(incompleteResponseJson("\"incomplete_details\": {\"reason\": \"content_filter\"},"));
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.CONTENT_FILTER);
+    }
+
+    @Test
+    void should_report_length_when_response_is_incomplete_because_of_the_token_limit() {
+        ChatResponse response =
+                chatWith(incompleteResponseJson("\"incomplete_details\": {\"reason\": \"max_output_tokens\"},"));
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+
+    @Test
+    void should_report_length_when_the_incomplete_reason_is_not_recognised() {
+        ChatResponse response =
+                chatWith(incompleteResponseJson("\"incomplete_details\": {\"reason\": \"future_reason\"},"));
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+
+    @Test
+    void should_report_length_when_response_is_incomplete_without_details() {
+        ChatResponse response = chatWith(incompleteResponseJson(""));
+
+        assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+
+    @Test
+    void should_report_content_filter_when_stream_ends_incomplete_because_of_the_content_filter() {
+        ServerSentEvent incompleteEvent = new ServerSentEvent(
+                null,
+                "{\"type\":\"response.incomplete\",\"response\":"
+                        + incompleteResponseJson("\"incomplete_details\": {\"reason\": \"content_filter\"},")
+                        + "}");
+
+        OpenAiResponsesStreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .apiKey("dummy")
+                .httpClientBuilder(
+                        new MockHttpClientBuilder(MockHttpClient.thatAlwaysResponds(List.of(incompleteEvent))))
+                .modelName("gpt-5.4-mini")
+                .build();
+
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat("Hello", handler);
+
+        assertThat(handler.get().metadata().finishReason()).isEqualTo(FinishReason.CONTENT_FILTER);
+    }
+}


### PR DESCRIPTION

## Issue

Closes #6181

## Change

Both Responses API implementations mapped every `incomplete` status to `FinishReason.LENGTH`:
`finishReasonFromStatus` in `langchain4j-open-ai` and `mapStatusToFinishReason` in
`langchain4j-open-ai-official`. OpenAI reports why a response is incomplete in
`incomplete_details.reason`, either `max_output_tokens` or `content_filter`, and neither implementation
read it. A content-filtered response was therefore reported as truncated, which invites the caller to
retry with a larger `maxOutputTokens` for a request that will never complete.

```
                     before              after
content_filter       LENGTH              CONTENT_FILTER
max_output_tokens    LENGTH              LENGTH
```

Only `content_filter` changes the mapping. A missing or unrecognised reason still maps to `LENGTH`, so
nothing that was correct before changes. `FinishReason.CONTENT_FILTER` already exists in core and the
Chat Completions path of `langchain4j-open-ai-official` already returns it, so this brings the Responses
paths in line with it rather than introducing a new value.

Both modules carry the same mapping, so both are fixed here; `"incomplete"` appears in no other
production file. Each reads the field in its own idiom: the official module adds
`extractIncompleteReason`, next to the existing `extractRefusal` and `extractTokenUsage`, while the
hand-rolled client adds `incompleteReasonFrom` and two `FIELD_*` constants alongside `FIELD_STATUS`.

The comment claiming an incomplete response only ever means the token limit was reached is removed,
since that is the assumption being corrected.

### Tests

- `OpenAiOfficialResponsesStreamingChatModelTest` (4 added) covers the sync path for `content_filter`,
  for `max_output_tokens` and for a response with no `incomplete_details`, plus the streaming path by
  feeding a `response.incomplete` event through `ResponsesEventHandler`.
- `OpenAiResponsesFinishReasonTest` (new) covers the same three sync cases in `langchain4j-open-ai`.

Both drive the public `chat` path over a canned HTTP response, so the real parsing runs. 3 of the 7 fail
on unmodified `main`, one per affected path; the other 4 assert the cases that were already correct and
pass either way.

```
$ mvn -pl langchain4j-open-ai test
Tests run: 193, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-open-ai-official test
Tests run: 28, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-core test
Tests run: 1282, Failures: 0, Errors: 0, Skipped: 5

$ mvn -pl langchain4j test
Tests run: 1365, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-open-ai verify
$ mvn -pl langchain4j-open-ai-official verify
[INFO] API checks completed without failures.
```

No integration test was added or run: reproducing a content-filtered response against the live API is not
something a test can arrange, and the mapping is fully exercised offline.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
