### PR TITLE
fix(kotlin): skip documents that fail to parse

### DIFF
--- a/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
@@ -6,6 +6,7 @@ import dev.langchain4j.data.document.loader.FileSystemDocumentLoader
 import dev.langchain4j.kotlin.data.document.parseAsync
 import dev.langchain4j.data.document.source.FileSystemSource
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -67,12 +68,20 @@ public suspend fun loadDocuments(
         matchedFiles
             .map { file ->
                 async(context) {
-                    documentParser.parseAsync(
-                        FileSystemSource(file),
-                        context
-                    )
+                    try {
+                        documentParser.parseAsync(
+                            FileSystemSource(file),
+                            context
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.warn("Failed to load document: {}", file, e)
+                        null
+                    }
                 }
             }.awaitAll()
+            .filterNotNull()
             .map { document ->
                 val metadata = document.metadata()
                 logger.info(

--- a/langchain4j-kotlin/src/test/kotlin/dev/langchain4j/kotlin/data/document/loader/AsyncDocumentLoaderTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/dev/langchain4j/kotlin/data/document/loader/AsyncDocumentLoaderTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.Files
 
 internal class AsyncDocumentLoaderTest {
     private lateinit var documentSource: DocumentSource
@@ -73,5 +74,48 @@ internal class AsyncDocumentLoaderTest {
                         "test-file-3.banana",
                         "test-file-4.banana"
                     )
+        }
+
+    @Test
+    fun `Should skip documents that fail to parse`() =
+        runTest {
+            val directory = Files.createTempDirectory("async-document-loader")
+            try {
+                Files.writeString(directory.resolve("good.txt"), "This document is valid.")
+                Files.writeString(directory.resolve("blank.txt"), "  \n")
+
+                val documents =
+                    loadDocuments(
+                        recursive = false,
+                        documentParser = parser,
+                        directoryPaths = listOf(directory)
+                    )
+
+                documents.map { it.metadata().getString("file_name") }
+                    .shouldContainExactly(listOf("good.txt"))
+            } finally {
+                directory.toFile().deleteRecursively()
+            }
+        }
+
+    @Test
+    fun `Should return an empty list when every document fails to parse`() =
+        runTest {
+            val directory = Files.createTempDirectory("async-document-loader")
+            try {
+                Files.writeString(directory.resolve("blank-1.txt"), "\n")
+                Files.writeString(directory.resolve("blank-2.txt"), "  \n")
+
+                val documents =
+                    loadDocuments(
+                        recursive = false,
+                        documentParser = parser,
+                        directoryPaths = listOf(directory)
+                    )
+
+                documents.shouldHaveSize(0)
+            } finally {
+                directory.toFile().deleteRecursively()
+            }
         }
 }


### PR DESCRIPTION
## Summary

- Keep successful documents when one file fails during asynchronous batch loading.
- Log the failed file and preserve coroutine cancellation semantics.
- Add regression coverage for mixed-success and all-failing batches.

Fixes #6095

## Validation

- `./mvnw -pl langchain4j-kotlin -am -Dtest=AsyncDocumentLoaderTest -Dsurefire.failIfNoSpecifiedTests=false test` (5 tests passed)
- `./mvnw -pl langchain4j-kotlin -am test` (running/see follow-up comment)
- `git diff --check`

The loader catches parser/I/O exceptions per file, logs the source path with the exception, and filters only failed documents from the result. `CancellationException` is rethrown so cancellation is not swallowed.