### PR TITLE
fix: load HTTP client factories from owning module

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilderLoader.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilderLoader.java
@@ -1,23 +1,28 @@
 package dev.langchain4j.http.client;
 
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
-
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class HttpClientBuilderLoader {
 
     public static HttpClientBuilder loadHttpClientBuilder() {
+        return loadHttpClientBuilder(loadFactories());
+    }
+
+    static HttpClientBuilder loadHttpClientBuilder(Collection<HttpClientBuilderFactory> factories) {
         String selectedClassName = System.getProperty("langchain4j.http.clientBuilderFactory");
 
         HttpClientBuilderFactory effectiveFactory = null;
-        Collection<HttpClientBuilderFactory> factories = loadFactories(HttpClientBuilderFactory.class);
         for (HttpClientBuilderFactory factory : factories) {
             if (effectiveFactory != null) {
                 throw new IllegalStateException(String.format(
-                        "Conflict: multiple HTTP clients have been found "
-                                + "in the classpath: %s. Please explicitly specify the one you wish to use using the `langchain4j.http.clientBuilderFactory` system property.",
+                        "Conflict: multiple HTTP clients have been found in the classpath: %s. Please explicitly"
+                                + " specify the one you wish to use using the `langchain4j.http.clientBuilderFactory`"
+                                + " system property.",
                         factoryNames(factories)));
             } else {
                 if (selectedClassName == null) {
@@ -36,12 +41,30 @@ public class HttpClientBuilderLoader {
                 throw new IllegalStateException("No HTTP client has been found in the classpath");
             } else {
                 throw new IllegalStateException(String.format(
-                        "The value of the `langchain4j.http.clientBuilderFactory` system property does not match any of the available HTTP Clients in the classpath: %s.",
+                        "The value of the `langchain4j.http.clientBuilderFactory` system property does not match any"
+                                + " of the available HTTP Clients in the classpath: %s.",
                         factoryNames(factories)));
             }
         }
 
         return effectiveFactory.create();
+    }
+
+    private static Collection<HttpClientBuilderFactory> loadFactories() {
+        // ServiceLoader validates that its caller module declares `uses HttpClientBuilderFactory`.
+        // Keep these calls in this module instead of delegating them to a generic helper in langchain4j-core.
+        List<HttpClientBuilderFactory> factories = loadAll(ServiceLoader.load(HttpClientBuilderFactory.class));
+        if (factories.isEmpty()) {
+            factories = loadAll(
+                    ServiceLoader.load(HttpClientBuilderFactory.class, HttpClientBuilderLoader.class.getClassLoader()));
+        }
+        return factories;
+    }
+
+    private static List<HttpClientBuilderFactory> loadAll(ServiceLoader<HttpClientBuilderFactory> loader) {
+        List<HttpClientBuilderFactory> factories = new ArrayList<>();
+        loader.iterator().forEachRemaining(factories::add);
+        return factories;
     }
 
     private static Set<String> factoryNames(Collection<HttpClientBuilderFactory> factories) {

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientBuilderLoaderTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientBuilderLoaderTest.java
@@ -3,17 +3,140 @@ package dev.langchain4j.http.client;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import dev.langchain4j.Internal;
 import dev.langchain4j.spi.ServiceHelper;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.module.Configuration;
+import java.lang.module.ModuleFinder;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import javax.tools.ToolProvider;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.io.TempDir;
 
 class HttpClientBuilderLoaderTest {
+
+    @Test
+    void loadsFactoryFromNamedModule(@TempDir Path tempDir) throws Exception {
+        Path coreModule = Files.createDirectory(tempDir.resolve("langchain4j-core"));
+        // Include ServiceHelper so this test fails if service loading is delegated back to langchain4j-core.
+        copyClass(Internal.class, coreModule);
+        copyClass(ServiceHelper.class, coreModule);
+        Path coreModuleInfo = writeSource(coreModule, "module-info.java", """
+            module langchain4j.core {
+                exports dev.langchain4j.spi;
+            }
+            """);
+        compile(
+                "-d",
+                coreModule.toString(),
+                "--patch-module",
+                "langchain4j.core=" + coreModule,
+                coreModuleInfo.toString());
+
+        Path httpClientModule = Files.createDirectory(tempDir.resolve("langchain4j-http-client"));
+        copyClass(HttpClient.class, httpClientModule);
+        copyClass(HttpClientBuilder.class, httpClientModule);
+        copyClass(HttpClientBuilderFactory.class, httpClientModule);
+        copyClass(HttpClientBuilderLoader.class, httpClientModule);
+        Path httpClientModuleInfo = writeSource(httpClientModule, "module-info.java", """
+            module langchain4j.http.client {
+                requires langchain4j.core;
+                exports dev.langchain4j.http.client;
+                uses dev.langchain4j.http.client.HttpClientBuilderFactory;
+            }
+            """);
+        compile(
+                "-d",
+                httpClientModule.toString(),
+                "--module-path",
+                coreModule.toString(),
+                "--patch-module",
+                "langchain4j.http.client=" + httpClientModule,
+                httpClientModuleInfo.toString());
+
+        Path providerSources = Files.createDirectory(tempDir.resolve("provider-sources"));
+        Path providerModuleInfo = writeSource(providerSources, "module-info.java", """
+            module test.http.client.provider {
+                requires langchain4j.http.client;
+                provides dev.langchain4j.http.client.HttpClientBuilderFactory
+                        with test.http.client.provider.TestHttpClientBuilderFactory;
+            }
+            """);
+        Path providerSource =
+                writeSource(providerSources, "test/http/client/provider/TestHttpClientBuilderFactory.java", """
+                    package test.http.client.provider;
+
+                    import dev.langchain4j.http.client.HttpClient;
+                    import dev.langchain4j.http.client.HttpClientBuilder;
+                    import dev.langchain4j.http.client.HttpClientBuilderFactory;
+                    import java.time.Duration;
+
+                    public class TestHttpClientBuilderFactory implements HttpClientBuilderFactory {
+                        @Override
+                        public HttpClientBuilder create() {
+                            return new TestHttpClientBuilder();
+                        }
+
+                        public static class TestHttpClientBuilder implements HttpClientBuilder {
+                            @Override
+                            public Duration connectTimeout() {
+                                return null;
+                            }
+
+                            @Override
+                            public HttpClientBuilder connectTimeout(Duration timeout) {
+                                return this;
+                            }
+
+                            @Override
+                            public Duration readTimeout() {
+                                return null;
+                            }
+
+                            @Override
+                            public HttpClientBuilder readTimeout(Duration timeout) {
+                                return this;
+                            }
+
+                            @Override
+                            public HttpClient build() {
+                                return null;
+                            }
+                        }
+                    }
+                    """);
+        Path providerModule = Files.createDirectory(tempDir.resolve("provider"));
+        compile(
+                "-d",
+                providerModule.toString(),
+                "--module-path",
+                modulePath(coreModule, httpClientModule),
+                providerModuleInfo.toString(),
+                providerSource.toString());
+
+        ModuleFinder finder = ModuleFinder.of(coreModule, httpClientModule, providerModule);
+        Configuration configuration = ModuleLayer.boot()
+                .configuration()
+                .resolveAndBind(finder, ModuleFinder.of(), Set.of("langchain4j.http.client"));
+        ModuleLayer layer =
+                ModuleLayer.boot().defineModulesWithOneLoader(configuration, ClassLoader.getPlatformClassLoader());
+        Class<?> loaderClass =
+                layer.findLoader("langchain4j.http.client").loadClass(HttpClientBuilderLoader.class.getName());
+        Method loadHttpClientBuilder = loaderClass.getMethod("loadHttpClientBuilder");
+
+        assertThat(loadHttpClientBuilder.invoke(null).getClass().getName())
+                .isEqualTo("test.http.client.provider.TestHttpClientBuilderFactory$TestHttpClientBuilder");
+    }
 
     @Test
     void noFactories() {
@@ -28,14 +151,9 @@ class HttpClientBuilderLoaderTest {
     }
 
     private void doNoFactories() {
-        try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
-            mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
-                    .thenReturn(Collections.emptyList());
-
-            assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("No HTTP client");
-        }
+        assertThatThrownBy(() -> HttpClientBuilderLoader.loadHttpClientBuilder(Collections.emptyList()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No HTTP client");
     }
 
     @Test
@@ -52,53 +170,35 @@ class HttpClientBuilderLoaderTest {
     }
 
     private void doSingleFactory() {
-        try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
-            mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
-                    .thenReturn(List.of(MockHttpClientBuilder.MockClientFactory.of()));
-
-            assertThat(HttpClientBuilderLoader.loadHttpClientBuilder()).isInstanceOf(MockHttpClientBuilder.class);
-        }
+        assertThat(HttpClientBuilderLoader.loadHttpClientBuilder(List.of(MockHttpClientBuilder.MockClientFactory.of())))
+                .isInstanceOf(MockHttpClientBuilder.class);
     }
 
     @Test
     void singleFactoryNonMatchingProperty() {
         try (var ignored = ResettableSystemProperties.of("langchain4j.http.clientBuilderFactory", "whatever")) {
-            try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
-                mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
-                        .thenReturn(List.of(MockHttpClientBuilder.MockClientFactory.of()));
-
-                assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("does not match any of the available HTTP Clients");
-            }
+            assertThatThrownBy(() -> HttpClientBuilderLoader.loadHttpClientBuilder(
+                            List.of(MockHttpClientBuilder.MockClientFactory.of())))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not match any of the available HTTP Clients");
         }
     }
 
     @Test
     void multipleFactories() {
-        try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
-            mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
-                    .thenReturn(
-                            List.of(MockHttpClientBuilder.MockClientFactory.of(), TestHttpClientBuilderFactory.of()));
-
-            assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("multiple HTTP clients");
-        }
+        assertThatThrownBy(() -> HttpClientBuilderLoader.loadHttpClientBuilder(
+                        List.of(MockHttpClientBuilder.MockClientFactory.of(), TestHttpClientBuilderFactory.of())))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("multiple HTTP clients");
     }
 
     @Test
     void multipleFactoriesNonMatchingProperty() {
         try (var ignored = ResettableSystemProperties.of("langchain4j.http.clientBuilderFactory", "whatever")) {
-            try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
-                mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
-                        .thenReturn(List.of(
-                                MockHttpClientBuilder.MockClientFactory.of(), TestHttpClientBuilderFactory.of()));
-
-                assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("does not match any of the available HTTP Clients");
-            }
+            assertThatThrownBy(() -> HttpClientBuilderLoader.loadHttpClientBuilder(
+                            List.of(MockHttpClientBuilder.MockClientFactory.of(), TestHttpClientBuilderFactory.of())))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not match any of the available HTTP Clients");
         }
     }
 
@@ -106,15 +206,11 @@ class HttpClientBuilderLoaderTest {
     void multipleFactoriesMatchingProperty() {
         try (var ignored = ResettableSystemProperties.of(
                 "langchain4j.http.clientBuilderFactory", MockHttpClientBuilder.MockClientFactory.class.getName())) {
-            try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
-                mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
-                        .thenReturn(List.of(
-                                TestHttpClientBuilderFactory.of(),
-                                MockHttpClientBuilder.MockClientFactory.of(),
-                                TestHttpClientBuilderFactory.of()));
-
-                assertThat(HttpClientBuilderLoader.loadHttpClientBuilder()).isInstanceOf(MockHttpClientBuilder.class);
-            }
+            assertThat(HttpClientBuilderLoader.loadHttpClientBuilder(List.of(
+                            TestHttpClientBuilderFactory.of(),
+                            MockHttpClientBuilder.MockClientFactory.of(),
+                            TestHttpClientBuilderFactory.of())))
+                    .isInstanceOf(MockHttpClientBuilder.class);
         }
     }
 
@@ -166,5 +262,31 @@ class HttpClientBuilderLoaderTest {
         public HttpClientBuilder create() {
             throw new IllegalStateException("should never be called");
         }
+    }
+
+    private static void copyClass(Class<?> type, Path moduleDirectory) throws IOException {
+        String resourceName = type.getName().replace('.', '/') + ".class";
+        Path target = moduleDirectory.resolve(resourceName);
+        Files.createDirectories(target.getParent());
+        try (InputStream source = type.getClassLoader().getResourceAsStream(resourceName)) {
+            Files.copy(Objects.requireNonNull(source), target);
+        }
+    }
+
+    private static Path writeSource(Path directory, String relativePath, String source) throws IOException {
+        Path path = directory.resolve(relativePath);
+        Files.createDirectories(path.getParent());
+        return Files.writeString(path, source);
+    }
+
+    private static void compile(String... arguments) {
+        int exitCode = ToolProvider.getSystemJavaCompiler().run(null, null, null, arguments);
+        assertThat(exitCode).isZero();
+    }
+
+    private static String modulePath(Path... modules) {
+        return String.join(
+                File.pathSeparator,
+                java.util.Arrays.stream(modules).map(Path::toString).toList());
     }
 }


### PR DESCRIPTION
## Issue

Closes #3668

## Change

- Load `HttpClientBuilderFactory` implementations directly from `langchain4j-http-client`, so JPMS validates the `uses` declaration against the module that owns and consumes the SPI instead of `langchain4j-core`.
- Preserve the existing context-class-loader fallback behavior and add a deterministic named-module regression test with a separate provider module.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (not applicable: internal service-loading bug fix)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (not applicable: bug fix)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (not applicable)

## Checklist for adding new maven module

- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml` (not applicable)

## Checklist for adding new embedding store integration

- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT` (not applicable)
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT` (not applicable)

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j (not applicable)

## Verification

- `./mvnw -pl langchain4j-http-client verify`
- 116 unit tests passed; no integration tests are defined for this module
- API compatibility check passed
- Palantir Java Format check passed
