### PR TITLE
test(qdrant): add server compatibility matrix

### DIFF
--- a/docs/docs/integrations/embedding-stores/qdrant.md
+++ b/docs/docs/integrations/embedding-stores/qdrant.md
@@ -23,6 +23,11 @@ https://qdrant.tech/
 - `QdrantEmbeddingStore`
 
 
+## Tested Qdrant Versions
+
+The Qdrant integration test suite exercises the `latest` image. A compatibility smoke test also runs against server versions `1.15.5`, `1.16.3`, `1.17.1`, `1.18.3`, and `1.19.0`.
+
+
 ## Examples
 
 - [QdrantEmbeddingStoreExample](https://github.com/langchain4j/langchain4j-examples/blob/main/qdrant-example/src/main/java/QdrantEmbeddingStoreExample.java)

--- a/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreCompatibilityIT.java
+++ b/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreCompatibilityIT.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.store.embedding.qdrant;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static io.qdrant.client.grpc.Collections.Distance.Cosine;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.qdrant.QdrantContainer;
+
+@Testcontainers(disabledWithoutDocker = true)
+class QdrantEmbeddingStoreCompatibilityIT {
+
+    private static final EmbeddingModel EMBEDDING_MODEL = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @ParameterizedTest(name = "Qdrant {0}")
+    @ValueSource(strings = {"1.15.5", "1.16.3", "1.17.1", "1.18.3", "1.19.0"})
+    void should_add_and_search_embeddings_across_supported_server_versions(String serverVersion)
+            throws InterruptedException, ExecutionException {
+        try (QdrantContainer container = new QdrantContainer("qdrant/qdrant:" + serverVersion)) {
+            container.start();
+
+            String collectionName = "langchain4j-compatibility-" + randomUUID();
+            createCollection(container, collectionName);
+
+            QdrantEmbeddingStore embeddingStore = QdrantEmbeddingStore.builder()
+                    .host(container.getHost())
+                    .port(container.getGrpcPort())
+                    .collectionName(collectionName)
+                    .build();
+
+            try {
+                TextSegment segment = TextSegment.from("Qdrant " + serverVersion);
+                Embedding embedding = EMBEDDING_MODEL.embed(segment).content();
+                String embeddingId = embeddingStore.add(embedding, segment);
+
+                List<EmbeddingMatch<TextSegment>> matches = embeddingStore
+                        .search(EmbeddingSearchRequest.builder()
+                                .queryEmbedding(embedding)
+                                .maxResults(1)
+                                .build())
+                        .matches();
+
+                assertThat(matches).singleElement().satisfies(match -> {
+                    assertThat(match.embeddingId()).isEqualTo(embeddingId);
+                    assertThat(match.embedded()).isEqualTo(segment);
+                });
+            } finally {
+                embeddingStore.close();
+            }
+        }
+    }
+
+    private static void createCollection(QdrantContainer container, String collectionName)
+            throws InterruptedException, ExecutionException {
+        QdrantClient client =
+                new QdrantClient(QdrantGrpcClient.newBuilder(container.getHost(), container.getGrpcPort(), false)
+                        .build());
+        try {
+            client.createCollectionAsync(
+                            collectionName,
+                            VectorParams.newBuilder()
+                                    .setDistance(Cosine)
+                                    .setSize(EMBEDDING_MODEL.dimension())
+                                    .build())
+                    .get();
+        } finally {
+            client.close();
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Contributes to #2142

## Change

- Add a parameterized Qdrant compatibility smoke test for server versions 1.15.5 through 1.19.0.
- Keep the existing full integration suite on the `latest` Qdrant image.
- Document the tested server versions.

## Validation

- `mvnw -f langchain4j-qdrant/pom.xml -DskipTests -DskipITs test` — passed
- `mvnw -f langchain4j-qdrant/pom.xml -DskipTests -DskipITs spotless:check` — passed
- The container matrix was not run locally because no container runtime is available; it will run in PR CI.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases (not applicable to this compatibility smoke test)
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [x] I have added/updated the documentation
- [ ] I have added an example in the examples repo (not applicable)
- [ ] I have added/updated Spring Boot starters (not applicable)
