### PR TITLE
feat(bedrock): support request metadata in Converse APIs

### DIFF
--- a/docs/docs/integrations/language-models/amazon-bedrock.md
+++ b/docs/docs/integrations/language-models/amazon-bedrock.md
@@ -52,6 +52,7 @@ ChatModel model = BedrockChatModel.builder()
                 .additionalModelRequestField(...)
                 .enableReasoning(...)
                 .promptCaching(...)
+                .requestMetadata(Map.of("team", "platform"))
                 .build())
         .build();
 ```
@@ -94,6 +95,7 @@ StreamingChatModel model = BedrockStreamingChatModel.builder()
                 .additionalModelRequestField(...)
                 .enableReasoning(...)
                 .promptCaching(...)
+                .requestMetadata(Map.of("team", "platform"))
                 .build())
         .build();
 ```
@@ -108,6 +110,23 @@ StreamingChatModel model = BedrockStreamingChatModel.builder()
 The field `additionalModelRequestFields` in the `BedrockChatRequestParameters` is a `Map<String, Object>`.
 As explained [here](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html#bedrock-runtime_Converse-request-additionalModelRequestFields)
 it allows you to add inference parameters for a specific model that is not covered by common `InferenceConfiguration`.
+
+
+## Request Metadata
+
+Use `requestMetadata` on `BedrockChatRequestParameters` to add key-value pairs to Converse and ConverseStream requests.
+The metadata can be used to filter Amazon Bedrock model invocation logs. It can be configured as part of the model's
+default request parameters or supplied for an individual request.
+
+```java
+BedrockChatRequestParameters parameters = BedrockChatRequestParameters.builder()
+        .requestMetadata(Map.of("team", "platform"))
+        .build();
+```
+
+Do not include personally identifiable information, credentials, or other sensitive data in request metadata.
+See [Per-request metadata tagging](https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html)
+for more information.
 
 
 ## Thinking / Reasoning

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -183,6 +183,7 @@ abstract class AbstractBedrockChatModel {
                 .promptCaching(bedrockParameters.cachePointPlacement(), bedrockParameters.cacheTtl())
                 .guardrailConfiguration(bedrockParameters.bedrockGuardrailConfiguration())
                 .serviceTier(bedrockParameters.serviceTier())
+                .requestMetadata(bedrockParameters.requestMetadata())
                 .build();
     }
 
@@ -805,6 +806,10 @@ abstract class AbstractBedrockChatModel {
         }
 
         return ServiceTier.builder().type(serviceTierType).build();
+    }
+
+    protected Map<String, String> requestMetadataFrom(BedrockChatRequestParameters parameters) {
+        return isNullOrEmpty(parameters.requestMetadata()) ? null : parameters.requestMetadata();
     }
 
     protected Document additionalRequestModelFieldsFrom(ChatRequestParameters chatRequestParameters) {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
@@ -94,6 +94,7 @@ public class BedrockChatModel extends AbstractBedrockChatModel implements ChatMo
                 .guardrailConfig(guardrailConfigFrom(bedrockGuardrailConfiguration))
                 .outputConfig(outputConfigFrom(chatRequest.responseFormat()))
                 .serviceTier(serviceTierFor(bedrockServiceTier))
+                .requestMetadata(requestMetadataFrom(parameters))
                 .build();
     }
 

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatRequestParameters.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatRequestParameters.java
@@ -20,6 +20,7 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
     private final CacheTTL cacheTtl;
     private final BedrockGuardrailConfiguration bedrockGuardrailConfiguration;
     private final BedrockServiceTier serviceTier;
+    private final Map<String, String> requestMetadata;
 
     private BedrockChatRequestParameters(Builder builder) {
         super(builder);
@@ -28,6 +29,7 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
         this.cacheTtl = builder.cacheTtl;
         this.bedrockGuardrailConfiguration = builder.bedrockGuardrailConfiguration;
         this.serviceTier = builder.serviceTier;
+        this.requestMetadata = copy(builder.requestMetadata);
     }
 
     @Override
@@ -70,6 +72,10 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
         return serviceTier;
     }
 
+    public Map<String, String> requestMetadata() {
+        return requestMetadata;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -80,7 +86,8 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
                 && Objects.equals(cachePointPlacement, that.cachePointPlacement)
                 && Objects.equals(cacheTtl, that.cacheTtl)
                 && Objects.equals(bedrockGuardrailConfiguration, that.bedrockGuardrailConfiguration)
-                && Objects.equals(serviceTier, that.serviceTier);
+                && Objects.equals(serviceTier, that.serviceTier)
+                && Objects.equals(requestMetadata, that.requestMetadata);
     }
 
     @Override
@@ -91,7 +98,8 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
                 cachePointPlacement,
                 cacheTtl,
                 bedrockGuardrailConfiguration,
-                serviceTier);
+                serviceTier,
+                requestMetadata);
     }
 
     @Override
@@ -112,7 +120,8 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
                 + cachePointPlacement + ", cacheTtl="
                 + cacheTtl + ", bedrockGuardrailConfiguration="
                 + bedrockGuardrailConfiguration + ", serviceTier="
-                + serviceTier + '}';
+                + serviceTier + ", requestMetadata="
+                + (requestMetadata.isEmpty() ? "{}" : "[REDACTED]") + '}';
     }
 
     public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {
@@ -122,6 +131,7 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
         private CacheTTL cacheTtl;
         private BedrockGuardrailConfiguration bedrockGuardrailConfiguration;
         private BedrockServiceTier serviceTier;
+        private Map<String, String> requestMetadata;
 
         @Override
         public Builder overrideWith(ChatRequestParameters parameters) {
@@ -141,6 +151,7 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
                 this.bedrockGuardrailConfiguration = getOrDefault(
                         bedrockRequestParameters.bedrockGuardrailConfiguration, bedrockGuardrailConfiguration);
                 this.serviceTier = getOrDefault(bedrockRequestParameters.serviceTier, serviceTier);
+                this.requestMetadata = getOrDefault(bedrockRequestParameters.requestMetadata, requestMetadata);
             }
             return this;
         }
@@ -155,6 +166,17 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
                 additionalModelRequestFields = new HashMap<>();
             }
             additionalModelRequestFields.put(key, value);
+            return this;
+        }
+
+        /**
+         * Sets key-value pairs that can be used to filter Amazon Bedrock model invocation logs.
+         * Do not include personally identifiable information, credentials, or other sensitive data.
+         *
+         * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html">Per-request metadata tagging</a>
+         */
+        public Builder requestMetadata(Map<String, String> requestMetadata) {
+            this.requestMetadata = requestMetadata;
             return this;
         }
 

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -219,6 +219,7 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
                 .guardrailConfig(guardrailStreamConfigFrom(bedrockGuardrailConfiguration))
                 .outputConfig(outputConfigFrom(chatRequest.responseFormat()))
                 .serviceTier(serviceTierFor(bedrockServiceTier))
+                .requestMetadata(requestMetadataFrom(parameters))
                 .build();
     }
 

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
@@ -2,11 +2,40 @@ package dev.langchain4j.model.bedrock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.bedrockruntime.model.CacheTTL;
 
 class BedrockChatRequestParametersTest {
+
+    @Test
+    void should_build_with_request_metadata() {
+        Map<String, String> requestMetadata = new HashMap<>();
+        requestMetadata.put("team", "platform");
+
+        BedrockChatRequestParameters parameters = BedrockChatRequestParameters.builder()
+                .requestMetadata(requestMetadata)
+                .build();
+
+        requestMetadata.put("environment", "production");
+
+        assertThat(parameters.requestMetadata()).isEqualTo(Map.of("team", "platform"));
+    }
+
+    @Test
+    void should_override_request_metadata() {
+        BedrockChatRequestParameters defaults = BedrockChatRequestParameters.builder()
+                .requestMetadata(Map.of("team", "platform"))
+                .build();
+        BedrockChatRequestParameters overrides = BedrockChatRequestParameters.builder()
+                .requestMetadata(Map.of("traceId", "abc-123"))
+                .build();
+
+        BedrockChatRequestParameters merged = defaults.overrideWith(overrides);
+
+        assertThat(merged.requestMetadata()).isEqualTo(Map.of("traceId", "abc-123"));
+    }
 
     @Test
     void should_enable_prompt_caching_with_placement() {
@@ -400,6 +429,19 @@ class BedrockChatRequestParametersTest {
     }
 
     @Test
+    void should_not_be_equal_when_request_metadata_differs() {
+        BedrockChatRequestParameters first = BedrockChatRequestParameters.builder()
+                .requestMetadata(Map.of("team", "platform"))
+                .build();
+        BedrockChatRequestParameters second = BedrockChatRequestParameters.builder()
+                .requestMetadata(Map.of("team", "application"))
+                .build();
+
+        assertThat(first).isNotEqualTo(second);
+        assertThat(first.hashCode()).isNotEqualTo(second.hashCode());
+    }
+
+    @Test
     void should_not_be_equal_when_an_inherited_parameter_differs() {
         BedrockChatRequestParameters first = fullyPopulated().temperature(0.1).build();
         BedrockChatRequestParameters second = fullyPopulated().temperature(0.2).build();
@@ -417,7 +459,9 @@ class BedrockChatRequestParametersTest {
                 .contains("cachePointPlacement=AFTER_SYSTEM")
                 .contains("cacheTtl=")
                 .contains("bedrockGuardrailConfiguration=")
-                .contains("serviceTier=DEFAULT");
+                .contains("serviceTier=DEFAULT")
+                .contains("requestMetadata=[REDACTED]")
+                .doesNotContain("platform");
     }
 
     private static BedrockChatRequestParameters.Builder fullyPopulated() {
@@ -427,7 +471,8 @@ class BedrockChatRequestParametersTest {
                 .additionalModelRequestField("key", "value")
                 .promptCaching(BedrockCachePointPlacement.AFTER_SYSTEM, CacheTTL.VALUE_5_M)
                 .guardrailConfiguration(guardrail())
-                .serviceTier(BedrockServiceTier.DEFAULT);
+                .serviceTier(BedrockServiceTier.DEFAULT)
+                .requestMetadata(Map.of("team", "platform"));
     }
 
     private static BedrockGuardrailConfiguration guardrail() {

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockDefaultRequestParametersTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockDefaultRequestParametersTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import dev.langchain4j.model.chat.request.ResponseFormat;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
@@ -38,11 +39,13 @@ class BedrockDefaultRequestParametersTest {
         return BedrockChatRequestParameters.builder()
                 .responseFormat(ResponseFormat.JSON)
                 .serviceTier(BedrockServiceTier.PRIORITY)
+                .requestMetadata(Map.of("team", "platform"))
                 .build();
     }
 
     private static void assertDefaultRequestParametersPreserved(BedrockChatRequestParameters parameters) {
         assertThat(parameters.responseFormat()).isEqualTo(ResponseFormat.JSON);
         assertThat(parameters.serviceTier()).isEqualTo(BedrockServiceTier.PRIORITY);
+        assertThat(parameters.requestMetadata()).isEqualTo(Map.of("team", "platform"));
     }
 }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockRequestMetadataTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockRequestMetadataTest.java
@@ -1,0 +1,136 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.awscore.AwsResponseMetadata;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
+import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
+
+class BedrockRequestMetadataTest {
+
+    @Test
+    void should_add_default_request_metadata_to_converse_request() {
+        BedrockRuntimeClient client = syncClient();
+        BedrockChatModel model = BedrockChatModel.builder()
+                .client(client)
+                .modelId("test-model")
+                .defaultRequestParameters(BedrockChatRequestParameters.builder()
+                        .requestMetadata(Map.of("team", "platform"))
+                        .build())
+                .build();
+
+        model.chat("hello");
+
+        ArgumentCaptor<ConverseRequest> requestCaptor = ArgumentCaptor.forClass(ConverseRequest.class);
+        verify(client).converse(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().requestMetadata()).isEqualTo(Map.of("team", "platform"));
+    }
+
+    @Test
+    void should_add_default_request_metadata_to_converse_stream_request() {
+        BedrockRuntimeAsyncClient client = asyncClient();
+        BedrockStreamingChatModel model = BedrockStreamingChatModel.builder()
+                .client(client)
+                .modelId("test-model")
+                .defaultRequestParameters(BedrockChatRequestParameters.builder()
+                        .requestMetadata(Map.of("team", "platform"))
+                        .build())
+                .build();
+
+        model.chat("hello", mock(StreamingChatResponseHandler.class));
+
+        ArgumentCaptor<ConverseStreamRequest> requestCaptor = ArgumentCaptor.forClass(ConverseStreamRequest.class);
+        verify(client).converseStream(requestCaptor.capture(), any(ConverseStreamResponseHandler.class));
+        assertThat(requestCaptor.getValue().requestMetadata()).isEqualTo(Map.of("team", "platform"));
+    }
+
+    @Test
+    void should_override_default_request_metadata_for_a_single_request() {
+        BedrockRuntimeClient client = syncClient();
+        BedrockChatModel model = BedrockChatModel.builder()
+                .client(client)
+                .modelId("test-model")
+                .defaultRequestParameters(BedrockChatRequestParameters.builder()
+                        .requestMetadata(Map.of("team", "platform"))
+                        .build())
+                .build();
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("hello"))
+                .parameters(BedrockChatRequestParameters.builder()
+                        .requestMetadata(Map.of("traceId", "abc-123"))
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        ArgumentCaptor<ConverseRequest> requestCaptor = ArgumentCaptor.forClass(ConverseRequest.class);
+        verify(client).converse(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().requestMetadata()).isEqualTo(Map.of("traceId", "abc-123"));
+    }
+
+    @Test
+    void should_not_add_request_metadata_when_not_configured() {
+        BedrockRuntimeClient client = syncClient();
+        BedrockChatModel model =
+                BedrockChatModel.builder().client(client).modelId("test-model").build();
+
+        model.chat("hello");
+
+        ArgumentCaptor<ConverseRequest> requestCaptor = ArgumentCaptor.forClass(ConverseRequest.class);
+        verify(client).converse(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().hasRequestMetadata()).isFalse();
+    }
+
+    private static BedrockRuntimeClient syncClient() {
+        BedrockRuntimeClient client = mock(BedrockRuntimeClient.class);
+        ConverseResponse response = successfulResponse();
+        when(client.converse(any(ConverseRequest.class))).thenReturn(response);
+        return client;
+    }
+
+    private static BedrockRuntimeAsyncClient asyncClient() {
+        BedrockRuntimeAsyncClient client = mock(BedrockRuntimeAsyncClient.class);
+        when(client.converseStream(any(ConverseStreamRequest.class), any(ConverseStreamResponseHandler.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        return client;
+    }
+
+    private static ConverseResponse successfulResponse() {
+        AwsResponseMetadata responseMetadata = new AwsResponseMetadata(Map.of("AWS_REQUEST_ID", "request-id")) {};
+
+        ConverseResponse.Builder builder = ConverseResponse.builder()
+                .output(ConverseOutput.fromMessage(Message.builder()
+                        .role(ConversationRole.ASSISTANT)
+                        .content(ContentBlock.fromText("ok"))
+                        .build()))
+                .stopReason(StopReason.END_TURN)
+                .usage(TokenUsage.builder()
+                        .inputTokens(1)
+                        .outputTokens(1)
+                        .totalTokens(2)
+                        .build());
+        builder.responseMetadata(responseMetadata);
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #6172

## Change
Add `requestMetadata` to `BedrockChatRequestParameters` and forward it to both Converse and ConverseStream requests.

Empty maps are not sent to Bedrock. Metadata values are also redacted from `toString()`.

Added tests for request parameters, default parameters, and the sync and streaming request paths. The Bedrock documentation now includes configuration examples and usage notes for request metadata.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [x] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for big features)
- [ ] I have added/updated Spring Boot starters (if applicable)

## Testing
- Bedrock module tests: 232 passed
- Core and main module verification: passed
- Spotless check: passed
- Docusaurus production build: passed
- GitHub Actions: all checks passed
