### PR TITLE
feat(mistral-ai): add Mistral Document AI (OCR) support

### DIFF
--- a/docs/docs/integrations/document-parsers/mistral-ai-ocr.md
+++ b/docs/docs/integrations/document-parsers/mistral-ai-ocr.md
@@ -1,0 +1,128 @@
+---
+sidebar_position: 8
+---
+
+# Mistral AI OCR
+
+[Mistral Document AI](https://docs.mistral.ai/api/endpoint/ocr) (also marketed as Mistral OCR) turns PDFs
+and images into markdown, keeping the layout, the tables and the reading order of the original. It makes
+scanned documents, which no local text extractor can handle, usable in an ingestion pipeline.
+
+Unlike the local parsers, this one sends the content to Mistral and is billed per page.
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-mistral-ai</artifactId>
+    <version>1.19.0</version>
+</dependency>
+```
+
+## Usage as a DocumentParser
+
+```java
+DocumentParser parser = MistralAiOcrDocumentParser.builder()
+        .ocrModel(MistralAiOcrModel.builder()
+                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .modelName("mistral-ocr-latest")
+                .build())
+        .build();
+
+Document document = FileSystemDocumentLoader.loadDocument("/home/me/scan.pdf", parser);
+```
+
+`DocumentParser` receives a bare `InputStream` with no indication of its type, so the mime type has to be
+stated up front. It defaults to `application/pdf`; use one parser instance per type when ingesting both
+PDFs and images:
+
+```java
+DocumentParser imageParser = MistralAiOcrDocumentParser.builder()
+        .ocrModel(ocrModel)
+        .mimeType("image/png")
+        .build();
+```
+
+## Usage as a model
+
+`MistralAiOcrModel` can be used directly, which additionally allows the page structure to be kept. One
+`Document` per page means a retrieved segment can be traced back to a page of the source document:
+
+```java
+MistralAiOcrModel model = MistralAiOcrModel.builder()
+        .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+        .modelName("mistral-ocr-latest")
+        .tableFormat(MistralAiOcrTableFormat.HTML)
+        .extractHeader(true)
+        .build();
+
+List<Document> pages = model.parsePages(Files.readAllBytes(path), "application/pdf");
+```
+
+The model can also let the service fetch the document itself, which avoids sending the bytes:
+
+```java
+Document document = model.parseDocumentUrl("https://example.com/invoice.pdf");
+Document receipt = model.parseImageUrl("https://example.com/receipt.png");
+```
+
+A document from which nothing could be recognized raises `BlankDocumentException`, matching the behaviour
+of the other parsers.
+
+### Metadata
+
+| Key                   | Set by                        | Meaning                                     |
+|-----------------------|-------------------------------|---------------------------------------------|
+| `ocr_model`           | all methods                   | the model version that produced the result  |
+| `pages_processed`     | all methods                   | how many pages the service billed           |
+| `page_count`          | all methods                   | how many pages the result consists of       |
+| `page_index`          | `parsePages`                  | zero-based index of the page in the source  |
+| `page_header`         | `parsePages`                  | header of the page, if extraction is on     |
+| `page_footer`         | `parsePages`                  | footer of the page, if extraction is on     |
+| `document_size_bytes` | `MistralAiOcrDocumentParser`  | size of the parsed input                    |
+
+### Headers and footers
+
+By default the header and footer of a page are part of the recognized content. `extractHeader` and
+`extractFooter` make the service report them separately instead, which `parsePages` then exposes as
+`page_header` and `page_footer` metadata:
+
+```java
+MistralAiOcrModel model = MistralAiOcrModel.builder()
+        .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+        .modelName("mistral-ocr-latest")
+        .extractHeader(true)
+        .extractFooter(true)
+        .build();
+```
+
+The text of the returned documents is the same either way — the header and footer stay part of it. The
+point of the options is that a header repeated on every page becomes identifiable, so it can be stripped
+from the body before embedding without having to guess which line it was.
+
+## Azure hosted deployments
+
+Mistral Document AI is also offered through Azure AI Foundry. Such a deployment lives on its own host,
+accepts the key in an `api-key` header and can take an `api-version` query parameter. All three are
+ordinary builder settings, so no separate model is needed:
+
+```java
+MistralAiOcrModel model = MistralAiOcrModel.builder()
+        .baseUrl("https://my-resource.services.ai.azure.com/providers/mistral/azure")
+        .apiKey(key)
+        .customHeaders(Map.of("api-key", key))
+        .customQueryParams(Map.of("api-version", "2024-05-01-preview"))
+        .modelName("mistral-document-ai-2512")
+        .build();
+```
+
+Note that on Azure `modelName` is the name of the *deployment*, not the catalog name. For a standalone
+serverless deployment the base URL ends in `/v1` instead:
+
+```java
+        .baseUrl("https://my-deployment.westus3.models.ai.azure.com/v1")
+```
+
+`customHeaders` and `customQueryParams` are available on the other Mistral models as well, so the same
+approach works for chat and embeddings served from Azure.

--- a/langchain4j-mistral-ai/revapi.json
+++ b/langchain4j-mistral-ai/revapi.json
@@ -30,6 +30,16 @@
           "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by MistralAiBatchChatModel"
         },
         {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.data.document.Document",
+          "justification": "Core langchain4j document type intentionally returned by MistralAiOcrModel and by the DocumentParser API implemented by MistralAiOcrDocumentParser"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.data.document.DocumentParser",
+          "justification": "Core langchain4j document type intentionally implemented by MistralAiOcrDocumentParser"
+        },
+        {
           "code": "java.method.returnTypeChanged",
           "old": "method dev.langchain4j.model.chat.request.ChatRequestParameters dev.langchain4j.model.mistralai.MistralAiChatModel::defaultRequestParameters()",
           "new": "method dev.langchain4j.model.mistralai.MistralAiChatRequestParameters dev.langchain4j.model.mistralai.MistralAiChatModel::defaultRequestParameters()",

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiOcrDocumentParser.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiOcrDocumentParser.java
@@ -1,0 +1,104 @@
+package dev.langchain4j.model.mistralai;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.document.BlankDocumentException;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+/**
+ * A {@link DocumentParser} that extracts the content of scanned PDFs and images with Mistral Document AI
+ * (also known as Mistral OCR), so that documents no text extractor can handle become usable in an
+ * ingestion pipeline:
+ *
+ * <pre>{@code
+ * DocumentParser parser = MistralAiOcrDocumentParser.builder()
+ *         .ocrModel(MistralAiOcrModel.builder()
+ *                 .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+ *                 .modelName("mistral-ocr-latest")
+ *                 .build())
+ *         .build();
+ *
+ * Document document = FileSystemDocumentLoader.loadDocument("/home/me/scan.pdf", parser);
+ * }</pre>
+ *
+ * <p>Unlike a local parser this sends the content to Mistral, and it is billed per page.</p>
+ *
+ * @since 1.20.0
+ */
+public class MistralAiOcrDocumentParser implements DocumentParser {
+
+    /**
+     * Metadata key holding the size of the parsed input, matching what the other remote parsers report.
+     */
+    public static final String DOCUMENT_SIZE_BYTES = "document_size_bytes";
+
+    private static final String DEFAULT_MIME_TYPE = "application/pdf";
+
+    private final MistralAiOcrModel ocrModel;
+    private final String mimeType;
+
+    private MistralAiOcrDocumentParser(Builder builder) {
+        this.ocrModel = ensureNotNull(builder.ocrModel, "ocrModel");
+        this.mimeType = ensureNotBlank(getOrDefault(builder.mimeType, DEFAULT_MIME_TYPE), "mimeType");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Document parse(InputStream inputStream) {
+        ensureNotNull(inputStream, "inputStream");
+
+        byte[] content;
+        try {
+            content = inputStream.readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        if (content.length == 0) {
+            throw new BlankDocumentException();
+        }
+
+        Document document = ocrModel.parse(content, mimeType);
+        document.metadata().put(DOCUMENT_SIZE_BYTES, content.length);
+        return document;
+    }
+
+    public static class Builder {
+
+        private MistralAiOcrModel ocrModel;
+        private String mimeType;
+
+        /**
+         * The model used to extract the content. Required.
+         */
+        public Builder ocrModel(MistralAiOcrModel ocrModel) {
+            this.ocrModel = ocrModel;
+            return this;
+        }
+
+        /**
+         * The mime type the parsed streams carry, {@code application/pdf} by default.
+         *
+         * <p>{@link DocumentParser} receives a bare {@link InputStream} with no indication of its type,
+         * so the mime type has to be stated up front. Use one parser instance per type when ingesting
+         * both PDFs and images.</p>
+         */
+        public Builder mimeType(String mimeType) {
+            this.mimeType = mimeType;
+            return this;
+        }
+
+        public MistralAiOcrDocumentParser build() {
+            return new MistralAiOcrDocumentParser(this);
+        }
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiOcrModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiOcrModel.java
@@ -1,0 +1,393 @@
+package dev.langchain4j.model.mistralai;
+
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.stream.Collectors.joining;
+
+import dev.langchain4j.data.document.BlankDocumentException;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiOcrDocument;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiOcrPage;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiOcrRequest;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiOcrResponse;
+import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+
+/**
+ * Extracts the content of a PDF or an image as markdown, using Mistral Document AI (also known as
+ * Mistral OCR).
+ *
+ * <p>The result is returned as a {@link Document} so that it feeds directly into an ingestion pipeline.
+ * Use {@link #parsePages(byte[], String)} to keep the page structure, which lets a retrieved segment be
+ * traced back to a page of the source document.</p>
+ *
+ * <p>Mistral Document AI is also offered through Azure, where the deployment lives on its own host,
+ * accepts the key in an {@code api-key} header and can take an {@code api-version} query parameter. All
+ * three are ordinary builder settings, so no Azure specific model is needed:</p>
+ *
+ * <pre>{@code
+ * MistralAiOcrModel model = MistralAiOcrModel.builder()
+ *         .baseUrl("https://my-resource.services.ai.azure.com/providers/mistral/azure")
+ *         .apiKey(key)
+ *         .customHeaders(Map.of("api-key", key))
+ *         .customQueryParams(Map.of("api-version", "2024-05-01-preview"))
+ *         .modelName("mistral-document-ai-2512")
+ *         .build();
+ * }</pre>
+ *
+ * @see MistralAiOcrDocumentParser
+ * @since 1.20.0
+ */
+public class MistralAiOcrModel {
+
+    /**
+     * Metadata key holding the model that produced the result.
+     */
+    public static final String OCR_MODEL = "ocr_model";
+
+    /**
+     * Metadata key holding how many pages the service billed.
+     */
+    public static final String PAGES_PROCESSED = "pages_processed";
+
+    /**
+     * Metadata key holding the number of pages the result consists of.
+     */
+    public static final String PAGE_COUNT = "page_count";
+
+    /**
+     * Metadata key holding the zero-based index of a page in the source document. Only set by
+     * {@link #parsePages(byte[], String)}.
+     */
+    public static final String PAGE_INDEX = "page_index";
+
+    /**
+     * Metadata key holding the header of a page, set by {@link #parsePages(byte[], String)} when header
+     * extraction is enabled and the service recognized one.
+     */
+    public static final String PAGE_HEADER = "page_header";
+
+    /**
+     * Metadata key holding the footer of a page, set by {@link #parsePages(byte[], String)} when footer
+     * extraction is enabled and the service recognized one.
+     */
+    public static final String PAGE_FOOTER = "page_footer";
+
+    private static final String PAGE_SEPARATOR = "\n\n";
+
+    private final MistralAiClient client;
+    private final String modelName;
+    private final Integer maxRetries;
+    private final List<Integer> pages;
+    private final Boolean extractHeader;
+    private final Boolean extractFooter;
+    private final MistralAiOcrTableFormat tableFormat;
+
+    public MistralAiOcrModel(Builder builder) {
+        this.client = MistralAiClient.builder()
+                .httpClientBuilder(builder.httpClientBuilder)
+                .baseUrl(getOrDefault(builder.baseUrl, "https://api.mistral.ai/v1"))
+                .apiKey(builder.apiKey)
+                .timeout(builder.timeout)
+                .logRequests(getOrDefault(builder.logRequests, false))
+                .logResponses(getOrDefault(builder.logResponses, false))
+                .logger(builder.logger)
+                .customHeaders(builder.customHeadersSupplier)
+                .customQueryParams(builder.customQueryParamsSupplier)
+                .build();
+        this.modelName = ensureNotBlank(builder.modelName, "modelName");
+        this.maxRetries = getOrDefault(builder.maxRetries, 2);
+        this.pages = copy(builder.pages);
+        this.extractHeader = builder.extractHeader;
+        this.extractFooter = builder.extractFooter;
+        this.tableFormat = builder.tableFormat;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public ModelProvider provider() {
+        return ModelProvider.MISTRAL_AI;
+    }
+
+    public String modelName() {
+        return modelName;
+    }
+
+    /**
+     * Extracts the content of the given bytes as a single {@link Document}.
+     *
+     * @param content the document or image to process
+     * @param mimeType the mime type of the content, e.g. {@code application/pdf} or {@code image/png}.
+     *        A mime type starting with {@code image/} is sent as an image, everything else as a document.
+     * @throws BlankDocumentException when the service did not recognize any content
+     */
+    public Document parse(byte[] content, String mimeType) {
+        return toDocument(ocr(toDataUriDocument(content, mimeType)));
+    }
+
+    /**
+     * Extracts the content of a document the service downloads itself.
+     *
+     * @throws BlankDocumentException when the service did not recognize any content
+     */
+    public Document parseDocumentUrl(String documentUrl) {
+        return toDocument(ocr(MistralAiOcrDocument.documentUrl(ensureNotBlank(documentUrl, "documentUrl"))));
+    }
+
+    /**
+     * Extracts the content of an image the service downloads itself.
+     *
+     * @throws BlankDocumentException when the service did not recognize any content
+     */
+    public Document parseImageUrl(String imageUrl) {
+        return toDocument(ocr(MistralAiOcrDocument.imageUrl(ensureNotBlank(imageUrl, "imageUrl"))));
+    }
+
+    /**
+     * Extracts the content of the given bytes as one {@link Document} per page, each carrying its
+     * {@link #PAGE_INDEX}. Pages without recognized content are skipped.
+     *
+     * @throws BlankDocumentException when no page contained any content
+     */
+    public List<Document> parsePages(byte[] content, String mimeType) {
+        MistralAiOcrResponse response = ocr(toDataUriDocument(content, mimeType));
+
+        List<Document> documents = new ArrayList<>();
+        for (MistralAiOcrPage page : pagesOf(response)) {
+            String text = textOf(page);
+            if (text.isBlank()) {
+                continue;
+            }
+            Metadata metadata = commonMetadata(response);
+            if (page.index != null) {
+                metadata.put(PAGE_INDEX, page.index);
+            }
+            if (!isNullOrBlank(page.header)) {
+                metadata.put(PAGE_HEADER, page.header);
+            }
+            if (!isNullOrBlank(page.footer)) {
+                metadata.put(PAGE_FOOTER, page.footer);
+            }
+            documents.add(Document.from(text, metadata));
+        }
+
+        if (documents.isEmpty()) {
+            throw new BlankDocumentException();
+        }
+        return documents;
+    }
+
+    private MistralAiOcrResponse ocr(MistralAiOcrDocument document) {
+        MistralAiOcrRequest request = new MistralAiOcrRequest();
+        request.model = modelName;
+        request.document = document;
+        request.pages = pages.isEmpty() ? null : pages;
+        request.extractHeader = extractHeader;
+        request.extractFooter = extractFooter;
+        request.tableFormat = tableFormat == null ? null : tableFormat.toString();
+
+        return withRetryMappingExceptions(() -> client.ocr(request), maxRetries);
+    }
+
+    private Document toDocument(MistralAiOcrResponse response) {
+        String markdown = pagesOf(response).stream()
+                .map(MistralAiOcrModel::textOf)
+                .filter(text -> !text.isBlank())
+                .collect(joining(PAGE_SEPARATOR));
+
+        if (markdown.isBlank()) {
+            throw new BlankDocumentException();
+        }
+
+        return Document.from(markdown, commonMetadata(response));
+    }
+
+    /**
+     * The full text of a page.
+     *
+     * <p>Enabling header or footer extraction moves that text out of {@code markdown} into its own field,
+     * so both have to be folded back in. Otherwise turning the option on would silently drop content.</p>
+     */
+    private static String textOf(MistralAiOcrPage page) {
+        return Stream.of(page.header, page.markdown, page.footer)
+                .filter(Objects::nonNull)
+                .filter(part -> !part.isBlank())
+                .collect(joining(PAGE_SEPARATOR));
+    }
+
+    private Metadata commonMetadata(MistralAiOcrResponse response) {
+        Metadata metadata = new Metadata();
+        if (response.model != null) {
+            metadata.put(OCR_MODEL, response.model);
+        }
+        if (response.usageInfo != null && response.usageInfo.pagesProcessed != null) {
+            metadata.put(PAGES_PROCESSED, response.usageInfo.pagesProcessed);
+        }
+        metadata.put(PAGE_COUNT, pagesOf(response).size());
+        return metadata;
+    }
+
+    private static List<MistralAiOcrPage> pagesOf(MistralAiOcrResponse response) {
+        return response.pages == null ? List.of() : response.pages;
+    }
+
+    private static MistralAiOcrDocument toDataUriDocument(byte[] content, String mimeType) {
+        ensureNotNull(content, "content");
+        ensureNotBlank(mimeType, "mimeType");
+
+        String dataUri = "data:" + mimeType + ";base64," + Base64.getEncoder().encodeToString(content);
+        return mimeType.startsWith("image/")
+                ? MistralAiOcrDocument.imageUrl(dataUri)
+                : MistralAiOcrDocument.documentUrl(dataUri);
+    }
+
+    public static class Builder {
+
+        private HttpClientBuilder httpClientBuilder;
+        private String baseUrl;
+        private String apiKey;
+        private String modelName;
+        private Duration timeout;
+        private Integer maxRetries;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Logger logger;
+        private Supplier<Map<String, String>> customHeadersSupplier;
+        private Supplier<Map<String, String>> customQueryParamsSupplier;
+        private List<Integer> pages;
+        private Boolean extractHeader;
+        private Boolean extractFooter;
+        private MistralAiOcrTableFormat tableFormat;
+
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * The model to use, e.g. {@code mistral-ocr-latest}. On Azure this is the name of the deployment.
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public Builder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public Builder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
+        }
+
+        /**
+         * Query parameters added to every request, needed for the {@code api-version} of Azure hosted
+         * deployments.
+         */
+        public Builder customQueryParams(Map<String, String> customQueryParams) {
+            this.customQueryParamsSupplier = () -> customQueryParams;
+            return this;
+        }
+
+        public Builder customQueryParams(Supplier<Map<String, String>> customQueryParamsSupplier) {
+            this.customQueryParamsSupplier = customQueryParamsSupplier;
+            return this;
+        }
+
+        /**
+         * The zero-based indices of the pages to process. When unset, the whole document is processed.
+         */
+        public Builder pages(List<Integer> pages) {
+            this.pages = pages;
+            return this;
+        }
+
+        /**
+         * Whether the header of a page is reported separately from its body.
+         *
+         * <p>By default the header is part of the recognized content. Enabling this moves it into its own
+         * field, which {@link #parsePages(byte[], String)} exposes as {@link #PAGE_HEADER} metadata. The
+         * text of the returned documents is unaffected either way, so a repeated header can be stripped
+         * from the body without having to guess which line it was.</p>
+         */
+        public Builder extractHeader(Boolean extractHeader) {
+            this.extractHeader = extractHeader;
+            return this;
+        }
+
+        /**
+         * Whether the footer of a page is reported separately from its body, exposed as
+         * {@link #PAGE_FOOTER} metadata. See {@link #extractHeader(Boolean)}.
+         */
+        public Builder extractFooter(Boolean extractFooter) {
+            this.extractFooter = extractFooter;
+            return this;
+        }
+
+        /**
+         * How tables are rendered in the returned markdown.
+         */
+        public Builder tableFormat(MistralAiOcrTableFormat tableFormat) {
+            this.tableFormat = tableFormat;
+            return this;
+        }
+
+        public MistralAiOcrModel build() {
+            return new MistralAiOcrModel(this);
+        }
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiOcrTableFormat.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiOcrTableFormat.java
@@ -1,0 +1,20 @@
+package dev.langchain4j.model.mistralai;
+
+/**
+ * How tables detected in a document are rendered inside the markdown returned by OCR.
+ */
+public enum MistralAiOcrTableFormat {
+    MARKDOWN("markdown"),
+    HTML("html");
+
+    private final String value;
+
+    MistralAiOcrTableFormat(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrDimensions.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrDimensions.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * The size of a processed page, in pixels, together with the resolution it was rendered at.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiOcrDimensions {
+
+    public Integer dpi;
+    public Integer height;
+    public Integer width;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrDocument.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrDocument.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * The document an OCR request refers to.
+ *
+ * <p>The service either downloads it from the given URL or reads it from a {@code data:} URI carrying
+ * the content inline. {@link #type} selects which of the two URL fields is meaningful.</p>
+ */
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiOcrDocument {
+
+    public String type;
+    public String documentUrl;
+    public String imageUrl;
+
+    public static MistralAiOcrDocument documentUrl(String url) {
+        MistralAiOcrDocument document = new MistralAiOcrDocument();
+        document.type = "document_url";
+        document.documentUrl = url;
+        return document;
+    }
+
+    public static MistralAiOcrDocument imageUrl(String url) {
+        MistralAiOcrDocument document = new MistralAiOcrDocument();
+        document.type = "image_url";
+        document.imageUrl = url;
+        return document;
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrImage.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrImage.java
@@ -1,0 +1,21 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * An image extracted from a page, located by its bounding box. {@link #imageBase64} is only populated
+ * when the request asked for the image contents.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiOcrImage {
+
+    public String id;
+    public Integer topLeftX;
+    public Integer topLeftY;
+    public Integer bottomRightX;
+    public Integer bottomRightY;
+    public String imageBase64;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrPage.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrPage.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+/**
+ * A single page of an OCR result. {@link #markdown} holds the recognized content, {@link #index} the
+ * zero-based position of the page in the source document.
+ *
+ * <p>{@link #header} and {@link #footer} are only populated when the request asked for them to be
+ * extracted, and in that case their text is no longer part of {@link #markdown}.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiOcrPage {
+
+    public Integer index;
+    public String markdown;
+    public String header;
+    public String footer;
+    public List<MistralAiOcrImage> images;
+    public MistralAiOcrDimensions dimensions;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrRequest.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrRequest.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+/**
+ * A request to the Mistral OCR API ({@code POST /v1/ocr}).
+ *
+ * <p>Only the fields produced by {@code MistralAiOcrModel} are declared. Properties left {@code null}
+ * are omitted so that the service applies its own defaults.</p>
+ */
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiOcrRequest {
+
+    public String model;
+    public MistralAiOcrDocument document;
+    public List<Integer> pages;
+    public Boolean extractHeader;
+    public Boolean extractFooter;
+    public String tableFormat;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrResponse.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrResponse.java
@@ -1,0 +1,21 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+/**
+ * The result of an OCR request, with one entry in {@link #pages} per processed page.
+ *
+ * <p>Fields not declared here are ignored, so newer model versions returning additional data do not
+ * break the deserialization.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiOcrResponse {
+
+    public List<MistralAiOcrPage> pages;
+    public String model;
+    public MistralAiOcrUsageInfo usageInfo;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrUsageInfo.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiOcrUsageInfo.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * How much of the document was processed. OCR is billed per page rather than per token, so this is not
+ * a {@link MistralAiUsage}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiOcrUsageInfo {
+
+    public Integer pagesProcessed;
+    public Long docSizeBytes;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
@@ -31,6 +31,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
     private final String baseUrl;
     private final String apiKey;
     private final Supplier<Map<String, String>> customHeadersSupplier;
+    private final Supplier<Map<String, String>> customQueryParamsSupplier;
 
     public static Builder builder() {
         return new Builder();
@@ -65,6 +66,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
         this.baseUrl = ensureNotBlank(builder.baseUrl, "baseUrl");
         this.apiKey = ensureNotBlank(builder.apiKey, "apiKey");
         this.customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, () -> Map::of);
+        this.customQueryParamsSupplier = getOrDefault(builder.customQueryParamsSupplier, () -> Map::of);
     }
 
     private java.util.Map<String, String> buildRequestHeaders() {
@@ -73,6 +75,14 @@ public class DefaultMistralAiClient extends MistralAiClient {
             return Map.of();
         }
         return dynamicHeaders;
+    }
+
+    private Map<String, String> buildRequestQueryParams() {
+        Map<String, String> dynamicQueryParams = customQueryParamsSupplier.get();
+        if (isNullOrEmpty(dynamicQueryParams)) {
+            return Map.of();
+        }
+        return dynamicQueryParams;
     }
 
     @Override
@@ -90,6 +100,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .body(toJson(request))
                 .build();
 
@@ -116,6 +127,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .body(toJson(request))
                 .build();
 
@@ -137,6 +149,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .body(toJson(request))
                 .build();
 
@@ -156,6 +169,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .body(toJson(request))
                 .build();
 
@@ -179,6 +193,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .body(toJson(request))
                 .build();
 
@@ -196,11 +211,29 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .body(toJson(request))
                 .build();
 
         SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
         return fromJson(successfulHttpResponse.body(), MistralAiModerationResponse.class);
+    }
+
+    @Override
+    public MistralAiOcrResponse ocr(MistralAiOcrRequest request) {
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(POST)
+                .url(baseUrl, "ocr")
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "langchain4j-mistral-ai")
+                .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
+                .body(toJson(request))
+                .build();
+
+        SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
+        return fromJson(successfulHttpResponse.body(), MistralAiOcrResponse.class);
     }
 
     @Override
@@ -212,6 +245,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .build();
 
         SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
@@ -227,6 +261,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .body(toJson(request))
                 .build();
 
@@ -243,6 +278,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .build();
 
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
@@ -258,6 +294,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .build();
 
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
@@ -285,6 +322,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .build();
 
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
@@ -299,6 +337,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .addHeader("Authorization", "Bearer " + apiKey)
                 .addHeader("User-Agent", "langchain4j-mistral-ai")
                 .addHeaders(buildRequestHeaders())
+                .addQueryParams(buildRequestQueryParams())
                 .build();
 
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
@@ -99,6 +99,17 @@ public abstract class MistralAiClient {
         throw batchNotSupported();
     }
 
+    /**
+     * Extracts the content of a document ({@code POST /v1/ocr}).
+     *
+     * <p>Implemented as a non-abstract method that throws by default so that adding OCR support does not
+     * break existing {@link MistralAiClient} implementations.</p>
+     */
+    public MistralAiOcrResponse ocr(MistralAiOcrRequest request) {
+        throw new UnsupportedFeatureException("OCR is not supported by this client implementation: "
+                + getClass().getName());
+    }
+
     private UnsupportedFeatureException batchNotSupported() {
         return new UnsupportedFeatureException("Batch operations are not supported by this client implementation: "
                 + getClass().getName());
@@ -124,6 +135,7 @@ public abstract class MistralAiClient {
         public Logger logger;
         public HttpClientBuilder httpClientBuilder;
         public Supplier<Map<String, String>> customHeadersSupplier;
+        public Supplier<Map<String, String>> customQueryParamsSupplier;
 
         public abstract T build();
 
@@ -183,6 +195,22 @@ public abstract class MistralAiClient {
 
         public B customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
             this.customHeadersSupplier = customHeadersSupplier;
+            return (B) this;
+        }
+
+        /**
+         * Query parameters added to every request.
+         *
+         * <p>Needed by gateways that route by query parameter rather than by path, most notably the
+         * {@code api-version} parameter of Azure hosted deployments.</p>
+         */
+        public B customQueryParams(Map<String, String> customQueryParams) {
+            this.customQueryParamsSupplier = () -> customQueryParams;
+            return (B) this;
+        }
+
+        public B customQueryParams(Supplier<Map<String, String>> customQueryParamsSupplier) {
+            this.customQueryParamsSupplier = customQueryParamsSupplier;
             return (B) this;
         }
     }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiOcrDocumentParserTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiOcrDocumentParserTest.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.document.BlankDocumentException;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
+
+class MistralAiOcrDocumentParserTest {
+
+    private static final String RESPONSE = """
+            {
+              "pages": [{ "index": 0, "markdown": "# Scanned" }],
+              "model": "mistral-ocr-2505",
+              "usage_info": { "pages_processed": 1 }
+            }
+            """;
+
+    @Test
+    void should_parse_stream_and_report_input_size() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(RESPONSE).build());
+
+        DocumentParser parser = MistralAiOcrDocumentParser.builder()
+                .ocrModel(MistralAiOcrModel.builder()
+                        .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                        .apiKey("dummy")
+                        .modelName("mistral-ocr-latest")
+                        .build())
+                .build();
+
+        // when
+        Document document = parser.parse(new ByteArrayInputStream("hello".getBytes()));
+
+        // then
+        assertThat(document.text()).isEqualTo("# Scanned");
+        assertThat(document.metadata().getInteger(MistralAiOcrDocumentParser.DOCUMENT_SIZE_BYTES))
+                .isEqualTo(5);
+        assertThat(mockHttpClient.request().body()).contains("data:application/pdf;base64,aGVsbG8=");
+    }
+
+    @Test
+    void should_use_configured_mime_type() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(RESPONSE).build());
+
+        DocumentParser parser = MistralAiOcrDocumentParser.builder()
+                .ocrModel(MistralAiOcrModel.builder()
+                        .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                        .apiKey("dummy")
+                        .modelName("mistral-ocr-latest")
+                        .build())
+                .mimeType("image/png")
+                .build();
+
+        // when
+        parser.parse(new ByteArrayInputStream("hello".getBytes()));
+
+        // then
+        assertThat(mockHttpClient.request().body()).contains("data:image/png;base64,aGVsbG8=");
+    }
+
+    @Test
+    void should_throw_for_empty_stream_without_calling_the_service() {
+        // given
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        DocumentParser parser = MistralAiOcrDocumentParser.builder()
+                .ocrModel(MistralAiOcrModel.builder()
+                        .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                        .apiKey("dummy")
+                        .modelName("mistral-ocr-latest")
+                        .build())
+                .build();
+
+        // when, then
+        assertThatThrownBy(() -> parser.parse(new ByteArrayInputStream(new byte[0])))
+                .isInstanceOf(BlankDocumentException.class);
+        assertThat(mockHttpClient.requests()).isEmpty();
+    }
+}

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiOcrModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiOcrModelIT.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Document;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
+class MistralAiOcrModelIT {
+
+    /**
+     * A publicly reachable multi-page PDF, so that the round trip can be exercised without a fixture.
+     */
+    private static final String DOCUMENT_URL = "https://arxiv.org/pdf/2201.04234";
+
+    MistralAiOcrModel model = MistralAiOcrModel.builder()
+            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .modelName("mistral-ocr-latest")
+            .logRequests(true)
+            .build();
+
+    @Test
+    void should_extract_content_of_a_document_url() {
+        Document document = model.parseDocumentUrl(DOCUMENT_URL);
+
+        assertThat(document.text()).isNotBlank();
+        assertThat(document.metadata().getString(MistralAiOcrModel.OCR_MODEL)).isNotBlank();
+        assertThat(document.metadata().getInteger(MistralAiOcrModel.PAGES_PROCESSED))
+                .isPositive();
+    }
+
+    /**
+     * Pages without recognized content are skipped, so the page indices may have gaps, but they have to
+     * stay in document order.
+     */
+    @Test
+    void should_return_one_document_per_page() {
+        List<Document> documents = model.parsePages(readDocument(), "application/pdf");
+
+        assertThat(documents).isNotEmpty();
+        assertThat(documents).allSatisfy(document -> {
+            assertThat(document.text()).isNotBlank();
+            assertThat(document.metadata().getInteger(MistralAiOcrModel.PAGE_INDEX))
+                    .isNotNegative();
+        });
+
+        List<Integer> indices = documents.stream()
+                .map(document -> document.metadata().getInteger(MistralAiOcrModel.PAGE_INDEX))
+                .toList();
+        assertThat(indices).isSorted();
+    }
+
+    private static byte[] readDocument() {
+        try (InputStream inputStream = URI.create(DOCUMENT_URL).toURL().openStream()) {
+            return inputStream.readAllBytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiOcrModelTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiOcrModelTest.java
@@ -1,0 +1,230 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.document.BlankDocumentException;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MistralAiOcrModelTest {
+
+    private static final String RESPONSE = """
+            {
+              "pages": [
+                {
+                  "index": 0,
+                  "markdown": "# Invoice",
+                  "images": [
+                    {
+                      "id": "img-0.jpeg",
+                      "top_left_x": 100,
+                      "top_left_y": 120,
+                      "bottom_right_x": 300,
+                      "bottom_right_y": 320
+                    }
+                  ],
+                  "dimensions": { "dpi": 200, "height": 2200, "width": 1700 }
+                },
+                { "index": 1, "markdown": "## Positions", "images": [] }
+              ],
+              "model": "mistral-ocr-2505",
+              "usage_info": { "pages_processed": 2, "doc_size_bytes": 1234 }
+            }
+            """;
+
+    @Test
+    void should_send_document_as_data_uri_and_join_pages() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(RESPONSE).build());
+
+        MistralAiOcrModel model = MistralAiOcrModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("https://api.mistral.ai/v1")
+                .apiKey("dummy")
+                .modelName("mistral-ocr-latest")
+                .tableFormat(MistralAiOcrTableFormat.HTML)
+                .extractHeader(true)
+                .build();
+
+        // when
+        Document document = model.parse("hello".getBytes(), "application/pdf");
+
+        // then
+        assertThat(document.text()).isEqualTo("# Invoice\n\n## Positions");
+        assertThat(document.metadata().getString(MistralAiOcrModel.OCR_MODEL)).isEqualTo("mistral-ocr-2505");
+        assertThat(document.metadata().getInteger(MistralAiOcrModel.PAGES_PROCESSED))
+                .isEqualTo(2);
+        assertThat(document.metadata().getInteger(MistralAiOcrModel.PAGE_COUNT)).isEqualTo(2);
+
+        HttpRequest request = mockHttpClient.request();
+        assertThat(request.url()).isEqualTo("https://api.mistral.ai/v1/ocr");
+        assertThat(request.headers()).containsEntry("Authorization", List.of("Bearer dummy"));
+        assertThat(request.body().replaceAll("\\s", ""))
+                .contains("\"model\":\"mistral-ocr-latest\"")
+                .contains("\"type\":\"document_url\"")
+                .contains("\"document_url\":\"data:application/pdf;base64,aGVsbG8=\"")
+                .contains("\"table_format\":\"html\"")
+                .contains("\"extract_header\":true")
+                .doesNotContain("extract_footer")
+                .doesNotContain("image_url");
+    }
+
+    @Test
+    void should_send_image_as_image_url() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(RESPONSE).build());
+
+        MistralAiOcrModel model = MistralAiOcrModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("dummy")
+                .modelName("mistral-ocr-latest")
+                .build();
+
+        // when
+        model.parse("hello".getBytes(), "image/png");
+
+        // then
+        assertThat(mockHttpClient.request().body().replaceAll("\\s", ""))
+                .contains("\"type\":\"image_url\"")
+                .contains("\"image_url\":\"data:image/png;base64,aGVsbG8=\"")
+                .doesNotContain("document_url");
+    }
+
+    @Test
+    void should_return_one_document_per_page() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(RESPONSE).build());
+
+        MistralAiOcrModel model = MistralAiOcrModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("dummy")
+                .modelName("mistral-ocr-latest")
+                .pages(List.of(0, 1))
+                .build();
+
+        // when
+        List<Document> documents = model.parsePages("hello".getBytes(), "application/pdf");
+
+        // then
+        assertThat(documents).hasSize(2);
+        assertThat(documents.get(0).text()).isEqualTo("# Invoice");
+        assertThat(documents.get(0).metadata().getInteger(MistralAiOcrModel.PAGE_INDEX))
+                .isZero();
+        assertThat(documents.get(1).metadata().getInteger(MistralAiOcrModel.PAGE_INDEX))
+                .isEqualTo(1);
+        assertThat(mockHttpClient.request().body().replaceAll("\\s", "")).contains("\"pages\":[0,1]");
+    }
+
+    @Test
+    void should_support_azure_hosted_deployments_via_headers_and_query_params() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(RESPONSE).build());
+
+        MistralAiOcrModel model = MistralAiOcrModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("https://my-resource.services.ai.azure.com/providers/mistral/azure")
+                .apiKey("azure-key")
+                .customHeaders(Map.of("api-key", "azure-key"))
+                .customQueryParams(Map.of("api-version", "2024-05-01-preview"))
+                .modelName("mistral-document-ai-2512")
+                .build();
+
+        // when
+        model.parseDocumentUrl("https://example.com/contract.pdf");
+
+        // then
+        HttpRequest request = mockHttpClient.request();
+        assertThat(request.url())
+                .isEqualTo("https://my-resource.services.ai.azure.com/providers/mistral/azure/ocr"
+                        + "?api-version=2024-05-01-preview");
+        assertThat(request.headers()).containsEntry("api-key", List.of("azure-key"));
+        assertThat(request.body().replaceAll("\\s", ""))
+                .contains("\"model\":\"mistral-document-ai-2512\"")
+                .contains("\"document_url\":\"https://example.com/contract.pdf\"");
+    }
+
+    /**
+     * Enabling header or footer extraction makes the service move that text out of {@code markdown} into
+     * its own field. Reading only {@code markdown} would therefore drop content, so both are folded back
+     * into the text and additionally reported as metadata. The response below has the shape a deployment
+     * returns with both options enabled, with the recognized text replaced by placeholders.
+     */
+    @Test
+    void should_not_lose_extracted_header_and_footer() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body("""
+                        {
+                          "pages": [
+                            {
+                              "index": 0,
+                              "markdown": "# Invoice 12345\\nAmount: 99.50 EUR",
+                              "header": "Example Corp - Accounts Receivable",
+                              "footer": "Page 1 of 1",
+                              "images": [],
+                              "hyperlinks": [],
+                              "tables": []
+                            }
+                          ],
+                          "model": "mistral-document-ai-2512",
+                          "document_annotation": null,
+                          "usage_info": { "pages_processed": 1, "doc_size_bytes": 19512 },
+                          "content_filter_results": null
+                        }
+                        """).build());
+
+        MistralAiOcrModel model = MistralAiOcrModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("dummy")
+                .modelName("mistral-document-ai-2512")
+                .extractHeader(true)
+                .extractFooter(true)
+                .build();
+
+        // when
+        List<Document> pages = model.parsePages("hello".getBytes(), "application/pdf");
+
+        // then
+        assertThat(pages).hasSize(1);
+        Document page = pages.get(0);
+        assertThat(page.text())
+                .contains("Example Corp - Accounts Receivable")
+                .contains("Invoice 12345")
+                .contains("Page 1 of 1");
+        assertThat(page.metadata().getString(MistralAiOcrModel.PAGE_HEADER))
+                .isEqualTo("Example Corp - Accounts Receivable");
+        assertThat(page.metadata().getString(MistralAiOcrModel.PAGE_FOOTER)).isEqualTo("Page 1 of 1");
+    }
+
+    @Test
+    void should_throw_when_nothing_was_recognized() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body("{\"pages\": [{\"index\": 0, \"markdown\": \"\"}], \"model\": \"mistral-ocr-2505\"}")
+                .build());
+
+        MistralAiOcrModel model = MistralAiOcrModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("dummy")
+                .modelName("mistral-ocr-latest")
+                .build();
+
+        // when, then
+        assertThatThrownBy(() -> model.parse("hello".getBytes(), "application/pdf"))
+                .isInstanceOf(BlankDocumentException.class);
+        assertThatThrownBy(() -> model.parsePages("hello".getBytes(), "application/pdf"))
+                .isInstanceOf(BlankDocumentException.class);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6111

## Change

Adds Mistral Document AI (OCR) support to `langchain4j-mistral-ai`, so that scanned PDFs and images — which the local parsers cannot read — become usable in an ingestion pipeline. As agreed in #6111, `customQueryParams` is part of this PR rather than a separate one.

The result is returned as a `Document`, so the feature needs no new public DTOs. Two entry points:

- **`MistralAiOcrModel`** — `parse(byte[], String)`, `parseDocumentUrl(String)`, `parseImageUrl(String)`, and `parsePages(byte[], String)` which returns one `Document` per page carrying a `page_index`, so a retrieved segment can be traced back to a page of the source document.
- **`MistralAiOcrDocumentParser`** — a `DocumentParser`, usable directly with `FileSystemDocumentLoader` and the other loaders.

Metadata carries `ocr_model`, `pages_processed`, `page_count`, and per page `page_index`, `page_header`, `page_footer`; the parser adds `document_size_bytes`. A document from which nothing was recognized raises `BlankDocumentException`, matching the other parsers.

**Client.** `MistralAiClient.ocr(...)` is a non-abstract method that throws by default, following the precedent of the batch API, so other `MistralAiClient` implementations keep compiling. Wire types live in `internal.api` and are `@Internal` like the rest of the module.

**Azure.** Mistral Document AI is also sold through Azure AI Foundry, where the deployment lives on its own host, accepts the key in an `api-key` header and can take an `api-version` query parameter. `baseUrl` and the existing `customHeaders` already covered host and header; the missing piece was query parameters, hence `customQueryParams` next to `customHeaders` on the client builder. It applies to every request, so Azure-hosted chat and embedding deployments become reachable as well. The model itself stays free of any Azure-specific concept:

```java
MistralAiOcrModel model = MistralAiOcrModel.builder()
        .baseUrl("https://my-resource.services.ai.azure.com/providers/mistral/azure")
        .apiKey(key)
        .customHeaders(Map.of("api-key", key))
        .customQueryParams(Map.of("api-version", "2024-05-01-preview"))
        .modelName("mistral-document-ai-2512")
        .build();
```

**One behaviour worth flagging**, verified against an Azure AI Foundry deployment of `mistral-document-ai-2512`: `extract_header` / `extract_footer` do not add anything, they *move* text. With the options off, header and footer are part of `markdown` and the response fields are `null`; with them on, that text is removed from `markdown` and appears in `page.header` / `page.footer`. Reading only `markdown` would therefore silently drop content as soon as a user enables either option. Both are folded back into the document text and additionally reported as metadata, so nothing is lost and a header repeated on every page becomes identifiable and strippable before embedding. `MistralAiOcrModelTest#should_not_lose_extracted_header_and_footer` covers this.

`revapi.json` gains two justifications, for `Document` and `DocumentParser` being exposed in the API — the same pattern as the existing `dev.langchain4j.model.batch.*` entries.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Happy to add an example in the examples repo once this is released — it pins a published version, so an example cannot compile against it before then.