### PR TITLE
fix(mcp): fail fast when the retried request gets 404 again after session reinitialization

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -9,8 +9,8 @@ import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpHeaderEncoding;
-import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -289,6 +289,11 @@ public class StreamableHttpMcpTransport implements McpTransport {
                                             future.completeExceptionally(t);
                                             return null;
                                         });
+                            } else {
+                                // Reinitialization did not help; fail instead of leaving the caller hanging
+                                future.completeExceptionally(new RuntimeException(
+                                        "Session expired again after reinitialization: server returned status code "
+                                                + responseInfo.statusCode()));
                             }
                         } else {
                             future.completeExceptionally(
@@ -675,5 +680,4 @@ public class StreamableHttpMcpTransport implements McpTransport {
     public void executeOperationWithoutResponse(McpCallContext context) {
         sendMessage(context);
     }
-
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
@@ -1,0 +1,138 @@
+package dev.langchain4j.mcp.client.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.mcp.protocol.McpInitializeRequest;
+import dev.langchain4j.mcp.protocol.McpListToolsRequest;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers transparent reinitialization of an expired legacy-protocol session on 404: the retry is
+ * sent with the new session id, and a second 404 fails fast instead of hanging.
+ */
+class StreamableHttpMcpTransportSessionExpiryTest {
+
+    private static final String INITIALIZE_RESULT =
+            "{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"test-server\",\"version\":\"1.0\"}}}";
+    private static final String TOOLS_LIST_RESULT = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}";
+
+    private HttpServer server;
+    private StreamableHttpMcpTransport transport;
+    private final AtomicInteger sessionCounter = new AtomicInteger();
+    private final List<String> toolsListSessionIds = Collections.synchronizedList(new ArrayList<>());
+    private volatile boolean retrySucceeds;
+
+    private void startServer(boolean retrySucceeds) throws IOException {
+        this.retrySucceeds = retrySucceeds;
+        sessionCounter.set(0);
+        toolsListSessionIds.clear();
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/mcp", exchange -> {
+            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            String method = McpJson.parse(body).path("method").asText();
+            String sessionId = exchange.getRequestHeaders().getFirst("Mcp-Session-Id");
+            if ("initialize".equals(method)) {
+                exchange.getResponseHeaders().set("Mcp-Session-Id", "session-" + sessionCounter.incrementAndGet());
+                respond(exchange, 200, INITIALIZE_RESULT);
+            } else if ("notifications/initialized".equals(method)) {
+                respond(exchange, 200, "{}");
+            } else if ("tools/list".equals(method)) {
+                toolsListSessionIds.add(sessionId);
+                if (retrySucceeds && "session-2".equals(sessionId)) {
+                    respond(exchange, 200, TOOLS_LIST_RESULT);
+                } else {
+                    // simulate an expired session
+                    respond(
+                            exchange,
+                            404,
+                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"Session not found\"}}");
+                }
+            } else {
+                respond(exchange, 500, "{}");
+            }
+        });
+        server.start();
+        transport = StreamableHttpMcpTransport.builder()
+                .url("http://localhost:" + server.getAddress().getPort() + "/mcp")
+                .setHttpVersion1_1()
+                .build();
+        transport.start(new McpOperationHandler(
+                new ConcurrentHashMap<>(),
+                () -> Collections.emptyList(),
+                transport,
+                null,
+                () -> {},
+                null,
+                () -> {},
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+    }
+
+    private static void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (transport != null) {
+            transport.close();
+        }
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void shouldRetryWithTheNewSessionAfterReinitialization() throws Exception {
+        startServer(true);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        assertThat(response.get(5, TimeUnit.SECONDS)).contains("\"tools\":[]");
+        // the first attempt used the original session, the retry used the reinitialized one
+        assertThat(toolsListSessionIds).containsExactly("session-1", "session-2");
+    }
+
+    @Test
+    void shouldFailFastWhenTheRetriedRequestIsRejectedWith404Again() throws Exception {
+        startServer(false);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        // before the fix this future stayed pending forever; now it must fail fast
+        assertThatThrownBy(() -> response.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("after reinitialization");
+        assertThat(toolsListSessionIds).containsExactly("session-1", "session-2");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6191

## Change

In the legacy protocol, `StreamableHttpMcpTransport#execute` reinitializes the session and retries a request when the server answers 404. The retried request could also get 404, and in that case the pending future was never completed, so the caller waited for its timeout (or forever, with none configured).

The retry now completes the future exceptionally with:

    Session expired again after reinitialization: server returned status code 404

Added `StreamableHttpMcpTransportSessionExpiryTest` with a local `HttpServer` that reproduces the sequence: initialize -> 404 -> reinitialize -> retry. Two cases:

- the retry succeeds and is sent with the new session id;
- the retry gets 404 again and fails fast. Before this change the second case hung until the test timeout.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)