### PR TITLE
fix: Detect the model provider in the Responses chat models

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesChatModel.java
@@ -16,6 +16,7 @@ import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStream
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.extractToolExecutionRequests;
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.mapStatusToFinishReason;
 import static dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel.validate;
+import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.detectModelProvider;
 import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
 import static java.util.Arrays.asList;
 
@@ -58,6 +59,7 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
     private final OpenAIClient client;
     private final OpenAiOfficialResponsesChatRequestParameters defaultRequestParameters;
     private final List<ChatModelListener> listeners;
+    private final ModelProvider modelProvider;
 
     private OpenAiOfficialResponsesChatModel(Builder builder) {
         this.client = builder.client != null
@@ -119,6 +121,12 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
                 .build();
 
         this.listeners = copy(builder.listeners);
+        this.modelProvider = detectModelProvider(
+                builder.isMicrosoftFoundry,
+                builder.isGitHubModels,
+                builder.baseUrl,
+                builder.microsoftFoundryDeploymentName,
+                builder.azureOpenAIServiceVersion);
     }
 
     public static Builder builder() {
@@ -176,7 +184,7 @@ public class OpenAiOfficialResponsesChatModel implements ChatModel {
 
     @Override
     public ModelProvider provider() {
-        return ModelProvider.OPEN_AI;
+        return modelProvider;
     }
 
     @Override

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -10,6 +10,7 @@ import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.detectModelProvider;
 import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
 import static java.util.Arrays.asList;
 
@@ -127,6 +128,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
     private final ExecutorService executorService;
     private final OpenAiOfficialResponsesChatRequestParameters defaultRequestParameters;
     private final List<ChatModelListener> listeners;
+    private final ModelProvider modelProvider;
 
     private OpenAiOfficialResponsesStreamingChatModel(Builder builder) {
         this.client = builder.client != null
@@ -192,6 +194,12 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 .build();
 
         this.listeners = copy(builder.listeners);
+        this.modelProvider = detectModelProvider(
+                builder.isMicrosoftFoundry,
+                builder.isGitHubModels,
+                builder.baseUrl,
+                builder.microsoftFoundryDeploymentName,
+                builder.azureOpenAIServiceVersion);
     }
 
     public static Builder builder() {
@@ -259,7 +267,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
 
     @Override
     public ModelProvider provider() {
-        return ModelProvider.OPEN_AI;
+        return modelProvider;
     }
 
     @Override

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBringYourOwnClientTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialBringYourOwnClientTest.java
@@ -39,4 +39,30 @@ class OpenAiOfficialBringYourOwnClientTest {
         assertThat(model.provider()).isEqualTo(ModelProvider.OPEN_AI);
         assertThat(model.supportedCapabilities()).isNotNull();
     }
+
+    @Test
+    void should_detect_provider_when_responses_chat_model_is_configured_for_github_models() {
+        OpenAIClient openAIClient = Mockito.mock(OpenAIClient.class);
+
+        OpenAiOfficialResponsesChatModel model = OpenAiOfficialResponsesChatModel.builder()
+                .client(openAIClient)
+                .isGitHubModels(true)
+                .modelName("gpt-4o-mini")
+                .build();
+
+        assertThat(model.provider()).isEqualTo(ModelProvider.GITHUB_MODELS);
+    }
+
+    @Test
+    void should_detect_provider_when_responses_streaming_chat_model_is_configured_for_microsoft_foundry() {
+        OpenAIClient openAIClient = Mockito.mock(OpenAIClient.class);
+
+        OpenAiOfficialResponsesStreamingChatModel model = OpenAiOfficialResponsesStreamingChatModel.builder()
+                .client(openAIClient)
+                .isMicrosoftFoundry(true)
+                .modelName("gpt-4o-mini")
+                .build();
+
+        assertThat(model.provider()).isEqualTo(ModelProvider.MICROSOFT_FOUNDRY);
+    }
 }


### PR DESCRIPTION
## Issue

Closes #6200

## Change

`OpenAiOfficialResponsesChatModel` and `OpenAiOfficialResponsesStreamingChatModel` returned
`ModelProvider.OPEN_AI` from `provider()` unconditionally, although both builders accept
`isMicrosoftFoundry`, `isGitHubModels`, `baseUrl`, `microsoftFoundryDeploymentName` and
`azureOpenAIServiceVersion` and pass all five to `setupSyncClient`. A model configured for
Microsoft Foundry or GitHub Models therefore reported itself as OpenAI to `ChatModelListener` and
to anything derived from it.

Both now resolve the provider with `detectModelProvider(...)` in the constructor, the same call
`OpenAiOfficialBaseChatModel.java:154` already makes. These two were the only chat models in the
module not doing so.

### Tests

Two tests added to `OpenAiOfficialBringYourOwnClientTest`, which already asserted `provider()` for the
non-Responses models. One per changed class. Both fail on unmodified `main`, and reverting each production
change on its own separates them; the existing OpenAI assertions there are untouched and pass either way.

```
$ mvn -pl langchain4j-open-ai-official test
Tests run: 36, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-open-ai-official test   # OpenAiOfficialResponsesChatModel reverted
Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
expected: GITHUB_MODELS
 but was: OPEN_AI

$ mvn -pl langchain4j-open-ai-official test   # OpenAiOfficialResponsesStreamingChatModel reverted
Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
expected: MICROSOFT_FOUNDRY
 but was: OPEN_AI

$ mvn -pl langchain4j-core test
Tests run: 1273, Failures: 0, Errors: 0, Skipped: 3

$ mvn -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0

$ mvn -pl langchain4j-open-ai-official revapi:check
[INFO] API checks completed without failures.
```

The module's live Foundry and GitHub Models ITs were not run; they need credentials I do not have.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)