### PR TITLE
fix: fail fast when a LangChain4j type is used as an AI Service return type

### DIFF
--- a/docs/docs/tutorials/ai-services.md
+++ b/docs/docs/tutorials/ai-services.md
@@ -423,6 +423,18 @@ List<ToolExecution> toolExecutions = result.toolExecutions();
 FinishReason finishReason = result.finishReason();
 ```
 
+:::note
+`T` in `Result<T>` is the content the LLM produces, so it has to be a type the LLM can actually generate:
+a `String`, an enum, a POJO, a collection of those, etc.
+LangChain4j's own types, such as `ChatResponse`, `ChatMessage`, `TextSegment`, `Embedding` or `TokenUsage`,
+cannot be used as `T` (nor as an element of a `List<T>`/`Set<T>` return type):
+the AI Service will fail with an `IllegalConfigurationException` when it is created.
+Everything the final `ChatResponse` carries is already available on `Result<T>` itself, for example:
+```java
+ChatResponse chatResponse = result.finalResponse();
+```
+:::
+
 ## Structured Outputs
 
 If you want to receive a structured output (e.g., a complex Java object,

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
@@ -1,8 +1,12 @@
 package dev.langchain4j.service;
 
+import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
+import static java.lang.reflect.Modifier.isStatic;
+
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -11,21 +15,18 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
-import static java.lang.reflect.Modifier.isStatic;
-
 class AiServiceValidation {
 
     private static final Set<Method> VALID_METHODS = new HashSet<>();
 
-    private AiServiceValidation() { }
+    private AiServiceValidation() {}
 
     static void validate(AiServiceContext context) {
         Class<?> serviceClass = context.aiServiceClass;
         validateContextMemory(serviceClass, context.hasChatMemory());
         validateClass(serviceClass);
-        Stream.of(serviceClass.getMethods()).forEach(m ->
-                validateMethod(serviceClass, m, context.hasChatMemory(), context.hasModerationModel()));
+        Stream.of(serviceClass.getMethods())
+                .forEach(m -> validateMethod(serviceClass, m, context.hasChatMemory(), context.hasModerationModel()));
     }
 
     private static void validateContextMemory(Class<?> serviceClass, boolean hasChatMemory) {
@@ -39,26 +40,31 @@ class AiServiceValidation {
     private static void validateClass(Class<?> serviceClass) {
         if (!serviceClass.isInterface()) {
             throw illegalConfiguration(
-                    "The type implemented by the AI Service must be an interface, found '%s'",
-                    serviceClass.getName());
+                    "The type implemented by the AI Service must be an interface, found '%s'", serviceClass.getName());
         }
     }
 
-    private static void validateMethod(Class<?> serviceClass, Method method, boolean hasChatMemory, boolean hasModerationModel) {
+    private static void validateMethod(
+            Class<?> serviceClass, Method method, boolean hasChatMemory, boolean hasModerationModel) {
         if (isStatic(method.getModifiers())) {
             // ignore static methods
             return;
         }
 
         if (!hasModerationModel && method.isAnnotationPresent(Moderate.class)) {
-            throw illegalConfiguration(
-                    "The @Moderate annotation is present, but the moderationModel is not set up. "
-                            + "Please ensure a valid moderationModel is configured before using the @Moderate annotation.");
+            throw illegalConfiguration("The @Moderate annotation is present, but the moderationModel is not set up. "
+                    + "Please ensure a valid moderationModel is configured before using the @Moderate annotation.");
         }
 
         Class<?> returnType = method.getReturnType();
         if (returnType == Result.class || returnType == List.class || returnType == Set.class) {
             TypeUtils.validateReturnTypesAreProperlyParametrized(method.getName(), method.getGenericReturnType());
+        }
+        if (returnType == Result.class
+                && TypeUtils.resolveFirstGenericParameterClass(method.getGenericReturnType()) == ChatResponse.class) {
+            throw illegalConfiguration(
+                    "The return type 'Result<ChatResponse>' of the method '%s' is invalid because Result already contains the final ChatResponse",
+                    method.getName());
         }
 
         if (!hasChatMemory) {
@@ -86,11 +92,13 @@ class AiServiceValidation {
         boolean chatRequestParametersExist = false;
 
         for (Parameter p : parameters) {
-            if (checkParamTypeUniqueness(InvocationParameters.class, p, serviceClass, method, invocationParametersExist)) {
+            if (checkParamTypeUniqueness(
+                    InvocationParameters.class, p, serviceClass, method, invocationParametersExist)) {
                 invocationParametersExist = true;
                 continue;
             }
-            if (checkParamTypeUniqueness(ChatRequestParameters.class, p, serviceClass, method, chatRequestParametersExist)) {
+            if (checkParamTypeUniqueness(
+                    ChatRequestParameters.class, p, serviceClass, method, chatRequestParametersExist)) {
                 chatRequestParametersExist = true;
                 continue;
             }
@@ -99,8 +107,10 @@ class AiServiceValidation {
                 continue;
             }
 
-            if (!ParameterNameResolver.hasName(p) && p.getAnnotation(UserMessage.class) == null &&
-                    p.getAnnotation(MemoryId.class) == null && p.getAnnotation(UserName.class) == null) {
+            if (!ParameterNameResolver.hasName(p)
+                    && p.getAnnotation(UserMessage.class) == null
+                    && p.getAnnotation(MemoryId.class) == null
+                    && p.getAnnotation(UserName.class) == null) {
                 throw illegalConfiguration(
                         "The parameter '%s' in the method '%s' of the class %s must be annotated with either "
                                 + "%s, %s, %s, or %s, or it should be of type %s or %s",
@@ -117,14 +127,13 @@ class AiServiceValidation {
         }
     }
 
-    private static boolean checkParamTypeUniqueness(Class<?> paramType, Parameter p, Class<?> serviceClass, Method method, boolean paramExists) {
+    private static boolean checkParamTypeUniqueness(
+            Class<?> paramType, Parameter p, Class<?> serviceClass, Method method, boolean paramExists) {
         if (paramType.isAssignableFrom(p.getType())) {
             if (paramExists) {
                 throw illegalConfiguration(
                         "The method '%s' of the class %s has more than one parameter of type %s",
-                        method.getName(),
-                        serviceClass.getName(),
-                        paramType.getName());
+                        method.getName(), serviceClass.getName(), paramType.getName());
             }
             return true;
         }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
@@ -2,14 +2,20 @@ package dev.langchain4j.service;
 
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
 import static java.lang.reflect.Modifier.isStatic;
+import static java.util.stream.Collectors.joining;
 
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.Response;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -18,6 +24,29 @@ import java.util.stream.Stream;
 class AiServiceValidation {
 
     private static final Set<Method> VALID_METHODS = new HashSet<>();
+
+    /**
+     * LangChain4j types that AI Services return as-is, without asking the LLM to produce them.
+     */
+    private static final Set<Class<?>> SUPPORTED_RETURN_TYPES =
+            Set.of(AiMessage.class, ChatResponse.class, Response.class, TokenStream.class);
+
+    /**
+     * LangChain4j types that are supported as the content of a {@link Result}, e.g. {@code Result<AiMessage>}.
+     */
+    private static final Set<Class<?>> SUPPORTED_RESULT_CONTENT_TYPES = Set.of(AiMessage.class, Response.class);
+
+    /**
+     * Packages containing LangChain4j types. Types from these packages are not valid content types.
+     */
+    private static final Set<String> LANGCHAIN4J_PACKAGES =
+            Set.of("dev.langchain4j.agent.", "dev.langchain4j.data.", "dev.langchain4j.model.", "dev.langchain4j.rag.");
+
+    /**
+     * LangChain4j types that are not valid content types,
+     * but live in a package that is also used by application code (e.g. in tests).
+     */
+    private static final Set<Class<?>> LANGCHAIN4J_TYPES = Set.of(Result.class, TokenStream.class);
 
     private AiServiceValidation() {}
 
@@ -46,9 +75,8 @@ class AiServiceValidation {
 
     private static void validateMethod(
             Class<?> serviceClass, Method method, boolean hasChatMemory, boolean hasModerationModel) {
-        if (isStatic(method.getModifiers())) {
-            // ignore static methods
-            return;
+        if (isStatic(method.getModifiers()) || method.isDefault()) {
+            return; // static and default methods are not implemented by the AI Service, they are invoked as-is
         }
 
         if (!hasModerationModel && method.isAnnotationPresent(Moderate.class)) {
@@ -60,12 +88,7 @@ class AiServiceValidation {
         if (returnType == Result.class || returnType == List.class || returnType == Set.class) {
             TypeUtils.validateReturnTypesAreProperlyParametrized(method.getName(), method.getGenericReturnType());
         }
-        if (returnType == Result.class
-                && TypeUtils.resolveFirstGenericParameterClass(method.getGenericReturnType()) == ChatResponse.class) {
-            throw illegalConfiguration(
-                    "The return type 'Result<ChatResponse>' of the method '%s' is invalid because Result already contains the final ChatResponse",
-                    method.getName());
-        }
+        validateReturnType(method.getName(), method.getGenericReturnType());
 
         if (!hasChatMemory) {
             for (Parameter parameter : method.getParameters()) {
@@ -76,6 +99,82 @@ class AiServiceValidation {
                 }
             }
         }
+    }
+
+    private static void validateReturnType(String methodName, Type returnType) {
+        if (!isResolvable(returnType)) {
+            return;
+        }
+
+        Class<?> rawReturnType = TypeUtils.getRawClass(returnType);
+        if (SUPPORTED_RETURN_TYPES.contains(rawReturnType) || isImage(returnType)) {
+            return;
+        }
+
+        if (rawReturnType == Result.class) {
+            Type contentType = TypeUtils.resolveFirstGenericParameterType(returnType);
+            if (isResolvable(contentType) && SUPPORTED_RESULT_CONTENT_TYPES.contains(TypeUtils.getRawClass(contentType))) {
+                return;
+            }
+            validateContentType(methodName, returnType, contentType);
+        } else {
+            validateContentType(methodName, returnType, returnType);
+        }
+    }
+
+    private static void validateContentType(String methodName, Type returnType, Type contentType) {
+        if (!isResolvable(contentType)) {
+            return;
+        }
+
+        Class<?> rawContentType = TypeUtils.getRawClass(contentType);
+        if (Collection.class.isAssignableFrom(rawContentType)) {
+            validateContentType(methodName, returnType, TypeUtils.resolveFirstGenericParameterType(contentType));
+            return;
+        }
+
+        if (isLangChain4jType(rawContentType)) {
+            throw illegalConfiguration(
+                    "The return type '%s' of the method '%s' is invalid: '%s' is a LangChain4j type, "
+                            + "so it cannot be parsed from the LLM output. Please return a type the LLM can produce "
+                            + "(e.g. String, an enum or a POJO). Metadata about the invocation "
+                            + "(token usage, sources, tool executions, the final ChatResponse) is available via 'Result<T>'.",
+                    typeName(returnType), methodName, rawContentType.getSimpleName());
+        }
+    }
+
+    /**
+     * Mirrors the image detection in {@code DefaultAiServices}: images are returned as-is, not parsed from text.
+     */
+    private static boolean isImage(Type type) {
+        Class<?> rawClass = TypeUtils.getRawClass(type);
+        if (TypeUtils.isImageType(rawClass)) {
+            return true;
+        }
+        if (Collection.class.isAssignableFrom(rawClass)) {
+            Class<?> genericParameter = TypeUtils.resolveFirstGenericParameterClass(type);
+            return genericParameter != null && TypeUtils.isImageType(genericParameter);
+        }
+        return false;
+    }
+
+    private static boolean isLangChain4jType(Class<?> type) {
+        return LANGCHAIN4J_TYPES.contains(type)
+                || LANGCHAIN4J_PACKAGES.stream().anyMatch(p -> type.getName().startsWith(p));
+    }
+
+    private static boolean isResolvable(Type type) {
+        return type instanceof Class<?> || type instanceof ParameterizedType;
+    }
+
+    private static String typeName(Type type) {
+        if (type instanceof ParameterizedType parameterizedType) {
+            return TypeUtils.getRawClass(parameterizedType).getSimpleName()
+                    + Stream.of(parameterizedType.getActualTypeArguments())
+                            .map(AiServiceValidation::typeName)
+                            .collect(joining(", ", "<", ">"));
+        }
+        return type instanceof Class<?> clazz ? clazz.getSimpleName() : type.getTypeName();
     }
 
     static void validateParameters(Class<?> serviceClass, Method method) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceValidationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceValidationTest.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Test;
+
+class AiServiceValidationTest {
+
+    private static final ChatModel CHAT_MODEL = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+    interface AssistantReturningResultOfChatResponse {
+
+        Result<ChatResponse> chat(String input);
+    }
+
+    @Test
+    void should_reject_result_of_chat_response() {
+        assertThatThrownBy(() -> AiServices.builder(AssistantReturningResultOfChatResponse.class)
+                        .chatModel(CHAT_MODEL)
+                        .build())
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage(
+                        "The return type 'Result<ChatResponse>' of the method 'chat' is invalid because Result already contains the final ChatResponse");
+    }
+
+    interface AssistantReturningResultOfAiMessage {
+
+        Result<AiMessage> chat(String input);
+    }
+
+    @Test
+    void should_allow_result_of_ai_message() {
+        assertThatCode(() -> AiServices.builder(AssistantReturningResultOfAiMessage.class)
+                        .chatModel(CHAT_MODEL)
+                        .build())
+                .doesNotThrowAnyException();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceValidationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceValidationTest.java
@@ -3,41 +3,194 @@ package dev.langchain4j.service;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import org.junit.jupiter.api.Test;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AiServiceValidationTest {
 
     private static final ChatModel CHAT_MODEL = ChatModelMock.thatAlwaysResponds("Hello there!");
 
-    interface AssistantReturningResultOfChatResponse {
+    record Person(String name) {}
 
-        Result<ChatResponse> chat(String input);
+    enum Sentiment {
+        POSITIVE,
+        NEGATIVE
     }
 
-    @Test
-    void should_reject_result_of_chat_response() {
-        assertThatThrownBy(() -> AiServices.builder(AssistantReturningResultOfChatResponse.class)
-                        .chatModel(CHAT_MODEL)
-                        .build())
+    interface WithChatResponseInResult {
+        Result<ChatResponse> chat(String userMessage);
+    }
+
+    interface WithTokenStreamInResult {
+        Result<TokenStream> chat(String userMessage);
+    }
+
+    interface WithNestedResult {
+        Result<Result<String>> chat(String userMessage);
+    }
+
+    interface WithTokenUsageInResult {
+        Result<TokenUsage> chat(String userMessage);
+    }
+
+    interface WithImageInResult {
+        Result<Image> chat(String userMessage);
+    }
+
+    interface WithChatResponseInList {
+        List<ChatResponse> chat(String userMessage);
+    }
+
+    interface WithAiMessageInSet {
+        Set<AiMessage> chat(String userMessage);
+    }
+
+    interface WithDocumentInResultOfList {
+        Result<List<Document>> chat(String userMessage);
+    }
+
+    interface WithTextSegment {
+        TextSegment chat(String userMessage);
+    }
+
+    interface WithEmbedding {
+        Embedding chat(String userMessage);
+    }
+
+    interface WithUserMessage {
+        UserMessage chat(String userMessage);
+    }
+
+    interface WithToolExecutionRequest {
+        ToolExecutionRequest chat(String userMessage);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            classes = {
+                WithChatResponseInResult.class,
+                WithTokenStreamInResult.class,
+                WithNestedResult.class,
+                WithTokenUsageInResult.class,
+                WithImageInResult.class,
+                WithChatResponseInList.class,
+                WithAiMessageInSet.class,
+                WithDocumentInResultOfList.class,
+                WithTextSegment.class,
+                WithEmbedding.class,
+                WithUserMessage.class,
+                WithToolExecutionRequest.class
+            })
+    void should_reject_langchain4j_types_as_content_type(Class<?> aiServiceClass) {
+        assertThatThrownBy(() ->
+                        AiServices.builder(aiServiceClass).chatModel(CHAT_MODEL).build())
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage(
-                        "The return type 'Result<ChatResponse>' of the method 'chat' is invalid because Result already contains the final ChatResponse");
+                .hasMessageContaining("is a LangChain4j type")
+                .hasMessageContaining("chat");
     }
 
-    interface AssistantReturningResultOfAiMessage {
-
-        Result<AiMessage> chat(String input);
+    interface WithString {
+        String chat(String userMessage);
     }
 
-    @Test
-    void should_allow_result_of_ai_message() {
-        assertThatCode(() -> AiServices.builder(AssistantReturningResultOfAiMessage.class)
-                        .chatModel(CHAT_MODEL)
-                        .build())
+    interface WithPojo {
+        Person chat(String userMessage);
+    }
+
+    interface WithEnum {
+        Sentiment chat(String userMessage);
+    }
+
+    interface WithVoid {
+        void chat(String userMessage);
+    }
+
+    interface WithStringInResult {
+        Result<String> chat(String userMessage);
+    }
+
+    interface WithPojoListInResult {
+        Result<List<Person>> chat(String userMessage);
+    }
+
+    interface WithAiMessageInResult {
+        Result<AiMessage> chat(String userMessage);
+    }
+
+    interface WithVoidInResult {
+        Result<Void> chat(String userMessage);
+    }
+
+    interface WithResponseInResult {
+        Result<Response<AiMessage>> chat(String userMessage);
+    }
+
+    interface WithAiMessage {
+        AiMessage chat(String userMessage);
+    }
+
+    interface WithChatResponse {
+        ChatResponse chat(String userMessage);
+    }
+
+    interface WithResponse {
+        Response<AiMessage> chat(String userMessage);
+    }
+
+    interface WithImage {
+        Image chat(String userMessage);
+    }
+
+    interface WithImageContentList {
+        List<ImageContent> chat(String userMessage);
+    }
+
+    interface WithDefaultMethodReturningLangChain4jType {
+
+        String chat(String userMessage);
+
+        default Result<ChatResponse> notAnAiServiceMethod() {
+            return null;
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            classes = {
+                WithString.class,
+                WithPojo.class,
+                WithEnum.class,
+                WithVoid.class,
+                WithStringInResult.class,
+                WithPojoListInResult.class,
+                WithAiMessageInResult.class,
+                WithVoidInResult.class,
+                WithResponseInResult.class,
+                WithAiMessage.class,
+                WithChatResponse.class,
+                WithResponse.class,
+                WithImage.class,
+                WithImageContentList.class,
+                WithDefaultMethodReturningLangChain4jType.class
+            })
+    void should_allow_supported_return_types(Class<?> aiServiceClass) {
+        assertThatCode(() ->
+                        AiServices.builder(aiServiceClass).chatModel(CHAT_MODEL).build())
                 .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## Issue

Closes #1918

## Change

AI Services silently treated LangChain4j's own types as POJOs that the LLM is supposed to produce.
For `Result<ChatResponse>`, the LLM was actually asked to fill in LangChain4j internals:

```
You must answer strictly in the following JSON format: {
  "aiMessage": (type: dev.langchain4j.data.message.AiMessage: {
      "text": (type: string),
      "thinking": (type: string),
      "toolExecutionRequests": (type: array of dev.langchain4j.agent.tool.ToolExecutionRequest: {
          "id": (type: string), "name": (type: string), "arguments": (type: string) }),
      "attributes": (type: java.util.Map<java.lang.String, java.lang.Object>) }),
  "metadata": (type: dev.langchain4j.model.chat.response.ChatResponseMetadata: {
      "id": (type: string), "modelName": (type: string),
      "tokenUsage": (type: dev.langchain4j.model.output.TokenUsage: { ... }), ... }) }
```

`ChatResponse` is not a special case. The same happened for `TextSegment`, `Embedding`, `TokenUsage`,
`UserMessage`, `ChatRequest`, `ToolExecutionRequest` and `Metadata`. Other combinations were not even
parseable: `List<Document>`, `List<AiMessage>` and `List<ChatResponse>` failed at invocation time with an
`IllegalStateException` whose message was `null`.

`AiServiceValidation` now fails fast, when the AI Service is created, whenever a LangChain4j type is used
as a *content type* - the type the LLM is asked to produce. This is checked for the return type itself,
for the content of `Result<T>`, and for elements of `List<T>`/`Set<T>`, at any nesting depth:

```java
interface Assistant {
    Result<ChatResponse> chat(String userMessage);
}

// IllegalConfigurationException: The return type 'Result<ChatResponse>' of the method 'chat' is invalid:
// 'ChatResponse' is a LangChain4j type, so it cannot be parsed from the LLM output. Please return a type
// the LLM can produce (e.g. String, an enum or a POJO). Metadata about the invocation (token usage,
// sources, tool executions, the final ChatResponse) is available via 'Result<T>'.
```

Unchanged and still valid:

- `String`, enums, POJOs, `Map`, `void`, and `List`/`Set` of them
- `Result<T>` of any of the above, e.g. `Result<String>`, `Result<List<MyPojo>>`, `Result<Void>`
- types that AI Services return as-is: `AiMessage`, `ChatResponse`, `Response<AiMessage>`, `TokenStream`,
  `Image`, `ImageContent`, `List<Image>`, `List<ImageContent>`
- `Result<AiMessage>` and `Result<Response<AiMessage>>`

`Result<AiMessage>` is mentioned in #1918, but it is intentionally kept valid: `AiMessage` is returned as-is,
no JSON schema is generated for it, so nothing leaks to the LLM, and it is a convenient way to get the message
together with token usage and tool executions.

A LangChain4j type is recognised by its package (`dev.langchain4j.agent.`, `dev.langchain4j.data.`,
`dev.langchain4j.model.`, `dev.langchain4j.rag.`) plus an explicit list for the types that live in
`dev.langchain4j.service`, which is a package application code can legitimately use as well.

One related fix in the same method: `default` methods are now skipped by validation. They are invoked as-is
by the proxy (`DefaultAiServices` delegates to `InvocationHandler.invokeDefault`) and never reach the LLM,
so validating their return type produced false positives.

## Breaking Changes

Interfaces that were accepted at creation time before are now rejected with `IllegalConfigurationException`.
Every one of them was already broken at invocation time, **except** the ones marked "worked" below, where the
LLM was asked to fill in a LangChain4j type.

| Return type | Before | Migration |
| --- | --- | --- |
| `Result<ChatResponse>` | `OutputParsingException` at invocation | `Result<String>` + `result.finalResponse()` |
| `Result<TokenStream>` | `OutputParsingException` at invocation | `TokenStream` as the return type |
| `Result<Result<T>>` | `OutputParsingException` at invocation | `Result<T>` |
| `Result<Image>`, `Result<List<Image>>` | parsed `Image` as a POJO | `Image` / `List<Image>` as the return type |
| `List<ChatResponse>`, `List<AiMessage>`, `List<Document>` | `IllegalStateException` at invocation | `List<String>` or `List<MyPojo>` |
| `TextSegment`, `Metadata`, `Embedding`, `TokenUsage`, `UserMessage`, `ChatRequest`, `ToolExecutionRequest` | worked - the LLM was asked to produce LangChain4j internals | a POJO of your own, or `Result<T>` for invocation metadata |

Getting the `ChatResponse` (or token usage, sources, tool executions) no longer requires an unsupported
return type - it is what `Result<T>` is for:

```java
interface Assistant {
    Result<String> chat(String userMessage);
}

Result<String> result = assistant.chat("Hello");
String answer = result.content();
ChatResponse chatResponse = result.finalResponse();
TokenUsage tokenUsage = result.tokenUsage();
```

## Testing

`AiServiceValidationTest` covers both directions with 27 cases: 12 rejected return types
(`Result<ChatResponse>`, `Result<TokenStream>`, `Result<Result<String>>`, `Result<TokenUsage>`,
`Result<Image>`, `List<ChatResponse>`, `Set<AiMessage>`, `Result<List<Document>>`, `TextSegment`,
`Embedding`, `UserMessage`, `ToolExecutionRequest`) and 15 accepted ones (`String`, POJO, enum, `void`,
`Result<String>`, `Result<List<Person>>`, `Result<AiMessage>`, `Result<Void>`, `Result<Response<AiMessage>>`,
`AiMessage`, `ChatResponse`, `Response<AiMessage>`, `Image`, `List<ImageContent>`, and an interface with a
`default` method returning `Result<ChatResponse>`).

Green locally, with `spotless:check` enabled:

| Module | Tests |
| --- | --- |
| `langchain4j` | 1392 |
| `langchain4j-agentic` | 202 |
| `langchain4j-mcp` | 119 |
| `langchain4j-skills` | 91 |
| `langchain4j-agentic-patterns` | 25 |
| `langchain4j-easy-rag` | 0 (no unit tests) |

`revapi:check` on `langchain4j` passes - no public API changed, `AiServiceValidation` is package-private.

## General checklist

- [ ] There are no breaking changes to supported APIs
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [x] I have added/updated documentation
