### PR TITLE
fix: Reject unsupported message and content types in the Responses API converter

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -578,7 +578,9 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
 
             return List.of(ResponseInputItem.ofFunctionCallOutput(outputBuilder.build()));
         } else {
-            return List.of(createTextMessage(EasyInputMessage.Role.USER, msg.toString()));
+            throw new UnsupportedFeatureException(
+                    "Unsupported message type: " + msg.getClass().getName()
+                            + ". Only SystemMessage, UserMessage, AiMessage, and ToolExecutionResultMessage are supported.");
         }
     }
 
@@ -630,6 +632,10 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                     throw new IllegalArgumentException("PDF must have either url or base64Data");
                 }
                 contentList.add(ResponseInputContent.ofInputFile(pdfInput.build()));
+            } else {
+                throw new UnsupportedFeatureException("Unsupported content type: "
+                        + content.getClass().getName()
+                        + ". Only TextContent, ImageContent, and PdfFileContent are supported.");
             }
         }
 

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModelTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModelTest.java
@@ -14,15 +14,26 @@ import com.openai.core.http.HttpRequest;
 import com.openai.core.http.HttpResponse;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCompletedEvent;
+import com.openai.models.responses.ResponseCreateParams.Input;
 import com.openai.models.responses.ResponseIncompleteEvent;
+import com.openai.models.responses.ResponseInputContent;
 import com.openai.models.responses.ResponseStreamEvent;
 import com.openai.models.responses.ResponseWebSearchCallInProgressEvent;
 import com.openai.models.responses.Tool;
 import com.openai.models.responses.ToolSearchTool;
 import com.openai.models.responses.WebSearchTool;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.CustomMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.VideoContent;
+import dev.langchain4j.data.pdf.PdfFile;
 import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -35,11 +46,17 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class OpenAiOfficialResponsesStreamingChatModelTest {
+
+    private static final OpenAiOfficialResponsesChatRequestParameters PARAMETERS =
+            OpenAiOfficialResponsesChatRequestParameters.builder()
+                    .modelName("gpt-5.4-mini")
+                    .build();
 
     @Test
     void should_store_server_tools_in_streaming_default_request_parameters() {
@@ -332,6 +349,112 @@ class OpenAiOfficialResponsesStreamingChatModelTest {
         assertThatThrownBy(() -> model.chat("Hello"))
                 .isInstanceOf(ContentFilteredException.class)
                 .hasMessage("I cannot help with that request.");
+    }
+
+    @Test
+    void should_throw_from_chat_when_message_type_is_not_supported() {
+        OpenAiOfficialResponsesChatModel model = OpenAiOfficialResponsesChatModel.builder()
+                .client(new OpenAIClientImpl(ClientOptions.builder()
+                        .apiKey("test-key")
+                        .httpClient(new CannedJsonHttpClient("{}"))
+                        .build()))
+                .modelName("gpt-5.4-mini")
+                .build();
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(CustomMessage.from(Map.of("role", "developer", "content", "internal note")))
+                .build();
+
+        assertThatThrownBy(() -> model.chat(chatRequest))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage(
+                        "Unsupported message type: dev.langchain4j.data.message.CustomMessage"
+                                + ". Only SystemMessage, UserMessage, AiMessage, and ToolExecutionResultMessage are supported.");
+    }
+
+    @Test
+    void should_map_text_image_and_pdf_user_content_to_responses_input() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from(
+                        TextContent.from("What is in these?"),
+                        ImageContent.from("QUJD", "image/png"),
+                        PdfFileContent.from(PdfFile.builder()
+                                .base64Data("QUJD")
+                                .mimeType("application/pdf")
+                                .build())))
+                .parameters(PARAMETERS)
+                .build();
+
+        var requestParams = OpenAiOfficialResponsesStreamingChatModel.buildRequestParams(chatRequest, PARAMETERS);
+
+        assertThat(requestParams.input().map(Input::asResponse)).hasValueSatisfying(items -> {
+            assertThat(items).hasSize(1);
+            List<ResponseInputContent> contents =
+                    items.get(0).asEasyInputMessage().content().asResponseInputMessageContentList();
+            assertThat(contents).hasSize(3);
+            assertThat(contents.get(0).isInputText()).isTrue();
+            assertThat(contents.get(1).isInputImage()).isTrue();
+            assertThat(contents.get(2).isInputFile()).isTrue();
+        });
+    }
+
+    @Test
+    void should_throw_when_message_type_is_not_supported() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(CustomMessage.from(Map.of("role", "developer", "content", "internal note")))
+                .parameters(PARAMETERS)
+                .build();
+
+        assertThatThrownBy(() -> OpenAiOfficialResponsesStreamingChatModel.buildRequestParams(chatRequest, PARAMETERS))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage(
+                        "Unsupported message type: dev.langchain4j.data.message.CustomMessage"
+                                + ". Only SystemMessage, UserMessage, AiMessage, and ToolExecutionResultMessage are supported.");
+    }
+
+    @Test
+    void should_throw_when_content_type_is_not_supported() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from(AudioContent.from(
+                        Audio.builder().base64Data("AAAA").mimeType("audio/mp3").build())))
+                .parameters(PARAMETERS)
+                .build();
+
+        assertThatThrownBy(() -> OpenAiOfficialResponsesStreamingChatModel.buildRequestParams(chatRequest, PARAMETERS))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage("Unsupported content type: dev.langchain4j.data.message.AudioContent"
+                        + ". Only TextContent, ImageContent, and PdfFileContent are supported.");
+    }
+
+    @Test
+    void should_throw_when_video_content_is_not_supported() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from(VideoContent.from("QUJD", "video/mp4")))
+                .parameters(PARAMETERS)
+                .build();
+
+        assertThatThrownBy(() -> OpenAiOfficialResponsesStreamingChatModel.buildRequestParams(chatRequest, PARAMETERS))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage("Unsupported content type: dev.langchain4j.data.message.VideoContent"
+                        + ". Only TextContent, ImageContent, and PdfFileContent are supported.");
+    }
+
+    @Test
+    void should_throw_when_user_message_mixes_supported_and_unsupported_content() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from(
+                        TextContent.from("Transcribe this"),
+                        AudioContent.from(Audio.builder()
+                                .base64Data("AAAA")
+                                .mimeType("audio/mp3")
+                                .build())))
+                .parameters(PARAMETERS)
+                .build();
+
+        assertThatThrownBy(() -> OpenAiOfficialResponsesStreamingChatModel.buildRequestParams(chatRequest, PARAMETERS))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage("Unsupported content type: dev.langchain4j.data.message.AudioContent"
+                        + ". Only TextContent, ImageContent, and PdfFileContent are supported.");
     }
 
     private static class CannedJsonHttpClient implements HttpClient {


### PR DESCRIPTION

## Issue

Closes #6195

## Change

The Responses API converter in `langchain4j-open-ai-official` accepted input it does not support and
changed its meaning instead of reporting it.

`toResponseInputItems` ended in a fallback that built a user message from `msg.toString()`, so a
`CustomMessage` reached the model as a prompt containing its debug representation. `createUserMessage`
looped over `TextContent`, `ImageContent` and `PdfFileContent` with no final branch, so `AudioContent`
and `VideoContent` were skipped: a text-plus-audio message was sent as text only, and an audio-only
message was sent with an empty content list. Both calls succeeded, so the application could not tell
the model had received something other than what it was given.

```
                                     before                              after
CustomMessage                        user message with its toString()    UnsupportedFeatureException
UserMessage(text + audio)            text only, audio dropped            UnsupportedFeatureException
UserMessage(audio)                   empty content list                  UnsupportedFeatureException
```

Both throw `UnsupportedFeatureException`, which is what the `ToolExecutionResultMessage` branch of that
same method already does for unsupported content, and what `toResponsesMessages` in `langchain4j-open-ai`
does for both cases. The message wording follows that converter so the two implementations of the same
API report the same thing.

The sweep covers the whole surface. `OpenAiOfficialResponsesChatModel` calls the same
`buildRequestParams`, so the sync and streaming models are both fixed here. No other production file in
the repository falls back to `toString()` for an unmapped message, and every other provider request
mapper already ends its content branch by throwing, so this was the only converter still accepting input
it cannot represent. The other mappers in this class, `toResponsesUserImageDetail` and
`toResponsesImageDetail`, already reject what they cannot map.

Supporting `AudioContent` and `VideoContent` is a separate change in both implementations; this one only
stops the input being silently altered.

### Tests

`OpenAiOfficialResponsesStreamingChatModelTest`, 6 added. Five prove rejection: an unsupported message
type, each of the two unsupported content types core defines, a message mixing supported and unsupported
content, and the same over the public `chat` method so the exception reaches the caller and not only the
converter. The sixth proves the three supported content types still map to the expected input parts, since
that loop had no offline coverage before; it passes on `main` as well.

The 5 rejection tests fail on unmodified `main`. Reverting each production change on its own separates
them: without the message-type branch the 2 message tests fail, without the content-type branch the 3
content tests do.

```
$ mvn -pl langchain4j-open-ai-official test
Tests run: 34, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-core test
Tests run: 1273, Failures: 0, Errors: 0, Skipped: 3

$ mvn -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-open-ai-official revapi:check
[INFO] API checks completed without failures.
```

No integration test was added or run: both paths fail before any HTTP call, so a live key would not
exercise anything the offline tests do not.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
