### PR TITLE
feat(google-genai): expose thoughts and cached content token counts

### DIFF
--- a/docs/docs/integrations/language-models/google-genai.md
+++ b/docs/docs/integrations/language-models/google-genai.md
@@ -30,6 +30,7 @@ https://github.com/googleapis/java-genai
 - [File API](#file-api)
 - [Cached Content Support](#cached-content-support)
 - [Thinking Models (Gemini 3.0+)](#thinking-models-gemini-30)
+- [Token Usage](#token-usage)
 - [Multimodality (Audio, Video, PDF)](#multimodality-audio-video-pdf)
 - [Token Count Estimator](#token-count-estimator)
 - [Model Catalog](#model-catalog)
@@ -474,6 +475,23 @@ preserved, regardless of this setting.
 > [!NOTE]
 > `returnThinking` is disabled by default. Thought summaries returned by the model are then discarded and
 > never appear in `AiMessage.text()`.
+
+## Token Usage
+
+Responses carry a `GoogleGenAiTokenUsage`, which adds the token counts Gemini reports for thinking, cached
+content and tool results to the standard input, output and total counts:
+
+```java
+GoogleGenAiTokenUsage tokenUsage = (GoogleGenAiTokenUsage) response.metadata().tokenUsage();
+
+Integer thoughtsTokenCount = tokenUsage.thoughtsTokenCount();
+Integer cachedContentTokenCount = tokenUsage.cachedContentTokenCount();
+Integer toolUsePromptTokenCount = tokenUsage.toolUsePromptTokenCount();
+```
+
+Each is `null` when the model does not report it. `cachedContentTokenCount` is a subset of
+`inputTokenCount()`, whereas `toolUsePromptTokenCount` and `thoughtsTokenCount` are counted on top of it:
+Gemini defines the total as `inputTokenCount + outputTokenCount + toolUsePromptTokenCount + thoughtsTokenCount`.
 
 ## GoogleGenAiEmbeddingModel
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
@@ -31,7 +31,6 @@ import dev.langchain4j.data.video.Video;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.FinishReason;
-import dev.langchain4j.model.output.TokenUsage;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -232,15 +231,45 @@ class GoogleGenAiContentMapper {
         return toChatResponse(response, modelName, false);
     }
 
+    private static GoogleGenAiTokenUsage toTokenUsage(GenerateContentResponse response) {
+        return response.usageMetadata()
+                .map(meta -> {
+                    int promptTokenCount = meta.promptTokenCount().orElse(0);
+                    int candidatesTokenCount = meta.candidatesTokenCount().orElse(0);
+                    Integer toolUsePromptTokenCount =
+                            meta.toolUsePromptTokenCount().orElse(null);
+                    Integer thoughtsTokenCount = meta.thoughtsTokenCount().orElse(null);
+                    return GoogleGenAiTokenUsage.builder()
+                            .inputTokenCount(promptTokenCount)
+                            .outputTokenCount(candidatesTokenCount)
+                            .totalTokenCount(meta.totalTokenCount()
+                                    .orElse(promptTokenCount
+                                            + candidatesTokenCount
+                                            + getOrDefault(toolUsePromptTokenCount, 0)
+                                            + getOrDefault(thoughtsTokenCount, 0)))
+                            .cachedContentTokenCount(
+                                    meta.cachedContentTokenCount().orElse(null))
+                            .thoughtsTokenCount(thoughtsTokenCount)
+                            .toolUsePromptTokenCount(toolUsePromptTokenCount)
+                            .build();
+                })
+                .orElse(GoogleGenAiTokenUsage.builder()
+                        .inputTokenCount(0)
+                        .outputTokenCount(0)
+                        .totalTokenCount(0)
+                        .build());
+    }
+
     static ChatResponse toChatResponse(GenerateContentResponse response, String modelName, boolean returnThinking) {
         List<Candidate> candidates = response.candidates().orElse(List.of());
+        GoogleGenAiTokenUsage usage = toTokenUsage(response);
 
         if (candidates.isEmpty()) {
             return ChatResponse.builder()
                     .aiMessage(AiMessage.from("Empty response"))
                     .metadata(GoogleGenAiChatResponseMetadata.builder()
                             .modelName(modelName)
-                            .tokenUsage(new TokenUsage(0, 0))
+                            .tokenUsage(usage)
                             .finishReason(FinishReason.OTHER)
                             .build())
                     .build();
@@ -315,21 +344,6 @@ class GoogleGenAiContentMapper {
             aiMessageBuilder.attributes(attributes);
         }
         AiMessage aiMessage = aiMessageBuilder.build();
-
-        TokenUsage usage = response.usageMetadata()
-                .map(meta -> {
-                    int promptTokenCount = meta.promptTokenCount().isPresent()
-                            ? meta.promptTokenCount().get()
-                            : 0;
-                    int candidatesTokenCount = meta.candidatesTokenCount().isPresent()
-                            ? meta.candidatesTokenCount().get()
-                            : 0;
-                    int totalTokenCount = meta.totalTokenCount().isPresent()
-                            ? meta.totalTokenCount().get()
-                            : promptTokenCount + candidatesTokenCount;
-                    return new TokenUsage(promptTokenCount, candidatesTokenCount, totalTokenCount);
-                })
-                .orElse(new TokenUsage(0, 0));
 
         FinishReason finishReason = !toolRequests.isEmpty()
                 ? FinishReason.TOOL_EXECUTION

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
@@ -173,7 +173,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                 StringBuilder thinkingBuilder = new StringBuilder();
                 List<ToolExecutionRequest> toolRequests = new ArrayList<>();
                 Map<String, Object> attributes = new java.util.HashMap<>();
-                TokenUsage tokenUsage = new TokenUsage();
+                TokenUsage tokenUsage = GoogleGenAiTokenUsage.builder().build();
                 FinishReason finishReason = null;
                 GenerateContentResponse lastChunk = null;
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiTokenUsage.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiTokenUsage.java
@@ -1,0 +1,186 @@
+package dev.langchain4j.model.google.genai;
+
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.Objects;
+
+/**
+ * Google GenAI-specific {@link TokenUsage} that additionally exposes the token counts
+ * reported by Gemini for cached content, for thinking and for tool results fed back to the model.
+ * <p>
+ * {@link #cachedContentTokenCount()} is a subset of {@link #inputTokenCount()}, whereas
+ * {@link #toolUsePromptTokenCount()} and {@link #thoughtsTokenCount()} are counted on top of it:
+ * Gemini defines the total as input + output + tool use prompt + thoughts. None of the three can be
+ * derived from the inherited counts. See
+ * <a href="https://ai.google.dev/gemini-api/docs/generate-content/thinking">thinking</a> and
+ * <a href="https://ai.google.dev/gemini-api/docs/caching">context caching</a>.
+ * <p>
+ * Instances are returned as the {@code tokenUsage} of {@link GoogleGenAiChatResponseMetadata}:
+ * <pre>{@code
+ * GoogleGenAiTokenUsage tokenUsage = (GoogleGenAiTokenUsage) chatResponse.metadata().tokenUsage();
+ * Integer thoughtsTokenCount = tokenUsage.thoughtsTokenCount();
+ * }</pre>
+ */
+public class GoogleGenAiTokenUsage extends TokenUsage {
+
+    private final Integer cachedContentTokenCount;
+    private final Integer thoughtsTokenCount;
+    private final Integer toolUsePromptTokenCount;
+
+    private GoogleGenAiTokenUsage(Builder builder) {
+        super(builder.inputTokenCount, builder.outputTokenCount, builder.totalTokenCount);
+        this.cachedContentTokenCount = builder.cachedContentTokenCount;
+        this.thoughtsTokenCount = builder.thoughtsTokenCount;
+        this.toolUsePromptTokenCount = builder.toolUsePromptTokenCount;
+    }
+
+    /**
+     * Returns the number of tokens read from the cached content, or {@code null} if the model
+     * did not report it. These tokens are already included in {@link #inputTokenCount()}.
+     *
+     * @return the cached content token count
+     */
+    public Integer cachedContentTokenCount() {
+        return cachedContentTokenCount;
+    }
+
+    /**
+     * Returns the number of tokens the model generated while thinking, or {@code null} if the model
+     * did not report it. These tokens are generated and billed in addition to
+     * {@link #outputTokenCount()}.
+     *
+     * @return the thoughts token count
+     */
+    public Integer thoughtsTokenCount() {
+        return thoughtsTokenCount;
+    }
+
+    /**
+     * Returns the number of tokens in the tool results that were fed back to the model as input,
+     * or {@code null} if the model did not report it. These tokens are <b>not</b> included in
+     * {@link #inputTokenCount()}; Gemini reports them as a separate part of the total.
+     *
+     * @return the tool use prompt token count
+     */
+    public Integer toolUsePromptTokenCount() {
+        return toolUsePromptTokenCount;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The cached content, thoughts and tool use prompt token counts are summed only when
+     * {@code that} is a {@code GoogleGenAiTokenUsage} as well; otherwise the counts of this
+     * instance are kept.
+     */
+    @Override
+    public GoogleGenAiTokenUsage add(TokenUsage that) {
+        if (that == null) {
+            return this;
+        }
+
+        return GoogleGenAiTokenUsage.builder()
+                .inputTokenCount(sum(this.inputTokenCount(), that.inputTokenCount()))
+                .outputTokenCount(sum(this.outputTokenCount(), that.outputTokenCount()))
+                .totalTokenCount(sum(this.totalTokenCount(), that.totalTokenCount()))
+                .cachedContentTokenCount(addCachedContentTokenCount(that))
+                .thoughtsTokenCount(addThoughtsTokenCount(that))
+                .toolUsePromptTokenCount(addToolUsePromptTokenCount(that))
+                .build();
+    }
+
+    private Integer addCachedContentTokenCount(TokenUsage that) {
+        if (that instanceof GoogleGenAiTokenUsage thatGoogleGenAiTokenUsage) {
+            return sum(this.cachedContentTokenCount, thatGoogleGenAiTokenUsage.cachedContentTokenCount);
+        }
+        return this.cachedContentTokenCount;
+    }
+
+    private Integer addThoughtsTokenCount(TokenUsage that) {
+        if (that instanceof GoogleGenAiTokenUsage thatGoogleGenAiTokenUsage) {
+            return sum(this.thoughtsTokenCount, thatGoogleGenAiTokenUsage.thoughtsTokenCount);
+        }
+        return this.thoughtsTokenCount;
+    }
+
+    private Integer addToolUsePromptTokenCount(TokenUsage that) {
+        if (that instanceof GoogleGenAiTokenUsage thatGoogleGenAiTokenUsage) {
+            return sum(this.toolUsePromptTokenCount, thatGoogleGenAiTokenUsage.toolUsePromptTokenCount);
+        }
+        return this.toolUsePromptTokenCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        GoogleGenAiTokenUsage that = (GoogleGenAiTokenUsage) o;
+        return Objects.equals(cachedContentTokenCount, that.cachedContentTokenCount)
+                && Objects.equals(thoughtsTokenCount, that.thoughtsTokenCount)
+                && Objects.equals(toolUsePromptTokenCount, that.toolUsePromptTokenCount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cachedContentTokenCount, thoughtsTokenCount, toolUsePromptTokenCount);
+    }
+
+    @Override
+    public String toString() {
+        return "GoogleGenAiTokenUsage {" + " inputTokenCount = "
+                + inputTokenCount() + ", outputTokenCount = "
+                + outputTokenCount() + ", totalTokenCount = "
+                + totalTokenCount() + ", cachedContentTokenCount = "
+                + cachedContentTokenCount + ", thoughtsTokenCount = "
+                + thoughtsTokenCount + ", toolUsePromptTokenCount = "
+                + toolUsePromptTokenCount + " }";
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Integer inputTokenCount;
+        private Integer outputTokenCount;
+        private Integer totalTokenCount;
+        private Integer cachedContentTokenCount;
+        private Integer thoughtsTokenCount;
+        private Integer toolUsePromptTokenCount;
+
+        public Builder inputTokenCount(Integer inputTokenCount) {
+            this.inputTokenCount = inputTokenCount;
+            return this;
+        }
+
+        public Builder outputTokenCount(Integer outputTokenCount) {
+            this.outputTokenCount = outputTokenCount;
+            return this;
+        }
+
+        public Builder totalTokenCount(Integer totalTokenCount) {
+            this.totalTokenCount = totalTokenCount;
+            return this;
+        }
+
+        public Builder cachedContentTokenCount(Integer cachedContentTokenCount) {
+            this.cachedContentTokenCount = cachedContentTokenCount;
+            return this;
+        }
+
+        public Builder thoughtsTokenCount(Integer thoughtsTokenCount) {
+            this.thoughtsTokenCount = thoughtsTokenCount;
+            return this;
+        }
+
+        public Builder toolUsePromptTokenCount(Integer toolUsePromptTokenCount) {
+            this.toolUsePromptTokenCount = toolUsePromptTokenCount;
+            return this;
+        }
+
+        public GoogleGenAiTokenUsage build() {
+            return new GoogleGenAiTokenUsage(this);
+        }
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelIT.java
@@ -45,7 +45,7 @@ class GoogleGenAiChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected String customModelName() {
-        return "gemini-2.5-pro";
+        return "gemini-3.8-flash";
     }
 
     @Override
@@ -153,5 +153,10 @@ class GoogleGenAiChatModelIT extends AbstractChatModelIT {
         String response = model.chat("Respond with exactly one word: Hello.");
 
         assertThat(response).isNotBlank();
+    }
+
+    @Override
+    protected Class<? extends TokenUsage> tokenUsageType(ChatModel model) {
+        return GoogleGenAiTokenUsage.class;
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
@@ -780,4 +780,98 @@ class GoogleGenAiContentMapperTest {
         assertThat(parts.get(0).text()).hasValue("");
         assertThat(parts.get(0).thought()).isEmpty();
     }
+
+    @Test
+    void should_map_cached_content_and_thoughts_token_counts() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .parts(Part.builder().text("42").build())
+                                .build())
+                        .build()))
+                .usageMetadata(GenerateContentResponseUsageMetadata.builder()
+                        .promptTokenCount(10)
+                        .candidatesTokenCount(5)
+                        .totalTokenCount(40)
+                        .cachedContentTokenCount(7)
+                        .thoughtsTokenCount(25)
+                        .toolUsePromptTokenCount(3)
+                        .build())
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        GoogleGenAiTokenUsage tokenUsage = (GoogleGenAiTokenUsage) result.tokenUsage();
+        assertThat(tokenUsage.inputTokenCount()).isEqualTo(10);
+        assertThat(tokenUsage.outputTokenCount()).isEqualTo(5);
+        assertThat(tokenUsage.totalTokenCount()).isEqualTo(40);
+        assertThat(tokenUsage.cachedContentTokenCount()).isEqualTo(7);
+        assertThat(tokenUsage.thoughtsTokenCount()).isEqualTo(25);
+        assertThat(tokenUsage.toolUsePromptTokenCount()).isEqualTo(3);
+    }
+
+    @Test
+    void should_map_usage_metadata_when_candidates_are_empty() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .usageMetadata(GenerateContentResponseUsageMetadata.builder()
+                        .promptTokenCount(10)
+                        .candidatesTokenCount(0)
+                        .totalTokenCount(35)
+                        .cachedContentTokenCount(7)
+                        .thoughtsTokenCount(25)
+                        .build())
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        GoogleGenAiTokenUsage tokenUsage = (GoogleGenAiTokenUsage) result.tokenUsage();
+        assertThat(tokenUsage.inputTokenCount()).isEqualTo(10);
+        assertThat(tokenUsage.totalTokenCount()).isEqualTo(35);
+        assertThat(tokenUsage.cachedContentTokenCount()).isEqualTo(7);
+        assertThat(tokenUsage.thoughtsTokenCount()).isEqualTo(25);
+    }
+
+    @Test
+    void should_include_thoughts_and_tool_use_tokens_in_the_fallback_total() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .parts(Part.builder().text("42").build())
+                                .build())
+                        .build()))
+                .usageMetadata(GenerateContentResponseUsageMetadata.builder()
+                        .promptTokenCount(10)
+                        .candidatesTokenCount(5)
+                        .thoughtsTokenCount(25)
+                        .toolUsePromptTokenCount(3)
+                        .build())
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        assertThat(result.tokenUsage().totalTokenCount()).isEqualTo(43);
+    }
+
+    @Test
+    void should_leave_cached_content_and_thoughts_token_counts_null_when_not_reported() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .parts(Part.builder().text("42").build())
+                                .build())
+                        .build()))
+                .usageMetadata(GenerateContentResponseUsageMetadata.builder()
+                        .promptTokenCount(10)
+                        .candidatesTokenCount(5)
+                        .build())
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        GoogleGenAiTokenUsage tokenUsage = (GoogleGenAiTokenUsage) result.tokenUsage();
+        assertThat(tokenUsage.cachedContentTokenCount()).isNull();
+        assertThat(tokenUsage.thoughtsTokenCount()).isNull();
+        assertThat(tokenUsage.toolUsePromptTokenCount()).isNull();
+        assertThat(tokenUsage.totalTokenCount()).isEqualTo(15);
+    }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingAiServiceIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingAiServiceIT.java
@@ -1,13 +1,13 @@
 package dev.langchain4j.model.google.genai;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.common.AbstractStreamingAiServiceIT;
 import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
 class GoogleGenAiStreamingAiServiceIT extends AbstractStreamingAiServiceIT {
@@ -30,5 +30,10 @@ class GoogleGenAiStreamingAiServiceIT extends AbstractStreamingAiServiceIT {
         // total token count can be more than input+output due to thinking/reasoning
         assertThat(tokenUsage.totalTokenCount())
                 .isGreaterThanOrEqualTo(tokenUsage.inputTokenCount() + tokenUsage.outputTokenCount());
+    }
+
+    @Override
+    protected Class<? extends TokenUsage> tokenUsageType(StreamingChatModel model) {
+        return GoogleGenAiTokenUsage.class;
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelIT.java
@@ -43,7 +43,7 @@ class GoogleGenAiStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected String customModelName() {
-        return "gemini-2.5-pro";
+        return "gemini-3.8-flash";
     }
 
     @Override
@@ -138,5 +138,10 @@ class GoogleGenAiStreamingChatModelIT extends AbstractStreamingChatModelIT {
         model.chat("Respond with exactly one word: Hello.", handler);
 
         assertThat(handler.get().aiMessage().text()).isNotBlank();
+    }
+
+    @Override
+    protected Class<? extends TokenUsage> tokenUsageType(StreamingChatModel model) {
+        return GoogleGenAiTokenUsage.class;
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -397,6 +398,34 @@ class GoogleGenAiStreamingChatModelTest {
 
         assertThat(configCaptor.getValue().cachedContent())
                 .contains("projects/123/locations/us-central1/cachedContents/per-request");
+    }
+
+    private static Client clientStreamingNothing() throws Exception {
+        Client client = mock(Client.class);
+        Models models = mock(Models.class);
+        Field modelsField = Client.class.getDeclaredField("models");
+        modelsField.setAccessible(true);
+        modelsField.set(client, models);
+
+        @SuppressWarnings("unchecked")
+        ResponseStream<GenerateContentResponse> stream = mock(ResponseStream.class);
+        when(models.generateContentStream(any(String.class), any(List.class), any()))
+                .thenReturn(stream);
+        when(stream.iterator())
+                .thenReturn(Collections.<GenerateContentResponse>emptyList().iterator());
+        return client;
+    }
+
+    @Test
+    void should_report_google_gen_ai_token_usage_when_the_stream_is_empty() throws Exception {
+        GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
+                .client(clientStreamingNothing())
+                .modelName("gemini-3.5-flash")
+                .build();
+
+        ChatResponse response = stream(model, new ArrayList<>(), new ArrayList<>());
+
+        assertThat(response.metadata().tokenUsage()).isInstanceOf(GoogleGenAiTokenUsage.class);
     }
 
     private static Client clientStreamingThoughtAndAnswer() throws Exception {

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiTokenUsageTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiTokenUsageTest.java
@@ -1,0 +1,168 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.output.TokenUsage;
+import org.junit.jupiter.api.Test;
+
+class GoogleGenAiTokenUsageTest {
+
+    private static GoogleGenAiTokenUsage.Builder fullyPopulated() {
+        return GoogleGenAiTokenUsage.builder()
+                .inputTokenCount(10)
+                .outputTokenCount(20)
+                .totalTokenCount(49)
+                .cachedContentTokenCount(5)
+                .thoughtsTokenCount(15)
+                .toolUsePromptTokenCount(4);
+    }
+
+    @Test
+    void should_expose_cached_content_and_thoughts_token_counts() {
+        GoogleGenAiTokenUsage tokenUsage = fullyPopulated().build();
+
+        assertThat(tokenUsage.inputTokenCount()).isEqualTo(10);
+        assertThat(tokenUsage.outputTokenCount()).isEqualTo(20);
+        assertThat(tokenUsage.totalTokenCount()).isEqualTo(49);
+        assertThat(tokenUsage.cachedContentTokenCount()).isEqualTo(5);
+        assertThat(tokenUsage.thoughtsTokenCount()).isEqualTo(15);
+        assertThat(tokenUsage.toolUsePromptTokenCount()).isEqualTo(4);
+    }
+
+    @Test
+    void should_leave_unset_counts_null() {
+        GoogleGenAiTokenUsage tokenUsage = GoogleGenAiTokenUsage.builder()
+                .inputTokenCount(10)
+                .outputTokenCount(20)
+                .totalTokenCount(30)
+                .build();
+
+        assertThat(tokenUsage.cachedContentTokenCount()).isNull();
+        assertThat(tokenUsage.thoughtsTokenCount()).isNull();
+        assertThat(tokenUsage.toolUsePromptTokenCount()).isNull();
+    }
+
+    @Test
+    void should_add_cached_content_and_thoughts_token_counts() {
+        GoogleGenAiTokenUsage first = fullyPopulated().build();
+        GoogleGenAiTokenUsage second = GoogleGenAiTokenUsage.builder()
+                .inputTokenCount(1)
+                .outputTokenCount(2)
+                .totalTokenCount(9)
+                .cachedContentTokenCount(4)
+                .thoughtsTokenCount(6)
+                .toolUsePromptTokenCount(2)
+                .build();
+
+        GoogleGenAiTokenUsage result = first.add(second);
+
+        assertThat(result.inputTokenCount()).isEqualTo(11);
+        assertThat(result.outputTokenCount()).isEqualTo(22);
+        assertThat(result.totalTokenCount()).isEqualTo(58);
+        assertThat(result.cachedContentTokenCount()).isEqualTo(9);
+        assertThat(result.thoughtsTokenCount()).isEqualTo(21);
+        assertThat(result.toolUsePromptTokenCount()).isEqualTo(6);
+    }
+
+    @Test
+    void should_keep_own_counts_when_adding_a_usage_without_them() {
+        GoogleGenAiTokenUsage first = fullyPopulated().build();
+        GoogleGenAiTokenUsage second = GoogleGenAiTokenUsage.builder()
+                .inputTokenCount(1)
+                .outputTokenCount(2)
+                .totalTokenCount(3)
+                .build();
+
+        GoogleGenAiTokenUsage result = first.add(second);
+
+        assertThat(result.cachedContentTokenCount()).isEqualTo(5);
+        assertThat(result.thoughtsTokenCount()).isEqualTo(15);
+        assertThat(result.toolUsePromptTokenCount()).isEqualTo(4);
+    }
+
+    @Test
+    void should_keep_own_counts_when_adding_a_base_token_usage() {
+        GoogleGenAiTokenUsage tokenUsage = fullyPopulated().build();
+
+        GoogleGenAiTokenUsage result = tokenUsage.add(new TokenUsage(1, 2, 3));
+
+        assertThat(result.inputTokenCount()).isEqualTo(11);
+        assertThat(result.outputTokenCount()).isEqualTo(22);
+        assertThat(result.totalTokenCount()).isEqualTo(52);
+        assertThat(result.cachedContentTokenCount()).isEqualTo(5);
+        assertThat(result.thoughtsTokenCount()).isEqualTo(15);
+        assertThat(result.toolUsePromptTokenCount()).isEqualTo(4);
+    }
+
+    @Test
+    void should_keep_google_gen_ai_counts_when_a_base_token_usage_is_added_to_it() {
+        GoogleGenAiTokenUsage tokenUsage = fullyPopulated().build();
+
+        TokenUsage result = new TokenUsage(1, 2, 3).add(tokenUsage);
+
+        assertThat(result).isInstanceOf(GoogleGenAiTokenUsage.class);
+        GoogleGenAiTokenUsage googleGenAiResult = (GoogleGenAiTokenUsage) result;
+        assertThat(googleGenAiResult.cachedContentTokenCount()).isEqualTo(5);
+        assertThat(googleGenAiResult.thoughtsTokenCount()).isEqualTo(15);
+        assertThat(googleGenAiResult.toolUsePromptTokenCount()).isEqualTo(4);
+    }
+
+    @Test
+    void should_return_same_instance_when_adding_null() {
+        GoogleGenAiTokenUsage tokenUsage = fullyPopulated().build();
+
+        assertThat(tokenUsage.add(null)).isSameAs(tokenUsage);
+    }
+
+    @Test
+    void should_be_equal_when_all_counts_match() {
+        assertThat(fullyPopulated().build())
+                .isEqualTo(fullyPopulated().build())
+                .hasSameHashCodeAs(fullyPopulated().build());
+    }
+
+    @Test
+    void should_not_be_equal_when_cached_content_token_count_differs() {
+        GoogleGenAiTokenUsage tokenUsage = fullyPopulated().build();
+        GoogleGenAiTokenUsage other =
+                fullyPopulated().cachedContentTokenCount(6).build();
+
+        assertThat(tokenUsage).isNotEqualTo(other);
+    }
+
+    @Test
+    void should_not_be_equal_when_thoughts_token_count_differs() {
+        GoogleGenAiTokenUsage tokenUsage = fullyPopulated().build();
+        GoogleGenAiTokenUsage other = fullyPopulated().thoughtsTokenCount(16).build();
+
+        assertThat(tokenUsage).isNotEqualTo(other);
+    }
+
+    @Test
+    void should_not_be_equal_when_tool_use_prompt_token_count_differs() {
+        GoogleGenAiTokenUsage tokenUsage = fullyPopulated().build();
+        GoogleGenAiTokenUsage other =
+                fullyPopulated().toolUsePromptTokenCount(5).build();
+
+        assertThat(tokenUsage).isNotEqualTo(other);
+    }
+
+    @Test
+    void should_not_be_equal_to_a_base_token_usage_with_the_same_counts() {
+        GoogleGenAiTokenUsage tokenUsage = GoogleGenAiTokenUsage.builder()
+                .inputTokenCount(10)
+                .outputTokenCount(20)
+                .totalTokenCount(30)
+                .build();
+
+        assertThat(tokenUsage).isNotEqualTo(new TokenUsage(10, 20, 30));
+    }
+
+    @Test
+    void should_include_cached_content_and_thoughts_token_counts_in_to_string() {
+        assertThat(fullyPopulated().build().toString())
+                .contains("cachedContentTokenCount = 5")
+                .contains("thoughtsTokenCount = 15")
+                .contains("toolUsePromptTokenCount = 4");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #4663

## Change

Gemini reports `thoughtsTokenCount`, `cachedContentTokenCount` and `toolUsePromptTokenCount` in its usage
metadata. `GoogleGenAiContentMapper` built a plain `TokenUsage` from the prompt, candidates and total counts
only, so all three were dropped and there was no way to see them. Thinking tokens are billed on top of the
output tokens, so a caller using `includeThoughts` could not measure what the thinking cost.

Chat, streaming and batch responses now carry a `GoogleGenAiTokenUsage`:

```java
GoogleGenAiTokenUsage tokenUsage = (GoogleGenAiTokenUsage) response.metadata().tokenUsage();

Integer thoughtsTokenCount = tokenUsage.thoughtsTokenCount();
Integer cachedContentTokenCount = tokenUsage.cachedContentTokenCount();
Integer toolUsePromptTokenCount = tokenUsage.toolUsePromptTokenCount();
```

Each is `null` when the model does not report it. All three models map through the same
`toChatResponse`, so this is one mapping change, plus the streaming model's initial value for a stream that
reports no usage at all. Those two fallbacks return the same subclass rather than a plain `TokenUsage`, so
the cast above always succeeds, as `AbstractBedrockChatModel.java:720` does for `BedrockTokenUsage`.

The mapping also runs before the empty-candidates early return, so usage reported for a blocked prompt, or a
streaming chunk that carries usage but no candidates, is no longer replaced with zeros. The fallback used
when Gemini omits `totalTokenCount` adds the tool use and thoughts counts, which the SDK documents as part of
that total. `cachedContentTokenCount` is a subset of `inputTokenCount()`, while `toolUsePromptTokenCount` and
`thoughtsTokenCount` are counted on top of it.

`GoogleAiGeminiTokenUsage` does exactly this in `langchain4j-google-ai-gemini` (added in #4930) and
`OpenAiTokenUsage` carries `reasoningTokens`; this mirrors the former, including keeping `outputTokenCount`
as the candidates count rather than folding the thinking tokens into it, and summing the extra counts in
`add()` only when both sides are a `GoogleGenAiTokenUsage`. It also carries `toolUsePromptTokenCount`, which
the older module's response type does not model.

### Tests

- `GoogleGenAiTokenUsageTest` (new): proves the three counts are exposed, stay `null` when unset, are summed
  by `add()` only when both sides carry them, survive `new TokenUsage(...).add(googleGenAiTokenUsage)` in
  either direction, and take part in `equals`/`hashCode`/`toString`. The equality cases build each side from
  an independent builder.
- `GoogleGenAiContentMapperTest`: proves the counts reach the response, stay `null` when Gemini does not
  report them, survive an empty candidate list, and are included in the fallback total.
- `GoogleGenAiChatModelIT`, `GoogleGenAiStreamingChatModelIT`, `GoogleGenAiStreamingAiServiceIT`: override
  `tokenUsageType` so the shared `isExactlyInstanceOf` assertion expects the new type.
- `GoogleGenAiStreamingChatModelTest`: proves a stream that reports no usage still yields a
  `GoogleGenAiTokenUsage`.

18 of the 18 new tests fail on unmodified `main`: the new class does not exist there, and reverting only the
mapper wiring fails `should_map_cached_content_and_thoughts_token_counts`.

```
mvn -pl langchain4j-google-genai verify
Tests run: 194, Failures: 0, Errors: 0, Skipped: 0
API checks completed without failures.

langchain4j-core: Tests run: 1354, Failures: 0, Errors: 0, Skipped: 3
langchain4j:      Tests run: 1705, Failures: 0, Errors: 0, Skipped: 19
```

The integration tests are gated on `GOOGLE_AI_GEMINI_API_KEY`, so the PR checks skip them. I ran them
locally, which needed one unrelated fix first.

#### Retired model in the integration tests

Two tests in each of `GoogleGenAiChatModelIT` and `GoogleGenAiStreamingChatModelIT` were already failing on
main before this change: `customModelName()` returned `gemini-2.5-pro`, which Google has retired for accounts
that were not already using it, so the call returns `404 NOT_FOUND ... no longer available to new users`.
`ListModels` still advertises it as supporting `generateContent`, so it is not visible without a real call.

Since this PR touches those two files anyway, they now use `gemini-3.8-flash`. The base class only requires a
model different from the default `gemini-2.5-flash`, and the current stable model avoids pinning a shared
integration test to a preview that would age the same way. Verified on the full class:

```
gemini-2.5-pro          Tests run: 36, Failures: 2
gemini-3.1-pro-preview  Tests run: 36, Failures: 0
gemini-3.8-flash        Tests run: 36, Failures: 0
```

Happy to drop this part if you would rather fix it separately or pick a different model; it is two lines.

With the override and that model change, the whole module is green, integration tests included:

```
mvn -pl langchain4j-google-genai verify   (with GOOGLE_AI_GEMINI_API_KEY set)
surefire  Tests run: 194, Failures: 0, Errors: 0, Skipped: 0
failsafe  Tests run: 205, Failures: 0, Errors: 0, Skipped: 37
API checks completed without failures.
```

Removing the `tokenUsageType` override again makes `GoogleGenAiStreamingAiServiceIT` fail on
`isExactlyInstanceOf`, so the override is what carries that part.

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
