### PR TITLE
feat: support ToolExecutionResult returned by @Tool methods

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -1107,6 +1107,18 @@ ToolExecutor toolExecutor = (toolExecutionRequest, context) -> ToolExecutionResu
         .attributes(Map.of("widget", weatherWidget)) // not sent to the LLM
         .build();
 ```
+
+An `@Tool`-annotated method can also return a `ToolExecutionResult` directly:
+```java
+@Tool
+ToolExecutionResult getWeather(String city) {
+    return ToolExecutionResult.builder()
+            .resultText("Sunny, 22 degrees") // sent to the LLM
+            .attributes(Map.of("widget", weatherWidget)) // not sent to the LLM
+            .build();
+}
+```
+
 For [MCP](/tutorials/mcp) tools, they originate from the `_meta` field of the tool call response.
 For those, the tool provider needs to be configured with
 [`returnToolResultAttributes(true)`](/tutorials/mcp#mcp-tool-result-metadata).

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -162,6 +162,10 @@ public class DefaultToolExecutor implements ToolExecutor {
     private ToolExecutionResult execute(Object[] arguments) throws IllegalAccessException, InvocationTargetException {
         Object result = methodToInvoke.invoke(object, arguments);
 
+        if (result instanceof ToolExecutionResult toolExecutionResult) {
+            return toolExecutionResult;
+        }
+
         List<Content> resultContents = toContents(result);
         if (resultContents != null) {
             return ToolExecutionResult.builder()

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -755,6 +755,47 @@ class DefaultToolExecutorTest implements WithAssertions {
         }
     }
 
+    static class ToolReturningToolExecutionResult {
+
+        private final ToolExecutionResult result;
+
+        ToolReturningToolExecutionResult(ToolExecutionResult result) {
+            this.result = result;
+        }
+
+        @Tool("Tool that returns a ToolExecutionResult")
+        public ToolExecutionResult execute() {
+            return result;
+        }
+    }
+
+    @Test
+    void should_return_ToolExecutionResult_returned_by_tool_method() throws Exception {
+        ToolExecutionResult expected = ToolExecutionResult.builder()
+                .isError(true)
+                .result("raw result")
+                .resultTextSupplier(() -> "result for the LLM")
+                .attributes(Map.of("recordId", 42))
+                .build();
+        ToolReturningToolExecutionResult tool = new ToolReturningToolExecutionResult(expected);
+        Method method = ToolReturningToolExecutionResult.class.getMethod("execute");
+        DefaultToolExecutor executor = new DefaultToolExecutor(tool, method);
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("1")
+                .name("execute")
+                .arguments("{}")
+                .build();
+
+        ToolExecutionResult actual =
+                executor.executeWithContext(request, InvocationContext.builder().build());
+
+        assertThat(actual).isSameAs(expected);
+        assertThat(actual.resultText()).isEqualTo("result for the LLM");
+        assertThat(actual.result()).isEqualTo("raw result");
+        assertThat(actual.attributes()).containsEntry("recordId", 42);
+        assertThat(actual.isError()).isTrue();
+    }
+
     @Test
     void should_return_error_result_when_tool_execution_fails() throws Exception {
         ToolWithException tool = new ToolWithException();


### PR DESCRIPTION
## Summary

- allow `@Tool`-annotated methods to return `ToolExecutionResult` directly
- preserve result contents, raw result, attributes, error state, and lazy result suppliers
- document how annotated tool methods can attach result attributes

## Testing

- `./mvnw -pl langchain4j -Dtest=DefaultToolExecutorTest,ToolExecutionResultTest,ToolExecutionTest,ToolServiceTest test` (68 tests passed)
- Spotless check for the modified Java files

Fixes #5943