### PR TITLE
Enhance langchain4j-watsonx with new Gateway models, streaming cancellation, and inline chat moderation

### DIFF
--- a/docs/docs/integrations/embedding-models/watsonx.md
+++ b/docs/docs/integrations/embedding-models/watsonx.md
@@ -133,6 +133,112 @@ System.out.println(embeddingModel.embed("Hello from watsonx.ai"));
 ```
 > 🔗 [View available embedding model IDs](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#embed)
 
+## Listeners
+
+`WatsonxEmbeddingModel` and `WatsonxGatewayEmbeddingModel` both accept a list of `EmbeddingModelListener`, notified before every request, after every response and on every error.
+
+```java
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .projectId("your-project-id")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .listeners(List.of(new EmbeddingModelListener() {
+
+        @Override
+        public void onRequest(EmbeddingModelRequestContext context) {
+            System.out.println(context.embeddingRequest().inputs().size() + " input(s)");
+        }
+
+        @Override
+        public void onResponse(EmbeddingModelResponseContext context) {
+            System.out.println(context.embeddingResponse().tokenUsage());
+        }
+
+        @Override
+        public void onError(EmbeddingModelErrorContext context) {
+            System.out.println(context.error().getMessage());
+        }
+    }))
+    .build();
+```
+
+## Model Gateway
+
+The IBM watsonx.ai **Model Gateway** exposes an embeddings endpoint compatible with the OpenAI one, able to route requests to models hosted by several providers (for example OpenAI, or the external providers you register yourself) behind a single watsonx.ai entry point. LangChain4j integrates with it through `WatsonxGatewayEmbeddingModel`.
+
+> **Note:** the gateway must be configured by an administrator before use. Every `modelName` you pass must be an id already registered in the gateway.
+
+### WatsonxGatewayEmbeddingModel
+
+To create an instance, specify:
+
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`)
+- `apiKey(...)` – IBM Cloud IAM API key (or a full `Authenticator` via `.authenticator(...)`)
+- `modelName(...)` – embedding model id registered in the gateway, written in the OpenAI style
+
+No `projectId` or `spaceId` is required, the gateway resolves the model on its own.
+
+```java
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayEmbeddingModel;
+import com.ibm.watsonx.ai.CloudRegion;
+
+EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("text-embedding-3-small")
+    .build();
+
+System.out.println(embeddingModel.embed("Hello from the watsonx.ai Model Gateway"));
+```
+
+### Gateway-only parameters
+
+The gateway accepts three parameters that the watsonx.ai embeddings endpoint does not have. They can be set once on the builder and apply to every request.
+
+| Builder method | Description |
+|---|---|
+| `dimensions(...)` | Number of dimensions of the returned vectors, for the models that support it |
+| `encodingFormat(...)` | Wire format of the returned vectors, `FLOAT` or `BASE64`. The SDK decodes `BASE64` for you, so both formats give the same vectors |
+| `user(...)` | Identifier of the end user, used for abuse monitoring |
+
+```java
+EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("text-embedding-3-small")
+    .dimensions(512)
+    .encodingFormat(EncodingFormat.BASE64)
+    .build();
+```
+
+The same values can be passed per request through `ModelGatewayEmbeddingParameters`. The given parameters replace the ones set on the builder, they are not merged with them.
+
+```java
+WatsonxGatewayEmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("text-embedding-3-small")
+    .build();
+
+ModelGatewayEmbeddingParameters parameters = ModelGatewayEmbeddingParameters.builder()
+    .dimensions(256)
+    .build();
+
+Response<List<Embedding>> response = embeddingModel.embedAll(
+    List.of(TextSegment.from("Hello"), TextSegment.from("World")), parameters);
+```
+
+`dimensions` is the only one of the three that is also part of the LangChain4j embedding request API, so it can be set per request without leaving the `EmbeddingModel` interface. The value of the request overrides the one of the builder, while `encodingFormat` and `user` keep the values set on the builder.
+
+```java
+EmbeddingResponse response = embeddingModel.embed(EmbeddingRequest.builder()
+    .input("Hello from the watsonx.ai Model Gateway")
+    .dimensions(256)
+    .build());
+```
+
 ## Examples
 
 - [WatsonxEmbeddingModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxEmbeddingModelTest.java)

--- a/docs/docs/integrations/image-models/watsonx.md
+++ b/docs/docs/integrations/image-models/watsonx.md
@@ -1,0 +1,201 @@
+---
+sidebar_position: 10
+---
+
+# watsonx.ai
+
+- [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai)
+- [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
+- [watsonx.ai Java SDK documentation](https://ibm.github.io/watsonx-ai-java-sdk/services/model-gateway/image-generation)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-watsonx</artifactId>
+    <version>1.18.1-beta28</version>
+</dependency>
+```
+
+## Model Gateway
+
+Image generation is available only through the IBM watsonx.ai **Model Gateway**, which exposes an images endpoint compatible with the OpenAI one and routes the requests to the models hosted by the providers registered in it. There is no foundation model counterpart, so `WatsonxGatewayImageModel` is the only image model of this integration.
+
+> **Note:** the gateway must be configured by an administrator before use. Every `modelName` you pass must be an id already registered in the gateway.
+
+## WatsonxGatewayImageModel
+
+The `WatsonxGatewayImageModel` implements the LangChain4j `ImageModel` interface. To create an instance, specify:
+
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`)
+- `apiKey(...)` – IBM Cloud IAM API key (or a full `Authenticator` via `.authenticator(...)`)
+- `modelName(...)` – image model id registered in the gateway, written in the OpenAI style
+
+No `projectId` or `spaceId` is required, the gateway resolves the model on its own.
+
+```java
+import com.ibm.watsonx.ai.CloudRegion;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayImageModel;
+
+ImageModel imageModel = WatsonxGatewayImageModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("gpt-image-1")
+    .build();
+
+Image image = imageModel.generate("A futuristic city at sunset").content();
+```
+
+### Generating more than one image
+
+```java
+Response<List<Image>> response = imageModel.generate("A futuristic city at sunset", 3);
+
+for (Image image : response.content()) {
+    System.out.println(image.base64Data());
+}
+```
+
+The number of images accepted per request depends on the model, so a value that one model allows can be rejected by another one.
+
+### Saving the generated image
+
+An image is returned either as a link or as Base64 data, depending on the model and on the response format that was requested.
+
+```java
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+Image image = imageModel.generate("A futuristic city at sunset").content();
+
+if (image.base64Data() != null) {
+    Files.write(Path.of("image.png"), Base64.getDecoder().decode(image.base64Data()));
+} else {
+    System.out.println(image.url());
+}
+```
+
+When the model reports the format of the images it generated, `mimeType()` carries it, for example `image/png`.
+
+## Parameters
+
+Every parameter can be set once on the builder and applies to all the requests.
+
+| Builder method | Description |
+|---|---|
+| `background(...)` | Background of the generated images, `TRANSPARENT`, `OPAQUE` or `AUTO`. Transparency requires an output format that supports it, so `PNG` or `WEBP` |
+| `moderation(...)` | How strictly the generated images are filtered, `LOW` or `AUTO` |
+| `outputCompression(...)` | Compression level from 0 to 100, accepted only by the `JPEG` and `WEBP` formats |
+| `outputFormat(...)` | File format of the generated images, `PNG`, `JPEG`, `WEBP` or `AUTO` |
+| `quality(...)` | Quality of the generated images, `AUTO`, `HIGH`, `MEDIUM`, `LOW`, `HD` or `STANDARD` |
+| `responseFormat(...)` | How the images are returned, `URL` for a link or `B64_JSON` for Base64 data |
+| `size(...)` | Dimensions of the generated images, for example `SIZE_1024X1024` |
+| `style(...)` | Visual style of the generated images, `VIVID` or `NATURAL` |
+| `user(...)` | Identifier of the end user, used for abuse monitoring |
+
+Each of them also has an overload that takes a `String`, useful for the values that the enums do not cover yet.
+
+```java
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.OutputFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Quality;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Size;
+
+ImageModel imageModel = WatsonxGatewayImageModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("gpt-image-1")
+    .size(Size.SIZE_1024X1024)
+    .quality(Quality.LOW)
+    .outputFormat(OutputFormat.PNG)
+    .build();
+```
+
+### Per request parameters
+
+The same values can be passed per request through `ModelGatewayImageParameters`. The given parameters replace the ones set on the builder, they are not merged with them.
+
+```java
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters;
+
+WatsonxGatewayImageModel imageModel = WatsonxGatewayImageModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .modelName("gpt-image-1")
+    .build();
+
+ModelGatewayImageParameters parameters = ModelGatewayImageParameters.builder()
+    .size(Size.SIZE_1024X1024)
+    .quality(Quality.HIGH)
+    .n(2)
+    .build();
+
+Response<List<Image>> response = imageModel.generate("A futuristic city at sunset", parameters);
+```
+
+`n` and `partialImages` are available only here, they are not on the builder. The number of images is already part of the LangChain4j image request API through `generate(prompt, n)`, and `partialImages` has no effect because the endpoint does not stream the result.
+
+## Model specific behavior
+
+The gateway forwards the request to the provider of the model, so not every parameter is honored by every model.
+
+| Model | Behavior |
+|---|---|
+| `gpt-image-1` | Always answers with Base64 data, it ignores `responseFormat`. It is the only model that reports the token usage |
+| `dall-e-3` | Honors `responseFormat` and it is the only model that returns a revised prompt, readable with `image.revisedPrompt()` |
+| `dall-e-2` | Honors `responseFormat`, it does not support `quality` or `style` |
+
+The defaults applied when a parameter is left unset are `responseFormat` as `url`, `outputFormat` as `jpeg`, `size` as `1024x1024`, `quality` as `auto` and one single image.
+
+## Token usage
+
+The token usage is reported only by the models that count the tokens of the prompt, so `response.tokenUsage()` can be `null`.
+
+```java
+Response<Image> response = imageModel.generate("A futuristic city at sunset");
+
+if (response.tokenUsage() != null) {
+    System.out.println(response.tokenUsage().totalTokenCount());
+}
+```
+
+## Unsupported operations
+
+The endpoint generates images from a prompt only, so it has no counterpart for the editing methods of the `ImageModel` interface. Calling `edit(Image, String)` or `edit(Image, Image, String)` throws an `IllegalArgumentException`.
+
+## Authentication
+
+Watsonx.ai supports authentication via the `Authenticator` interface.
+
+This allows you to use different authentication mechanisms depending on your deployment:
+
+- **IBMCloudAuthenticator** – authenticates with **IBM Cloud** using an API key. This is the simplest approach and is used when you provide the `apiKey(...)` builder method.
+- **CP4DAuthenticator** – authenticates with **Cloud Pak for Data** deployments.
+- **Custom authenticators** – any implementation of the `Authenticator` interface can be used.
+
+The `WatsonxGatewayImageModel` and other service builders accept either a shortcut via `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
+
+### Example
+
+```java
+WatsonxGatewayImageModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key") // Simple IBM Cloud authentication
+    .modelName("gpt-image-1")
+    .build();
+
+WatsonxGatewayImageModel.builder()
+    .baseUrl("https://my-instance-url")
+    .authenticator( // For Cloud Pak for Data deployments
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .build()
+    )
+    .modelName("gpt-image-1")
+    .build();
+```

--- a/docs/docs/integrations/image-models/watsonx.md
+++ b/docs/docs/integrations/image-models/watsonx.md
@@ -14,7 +14,7 @@ sidebar_position: 10
 <dependency>
     <groupId>dev.langchain4j</groupId>
     <artifactId>langchain4j-watsonx</artifactId>
-    <version>1.18.1-beta28</version>
+    <version>1.19.0-beta29</version>
 </dependency>
 ```
 

--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -409,10 +409,132 @@ import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
 ChatResponse response = chatModel.chat(request);
 var metadata = (WatsonxChatResponseMetadata) response.metadata();
 
-metadata.getServiceTier();       // service tier that served the request (gateway only)
-metadata.getSystemFingerprint(); // provider system fingerprint (gateway only)
-metadata.getCached();            // whether the response was served from cache (gateway only)
+metadata.serviceTier();       // service tier that served the request (gateway only)
+metadata.systemFingerprint(); // provider system fingerprint (gateway only)
+metadata.cached();            // whether the response was served from cache (gateway only)
 ```
+
+## Inline moderation
+
+`WatsonxChatModel` and `WatsonxStreamingChatModel` can screen the input and the output of a chat request while the answer is generated, without any additional call to a moderation service. The screening is enabled with the `moderations(...)` builder method.
+
+```java
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.watsonx.WatsonxChatModel;
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.chat.ChatModeration;
+
+ChatModel chatModel = WatsonxChatModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .projectId("your-project-id")
+    .modelName("ibm/granite-4-h-small")
+    .moderations(
+        ChatModeration.builder()
+            .pii(pii -> pii.input(true).output(true))
+            .hap(hap -> hap.output(0.8f))
+            .graniteGuardian(guardian -> guardian.input(0.85f))
+            .build()
+    )
+    .build();
+```
+
+Three detectors are available. `pii` and `hap` can be enabled on the input, on the output or on both, while `graniteGuardian` only screens the input.
+
+| Detector | Purpose | Enable via |
+|---|---|---|
+| `pii` | Detects personal data such as phone numbers, emails and credit cards. | `.pii(pii -> pii.input(true).output(true))` |
+| `hap` | Detects hate and profanity above a confidence threshold. | `.hap(hap -> hap.input(0.8f).output(0.9f))` |
+| `graniteGuardian` | General purpose classifier of harmful content. | `.graniteGuardian(guardian -> guardian.input(0.85f))` |
+
+`inputRanges(...)` narrows the screening of the input to the given ranges, where the start is inclusive and the end is exclusive.
+
+```java
+import com.ibm.watsonx.ai.chat.ChatModeration.InputRanges;
+
+ChatModeration.builder()
+    .pii(pii -> pii.input(true))
+    .inputRanges(List.of(InputRanges.of(0, 50), InputRanges.of(100, 150)))
+    .build();
+```
+
+### Reading the matches
+
+The matches are reported on the `WatsonxChatResponseMetadata` of the response.
+
+```java
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
+
+ChatResponse response = chatModel.chat(request);
+var metadata = (WatsonxChatResponseMetadata) response.metadata();
+
+metadata.moderations(); // matches keyed by detector name, "pii", "hap" or "granite_guardian"
+metadata.detections();  // Granite Guardian detections keyed by position, "input" or "output"
+```
+
+Both maps are `null` when the moderation is disabled and when no detector matched. Every match tells whether it comes from the input or from the output, the score assigned by the detector, the type of entity that has been recognized and the position of the offending word inside the text. With `WatsonxStreamingChatModel` the matches of every chunk are merged and reported on the metadata of the response passed to `onCompleteResponse(...)`.
+
+| Field | Type | Description |
+|---|---|---|
+| `score()` | `float` | Confidence of the match. |
+| `input()` | `boolean` | `true` when the match comes from the input, `false` when it comes from the output. |
+| `position()` | `Position` | Start (inclusive) and end (exclusive) offsets of the match inside the text. |
+| `entity()` | `String` | Type of the recognized entity, for instance `PhoneNumber`. |
+| `word()` | `String` | The matched text. |
+
+The service reports the matches of the output without ever rewriting the answer, so redacting the text is left to the caller, which can use the offsets of every match. Every detector also accepts `mask(true)`, asking the service to remove the value of the detected entity, while the answer of the chat service keeps coming back as it is.
+
+```java
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult;
+
+static String mask(String text, ModerationResult result) {
+    var position = result.position();
+    return text.substring(0, position.start())
+        + "*".repeat(position.end() - position.start())
+        + text.substring(position.end());
+}
+```
+
+### Input blocked by a detector
+
+An input that matches a detector blocks the generation. LangChain4j reports it as a `ContentFilteredException` whose cause is the `ModerationException` raised by the SDK, so the matches of every detector that triggered the block stay reachable.
+
+```java
+import com.ibm.watsonx.ai.chat.exception.ModerationException;
+import dev.langchain4j.exception.ContentFilteredException;
+
+try {
+    chatModel.chat(request);
+} catch (ContentFilteredException e) {
+    var cause = (ModerationException) e.getCause();
+    System.out.println(cause.moderations());
+}
+```
+
+On `WatsonxStreamingChatModel` the same exception is delivered to `onError(...)`.
+
+### Moderation of a single request
+
+`WatsonxChatRequestParameters` carries the same setting, taking precedence over the one configured on the builder.
+
+```java
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
+
+ChatRequest request = ChatRequest.builder()
+    .messages(UserMessage.from("Contact me at john@example.com."))
+    .parameters(
+        WatsonxChatRequestParameters.builder()
+            .moderations(ChatModeration.builder().pii(pii -> pii.output(true)).build())
+            .build()
+    ).build();
+```
+
+> **NOTE:** the inline moderation is only available on the foundation models. `WatsonxDeploymentChatModel` and  `WatsonxDeploymentStreamingChatModel` reject it with an `UnsupportedFeatureException`, while the Model Gateway does not support it. To screen a text outside a chat flow, use the [WatsonxModerationModel](#watsonxmoderationmodel).
+
+> 🔗 [SDK content moderation](https://ibm.github.io/watsonx-ai-java-sdk/services/chat-service#content-moderation), for the full list of options of every detector.
 
 ## Tool Integration
 
@@ -784,8 +906,7 @@ the same way as with any other provider. The mapping is driven by the error code
 | `token_quota_reached` | `RateLimitException` |
 | any other error code | `LangChain4jException` |
 
-When the response carries no error body, the exception is chosen from the HTTP status code instead. A request that
-exceeds its `timeout(...)` is reported as a `TimeoutException`.
+When the response carries no error body, the exception is chosen from the HTTP status code instead. A request that exceeds its `timeout(...)` is reported as a `TimeoutException`. A model that refuses to answer, and an input blocked by the [inline moderation](#inline-moderation), are reported as a `ContentFilteredException`.
 
 ```java
 try {

--- a/langchain4j-watsonx/pom.xml
+++ b/langchain4j-watsonx/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.watsonx</groupId>
             <artifactId>watsonx-ai</artifactId>
-            <version>0.30.1</version>
+            <version>0.40.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-watsonx/revapi.json
+++ b/langchain4j-watsonx/revapi.json
@@ -20,18 +20,18 @@
           "regex": true,
           "code": "java\\.method\\.removed",
           "old": ".*::deploymentId\\(java\\.lang\\.String\\).*",
-          "justification": "Deployments are now served by their own models (WatsonxDeploymentChatModel / WatsonxDeploymentStreamingChatModel), so deploymentId no longer belongs to the foundation-model builders or to WatsonxChatRequestParameters. The module is still in beta."
+          "justification": "Deployments are now served by their own models (WatsonxDeploymentChatModel / WatsonxDeploymentStreamingChatModel), so deploymentId no longer belongs to the foundation-model builders or to WatsonxChatRequestParameters."
         },
         {
           "code": "java.method.removed",
           "old": "method java.lang.String dev.langchain4j.model.watsonx.WatsonxChatRequestParameters::deploymentId()",
-          "justification": "Deployments now have their own parameters type, because the deployment service does not accept the same parameters as the text-chat service. The module is still in beta."
+          "justification": "Deployments now have their own parameters type, because the deployment service does not accept the same parameters as the text-chat service."
         },
         {
           "regex": true,
           "code": "java\\.(method|field)\\.removed",
           "old": ".*[.:](projectId|spaceId).*@ dev\\.langchain4j\\.model\\.watsonx\\.WatsonxModelCatalog\\.Builder",
-          "justification": "The foundation-model specs endpoint is global: projectId and spaceId were accepted and then silently ignored. WatsonxModelCatalog.Builder now extends the connection-only builder base, so they can no longer be set. The module is still in beta."
+          "justification": "The foundation-model specs endpoint is global: projectId and spaceId were accepted and then silently ignored. WatsonxModelCatalog.Builder now extends the connection-only builder base, so they can no longer be set."
         },
         {
           "regex": true,
@@ -43,7 +43,7 @@
           "regex": true,
           "code": "java\\.method\\.returnTypeErasureChanged",
           "old": "method T dev\\.langchain4j\\.model\\.watsonx\\.Watsonx(Builder|ConnectionBuilder|Chat\\.Builder|ChatBase\\.Builder)<.*",
-          "justification": "The chat support was refactored into three backends (foundation models, deployments and Model Gateway), each exposing only the parameters its watsonx.ai service actually accepts. The @Internal builder base classes were reorganised accordingly, so the self-typed setters are declared on different @Internal classes than in 1.18.1-beta28 and their erased return type changed. Source-compatible: callers only need to recompile. The module is still in beta."
+          "justification": "The chat support was refactored into three backends (foundation models, deployments and Model Gateway), each exposing only the parameters its watsonx.ai service actually accepts. The @Internal builder base classes were reorganised accordingly, so the self-typed setters are declared on different @Internal classes than in 1.18.1-beta28 and their erased return type changed. Source-compatible: callers only need to recompile."
         },
         {
           "regex": true,
@@ -64,6 +64,17 @@
           "justification": "Same refactor: the @Internal base classes sitting between the public models/builders and their common code were reorganised. See the java.method.returnTypeErasureChanged justification."
         },
         {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.output.Response<java.util.List<dev.langchain4j.data.embedding.Embedding>> dev.langchain4j.model.watsonx.WatsonxEmbeddingModel::embedAll(java.util.List<dev.langchain4j.data.segment.TextSegment>)",
+          "justification": "embedAll now inherits its default implementation from EmbeddingModel, routing through embed(EmbeddingRequest) so the listeners are notified. The method is still present and callable via inheritance."
+        },
+        {
+          "regex": true,
+          "code": "java\\.method\\.removed",
+          "old": "method .* dev\\.langchain4j\\.model\\.watsonx\\.WatsonxChatResponseMetadata::get(Created|ModelVersion|ServiceTier|SystemFingerprint|Cached)\\(\\)",
+          "justification": "The accessors now follow the fluent naming used by every other provider metadata (created(), modelVersion(), serviceTier(), systemFingerprint(), cached())."
+        },
+        {
           "regex": true,
           "code": "java\\.method\\.finalMethodAddedToNonFinalClass",
           "new": "method .* dev\\.langchain4j\\.model\\.watsonx\\.WatsonxChatBase<R extends com\\.ibm\\.watsonx\\.ai\\.chat\\.BaseChatRequest>::.*",
@@ -74,6 +85,25 @@
           "old": "method dev.langchain4j.model.chat.response.ChatResponseMetadata dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata.Builder::build()",
           "new": "method dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata.Builder::build()",
           "justification": "Covariant override: javac emits a bridge method retaining the original ()Ldev/langchain4j/model/chat/response/ChatResponseMetadata; descriptor (ACC_BRIDGE, ACC_SYNTHETIC), so callers compiled against the previous signature still link and run. Source-compatible as well, and consistent with the other nine ChatResponseMetadata subclasses."
+        },
+        {
+          "regex": true,
+          "code": "java\\.(method\\.parameterTypeChanged|method\\.returnTypeChanged)",
+          "old": ".*com\\.ibm\\.watsonx\\.ai\\.gateway\\.chat\\.ModelGatewayParameters\\..*",
+          "new": ".*com\\.ibm\\.watsonx\\.ai\\.gateway\\.chat\\.ModelGatewayChatParameters\\..*",
+          "justification": "The watsonx.ai SDK renamed the ModelGatewayParameters inner types (Cache, Router, ReasoningEffort, ServiceTier) to ModelGatewayChatParameters. This is a rename-only change in the SDK; the public API of this module is unchanged in behaviour."
+        },
+        {
+          "regex": true,
+          "code": "java\\.field\\.typeChanged",
+          "new": "field dev\\.langchain4j\\.model\\.watsonx\\.WatsonxGatewayChat\\.Builder.*\\.(reasoningEffort|router|serviceTier|cache) @ .*",
+          "justification": "The watsonx.ai SDK renamed the ModelGatewayParameters inner types to ModelGatewayChatParameters. The field types of these @Internal builder fields changed accordingly."
+        },
+        {
+          "regex": true,
+          "code": "java\\.field\\.removed",
+          "old": "field dev\\.langchain4j\\.model\\.watsonx\\.WatsonxGatewayChat\\.modelGatewayService @ .*",
+          "justification": "The modelGatewayService field was moved into the WatsonxTextChatBase refactor. WatsonxGatewayChat is @Internal."
         }
       ]
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.watsonx;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static java.util.Comparator.comparingInt;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
@@ -18,11 +20,14 @@ import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.ToolMessage;
 import com.ibm.watsonx.ai.chat.model.UserContent;
+import com.ibm.watsonx.ai.embedding.EmbeddingResponse.Result;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingResponse;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.Content;
@@ -39,6 +44,8 @@ import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.embedding.response.EmbeddingResponse;
+import dev.langchain4j.model.embedding.response.EmbeddingResponseMetadata;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import java.util.List;
@@ -138,6 +145,42 @@ class Converter {
         return ChatResponse.builder()
                 .aiMessage(aiMessage.build())
                 .metadata(metadata.build())
+                .build();
+    }
+
+    static EmbeddingResponse toEmbeddingResponse(
+            com.ibm.watsonx.ai.embedding.EmbeddingResponse response, String defaultModelName) {
+
+        List<Embedding> embeddings = response.results().stream()
+                .map(Result::embedding)
+                .map(Embedding::from)
+                .toList();
+
+        return toEmbeddingResponse(
+                embeddings, getOrDefault(response.modelId(), defaultModelName), response.inputTokenCount());
+    }
+
+    static EmbeddingResponse toEmbeddingResponse(ModelGatewayEmbeddingResponse response, String defaultModelName) {
+
+        List<Embedding> embeddings = response.data().stream()
+                .sorted(comparingInt(ModelGatewayEmbeddingResponse.Embedding::index))
+                .map(ModelGatewayEmbeddingResponse.Embedding::embedding)
+                .map(Embedding::from)
+                .toList();
+
+        Integer inputTokenCount = nonNull(response.usage()) ? response.usage().promptTokens() : null;
+        return toEmbeddingResponse(embeddings, getOrDefault(response.model(), defaultModelName), inputTokenCount);
+    }
+
+    private static EmbeddingResponse toEmbeddingResponse(
+            List<Embedding> embeddings, String modelName, Integer inputTokenCount) {
+
+        return EmbeddingResponse.builder()
+                .embeddings(embeddings)
+                .metadata(EmbeddingResponseMetadata.builder()
+                        .modelName(modelName)
+                        .tokenUsage(nonNull(inputTokenCount) ? new TokenUsage(inputTokenCount) : null)
+                        .build())
                 .build();
     }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -18,8 +18,8 @@ import com.ibm.watsonx.ai.chat.model.Tool;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.ToolMessage;
 import com.ibm.watsonx.ai.chat.model.UserContent;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -165,9 +165,10 @@ class Converter {
         return builder.build();
     }
 
-    static ModelGatewayParameters toModelGatewayParameters(ChatRequestParameters parameters, boolean strictJsonSchema) {
+    static ModelGatewayChatParameters toModelGatewayChatParameters(
+            ChatRequestParameters parameters, boolean strictJsonSchema) {
 
-        ModelGatewayParameters.Builder builder = ModelGatewayParameters.builder();
+        ModelGatewayChatParameters.Builder builder = ModelGatewayChatParameters.builder();
         applyBaseParameters(builder, parameters, strictJsonSchema);
 
         if (parameters instanceof WatsonxGatewayChatRequestParameters gatewayParameters) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.watsonx;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static java.lang.Math.toIntExact;
 import static java.util.Comparator.comparingInt;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -24,10 +25,14 @@ import com.ibm.watsonx.ai.embedding.EmbeddingResponse.Result;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
 import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingResponse;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse.ImageData;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse.Usage;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.Content;
@@ -47,6 +52,7 @@ import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.embedding.response.EmbeddingResponse;
 import dev.langchain4j.model.embedding.response.EmbeddingResponseMetadata;
 import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import java.util.List;
 
@@ -186,6 +192,24 @@ class Converter {
                 .build();
     }
 
+    static Response<List<Image>> toImageResponse(ModelGatewayImageResponse response) {
+
+        List<Image> images = response.data().stream()
+                .map(imageData -> toImage(imageData, response.outputFormat()))
+                .toList();
+
+        Usage usage = response.usage();
+
+        TokenUsage tokenUsage = nonNull(usage)
+                ? new TokenUsage(
+                        toIntExact(usage.inputTokens()),
+                        toIntExact(usage.outputTokens()),
+                        toIntExact(usage.totalTokens()))
+                : null;
+
+        return Response.from(images, tokenUsage);
+    }
+
     static ChatParameters toChatParameters(ChatRequestParameters parameters, boolean strictJsonSchema) {
 
         ChatParameters.Builder builder = ChatParameters.builder();
@@ -315,6 +339,19 @@ class Converter {
                 case NONE -> builder.toolChoiceOption(ToolChoiceOption.NONE);
             }
         }
+    }
+
+    private static Image toImage(ImageData imageData, String outputFormat) {
+
+        Image.Builder builder =
+                Image.builder().base64Data(imageData.b64Json()).revisedPrompt(imageData.revisedPrompt());
+
+        if (nonNull(imageData.url())) builder.url(imageData.url());
+
+        // Only some models report the format of the images they generated, so the mime type can stay unset.
+        if (nonNull(outputFormat)) builder.mimeType("image/" + outputFormat);
+
+        return builder.build();
     }
 
     private static ToolCall toToolCall(ToolExecutionRequest toolExecutionRequest) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -132,7 +132,9 @@ class Converter {
                 .finishReason(toFinishReason(choice.finishReason()))
                 .id(textChatResponse.id())
                 .modelName(textChatResponse.modelId())
-                .tokenUsage(tokenUsage);
+                .tokenUsage(tokenUsage)
+                .moderations(textChatResponse.moderations())
+                .detections(textChatResponse.detections());
 
         if (textChatResponse instanceof ModelGatewayChatResponse gatewayResponse) {
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.watsonx;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.util.Objects.nonNull;
 
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.ChatProvider;
 import com.ibm.watsonx.ai.chat.ChatRequest;
 import com.ibm.watsonx.ai.chat.ChatService;
@@ -10,6 +11,7 @@ import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
 import dev.langchain4j.Internal;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import java.util.List;
 
@@ -45,8 +47,13 @@ abstract class WatsonxChat extends WatsonxTextChatBase<ChatRequest> {
     protected ChatRequest buildChatRequest(
             List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
 
-        return applyChatRequest(ChatRequest.builder(), messages, tools, parameters)
-                .build();
+        var requestBuilder = applyChatRequest(ChatRequest.builder(), messages, tools, parameters);
+
+        if (parameters instanceof WatsonxChatRequestParameters watsonxParameters) {
+            requestBuilder.moderations(watsonxParameters.moderations());
+        }
+
+        return requestBuilder.build();
     }
 
     @Override
@@ -65,6 +72,7 @@ abstract class WatsonxChat extends WatsonxTextChatBase<ChatRequest> {
 
         return target.projectId(getOrDefault(builder.projectId, watsonxParameters.projectId()))
                 .spaceId(getOrDefault(builder.spaceId, watsonxParameters.spaceId()))
+                .moderations(getOrDefault(builder.moderations, watsonxParameters.moderations()))
                 .build();
     }
 
@@ -72,6 +80,7 @@ abstract class WatsonxChat extends WatsonxTextChatBase<ChatRequest> {
     abstract static class Builder<T extends Builder<T>> extends WatsonxTextChatBase.Builder<T> {
         protected String projectId;
         protected String spaceId;
+        protected ChatModeration moderations;
 
         /**
          * Sets the foundation model id, e.g. {@code "ibm/granite-4-h-small"}.
@@ -103,6 +112,28 @@ abstract class WatsonxChat extends WatsonxTextChatBase<ChatRequest> {
          */
         public T spaceId(String spaceId) {
             this.spaceId = spaceId;
+            return (T) this;
+        }
+
+        /**
+         * Enables the inline moderation of the request, screening the input and the output for personal data, hate and
+         * profanity, or the categories of Granite Guardian.
+         *
+         * <p>The matches are reported on {@link WatsonxChatResponseMetadata#moderations()} and {@link WatsonxChatResponseMetadata#detections()}. When a detector blocks the generation the call fails with a
+         * {@link ContentFilteredException}.
+         *
+         * <pre>{@code
+         * .moderations(ChatModeration.builder()
+         *     .pii(p -> p.output(true))
+         *     .hap(h -> h.output(0.8f))
+         *     .build())
+         * }</pre>
+         *
+         * @param moderations the moderation configuration
+         * @return {@code this}
+         */
+        public T moderations(ChatModeration moderations) {
+            this.moderations = moderations;
             return (T) this;
         }
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -12,6 +12,7 @@ import com.ibm.watsonx.ai.chat.BaseChatRequest;
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatProvider;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
+import com.ibm.watsonx.ai.chat.exception.ModerationException;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
@@ -80,7 +81,13 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
         TextChatResponse chatResponse = WatsonxExceptionMapper.INSTANCE.withExceptionMapper(
                 () -> chatProvider().chat(watsonxChatRequest));
 
-        String refusal = chatResponse.toAssistantMessage().refusal();
+        String refusal;
+
+        try {
+            refusal = chatResponse.toAssistantMessage().refusal();
+        } catch (ModerationException e) {
+            throw WatsonxExceptionMapper.INSTANCE.mapException(e);
+        }
 
         if (isNotNullOrBlank(refusal)) throw new ContentFilteredException(refusal);
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -12,7 +12,6 @@ import com.ibm.watsonx.ai.chat.BaseChatRequest;
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatProvider;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
-import com.ibm.watsonx.ai.chat.exception.ModerationException;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
@@ -81,13 +80,8 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
         TextChatResponse chatResponse = WatsonxExceptionMapper.INSTANCE.withExceptionMapper(
                 () -> chatProvider().chat(watsonxChatRequest));
 
-        String refusal;
-
-        try {
-            refusal = chatResponse.toAssistantMessage().refusal();
-        } catch (ModerationException e) {
-            throw WatsonxExceptionMapper.INSTANCE.mapException(e);
-        }
+        String refusal = WatsonxExceptionMapper.INSTANCE.withExceptionMapper(
+                () -> chatResponse.toAssistantMessage().refusal());
 
         if (isNotNullOrBlank(refusal)) throw new ContentFilteredException(refusal);
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatBase.java
@@ -32,7 +32,6 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.model.chat.response.StreamingHandle;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -41,8 +40,6 @@ import java.util.Set;
 
 @Internal
 abstract class WatsonxChatBase<R extends BaseChatRequest> {
-
-    private static final StreamingHandle CANCELLATION_UNSUPPORTED = new CancellationUnsupportedStreamingHandle();
 
     protected final List<ChatModelListener> listeners;
     protected final ChatRequestParameters defaultRequestParameters;
@@ -93,8 +90,9 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
     protected final void executeChatStreaming(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
 
         var watsonxChatRequest = toWatsonxChatRequest(chatRequest);
+        var streamingHandle = new WatsonxStreamingHandle();
 
-        chatProvider().chatStreaming(watsonxChatRequest, new ChatHandler() {
+        var streamingFuture = chatProvider().chatStreaming(watsonxChatRequest, new ChatHandler() {
             @Override
             public void onCompleteResponse(com.ibm.watsonx.ai.chat.ChatResponse completeResponse) {
 
@@ -125,8 +123,7 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
 
             @Override
             public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {
-                InternalStreamingChatResponseHandlerUtils.onPartialResponse(
-                        handler, partialResponse, CANCELLATION_UNSUPPORTED);
+                InternalStreamingChatResponseHandlerUtils.onPartialResponse(handler, partialResponse, streamingHandle);
             }
 
             @Override
@@ -136,16 +133,17 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
 
             @Override
             public void onPartialThinking(String partialThinking, PartialChatResponse partialChatResponse) {
-                InternalStreamingChatResponseHandlerUtils.onPartialThinking(
-                        handler, partialThinking, CANCELLATION_UNSUPPORTED);
+                InternalStreamingChatResponseHandlerUtils.onPartialThinking(handler, partialThinking, streamingHandle);
             }
 
             @Override
             public void onPartialToolCall(PartialToolCall partialToolCall) {
                 InternalStreamingChatResponseHandlerUtils.onPartialToolCall(
-                        handler, Converter.toPartialToolCall(partialToolCall), CANCELLATION_UNSUPPORTED);
+                        handler, Converter.toPartialToolCall(partialToolCall), streamingHandle);
             }
         });
+
+        streamingHandle.bindTo(streamingFuture);
     }
 
     protected static final void applyCommonParameters(
@@ -188,19 +186,6 @@ abstract class WatsonxChatBase<R extends BaseChatRequest> {
     private static void validate(ChatRequestParameters parameters) {
         if (nonNull(parameters.topK()))
             throw new UnsupportedFeatureException("'topK' parameter is not supported by watsonx.ai");
-    }
-
-    private static final class CancellationUnsupportedStreamingHandle implements StreamingHandle {
-
-        @Override
-        public void cancel() {
-            throw new UnsupportedFeatureException("Streaming cancellation is not supported by watsonx.ai");
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return false;
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.watsonx;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.util.Objects.nonNull;
 
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.Thinking;
 import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
@@ -32,6 +33,7 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
     private final String guidedGrammar;
     private final Double repetitionPenalty;
     private final Double lengthPenalty;
+    private final ChatModeration moderations;
 
     private WatsonxChatRequestParameters(Builder builder) {
         super(builder);
@@ -49,6 +51,7 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
         guidedGrammar = builder.guidedGrammar;
         repetitionPenalty = builder.repetitionPenalty;
         lengthPenalty = builder.lengthPenalty;
+        moderations = builder.moderations;
     }
 
     public Map<String, Integer> logitBias() {
@@ -107,6 +110,10 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
         return lengthPenalty;
     }
 
+    public ChatModeration moderations() {
+        return moderations;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -144,7 +151,8 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
                 && Objects.equals(guidedRegex, that.guidedRegex)
                 && Objects.equals(guidedGrammar, that.guidedGrammar)
                 && Objects.equals(repetitionPenalty, that.repetitionPenalty)
-                && Objects.equals(lengthPenalty, that.lengthPenalty);
+                && Objects.equals(lengthPenalty, that.lengthPenalty)
+                && Objects.equals(moderations, that.moderations);
     }
 
     @Override
@@ -164,7 +172,8 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
                 guidedRegex,
                 guidedGrammar,
                 repetitionPenalty,
-                lengthPenalty);
+                lengthPenalty,
+                moderations);
     }
 
     @Override
@@ -193,7 +202,8 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
                 + guidedRegex + ", guidedGrammar="
                 + guidedGrammar + ", repetitionPenalty="
                 + repetitionPenalty + ", lengthPenalty="
-                + lengthPenalty + ", timeout="
+                + lengthPenalty + ", moderations="
+                + moderations + ", timeout="
                 + timeout + '}';
     }
 
@@ -213,6 +223,7 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
         private String guidedGrammar;
         private Double repetitionPenalty;
         private Double lengthPenalty;
+        private ChatModeration moderations;
 
         @Override
         public Builder overrideWith(ChatRequestParameters parameters) {
@@ -232,6 +243,7 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
                 guidedGrammar(getOrDefault(watsonxParameters.guidedGrammar(), guidedGrammar));
                 repetitionPenalty(getOrDefault(watsonxParameters.repetitionPenalty(), repetitionPenalty));
                 lengthPenalty(getOrDefault(watsonxParameters.lengthPenalty(), lengthPenalty));
+                moderations(getOrDefault(watsonxParameters.moderations(), moderations));
             }
             return this;
         }
@@ -325,6 +337,11 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
 
         public Builder lengthPenalty(Double lengthPenalty) {
             this.lengthPenalty = lengthPenalty;
+            return this;
+        }
+
+        public Builder moderations(ChatModeration moderations) {
+            this.moderations = moderations;
             return this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadata.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadata.java
@@ -1,6 +1,10 @@
 package dev.langchain4j.model.watsonx;
 
+import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionEntry;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
@@ -10,6 +14,8 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
     private final String serviceTier;
     private final String systemFingerprint;
     private final Boolean cached;
+    private final Map<String, List<ModerationResult>> moderations;
+    private final Map<String, List<DetectionEntry>> detections;
 
     private WatsonxChatResponseMetadata(Builder builder) {
         super(builder);
@@ -18,26 +24,36 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
         serviceTier = builder.serviceTier;
         systemFingerprint = builder.systemFingerprint;
         cached = builder.cached;
+        moderations = builder.moderations;
+        detections = builder.detections;
     }
 
-    public Long getCreated() {
+    public Long created() {
         return created;
     }
 
-    public String getModelVersion() {
+    public String modelVersion() {
         return modelVersion;
     }
 
-    public String getServiceTier() {
+    public String serviceTier() {
         return serviceTier;
     }
 
-    public String getSystemFingerprint() {
+    public String systemFingerprint() {
         return systemFingerprint;
     }
 
-    public Boolean getCached() {
+    public Boolean cached() {
         return cached;
+    }
+
+    public Map<String, List<ModerationResult>> moderations() {
+        return moderations;
+    }
+
+    public Map<String, List<DetectionEntry>> detections() {
+        return detections;
     }
 
     @Override
@@ -47,7 +63,9 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
                 .modelVersion(modelVersion)
                 .serviceTier(serviceTier)
                 .systemFingerprint(systemFingerprint)
-                .cached(cached);
+                .cached(cached)
+                .moderations(moderations)
+                .detections(detections);
     }
 
     @Override
@@ -60,12 +78,22 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
                 && Objects.equals(modelVersion, that.modelVersion)
                 && Objects.equals(serviceTier, that.serviceTier)
                 && Objects.equals(systemFingerprint, that.systemFingerprint)
-                && Objects.equals(cached, that.cached);
+                && Objects.equals(cached, that.cached)
+                && Objects.equals(moderations, that.moderations)
+                && Objects.equals(detections, that.detections);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), created, modelVersion, serviceTier, systemFingerprint, cached);
+        return Objects.hash(
+                super.hashCode(),
+                created,
+                modelVersion,
+                serviceTier,
+                systemFingerprint,
+                cached,
+                moderations,
+                detections);
     }
 
     @Override
@@ -79,7 +107,9 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
                 + modelVersion + '\'' + ", serviceTier='"
                 + serviceTier + '\'' + ", systemFingerprint='"
                 + systemFingerprint + '\'' + ", cached="
-                + cached + '}';
+                + cached + ", moderations="
+                + moderations + ", detections="
+                + detections + '}';
     }
 
     public static Builder builder() {
@@ -92,6 +122,8 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
         private String serviceTier;
         private String systemFingerprint;
         private Boolean cached;
+        private Map<String, List<ModerationResult>> moderations;
+        private Map<String, List<DetectionEntry>> detections;
 
         public Builder created(Long created) {
             this.created = created;
@@ -115,6 +147,16 @@ public class WatsonxChatResponseMetadata extends ChatResponseMetadata {
 
         public Builder cached(Boolean cached) {
             this.cached = cached;
+            return this;
+        }
+
+        public Builder moderations(Map<String, List<ModerationResult>> moderations) {
+            this.moderations = moderations;
+            return this;
+        }
+
+        public Builder detections(Map<String, List<DetectionEntry>> detections) {
+            this.detections = detections;
             return this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChat.java
@@ -46,6 +46,7 @@ abstract class WatsonxDeploymentChat extends WatsonxTextChatBase<DeploymentChatR
             List<ChatMessage> messages, List<Tool> tools, ChatRequestParameters parameters) {
 
         validateModelName(parameters);
+        validateModerations(parameters);
 
         return applyChatRequest(DeploymentChatRequest.builder().deploymentId(deploymentId), messages, tools, parameters)
                 .build();
@@ -59,6 +60,7 @@ abstract class WatsonxDeploymentChat extends WatsonxTextChatBase<DeploymentChatR
     private static WatsonxChatRequestParameters mergeParameters(Builder<?> builder) {
 
         validateModelName(builder.defaultRequestParameters);
+        validateModerations(builder.defaultRequestParameters);
 
         var target = WatsonxChatRequestParameters.builder();
         applyTextChatParameters(target, builder);
@@ -70,6 +72,13 @@ abstract class WatsonxDeploymentChat extends WatsonxTextChatBase<DeploymentChatR
         if (nonNull(parameters) && nonNull(parameters.modelName()))
             throw new UnsupportedFeatureException(
                     "The 'modelName' parameter is not supported, the deployment id defines the model to call");
+    }
+
+    private static void validateModerations(ChatRequestParameters parameters) {
+        if (parameters instanceof WatsonxChatRequestParameters watsonxParameters
+                && nonNull(watsonxParameters.moderations()))
+            throw new UnsupportedFeatureException(
+                    "The 'moderations' parameter is not supported by the on-demand deployments");
     }
 
     @SuppressWarnings("unchecked")

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
@@ -11,6 +11,7 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModelListenerUtils;
 import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
 import dev.langchain4j.model.embedding.request.EmbeddingInput;
 import dev.langchain4j.model.embedding.request.EmbeddingRequest;
@@ -86,6 +87,9 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
     /**
      * Embeds the text content of a list of TextSegment using the specified {@link EmbeddingParameters}.
      *
+     * <p>The registered {@link EmbeddingModelListener}s are notified around the call, as they are for every other
+     * embedding method.
+     *
      * @param textSegments the text segments to embed.
      * @param parameters the embedding parameters to use.
      * @return the embeddings.
@@ -94,10 +98,11 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
 
         if (isNull(textSegments) || textSegments.isEmpty()) return Response.from(List.of());
 
-        List<String> inputs = textSegments.stream().map(TextSegment::text).toList();
-        EmbeddingResponse response = embed(inputs, parameters);
-
-        return Response.from(response.embeddings(), response.metadata().tokenUsage());
+        return EmbeddingModelListenerUtils.withListeners(this, textSegments, () -> {
+            List<String> inputs = textSegments.stream().map(TextSegment::text).toList();
+            EmbeddingResponse response = embed(inputs, parameters);
+            return Response.from(response.embeddings(), response.metadata().tokenUsage());
+        });
     }
 
     private EmbeddingResponse embed(List<String> inputs, EmbeddingParameters parameters) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
@@ -1,15 +1,20 @@
 package dev.langchain4j.model.watsonx;
 
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.model.ModelProvider.WATSONX;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 import com.ibm.watsonx.ai.embedding.EmbeddingParameters;
-import com.ibm.watsonx.ai.embedding.EmbeddingResponse;
-import com.ibm.watsonx.ai.embedding.EmbeddingResponse.Result;
 import com.ibm.watsonx.ai.embedding.EmbeddingService;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
+import dev.langchain4j.model.embedding.request.EmbeddingInput;
+import dev.langchain4j.model.embedding.request.EmbeddingRequest;
+import dev.langchain4j.model.embedding.response.EmbeddingResponse;
 import dev.langchain4j.model.output.Response;
 import java.util.List;
 
@@ -32,6 +37,7 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
 
     private final EmbeddingService embeddingService;
     private final String modelName;
+    private final List<EmbeddingModelListener> listeners;
 
     private WatsonxEmbeddingModel(Builder builder) {
 
@@ -52,16 +58,29 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
                 .verifySsl(builder.verifySsl)
                 .build();
         this.modelName = builder.modelName;
+        this.listeners = copy(builder.listeners);
     }
 
     @Override
-    public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
-        return embedAll(textSegments, null);
+    public List<EmbeddingModelListener> listeners() {
+        return listeners;
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return WATSONX;
     }
 
     @Override
     public String modelName() {
         return this.modelName;
+    }
+
+    @Override
+    public EmbeddingResponse doEmbed(EmbeddingRequest request) {
+        List<String> inputs =
+                request.inputs().stream().map(EmbeddingInput::text).toList();
+        return embed(inputs, null);
     }
 
     /**
@@ -76,14 +95,17 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
         if (isNull(textSegments) || textSegments.isEmpty()) return Response.from(List.of());
 
         List<String> inputs = textSegments.stream().map(TextSegment::text).toList();
+        EmbeddingResponse response = embed(inputs, parameters);
 
-        EmbeddingResponse response =
+        return Response.from(response.embeddings(), response.metadata().tokenUsage());
+    }
+
+    private EmbeddingResponse embed(List<String> inputs, EmbeddingParameters parameters) {
+
+        com.ibm.watsonx.ai.embedding.EmbeddingResponse response =
                 WatsonxExceptionMapper.INSTANCE.withExceptionMapper(() -> embeddingService.embed(inputs, parameters));
 
-        return Response.from(response.results().stream()
-                .map(Result::embedding)
-                .map(Embedding::from)
-                .toList());
+        return Converter.toEmbeddingResponse(response, modelName);
     }
 
     /**
@@ -111,6 +133,7 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
      */
     public static class Builder extends WatsonxBuilder<Builder> {
         private String modelName;
+        private List<EmbeddingModelListener> listeners;
 
         private Builder() {}
 
@@ -122,6 +145,17 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
          */
         public Builder modelName(String modelName) {
             this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * Sets the {@link EmbeddingModelListener}s notified around every embedding request.
+         *
+         * @param listeners the listeners to register
+         * @return {@code this}
+         */
+        public Builder listeners(List<EmbeddingModelListener> listeners) {
+            this.listeners = listeners;
             return this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
@@ -1,9 +1,11 @@
 package dev.langchain4j.model.watsonx;
 
+import com.ibm.watsonx.ai.chat.exception.ModerationException;
 import com.ibm.watsonx.ai.core.exception.WatsonxException;
 import com.ibm.watsonx.ai.core.exception.model.WatsonxError;
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.InternalServerException;
 import dev.langchain4j.exception.InvalidRequestException;
 import dev.langchain4j.exception.LangChain4jException;
@@ -46,6 +48,8 @@ class WatsonxExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
 
         } else if (t instanceof HttpTimeoutException || t instanceof java.util.concurrent.TimeoutException) {
             return new TimeoutException(t);
+        } else if (t instanceof ModerationException moderationException) {
+            return new ContentFilteredException(moderationException.getMessage(), moderationException);
         }
 
         return t instanceof RuntimeException re ? re : new LangChain4jException(t);

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChat.java
@@ -6,13 +6,13 @@ import static java.util.Objects.nonNull;
 import com.ibm.watsonx.ai.chat.ChatProvider;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ServiceTier;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatService;
 import dev.langchain4j.Internal;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import java.util.List;
@@ -21,7 +21,7 @@ import java.util.Map;
 @Internal
 abstract class WatsonxGatewayChat extends WatsonxChatBase<ModelGatewayChatRequest> {
 
-    protected final ModelGatewayService modelGatewayService;
+    protected final ModelGatewayChatService modelGatewayChatService;
 
     protected WatsonxGatewayChat(Builder<?> builder) {
         super(builder, mergeParameters(builder));
@@ -29,10 +29,10 @@ abstract class WatsonxGatewayChat extends WatsonxChatBase<ModelGatewayChatReques
         var parameters = (WatsonxGatewayChatRequestParameters) defaultRequestParameters;
 
         var serviceBuilder = nonNull(builder.authenticator)
-                ? ModelGatewayService.builder().authenticator(builder.authenticator)
-                : ModelGatewayService.builder().apiKey(builder.apiKey);
+                ? ModelGatewayChatService.builder().authenticator(builder.authenticator)
+                : ModelGatewayChatService.builder().apiKey(builder.apiKey);
 
-        modelGatewayService = serviceBuilder
+        modelGatewayChatService = serviceBuilder
                 .baseUrl(builder.baseUrl)
                 .version(builder.version)
                 .modelId(parameters.modelName())
@@ -46,7 +46,7 @@ abstract class WatsonxGatewayChat extends WatsonxChatBase<ModelGatewayChatReques
 
     @Override
     protected ChatProvider<ModelGatewayChatRequest, ModelGatewayChatResponse> chatProvider() {
-        return modelGatewayService;
+        return modelGatewayChatService;
     }
 
     @Override
@@ -56,7 +56,7 @@ abstract class WatsonxGatewayChat extends WatsonxChatBase<ModelGatewayChatReques
         return ModelGatewayChatRequest.builder()
                 .messages(messages)
                 .tools(tools)
-                .parameters(Converter.toModelGatewayParameters(parameters, strictJsonSchema))
+                .parameters(Converter.toModelGatewayChatParameters(parameters, strictJsonSchema))
                 .build();
     }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParameters.java
@@ -2,10 +2,10 @@ package dev.langchain4j.model.watsonx;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ServiceTier;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import java.time.Duration;

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModel.java
@@ -1,0 +1,255 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.ModelProvider.WATSONX;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingParameters;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingParameters.EncodingFormat;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingResponse;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingService;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
+import dev.langchain4j.model.embedding.request.EmbeddingInput;
+import dev.langchain4j.model.embedding.request.EmbeddingParameter;
+import dev.langchain4j.model.embedding.request.EmbeddingRequest;
+import dev.langchain4j.model.embedding.request.EmbeddingRequestParameters;
+import dev.langchain4j.model.embedding.response.EmbeddingResponse;
+import dev.langchain4j.model.output.Response;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A {@link EmbeddingModel} implementation that integrates the IBM watsonx.ai Model Gateway with LangChain4j.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+ *     .baseUrl("https://...") // or use CloudRegion
+ *     .apiKey("...")
+ *     .modelName("text-embedding-3-small")
+ *     .build();
+ * }</pre>
+ *
+ */
+public class WatsonxGatewayEmbeddingModel implements EmbeddingModel {
+
+    private final ModelGatewayEmbeddingService modelGatewayEmbeddingService;
+    private final ModelGatewayEmbeddingParameters defaultParameters;
+    private final EmbeddingRequestParameters defaultRequestParameters;
+    private final String modelName;
+    private final String encodingFormat;
+    private final String user;
+    private final List<EmbeddingModelListener> listeners;
+
+    private WatsonxGatewayEmbeddingModel(Builder builder) {
+
+        var serviceBuilder = nonNull(builder.authenticator)
+                ? ModelGatewayEmbeddingService.builder().authenticator(builder.authenticator)
+                : ModelGatewayEmbeddingService.builder().apiKey(builder.apiKey);
+
+        modelGatewayEmbeddingService = serviceBuilder
+                .baseUrl(builder.baseUrl)
+                .modelId(builder.modelName)
+                .version(builder.version)
+                .timeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
+                .build();
+
+        this.defaultParameters = ModelGatewayEmbeddingParameters.builder()
+                .dimensions(builder.dimensions)
+                .encodingFormat(builder.encodingFormat)
+                .user(builder.user)
+                .build();
+
+        this.defaultRequestParameters = EmbeddingRequestParameters.builder()
+                .dimensions(builder.dimensions)
+                .build();
+
+        this.modelName = builder.modelName;
+        this.encodingFormat = builder.encodingFormat;
+        this.user = builder.user;
+        this.listeners = copy(builder.listeners);
+    }
+
+    @Override
+    public List<EmbeddingModelListener> listeners() {
+        return listeners;
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return WATSONX;
+    }
+
+    @Override
+    public String modelName() {
+        return this.modelName;
+    }
+
+    @Override
+    public EmbeddingRequestParameters defaultRequestParameters() {
+        return defaultRequestParameters;
+    }
+
+    @Override
+    public Set<EmbeddingParameter<?>> supportedParameters() {
+        return Set.of(EmbeddingRequestParameters.DIMENSIONS);
+    }
+
+    @Override
+    public EmbeddingResponse doEmbed(EmbeddingRequest request) {
+
+        List<String> inputs =
+                request.inputs().stream().map(EmbeddingInput::text).toList();
+
+        ModelGatewayEmbeddingParameters parameters = ModelGatewayEmbeddingParameters.builder()
+                .dimensions(request.parameters().dimensions())
+                .encodingFormat(encodingFormat)
+                .user(user)
+                .build();
+
+        return embed(inputs, parameters);
+    }
+
+    /**
+     * Embeds the text content of a list of TextSegment using the specified {@link ModelGatewayEmbeddingParameters}.
+     *
+     * <p>The given parameters replace the ones set on the builder, they are not merged with them.
+     *
+     * @param textSegments the text segments to embed.
+     * @param parameters the embedding parameters to use, or {@code null} to use the ones set on the builder.
+     * @return the embeddings.
+     */
+    public Response<List<Embedding>> embedAll(
+            List<TextSegment> textSegments, ModelGatewayEmbeddingParameters parameters) {
+
+        if (isNull(textSegments) || textSegments.isEmpty()) return Response.from(List.of());
+
+        List<String> inputs = textSegments.stream().map(TextSegment::text).toList();
+        EmbeddingResponse response = embed(inputs, getOrDefault(parameters, defaultParameters));
+
+        return Response.from(response.embeddings(), response.metadata().tokenUsage());
+    }
+
+    private EmbeddingResponse embed(List<String> inputs, ModelGatewayEmbeddingParameters parameters) {
+
+        ModelGatewayEmbeddingResponse response = WatsonxExceptionMapper.INSTANCE.withExceptionMapper(
+                () -> modelGatewayEmbeddingService.embed(inputs, parameters));
+
+        return Converter.toEmbeddingResponse(response, modelName);
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+     *     .baseUrl("https://...") // or use CloudRegion
+     *     .apiKey("...")
+     *     .modelName("text-embedding-3-small")
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link WatsonxGatewayEmbeddingModel} instances with configurable parameters.
+     */
+    public static class Builder extends WatsonxConnectionBuilder<Builder> {
+        private String modelName;
+        private Integer dimensions;
+        private String encodingFormat;
+        private String user;
+        private List<EmbeddingModelListener> listeners;
+
+        private Builder() {}
+
+        /**
+         * Sets the gateway embedding model id, e.g. {@code "text-embedding-3-small"}.
+         *
+         * @param modelName the model id
+         * @return {@code this}
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * Sets the number of dimensions of the returned embeddings. Only the models that support it accept this value.
+         *
+         * @param dimensions the number of dimensions
+         * @return {@code this}
+         */
+        public Builder dimensions(Integer dimensions) {
+            this.dimensions = dimensions;
+            return this;
+        }
+
+        /**
+         * Sets the wire format of the returned embeddings. The SDK decodes
+         * {@link EncodingFormat#BASE64} for you, so both formats give the same vectors.
+         *
+         * @param encodingFormat the {@link EncodingFormat}
+         * @return {@code this}
+         */
+        public Builder encodingFormat(EncodingFormat encodingFormat) {
+            this.encodingFormat = isNull(encodingFormat) ? null : encodingFormat.value();
+            return this;
+        }
+
+        /**
+         * Sets the wire format of the returned embeddings as a raw string, for the formats that
+         * {@link EncodingFormat} does not cover yet.
+         *
+         * @param encodingFormat the encoding format
+         * @return {@code this}
+         */
+        public Builder encodingFormat(String encodingFormat) {
+            this.encodingFormat = encodingFormat;
+            return this;
+        }
+
+        /**
+         * Sets the identifier of the end user, used for abuse monitoring.
+         *
+         * @param user the user identifier
+         * @return {@code this}
+         */
+        public Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        /**
+         * Sets the {@link EmbeddingModelListener}s notified around every embedding request.
+         *
+         * @param listeners the listeners to register
+         * @return {@code this}
+         */
+        public Builder listeners(List<EmbeddingModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public WatsonxGatewayEmbeddingModel build() {
+            return new WatsonxGatewayEmbeddingModel(this);
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModel.java
@@ -14,6 +14,7 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModelListenerUtils;
 import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
 import dev.langchain4j.model.embedding.request.EmbeddingInput;
 import dev.langchain4j.model.embedding.request.EmbeddingParameter;
@@ -126,6 +127,9 @@ public class WatsonxGatewayEmbeddingModel implements EmbeddingModel {
      *
      * <p>The given parameters replace the ones set on the builder, they are not merged with them.
      *
+     * <p>The registered {@link EmbeddingModelListener}s are notified around the call, as they are for every other
+     * embedding method.
+     *
      * @param textSegments the text segments to embed.
      * @param parameters the embedding parameters to use, or {@code null} to use the ones set on the builder.
      * @return the embeddings.
@@ -135,10 +139,11 @@ public class WatsonxGatewayEmbeddingModel implements EmbeddingModel {
 
         if (isNull(textSegments) || textSegments.isEmpty()) return Response.from(List.of());
 
-        List<String> inputs = textSegments.stream().map(TextSegment::text).toList();
-        EmbeddingResponse response = embed(inputs, getOrDefault(parameters, defaultParameters));
-
-        return Response.from(response.embeddings(), response.metadata().tokenUsage());
+        return EmbeddingModelListenerUtils.withListeners(this, textSegments, () -> {
+            List<String> inputs = textSegments.stream().map(TextSegment::text).toList();
+            EmbeddingResponse response = embed(inputs, getOrDefault(parameters, defaultParameters));
+            return Response.from(response.embeddings(), response.metadata().tokenUsage());
+        });
     }
 
     private EmbeddingResponse embed(List<String> inputs, ModelGatewayEmbeddingParameters parameters) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayImageModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayImageModel.java
@@ -40,6 +40,15 @@ public class WatsonxGatewayImageModel implements ImageModel {
     private final ModelGatewayImageService modelGatewayImageService;
     private final ModelGatewayImageParameters defaultParameters;
     private final String modelName;
+    private final String background;
+    private final String moderation;
+    private final Integer outputCompression;
+    private final String outputFormat;
+    private final String quality;
+    private final String responseFormat;
+    private final String size;
+    private final String style;
+    private final String user;
 
     private WatsonxGatewayImageModel(Builder builder) {
 
@@ -58,19 +67,18 @@ public class WatsonxGatewayImageModel implements ImageModel {
                 .verifySsl(builder.verifySsl)
                 .build();
 
-        defaultParameters = ModelGatewayImageParameters.builder()
-                .background(builder.background)
-                .moderation(builder.moderation)
-                .outputCompression(builder.outputCompression)
-                .outputFormat(builder.outputFormat)
-                .quality(builder.quality)
-                .responseFormat(builder.responseFormat)
-                .size(builder.size)
-                .style(builder.style)
-                .user(builder.user)
-                .build();
-
         modelName = builder.modelName;
+        background = builder.background;
+        moderation = builder.moderation;
+        outputCompression = builder.outputCompression;
+        outputFormat = builder.outputFormat;
+        quality = builder.quality;
+        responseFormat = builder.responseFormat;
+        size = builder.size;
+        style = builder.style;
+        user = builder.user;
+
+        defaultParameters = parameters(null);
     }
 
     /**
@@ -103,7 +111,7 @@ public class WatsonxGatewayImageModel implements ImageModel {
      */
     @Override
     public Response<List<Image>> generate(String prompt, int n) {
-        return generate(prompt, withNumberOfImages(n));
+        return generate(prompt, parameters(n));
     }
 
     /**
@@ -123,18 +131,18 @@ public class WatsonxGatewayImageModel implements ImageModel {
         return Converter.toImageResponse(response);
     }
 
-    private ModelGatewayImageParameters withNumberOfImages(int n) {
+    private ModelGatewayImageParameters parameters(Integer n) {
         return ModelGatewayImageParameters.builder()
-                .background(defaultParameters.background())
-                .moderation(defaultParameters.moderation())
+                .background(background)
+                .moderation(moderation)
                 .n(n)
-                .outputCompression(defaultParameters.outputCompression())
-                .outputFormat(defaultParameters.outputFormat())
-                .quality(defaultParameters.quality())
-                .responseFormat(defaultParameters.responseFormat())
-                .size(defaultParameters.size())
-                .style(defaultParameters.style())
-                .user(defaultParameters.user())
+                .outputCompression(outputCompression)
+                .outputFormat(outputFormat)
+                .quality(quality)
+                .responseFormat(responseFormat)
+                .size(size)
+                .style(style)
+                .user(user)
                 .build();
     }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayImageModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxGatewayImageModel.java
@@ -1,0 +1,377 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Background;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Moderation;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.OutputFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Quality;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.ResponseFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Size;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Style;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageService;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.output.Response;
+import java.util.List;
+
+/**
+ * An {@link ImageModel} implementation that integrates the IBM watsonx.ai Model Gateway with LangChain4j.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ImageModel imageModel = WatsonxGatewayImageModel.builder()
+ *     .baseUrl("https://...") // or use CloudRegion
+ *     .apiKey("...")
+ *     .modelName("gpt-image-1")
+ *     .build();
+ *
+ * Image image = imageModel.generate("A futuristic city at sunset").content();
+ * }</pre>
+ *
+ */
+public class WatsonxGatewayImageModel implements ImageModel {
+
+    private final ModelGatewayImageService modelGatewayImageService;
+    private final ModelGatewayImageParameters defaultParameters;
+    private final String modelName;
+
+    private WatsonxGatewayImageModel(Builder builder) {
+
+        var serviceBuilder = nonNull(builder.authenticator)
+                ? ModelGatewayImageService.builder().authenticator(builder.authenticator)
+                : ModelGatewayImageService.builder().apiKey(builder.apiKey);
+
+        modelGatewayImageService = serviceBuilder
+                .baseUrl(builder.baseUrl)
+                .modelId(builder.modelName)
+                .version(builder.version)
+                .timeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
+                .build();
+
+        defaultParameters = ModelGatewayImageParameters.builder()
+                .background(builder.background)
+                .moderation(builder.moderation)
+                .outputCompression(builder.outputCompression)
+                .outputFormat(builder.outputFormat)
+                .quality(builder.quality)
+                .responseFormat(builder.responseFormat)
+                .size(builder.size)
+                .style(builder.style)
+                .user(builder.user)
+                .build();
+
+        modelName = builder.modelName;
+    }
+
+    /**
+     * Returns the id of the gateway model used to generate the images.
+     *
+     * @return the model id
+     */
+    public String modelName() {
+        return modelName;
+    }
+
+    /**
+     * Generates a single image from the given prompt, using the parameters set on the builder.
+     *
+     * @param prompt the description of the image to generate
+     * @return the generated image
+     */
+    @Override
+    public Response<Image> generate(String prompt) {
+        Response<List<Image>> response = generate(prompt, defaultParameters);
+        return Response.from(response.content().get(0), response.tokenUsage());
+    }
+
+    /**
+     * Generates {@code n} images from the given prompt, using the parameters set on the builder.
+     *
+     * @param prompt the description of the images to generate
+     * @param n the number of images to generate, from 1 to 10
+     * @return the generated images
+     */
+    @Override
+    public Response<List<Image>> generate(String prompt, int n) {
+        return generate(prompt, withNumberOfImages(n));
+    }
+
+    /**
+     * Generates images from the given prompt, using the specified {@link ModelGatewayImageParameters}.
+     *
+     * <p>The given parameters replace the ones set on the builder, they are not merged with them.
+     *
+     * @param prompt the description of the images to generate
+     * @param parameters the image parameters to use, or {@code null} to use the ones set on the builder
+     * @return the generated images
+     */
+    public Response<List<Image>> generate(String prompt, ModelGatewayImageParameters parameters) {
+
+        ModelGatewayImageResponse response = WatsonxExceptionMapper.INSTANCE.withExceptionMapper(
+                () -> modelGatewayImageService.generate(prompt, getOrDefault(parameters, defaultParameters)));
+
+        return Converter.toImageResponse(response);
+    }
+
+    private ModelGatewayImageParameters withNumberOfImages(int n) {
+        return ModelGatewayImageParameters.builder()
+                .background(defaultParameters.background())
+                .moderation(defaultParameters.moderation())
+                .n(n)
+                .outputCompression(defaultParameters.outputCompression())
+                .outputFormat(defaultParameters.outputFormat())
+                .quality(defaultParameters.quality())
+                .responseFormat(defaultParameters.responseFormat())
+                .size(defaultParameters.size())
+                .style(defaultParameters.style())
+                .user(defaultParameters.user())
+                .build();
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ImageModel imageModel = WatsonxGatewayImageModel.builder()
+     *     .baseUrl("https://...") // or use CloudRegion
+     *     .apiKey("...")
+     *     .modelName("gpt-image-1")
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for constructing {@link WatsonxGatewayImageModel} instances with configurable parameters.
+     */
+    public static class Builder extends WatsonxConnectionBuilder<Builder> {
+        private String modelName;
+        private String background;
+        private String moderation;
+        private Integer outputCompression;
+        private String outputFormat;
+        private String quality;
+        private String responseFormat;
+        private String size;
+        private String style;
+        private String user;
+
+        private Builder() {}
+
+        /**
+         * Sets the gateway image model id, e.g. {@code "gpt-image-1"}.
+         *
+         * @param modelName the model id
+         * @return {@code this}
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * Sets the background of the generated images. Transparency requires an output format that supports it, so
+         * {@link OutputFormat#PNG} or {@link OutputFormat#WEBP}.
+         *
+         * @param background the {@link Background}
+         * @return {@code this}
+         */
+        public Builder background(Background background) {
+            this.background = isNull(background) ? null : background.value();
+            return this;
+        }
+
+        /**
+         * Sets the background of the generated images as a raw string, for the values that {@link Background} does not
+         * cover yet.
+         *
+         * @param background the background
+         * @return {@code this}
+         */
+        public Builder background(String background) {
+            this.background = background;
+            return this;
+        }
+
+        /**
+         * Sets how strictly the generated images are filtered, {@link Moderation#LOW} being the least restrictive.
+         *
+         * @param moderation the {@link Moderation}
+         * @return {@code this}
+         */
+        public Builder moderation(Moderation moderation) {
+            this.moderation = isNull(moderation) ? null : moderation.value();
+            return this;
+        }
+
+        /**
+         * Sets how strictly the generated images are filtered as a raw string, for the values that {@link Moderation}
+         * does not cover yet.
+         *
+         * @param moderation the moderation level
+         * @return {@code this}
+         */
+        public Builder moderation(String moderation) {
+            this.moderation = moderation;
+            return this;
+        }
+
+        /**
+         * Sets the compression level of the generated images, from 0 to 100. Only the {@link OutputFormat#JPEG} and
+         * {@link OutputFormat#WEBP} formats accept it.
+         *
+         * @param outputCompression the compression level
+         * @return {@code this}
+         */
+        public Builder outputCompression(Integer outputCompression) {
+            this.outputCompression = outputCompression;
+            return this;
+        }
+
+        /**
+         * Sets the file format of the generated images.
+         *
+         * @param outputFormat the {@link OutputFormat}
+         * @return {@code this}
+         */
+        public Builder outputFormat(OutputFormat outputFormat) {
+            this.outputFormat = isNull(outputFormat) ? null : outputFormat.value();
+            return this;
+        }
+
+        /**
+         * Sets the file format of the generated images as a raw string, for the formats that {@link OutputFormat} does
+         * not cover yet.
+         *
+         * @param outputFormat the output format
+         * @return {@code this}
+         */
+        public Builder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
+            return this;
+        }
+
+        /**
+         * Sets the quality of the generated images.
+         *
+         * @param quality the {@link Quality}
+         * @return {@code this}
+         */
+        public Builder quality(Quality quality) {
+            this.quality = isNull(quality) ? null : quality.value();
+            return this;
+        }
+
+        /**
+         * Sets the quality of the generated images as a raw string, for the values that {@link Quality} does not cover
+         * yet.
+         *
+         * @param quality the image quality
+         * @return {@code this}
+         */
+        public Builder quality(String quality) {
+            this.quality = quality;
+            return this;
+        }
+
+        /**
+         * Sets how the generated images are returned, as a link with {@link ResponseFormat#URL} or as Base64 data with
+         * {@link ResponseFormat#B64_JSON}. Only the models that support it accept this value.
+         *
+         * @param responseFormat the {@link ResponseFormat}
+         * @return {@code this}
+         */
+        public Builder responseFormat(ResponseFormat responseFormat) {
+            this.responseFormat = isNull(responseFormat) ? null : responseFormat.value();
+            return this;
+        }
+
+        /**
+         * Sets how the generated images are returned as a raw string, for the formats that {@link ResponseFormat} does
+         * not cover yet.
+         *
+         * @param responseFormat the response format
+         * @return {@code this}
+         */
+        public Builder responseFormat(String responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        /**
+         * Sets the dimensions of the generated images.
+         *
+         * @param size the {@link Size}
+         * @return {@code this}
+         */
+        public Builder size(Size size) {
+            this.size = isNull(size) ? null : size.value();
+            return this;
+        }
+
+        /**
+         * Sets the dimensions of the generated images as a raw string, e.g. {@code "1024x1024"}.
+         *
+         * @param size the image size
+         * @return {@code this}
+         */
+        public Builder size(String size) {
+            this.size = size;
+            return this;
+        }
+
+        /**
+         * Sets the visual style of the generated images.
+         *
+         * @param style the {@link Style}
+         * @return {@code this}
+         */
+        public Builder style(Style style) {
+            this.style = isNull(style) ? null : style.value();
+            return this;
+        }
+
+        /**
+         * Sets the visual style of the generated images as a raw string, for the values that {@link Style} does not
+         * cover yet.
+         *
+         * @param style the image style
+         * @return {@code this}
+         */
+        public Builder style(String style) {
+            this.style = style;
+            return this;
+        }
+
+        /**
+         * Sets the identifier of the end user, used for abuse monitoring.
+         *
+         * @param user the user identifier
+         * @return {@code this}
+         */
+        public Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public WatsonxGatewayImageModel build() {
+            return new WatsonxGatewayImageModel(this);
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingHandle.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingHandle.java
@@ -1,0 +1,41 @@
+package dev.langchain4j.model.watsonx;
+
+import static java.util.Objects.nonNull;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.model.chat.response.StreamingHandle;
+import java.util.concurrent.CompletableFuture;
+
+@Internal
+class WatsonxStreamingHandle implements StreamingHandle {
+
+    private volatile CompletableFuture<?> streamingFuture;
+    private volatile boolean isCancelled;
+
+    void bindTo(CompletableFuture<?> streamingFuture) {
+        this.streamingFuture = streamingFuture;
+        if (isCancelled) cancelStreaming();
+    }
+
+    @Override
+    public void cancel() {
+        isCancelled = true;
+        cancelStreaming();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    private void cancelStreaming() {
+        var future = streamingFuture;
+        if (nonNull(future)) {
+            try {
+                future.cancel(true);
+            } catch (Exception ignored) {
+                // The stream is already over, there is nothing left to cancel.
+            }
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
@@ -13,10 +13,10 @@ import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.ToolMessage;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ServiceTier;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -545,7 +545,7 @@ public class ConverterTest {
     }
 
     @Test
-    void testToModelGatewayParameters_withAllFieldsSet() {
+    void testToModelGatewayChatParameters_withAllFieldsSet() {
         var parameters = WatsonxGatewayChatRequestParameters.builder()
                 .frequencyPenalty(0.1)
                 .maxOutputTokens(0)
@@ -573,7 +573,7 @@ public class ConverterTest {
                 .metadata(Map.of("k", "v"))
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters, false);
+        var p = Converter.toModelGatewayChatParameters(parameters, false);
         assertEquals(0.1, p.frequencyPenalty());
         assertEquals(0, p.maxCompletionTokens());
         assertEquals("modelName", p.modelId());
@@ -600,14 +600,14 @@ public class ConverterTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    void testToModelGatewayParameters_withToolChoiceRequiredAndMatchingTool() {
+    void testToModelGatewayChatParameters_withToolChoiceRequiredAndMatchingTool() {
         var parameters = WatsonxGatewayChatRequestParameters.builder()
                 .toolChoice(ToolChoice.REQUIRED)
                 .toolSpecifications(
                         ToolSpecification.builder().name("toolChoiceName").build())
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters, false);
+        var p = Converter.toModelGatewayChatParameters(parameters, false);
         assertEquals("required", p.toolChoiceOption());
 
         parameters = WatsonxGatewayChatRequestParameters.builder()
@@ -617,30 +617,30 @@ public class ConverterTest {
                         ToolSpecification.builder().name("toolChoiceName").build())
                 .build();
 
-        p = Converter.toModelGatewayParameters(parameters, false);
+        p = Converter.toModelGatewayChatParameters(parameters, false);
         assertNull(p.toolChoiceOption());
         assertEquals("function", p.toolChoice().get("type"));
         assertEquals("toolChoiceName", ((Map) p.toolChoice().get("function")).get("name"));
     }
 
     @Test
-    void testToModelGatewayParameters_withToolChoiceNone() {
+    void testToModelGatewayChatParameters_withToolChoiceNone() {
         var parameters = WatsonxGatewayChatRequestParameters.builder()
                 .toolChoice(ToolChoice.NONE)
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters, false);
+        var p = Converter.toModelGatewayChatParameters(parameters, false);
         assertEquals("none", p.toolChoiceOption());
     }
 
     @Test
-    void testToModelGatewayParameters_withoutStopSequences() {
+    void testToModelGatewayChatParameters_withoutStopSequences() {
         // The Model Gateway rejects an empty "stop" array with "Field validation for 'Sequences' failed on the
         // 'min' tag", so it must not be sent.
-        assertNull(Converter.toModelGatewayParameters(
+        assertNull(Converter.toModelGatewayChatParameters(
                         WatsonxGatewayChatRequestParameters.builder().build(), false)
                 .stop());
-        assertNull(Converter.toModelGatewayParameters(
+        assertNull(Converter.toModelGatewayChatParameters(
                         WatsonxGatewayChatRequestParameters.builder()
                                 .stopSequences(List.of())
                                 .build(),
@@ -649,10 +649,10 @@ public class ConverterTest {
     }
 
     @Test
-    void testToModelGatewayParameters_withInvalidToolChoice() {
+    void testToModelGatewayChatParameters_withInvalidToolChoice() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(
+                () -> Converter.toModelGatewayChatParameters(
                         WatsonxGatewayChatRequestParameters.builder()
                                 .toolChoice(ToolChoice.REQUIRED)
                                 .build(),
@@ -660,7 +660,7 @@ public class ConverterTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(
+                () -> Converter.toModelGatewayChatParameters(
                         WatsonxGatewayChatRequestParameters.builder()
                                 .toolChoice(ToolChoice.REQUIRED)
                                 .toolChoiceName("toolChoiceName")
@@ -669,7 +669,7 @@ public class ConverterTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(
+                () -> Converter.toModelGatewayChatParameters(
                         WatsonxGatewayChatRequestParameters.builder()
                                 .toolChoice(ToolChoice.REQUIRED)
                                 .toolChoiceName("toolChoiceName")
@@ -679,7 +679,7 @@ public class ConverterTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> Converter.toModelGatewayParameters(
+                () -> Converter.toModelGatewayChatParameters(
                         WatsonxGatewayChatRequestParameters.builder()
                                 .toolChoice(ToolChoice.REQUIRED)
                                 .toolChoiceName("toolChoiceName")
@@ -691,12 +691,12 @@ public class ConverterTest {
     }
 
     @Test
-    void testToModelGatewayParameters_withResponseFormat() throws Exception {
+    void testToModelGatewayChatParameters_withResponseFormat() throws Exception {
         var parameters = WatsonxGatewayChatRequestParameters.builder()
                 .responseFormat(ResponseFormat.JSON)
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters, false);
+        var p = Converter.toModelGatewayChatParameters(parameters, false);
         assertEquals("json_object", p.responseFormat());
 
         parameters = WatsonxGatewayChatRequestParameters.builder()
@@ -708,7 +708,7 @@ public class ConverterTest {
                         .build())
                 .build();
 
-        p = Converter.toModelGatewayParameters(parameters, false);
+        p = Converter.toModelGatewayChatParameters(parameters, false);
         assertEquals("json_schema", p.responseFormat());
         assertEquals("test", p.jsonSchema().name());
         assertEquals(false, p.jsonSchema().strict());
@@ -725,7 +725,7 @@ public class ConverterTest {
     }
 
     @Test
-    void testToModelGatewayParameters_withStrictJsonSchema() throws Exception {
+    void testToModelGatewayChatParameters_withStrictJsonSchema() throws Exception {
         var parameters = WatsonxGatewayChatRequestParameters.builder()
                 .responseFormat(JsonSchema.builder()
                         .name("test")
@@ -737,7 +737,7 @@ public class ConverterTest {
                         .build())
                 .build();
 
-        var p = Converter.toModelGatewayParameters(parameters, true);
+        var p = Converter.toModelGatewayChatParameters(parameters, true);
         assertEquals("json_schema", p.responseFormat());
         assertEquals("test", p.jsonSchema().name());
         assertEquals(true, p.jsonSchema().strict());
@@ -758,7 +758,7 @@ public class ConverterTest {
     }
 
     @Test
-    void testToModelGatewayParameters_withInvalidJsonSchemaRootElement() {
+    void testToModelGatewayChatParameters_withInvalidJsonSchemaRootElement() {
         var parameters = WatsonxGatewayChatRequestParameters.builder()
                 .responseFormat(JsonSchema.builder()
                         .name("test")
@@ -767,7 +767,7 @@ public class ConverterTest {
                 .build();
 
         var exception = assertThrows(
-                IllegalArgumentException.class, () -> Converter.toModelGatewayParameters(parameters, false));
+                IllegalArgumentException.class, () -> Converter.toModelGatewayChatParameters(parameters, false));
 
         assertEquals(
                 "The root element of the JSON Schema must be either a JsonObjectSchema or a JsonRawSchema, but it was: "

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
@@ -808,8 +808,10 @@ public class ConverterTest {
                 WatsonxChatResponseMetadata.class,
                 Converter.toChatResponse(plainResponse).metadata());
 
-        assertNull(metadata.getServiceTier());
-        assertNull(metadata.getSystemFingerprint());
-        assertNull(metadata.getCached());
+        assertNull(metadata.serviceTier());
+        assertNull(metadata.systemFingerprint());
+        assertNull(metadata.cached());
+        assertNull(metadata.moderations());
+        assertNull(metadata.detections());
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,11 +18,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.ChatService;
-import com.ibm.watsonx.ai.chat.EmptyChatResponseException;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
+import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionEntry;
+import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionResult;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult.Position;
+import com.ibm.watsonx.ai.chat.exception.EmptyChatResponseException;
+import com.ibm.watsonx.ai.chat.exception.ModerationException;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
@@ -496,8 +503,8 @@ public class WatsonxChatModelTest {
             var metadata = (WatsonxChatResponseMetadata) response.metadata();
             assertEquals("id", response.id());
             assertEquals("modelId", response.modelName());
-            assertEquals("modelVersion", metadata.getModelVersion());
-            assertEquals(1L, metadata.getCreated());
+            assertEquals("modelVersion", metadata.modelVersion());
+            assertEquals(1L, metadata.created());
             assertEquals(FinishReason.STOP, response.finishReason());
             assertEquals(10, response.tokenUsage().inputTokenCount());
             assertEquals(10, response.tokenUsage().outputTokenCount());
@@ -1042,6 +1049,182 @@ public class WatsonxChatModelTest {
             assertFalse(jsonSchema.strict());
             assertEquals(List.of("content"), schema.get("required"));
             assertFalse(schema.containsKey("additionalProperties"));
+        });
+    }
+
+    @Test
+    void should_do_chat_with_inline_moderation() {
+
+        var moderation = ChatModeration.builder()
+                .pii(p -> p.input(true).output(true))
+                .hap(h -> h.output(0.8f))
+                .build();
+
+        var moderationResult = new ModerationResult(0.98f, false, new Position(11, 23), "PhoneNumber", "555-123-4567");
+        var detectionEntry = new DetectionEntry(
+                0, List.of(new DetectionResult("granite_guardian", "risk", "Yes", 0.9, "Call me", 0, 7)));
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Call me at 555-123-4567", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse
+                .choices(List.of(resultChoice))
+                .moderations(Map.of("pii", List.of(moderationResult)))
+                .detections(Map.of("output", List.of(detectionEntry)));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .moderations(moderation)
+                    .build();
+
+            var defaultRequestParameters =
+                    assertInstanceOf(WatsonxChatRequestParameters.class, chatModel.defaultRequestParameters());
+            assertSame(moderation, defaultRequestParameters.moderations());
+
+            var response = chatModel.chat(ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Give me a phone number"))
+                    .build());
+
+            assertSame(moderation, chatRequestCaptor.getValue().moderations());
+
+            var metadata = assertInstanceOf(WatsonxChatResponseMetadata.class, response.metadata());
+            assertEquals(Map.of("pii", List.of(moderationResult)), metadata.moderations());
+            assertEquals(Map.of("output", List.of(detectionEntry)), metadata.detections());
+            assertEquals("Call me at 555-123-4567", response.aiMessage().text());
+        });
+    }
+
+    @Test
+    void should_override_the_inline_moderation_of_the_builder() {
+
+        var builderModeration = ChatModeration.builder().pii(p -> p.input(true)).build();
+        var requestModeration =
+                ChatModeration.builder().hap(h -> h.output(0.5f)).build();
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .moderations(builderModeration)
+                    .build();
+
+            chatModel.chat(ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                    .parameters(WatsonxChatRequestParameters.builder()
+                            .moderations(requestModeration)
+                            .build())
+                    .build());
+
+            assertSame(requestModeration, chatRequestCaptor.getValue().moderations());
+
+            chatModel.chat(ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                    .parameters(WatsonxChatRequestParameters.builder()
+                            .temperature(0.5)
+                            .build())
+                    .build());
+
+            assertSame(builderModeration, chatRequestCaptor.getValue().moderations());
+        });
+    }
+
+    @Test
+    void should_not_send_any_moderation_when_it_is_not_configured() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .build();
+
+            var response = chatModel.chat(ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                    .build());
+
+            assertNull(chatRequestCaptor.getValue().moderations());
+
+            var metadata = assertInstanceOf(WatsonxChatResponseMetadata.class, response.metadata());
+            assertNull(metadata.moderations());
+            assertNull(metadata.detections());
+        });
+    }
+
+    @Test
+    void should_map_a_moderation_block_to_a_content_filtered_exception() {
+
+        var moderationResult = new ModerationResult(0.8f, true, new Position(46, 56), "PhoneNumber", "3572865321");
+        var detectionEntry = new DetectionEntry(
+                0, List.of(new DetectionResult("en_syntax_rbr_pii", "pii", "PhoneNumber", 0.8, "3572865321", 46, 56)));
+
+        var resultChoice = new ResultChoice(0, null, null);
+        chatResponse
+                .choices(List.of(resultChoice))
+                .moderations(Map.of("pii", List.of(moderationResult)))
+                .detections(Map.of("input", List.of(detectionEntry)));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .moderations(
+                            ChatModeration.builder().pii(p -> p.input(true)).build())
+                    .build();
+
+            var ex = assertThrows(ContentFilteredException.class, () -> chatModel.chat("hello"));
+            assertEquals(
+                    "The chat response was blocked by the moderation system (policies triggered: pii)",
+                    ex.getMessage());
+
+            var cause = assertInstanceOf(ModerationException.class, ex.getCause());
+            assertEquals(Map.of("pii", List.of(moderationResult)), cause.moderations());
+        });
+    }
+
+    @Test
+    void should_propagate_the_empty_response_when_the_moderation_did_not_block_the_generation() {
+
+        var moderationResult = new ModerationResult(0.8f, false, new Position(0, 10), "PhoneNumber", "3572865321");
+        var resultChoice = new ResultChoice(0, null, "length");
+        chatResponse.choices(List.of(resultChoice)).moderations(Map.of("pii", List.of(moderationResult)));
+
+        when(mockChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withChatServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("project-id")
+                    .apiKey("api-key")
+                    .moderations(
+                            ChatModeration.builder().pii(p -> p.output(true)).build())
+                    .build();
+
+            assertThrows(EmptyChatResponseException.class, () -> chatModel.chat("hello"));
         });
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadataTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadataTest.java
@@ -125,7 +125,8 @@ class WatsonxChatResponseMetadataTest {
         assertThat(base).isNotEqualTo(fullyPopulated().created(1L).build());
         assertThat(base).isNotEqualTo(fullyPopulated().modelVersion("other").build());
         assertThat(base).isNotEqualTo(fullyPopulated().serviceTier("other").build());
-        assertThat(base).isNotEqualTo(fullyPopulated().systemFingerprint("other").build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().systemFingerprint("other").build());
         assertThat(base).isNotEqualTo(fullyPopulated().cached(false).build());
         assertThat(base).isNotEqualTo(fullyPopulated().moderations(Map.of()).build());
         assertThat(base).isNotEqualTo(fullyPopulated().detections(Map.of()).build());

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadataTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatResponseMetadataTest.java
@@ -2,12 +2,25 @@ package dev.langchain4j.model.watsonx;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionEntry;
+import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionResult;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult.Position;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class WatsonxChatResponseMetadataTest {
+
+    private static final Map<String, List<ModerationResult>> MODERATIONS =
+            Map.of("hate", List.of(new ModerationResult(0.9f, true, new Position(0, 4), "hate", "word")));
+    private static final Map<String, List<DetectionEntry>> DETECTIONS = Map.of(
+            "pii",
+            List.of(new DetectionEntry(
+                    0, List.of(new DetectionResult("det-1", "pii", "email", 0.95, "test@test.com", 0, 13)))));
 
     private static WatsonxChatResponseMetadata.Builder fullyPopulated() {
         return WatsonxChatResponseMetadata.builder()
@@ -19,7 +32,9 @@ class WatsonxChatResponseMetadataTest {
                 .modelVersion("2.0.0")
                 .serviceTier("premium")
                 .systemFingerprint("fp-1")
-                .cached(true);
+                .cached(true)
+                .moderations(MODERATIONS)
+                .detections(DETECTIONS);
     }
 
     @Test
@@ -29,11 +44,13 @@ class WatsonxChatResponseMetadataTest {
         assertThat(rebuilt).isInstanceOf(WatsonxChatResponseMetadata.class);
 
         WatsonxChatResponseMetadata watsonxMetadata = (WatsonxChatResponseMetadata) rebuilt;
-        assertThat(watsonxMetadata.getCreated()).isEqualTo(1754000000L);
-        assertThat(watsonxMetadata.getModelVersion()).isEqualTo("2.0.0");
-        assertThat(watsonxMetadata.getServiceTier()).isEqualTo("premium");
-        assertThat(watsonxMetadata.getSystemFingerprint()).isEqualTo("fp-1");
-        assertThat(watsonxMetadata.getCached()).isTrue();
+        assertThat(watsonxMetadata.created()).isEqualTo(1754000000L);
+        assertThat(watsonxMetadata.modelVersion()).isEqualTo("2.0.0");
+        assertThat(watsonxMetadata.serviceTier()).isEqualTo("premium");
+        assertThat(watsonxMetadata.systemFingerprint()).isEqualTo("fp-1");
+        assertThat(watsonxMetadata.cached()).isTrue();
+        assertThat(watsonxMetadata.moderations()).isEqualTo(MODERATIONS);
+        assertThat(watsonxMetadata.detections()).isEqualTo(DETECTIONS);
     }
 
     @Test
@@ -54,11 +71,11 @@ class WatsonxChatResponseMetadataTest {
 
         assertThat(rebuilt).isInstanceOf(WatsonxChatResponseMetadata.class);
         assertThat(rebuilt.tokenUsage()).isEqualTo(new TokenUsage(10, 20, 30));
-        assertThat(((WatsonxChatResponseMetadata) rebuilt).getModelVersion()).isEqualTo("2.0.0");
+        assertThat(((WatsonxChatResponseMetadata) rebuilt).modelVersion()).isEqualTo("2.0.0");
     }
 
     @Test
-    void toBuilder_should_preserve_a_metadata_without_the_gateway_fields() {
+    void toBuilder_should_preserve_a_metadata_with_only_base_fields() {
         ChatResponseMetadata rebuilt =
                 WatsonxChatResponseMetadata.builder()
                         .id("chat-id")
@@ -71,11 +88,13 @@ class WatsonxChatResponseMetadataTest {
         assertThat(rebuilt).isInstanceOf(WatsonxChatResponseMetadata.class);
 
         WatsonxChatResponseMetadata watsonxMetadata = (WatsonxChatResponseMetadata) rebuilt;
-        assertThat(watsonxMetadata.getCreated()).isEqualTo(1754000000L);
-        assertThat(watsonxMetadata.getModelVersion()).isEqualTo("2.0.0");
-        assertThat(watsonxMetadata.getServiceTier()).isNull();
-        assertThat(watsonxMetadata.getSystemFingerprint()).isNull();
-        assertThat(watsonxMetadata.getCached()).isNull();
+        assertThat(watsonxMetadata.created()).isEqualTo(1754000000L);
+        assertThat(watsonxMetadata.modelVersion()).isEqualTo("2.0.0");
+        assertThat(watsonxMetadata.serviceTier()).isNull();
+        assertThat(watsonxMetadata.systemFingerprint()).isNull();
+        assertThat(watsonxMetadata.cached()).isNull();
+        assertThat(watsonxMetadata.moderations()).isNull();
+        assertThat(watsonxMetadata.detections()).isNull();
     }
 
     @Test
@@ -106,9 +125,10 @@ class WatsonxChatResponseMetadataTest {
         assertThat(base).isNotEqualTo(fullyPopulated().created(1L).build());
         assertThat(base).isNotEqualTo(fullyPopulated().modelVersion("other").build());
         assertThat(base).isNotEqualTo(fullyPopulated().serviceTier("other").build());
-        assertThat(base)
-                .isNotEqualTo(fullyPopulated().systemFingerprint("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().systemFingerprint("other").build());
         assertThat(base).isNotEqualTo(fullyPopulated().cached(false).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().moderations(Map.of()).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().detections(Map.of()).build());
     }
 
     @Test
@@ -137,6 +157,8 @@ class WatsonxChatResponseMetadataTest {
                 .contains("modelVersion='2.0.0'")
                 .contains("serviceTier='premium'")
                 .contains("systemFingerprint='fp-1'")
-                .contains("cached=true");
+                .contains("cached=true")
+                .contains("moderations=")
+                .contains("detections=");
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -11,6 +11,7 @@ import dev.langchain4j.model.catalog.ModelCatalog;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.scoring.ScoringModel;
 import java.net.http.HttpClient;
@@ -498,6 +499,58 @@ public class WatsonxCustomHttpClientTest {
 
                 Object modelGatewayEmbeddingService = getFieldValue(embeddingModel, "modelGatewayEmbeddingService");
                 Object restclient = getFieldValue(modelGatewayEmbeddingService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_use_custom_http_client_for_gateway_image_model() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        ImageModel imageModel = WatsonxGatewayImageModel.builder()
+                .baseUrl("https://localhost")
+                .modelName("gpt-image-1")
+                .apiKey("apiKey")
+                .httpClient(customClient)
+                .build();
+
+        Object modelGatewayImageService = getFieldValue(imageModel, "modelGatewayImageService");
+        Object restclient = getFieldValue(modelGatewayImageService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_gateway_image_model() {
+
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
+
+                HttpClient customClient = HttpClient.newHttpClient();
+                ImageModel imageModel = WatsonxGatewayImageModel.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("gpt-image-1")
+                        .apiKey("apiKey")
+                        .verifySsl(verifySsl)
+                        .build();
+
+                Object modelGatewayImageService = getFieldValue(imageModel, "modelGatewayImageService");
+                Object restclient = getFieldValue(modelGatewayImageService, "client");
                 assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
                 assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -156,8 +156,8 @@ public class WatsonxCustomHttpClientTest {
                 .httpClient(customClient)
                 .build();
 
-        Object modelGatewayService = getFieldValue(chatModel, "modelGatewayService");
-        Object restclient = getFieldValue(modelGatewayService, "client");
+        Object modelGatewayChatService = getFieldValue(chatModel, "modelGatewayChatService");
+        Object restclient = getFieldValue(modelGatewayChatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
@@ -187,8 +187,8 @@ public class WatsonxCustomHttpClientTest {
                         .verifySsl(verifySsl)
                         .build();
 
-                Object modelGatewayService = getFieldValue(chatModel, "modelGatewayService");
-                Object restclient = getFieldValue(modelGatewayService, "client");
+                Object modelGatewayChatService = getFieldValue(chatModel, "modelGatewayChatService");
+                Object restclient = getFieldValue(modelGatewayChatService, "client");
                 assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
                 assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 
@@ -217,8 +217,8 @@ public class WatsonxCustomHttpClientTest {
                 .httpClient(customClient)
                 .build();
 
-        Object modelGatewayService = getFieldValue(streamingChatModel, "modelGatewayService");
-        Object restclient = getFieldValue(modelGatewayService, "client");
+        Object modelGatewayChatService = getFieldValue(streamingChatModel, "modelGatewayChatService");
+        Object restclient = getFieldValue(modelGatewayChatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
@@ -248,8 +248,8 @@ public class WatsonxCustomHttpClientTest {
                         .verifySsl(verifySsl)
                         .build();
 
-                Object modelGatewayService = getFieldValue(streamingChatModel, "modelGatewayService");
-                Object restclient = getFieldValue(modelGatewayService, "client");
+                Object modelGatewayChatService = getFieldValue(streamingChatModel, "modelGatewayChatService");
+                Object restclient = getFieldValue(modelGatewayChatService, "client");
                 assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
                 assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -460,6 +460,58 @@ public class WatsonxCustomHttpClientTest {
     }
 
     @Test
+    void should_use_custom_http_client_for_gateway_embedding_model() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                .baseUrl("https://localhost")
+                .modelName("text-embedding-3-small")
+                .apiKey("apiKey")
+                .httpClient(customClient)
+                .build();
+
+        Object modelGatewayEmbeddingService = getFieldValue(embeddingModel, "modelGatewayEmbeddingService");
+        Object restclient = getFieldValue(modelGatewayEmbeddingService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_gateway_embedding_model() {
+
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
+
+                HttpClient customClient = HttpClient.newHttpClient();
+                EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("text-embedding-3-small")
+                        .apiKey("apiKey")
+                        .verifySsl(verifySsl)
+                        .build();
+
+                Object modelGatewayEmbeddingService = getFieldValue(embeddingModel, "modelGatewayEmbeddingService");
+                Object restclient = getFieldValue(modelGatewayEmbeddingService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
     void should_use_custom_http_client_for_moderation_model() throws Exception {
 
         HttpClient customClient = HttpClient.newHttpClient();

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxDeploymentChatModelTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
@@ -241,6 +242,50 @@ public class WatsonxDeploymentChatModelTest {
                                 .modelName("my-model")
                                 .build())
                         .build());
+    }
+
+    @Test
+    void should_throw_exception_for_chat_request_with_moderations() {
+
+        var moderation = ChatModeration.builder().pii(p -> p.input(true)).build();
+
+        var chatModel = WatsonxDeploymentChatModel.builder()
+                .baseUrl("https://test.com")
+                .deploymentId("deployment-id")
+                .apiKey("api-key")
+                .build();
+
+        var ex = assertThrows(
+                UnsupportedFeatureException.class,
+                () -> chatModel.chat(ChatRequest.builder()
+                        .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                        .parameters(WatsonxChatRequestParameters.builder()
+                                .moderations(moderation)
+                                .build())
+                        .build()));
+
+        assertEquals("The 'moderations' parameter is not supported by the on-demand deployments", ex.getMessage());
+
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxDeploymentChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .deploymentId("deployment-id")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(WatsonxChatRequestParameters.builder()
+                                .moderations(moderation)
+                                .build())
+                        .build());
+    }
+
+    @Test
+    void should_not_expose_the_moderations_setter() throws Exception {
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> WatsonxDeploymentChatModel.Builder.class.getMethod("moderations", ChatModeration.class));
+        assertThrows(
+                NoSuchMethodException.class,
+                () -> WatsonxDeploymentStreamingChatModel.Builder.class.getMethod("moderations", ChatModeration.class));
     }
 
     @Test

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.model.watsonx;
 
+import static dev.langchain4j.model.ModelProvider.WATSONX;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -19,6 +21,10 @@ import com.ibm.watsonx.ai.embedding.EmbeddingService;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelRequestContext;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelResponseContext;
+import dev.langchain4j.model.embedding.request.EmbeddingRequest;
 import dev.langchain4j.model.watsonx.utils.HttpUtils;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -27,6 +33,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -175,6 +182,78 @@ public class WatsonxEmbeddingModelTest {
             assertEquals(0, embeddingModel.embedAll(null).content().size());
             assertEquals(0, embeddingModel.embedAll(List.of()).content().size());
         });
+    }
+
+    @Test
+    void should_return_the_model_name_and_the_token_usage() {
+
+        List<EmbeddingResponse.Result> results = List.of(new EmbeddingResponse.Result(List.of(0f, 1f), "test1"));
+
+        when(mockEmbeddingService.embed(List.of("test1"), null))
+                .thenReturn(new EmbeddingResponse("modelId", "createdAt", results, 10));
+
+        withEmbeddingServiceMock(() -> {
+            EmbeddingModel embeddingModel = createEmbeddingModel().build();
+
+            var response = embeddingModel.embed(
+                    EmbeddingRequest.builder().input("test1").build());
+
+            assertEquals(WATSONX, embeddingModel.provider());
+            assertEquals("modelId", response.metadata().modelName());
+            assertEquals(10, response.metadata().tokenUsage().inputTokenCount());
+        });
+    }
+
+    @Test
+    void should_notify_the_listeners() {
+
+        List<EmbeddingResponse.Result> results = List.of(new EmbeddingResponse.Result(List.of(0f, 1f), "test1"));
+
+        when(mockEmbeddingService.embed(List.of("test1"), null))
+                .thenReturn(new EmbeddingResponse("modelId", "createdAt", results, 10));
+
+        var requestContext = new AtomicReference<EmbeddingModelRequestContext>();
+        var responseContext = new AtomicReference<EmbeddingModelResponseContext>();
+
+        EmbeddingModelListener listener = new EmbeddingModelListener() {
+            @Override
+            public void onRequest(EmbeddingModelRequestContext context) {
+                requestContext.set(context);
+            }
+
+            @Override
+            public void onResponse(EmbeddingModelResponseContext context) {
+                responseContext.set(context);
+            }
+        };
+
+        withEmbeddingServiceMock(() -> {
+            EmbeddingModel embeddingModel =
+                    createEmbeddingModel().listeners(List.of(listener)).build();
+
+            embeddingModel.embed("test1");
+
+            assertNotNull(requestContext.get());
+            assertEquals(WATSONX, requestContext.get().modelProvider());
+            assertEquals(
+                    List.of("test1"),
+                    requestContext.get().textSegments().stream()
+                            .map(TextSegment::text)
+                            .toList());
+
+            assertNotNull(responseContext.get());
+            assertEquals(
+                    1, responseContext.get().embeddingResponse().embeddings().size());
+            assertEquals(10, responseContext.get().response().tokenUsage().inputTokenCount());
+        });
+    }
+
+    private WatsonxEmbeddingModel.Builder createEmbeddingModel() {
+        return WatsonxEmbeddingModel.builder()
+                .baseUrl("https://test.com")
+                .projectId("projectId")
+                .modelName("modelName")
+                .apiKey("apiKey");
     }
 
     private void withEmbeddingServiceMock(Runnable action) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
@@ -205,6 +205,53 @@ public class WatsonxEmbeddingModelTest {
     }
 
     @Test
+    void should_notify_the_listeners_when_embedding_with_the_watsonx_parameters() {
+
+        var parameters = EmbeddingParameters.builder().truncateInputTokens(10).build();
+        List<EmbeddingResponse.Result> results = List.of(new EmbeddingResponse.Result(List.of(0f, 1f), "test1"));
+
+        when(mockEmbeddingService.embed(List.of("test1"), parameters))
+                .thenReturn(new EmbeddingResponse("modelId", "createdAt", results, 10));
+
+        var requestContext = new AtomicReference<EmbeddingModelRequestContext>();
+        var responseContext = new AtomicReference<EmbeddingModelResponseContext>();
+
+        EmbeddingModelListener listener = new EmbeddingModelListener() {
+            @Override
+            public void onRequest(EmbeddingModelRequestContext context) {
+                requestContext.set(context);
+            }
+
+            @Override
+            public void onResponse(EmbeddingModelResponseContext context) {
+                responseContext.set(context);
+            }
+        };
+
+        withEmbeddingServiceMock(() -> {
+            WatsonxEmbeddingModel embeddingModel =
+                    createEmbeddingModel().listeners(List.of(listener)).build();
+
+            var response = embeddingModel.embedAll(List.of(TextSegment.from("test1")), parameters);
+
+            assertEquals(1, response.content().size());
+
+            assertNotNull(requestContext.get());
+            assertEquals(WATSONX, requestContext.get().modelProvider());
+            assertEquals(
+                    List.of("test1"),
+                    requestContext.get().textSegments().stream()
+                            .map(TextSegment::text)
+                            .toList());
+
+            assertNotNull(responseContext.get());
+            assertEquals(
+                    1, responseContext.get().embeddingResponse().embeddings().size());
+            assertEquals(10, responseContext.get().response().tokenUsage().inputTokenCount());
+        });
+    }
+
+    @Test
     void should_notify_the_listeners() {
 
         List<EmbeddingResponse.Result> results = List.of(new EmbeddingResponse.Result(List.of(0f, 1f), "test1"));

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
@@ -229,11 +229,11 @@ public class WatsonxGatewayChatModelTest {
             var metadata = (WatsonxChatResponseMetadata) response.metadata();
             assertEquals("id", response.id());
             assertEquals("model", response.modelName());
-            assertEquals("modelVersion", metadata.getModelVersion());
-            assertEquals(1L, metadata.getCreated());
-            assertEquals("auto", metadata.getServiceTier());
-            assertEquals("fp", metadata.getSystemFingerprint());
-            assertEquals(true, metadata.getCached());
+            assertEquals("modelVersion", metadata.modelVersion());
+            assertEquals(1L, metadata.created());
+            assertEquals("auto", metadata.serviceTier());
+            assertEquals("fp", metadata.systemFingerprint());
+            assertEquals(true, metadata.cached());
             assertEquals(FinishReason.STOP, response.finishReason());
             assertEquals(10, response.tokenUsage().inputTokenCount());
             assertEquals(10, response.tokenUsage().outputTokenCount());

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatModelTest.java
@@ -25,13 +25,13 @@ import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ServiceTier;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatService;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
@@ -66,10 +66,10 @@ import org.mockito.quality.Strictness;
 public class WatsonxGatewayChatModelTest {
 
     @Mock
-    ModelGatewayService mockModelGatewayService;
+    ModelGatewayChatService mockModelGatewayChatService;
 
     @Mock
-    ModelGatewayService.Builder mockModelGatewayServiceBuilder;
+    ModelGatewayChatService.Builder mockModelGatewayChatServiceBuilder;
 
     @Captor
     ArgumentCaptor<ModelGatewayChatRequest> chatRequestCaptor;
@@ -79,17 +79,17 @@ public class WatsonxGatewayChatModelTest {
     @BeforeEach
     void setUp() {
 
-        when(mockModelGatewayServiceBuilder.modelId(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.timeout(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.version(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.logRequests(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.logResponses(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.authenticator(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.httpClient(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.build()).thenReturn(mockModelGatewayService);
+        when(mockModelGatewayChatServiceBuilder.modelId(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.timeout(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.version(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.logRequests(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.logResponses(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.authenticator(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.httpClient(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.build()).thenReturn(mockModelGatewayChatService);
 
         var chatUsage = new ChatUsage(10, 10, 20);
         chatResponse = ModelGatewayChatResponse.builder()
@@ -121,11 +121,11 @@ public class WatsonxGatewayChatModelTest {
         var defaultRequestParameters =
                 assertInstanceOf(WatsonxGatewayChatRequestParameters.class, chatModel.defaultRequestParameters());
 
-        var modelGatewayServiceField =
-                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("modelGatewayService"));
-        var modelGatewayService = assertDoesNotThrow(() -> modelGatewayServiceField.get(chatModel));
+        var modelGatewayChatServiceField = assertDoesNotThrow(
+                () -> chatModel.getClass().getSuperclass().getDeclaredField("modelGatewayChatService"));
+        var modelGatewayChatService = assertDoesNotThrow(() -> modelGatewayChatServiceField.get(chatModel));
 
-        assertInstanceOf(ModelGatewayService.class, modelGatewayService);
+        assertInstanceOf(ModelGatewayChatService.class, modelGatewayChatService);
         assertEquals(ModelProvider.WATSONX, chatModel.provider());
         assertNull(defaultRequestParameters.frequencyPenalty());
         assertNull(defaultRequestParameters.logitBias());
@@ -161,9 +161,9 @@ public class WatsonxGatewayChatModelTest {
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
 
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -184,9 +184,9 @@ public class WatsonxGatewayChatModelTest {
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
 
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -204,9 +204,9 @@ public class WatsonxGatewayChatModelTest {
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, null, null, null, List.of(toolCall));
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -256,9 +256,9 @@ public class WatsonxGatewayChatModelTest {
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
 
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -331,9 +331,9 @@ public class WatsonxGatewayChatModelTest {
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
 
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -393,9 +393,9 @@ public class WatsonxGatewayChatModelTest {
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
 
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .apiKey("api-key")
@@ -447,9 +447,9 @@ public class WatsonxGatewayChatModelTest {
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
 
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -581,15 +581,15 @@ public class WatsonxGatewayChatModelTest {
 
         var authenticator = mock(IBMCloudAuthenticator.class);
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             assertDoesNotThrow(() -> WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
                     .authenticator(authenticator)
                     .build());
 
-            verify(mockModelGatewayServiceBuilder).authenticator(authenticator);
-            verify(mockModelGatewayServiceBuilder, never()).apiKey(any());
+            verify(mockModelGatewayChatServiceBuilder).authenticator(authenticator);
+            verify(mockModelGatewayChatServiceBuilder, never()).apiKey(any());
         });
     }
 
@@ -600,7 +600,7 @@ public class WatsonxGatewayChatModelTest {
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
 
-        when(mockModelGatewayService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+        when(mockModelGatewayChatService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
 
         var responseFormat = ResponseFormat.builder()
                 .type(ResponseFormatType.JSON)
@@ -614,7 +614,7 @@ public class WatsonxGatewayChatModelTest {
                         .build())
                 .build();
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -631,7 +631,7 @@ public class WatsonxGatewayChatModelTest {
             assertEquals(false, schema.get("additionalProperties"));
         });
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var chatModel = WatsonxGatewayChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -650,9 +650,9 @@ public class WatsonxGatewayChatModelTest {
         });
     }
 
-    private void withModelGatewayServiceMock(Runnable action) {
-        try (MockedStatic<ModelGatewayService> mockedStatic = mockStatic(ModelGatewayService.class)) {
-            mockedStatic.when(ModelGatewayService::builder).thenReturn(mockModelGatewayServiceBuilder);
+    private void withModelGatewayChatServiceMock(Runnable action) {
+        try (MockedStatic<ModelGatewayChatService> mockedStatic = mockStatic(ModelGatewayChatService.class)) {
+            mockedStatic.when(ModelGatewayChatService::builder).thenReturn(mockModelGatewayChatServiceBuilder);
             action.run();
         }
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParametersTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayChatRequestParametersTest.java
@@ -2,10 +2,10 @@ package dev.langchain4j.model.watsonx;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Cache;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.Router;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Cache;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.Router;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ServiceTier;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModelTest.java
@@ -1,0 +1,390 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.model.ModelProvider.WATSONX;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.core.Json;
+import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
+import com.ibm.watsonx.ai.core.provider.HttpClientProvider;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingParameters;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingParameters.EncodingFormat;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingPayload;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingResponse;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingResponse.Usage;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingService;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelRequestContext;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelResponseContext;
+import dev.langchain4j.model.embedding.request.EmbeddingInputType;
+import dev.langchain4j.model.embedding.request.EmbeddingRequest;
+import dev.langchain4j.model.embedding.request.EmbeddingRequestParameters;
+import dev.langchain4j.model.watsonx.utils.HttpUtils;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WatsonxGatewayEmbeddingModelTest {
+
+    @Mock
+    ModelGatewayEmbeddingService mockModelGatewayEmbeddingService;
+
+    @Mock
+    ModelGatewayEmbeddingService.Builder mockModelGatewayEmbeddingServiceBuilder;
+
+    @Captor
+    ArgumentCaptor<ModelGatewayEmbeddingParameters> parametersCaptor;
+
+    @BeforeEach
+    void setUp() {
+        when(mockModelGatewayEmbeddingServiceBuilder.modelId(any()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.baseUrl(any(URI.class)))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.timeout(any()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.version(any()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.logRequests(any()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.logResponses(any()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.authenticator(any()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.httpClient(any()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.verifySsl(anyBoolean()))
+                .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+        when(mockModelGatewayEmbeddingServiceBuilder.build()).thenReturn(mockModelGatewayEmbeddingService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_create_a_watsonx_gateway_embedding_model() throws Exception {
+
+        var data = List.of(new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));
+
+        var mockHttpClient = mock(HttpClient.class);
+        var mockHttpResponse = mock(HttpResponse.class);
+        var mockAuthenticatorProvider = mock(IBMCloudAuthenticator.class);
+        var mockHttpRequest = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(mockAuthenticatorProvider.token()).thenReturn("my-token");
+        when(mockHttpResponse.statusCode()).thenReturn(200);
+        when(mockHttpResponse.body())
+                .thenReturn(Json.toJson(
+                        new ModelGatewayEmbeddingResponse("list", "text-embedding-3-small", data, new Usage(10, 10))));
+        when(mockHttpClient.send(mockHttpRequest.capture(), any(BodyHandler.class)))
+                .thenReturn(mockHttpResponse);
+
+        try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mockHttpClient);
+
+            var embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl(CloudRegion.FRANKFURT)
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key-test")
+                    .version("my-version")
+                    .dimensions(512)
+                    .encodingFormat(EncodingFormat.BASE64)
+                    .user("my-user")
+                    .logRequests(true)
+                    .logResponses(true)
+                    .authenticator(mockAuthenticatorProvider)
+                    .timeout(Duration.ofSeconds(10))
+                    .build();
+
+            var response = embeddingModel.embed(TextSegment.from("test1"));
+
+            var payload =
+                    Json.fromJson(HttpUtils.bodyPublisherToString(mockHttpRequest), ModelGatewayEmbeddingPayload.class);
+
+            assertEquals("text-embedding-3-small", payload.model());
+            assertEquals(List.of("test1"), payload.input());
+            assertEquals(512, payload.dimensions());
+            assertEquals("base64", payload.encodingFormat());
+            assertEquals("my-user", payload.user());
+
+            var serviceField = assertDoesNotThrow(
+                    () -> embeddingModel.getClass().getDeclaredField("modelGatewayEmbeddingService"));
+            serviceField.setAccessible(true);
+            var service = assertDoesNotThrow(() -> serviceField.get(embeddingModel));
+
+            assertInstanceOf(ModelGatewayEmbeddingService.class, service);
+            assertEquals("text-embedding-3-small", embeddingModel.modelName());
+            assertEquals(Embedding.from(List.of(0f, 1f)), response.content());
+            assertEquals(10, response.tokenUsage().inputTokenCount());
+
+            assertDoesNotThrow(() -> WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .build());
+        }
+    }
+
+    @Test
+    void should_embed_all() {
+
+        var data = List.of(
+                new ModelGatewayEmbeddingResponse.Embedding("embedding", 1, List.of(2f, 3f), null),
+                new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));
+
+        when(mockModelGatewayEmbeddingService.embed(
+                        List.of("test1", "test2"),
+                        ModelGatewayEmbeddingParameters.builder().build()))
+                .thenReturn(
+                        new ModelGatewayEmbeddingResponse("list", "text-embedding-3-small", data, new Usage(10, 10)));
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .build();
+
+            var response = embeddingModel.embedAll(List.of(TextSegment.from("test1"), TextSegment.from("test2")));
+
+            assertEquals(2, response.content().size());
+            assertEquals(Embedding.from(List.of(0f, 1f)), response.content().get(0));
+            assertEquals(Embedding.from(List.of(2f, 3f)), response.content().get(1));
+            assertEquals(10, response.tokenUsage().inputTokenCount());
+        });
+    }
+
+    @Test
+    void should_embed_all_with_the_builder_parameters() {
+
+        var data = List.of(new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));
+
+        when(mockModelGatewayEmbeddingService.embed(any(), parametersCaptor.capture()))
+                .thenReturn(new ModelGatewayEmbeddingResponse("list", "text-embedding-3-small", data, null));
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            var embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .dimensions(512)
+                    .encodingFormat("float")
+                    .user("my-user")
+                    .build();
+
+            var response = embeddingModel.embedAll(List.of(TextSegment.from("test1")));
+            var parameters = parametersCaptor.getValue();
+
+            assertEquals(512, parameters.dimensions());
+            assertEquals("float", parameters.encodingFormat());
+            assertEquals("my-user", parameters.user());
+            assertEquals(1, response.content().size());
+            assertNull(response.tokenUsage());
+        });
+    }
+
+    @Test
+    void should_override_the_builder_parameters_with_the_given_parameters() {
+
+        var data = List.of(new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));
+
+        var parameters = ModelGatewayEmbeddingParameters.builder()
+                .dimensions(256)
+                .encodingFormat(EncodingFormat.FLOAT)
+                .build();
+
+        when(mockModelGatewayEmbeddingService.embed(List.of("test1"), parameters))
+                .thenReturn(
+                        new ModelGatewayEmbeddingResponse("list", "text-embedding-3-small", data, new Usage(10, 10)));
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            var embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .dimensions(512)
+                    .user("my-user")
+                    .build();
+
+            var response = embeddingModel.embedAll(List.of(TextSegment.from("test1")), parameters);
+
+            assertEquals(1, response.content().size());
+            assertEquals(Embedding.from(List.of(0f, 1f)), response.content().get(0));
+            assertEquals(10, response.tokenUsage().inputTokenCount());
+        });
+    }
+
+    @Test
+    void should_return_no_embeddings_when_there_is_no_input() {
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            var embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .build();
+
+            assertEquals(0, embeddingModel.embedAll(null).content().size());
+            assertEquals(0, embeddingModel.embedAll(List.of()).content().size());
+            assertEquals(
+                    0,
+                    embeddingModel
+                            .embedAll(
+                                    List.of(),
+                                    ModelGatewayEmbeddingParameters.builder().build())
+                            .content()
+                            .size());
+        });
+    }
+
+    @Test
+    void should_override_the_builder_dimensions_with_the_dimensions_of_the_request() {
+
+        var data = List.of(new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));
+
+        when(mockModelGatewayEmbeddingService.embed(any(), parametersCaptor.capture()))
+                .thenReturn(
+                        new ModelGatewayEmbeddingResponse("list", "text-embedding-3-small", data, new Usage(10, 10)));
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            var embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .dimensions(512)
+                    .user("my-user")
+                    .build();
+
+            assertEquals(Set.of(EmbeddingRequestParameters.DIMENSIONS), embeddingModel.supportedParameters());
+            assertEquals(512, embeddingModel.defaultRequestParameters().dimensions());
+
+            var response = embeddingModel.embed(
+                    EmbeddingRequest.builder().input("test1").dimensions(256).build());
+
+            assertEquals(256, parametersCaptor.getValue().dimensions());
+            assertEquals("my-user", parametersCaptor.getValue().user());
+            assertEquals("text-embedding-3-small", response.metadata().modelName());
+            assertEquals(10, response.metadata().tokenUsage().inputTokenCount());
+        });
+    }
+
+    @Test
+    void should_reject_the_parameters_the_gateway_does_not_support() {
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            var embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .build();
+
+            assertThrows(
+                    UnsupportedFeatureException.class,
+                    () -> embeddingModel.embed(EmbeddingRequest.builder()
+                            .input("test1")
+                            .inputType(EmbeddingInputType.QUERY)
+                            .build()));
+        });
+    }
+
+    @Test
+    void should_notify_the_listeners() {
+
+        var data = List.of(new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));
+
+        when(mockModelGatewayEmbeddingService.embed(any(), any()))
+                .thenReturn(
+                        new ModelGatewayEmbeddingResponse("list", "text-embedding-3-small", data, new Usage(10, 10)));
+
+        var requestContext = new AtomicReference<EmbeddingModelRequestContext>();
+        var responseContext = new AtomicReference<EmbeddingModelResponseContext>();
+
+        EmbeddingModelListener listener = new EmbeddingModelListener() {
+            @Override
+            public void onRequest(EmbeddingModelRequestContext context) {
+                requestContext.set(context);
+            }
+
+            @Override
+            public void onResponse(EmbeddingModelResponseContext context) {
+                responseContext.set(context);
+            }
+        };
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .listeners(List.of(listener))
+                    .build();
+
+            embeddingModel.embed("test1");
+
+            assertNotNull(requestContext.get());
+            assertEquals(WATSONX, requestContext.get().modelProvider());
+            assertNotNull(responseContext.get());
+            assertEquals(
+                    1, responseContext.get().embeddingResponse().embeddings().size());
+        });
+    }
+
+    @Test
+    void should_authenticate_with_an_authenticator_instead_of_an_api_key() {
+
+        var authenticator = mock(IBMCloudAuthenticator.class);
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            assertDoesNotThrow(() -> WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .authenticator(authenticator)
+                    .build());
+
+            verify(mockModelGatewayEmbeddingServiceBuilder).authenticator(authenticator);
+            verify(mockModelGatewayEmbeddingServiceBuilder, never()).apiKey(any());
+        });
+    }
+
+    private void withModelGatewayEmbeddingServiceMock(Runnable action) {
+        try (MockedStatic<ModelGatewayEmbeddingService> mockedStatic = mockStatic(ModelGatewayEmbeddingService.class)) {
+            mockedStatic
+                    .when(ModelGatewayEmbeddingService::builder)
+                    .thenReturn(mockModelGatewayEmbeddingServiceBuilder);
+            action.run();
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayEmbeddingModelTest.java
@@ -321,6 +321,60 @@ public class WatsonxGatewayEmbeddingModelTest {
     }
 
     @Test
+    void should_notify_the_listeners_when_embedding_with_the_gateway_parameters() {
+
+        var data = List.of(new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));
+        var parameters = ModelGatewayEmbeddingParameters.builder().dimensions(256).build();
+
+        when(mockModelGatewayEmbeddingService.embed(any(), parametersCaptor.capture()))
+                .thenReturn(
+                        new ModelGatewayEmbeddingResponse("list", "text-embedding-3-small", data, new Usage(10, 10)));
+
+        var requestContext = new AtomicReference<EmbeddingModelRequestContext>();
+        var responseContext = new AtomicReference<EmbeddingModelResponseContext>();
+
+        EmbeddingModelListener listener = new EmbeddingModelListener() {
+            @Override
+            public void onRequest(EmbeddingModelRequestContext context) {
+                requestContext.set(context);
+            }
+
+            @Override
+            public void onResponse(EmbeddingModelResponseContext context) {
+                responseContext.set(context);
+            }
+        };
+
+        withModelGatewayEmbeddingServiceMock(() -> {
+            var embeddingModel = WatsonxGatewayEmbeddingModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("text-embedding-3-small")
+                    .apiKey("api-key")
+                    .dimensions(512)
+                    .listeners(List.of(listener))
+                    .build();
+
+            var response = embeddingModel.embedAll(List.of(TextSegment.from("test1")), parameters);
+
+            assertEquals(256, parametersCaptor.getValue().dimensions());
+            assertEquals(1, response.content().size());
+
+            assertNotNull(requestContext.get());
+            assertEquals(WATSONX, requestContext.get().modelProvider());
+            assertEquals(
+                    List.of("test1"),
+                    requestContext.get().textSegments().stream()
+                            .map(TextSegment::text)
+                            .toList());
+
+            assertNotNull(responseContext.get());
+            assertEquals(
+                    1, responseContext.get().embeddingResponse().embeddings().size());
+            assertEquals(10, responseContext.get().response().tokenUsage().inputTokenCount());
+        });
+    }
+
+    @Test
     void should_notify_the_listeners() {
 
         var data = List.of(new ModelGatewayEmbeddingResponse.Embedding("embedding", 0, List.of(0f, 1f), null));

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayImageModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayImageModelTest.java
@@ -1,0 +1,357 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.core.Json;
+import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
+import com.ibm.watsonx.ai.core.exception.WatsonxException;
+import com.ibm.watsonx.ai.core.provider.HttpClientProvider;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageGenerationRequest;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Background;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Moderation;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.OutputFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Quality;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.ResponseFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Size;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Style;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse.ImageData;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse.InputTokensDetails;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse.Usage;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageService;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.exception.InternalServerException;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.watsonx.utils.HttpUtils;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WatsonxGatewayImageModelTest {
+
+    @Mock
+    ModelGatewayImageService mockModelGatewayImageService;
+
+    @Mock
+    ModelGatewayImageService.Builder mockModelGatewayImageServiceBuilder;
+
+    @Captor
+    ArgumentCaptor<ModelGatewayImageParameters> parametersCaptor;
+
+    @BeforeEach
+    void setUp() {
+        when(mockModelGatewayImageServiceBuilder.modelId(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.baseUrl(any(URI.class)))
+                .thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.timeout(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.version(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.logRequests(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.logResponses(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.authenticator(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.httpClient(any())).thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.verifySsl(anyBoolean()))
+                .thenReturn(mockModelGatewayImageServiceBuilder);
+        when(mockModelGatewayImageServiceBuilder.build()).thenReturn(mockModelGatewayImageService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_create_a_watsonx_gateway_image_model() throws Exception {
+
+        var data = List.of(new ImageData(null, "aGVsbG8=", "A revised prompt"));
+        var usage = new Usage(10, 20, 30, new InputTokensDetails(0, 10));
+
+        var mockHttpClient = mock(HttpClient.class);
+        var mockHttpResponse = mock(HttpResponse.class);
+        var mockAuthenticatorProvider = mock(IBMCloudAuthenticator.class);
+        var mockHttpRequest = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(mockAuthenticatorProvider.token()).thenReturn("my-token");
+        when(mockHttpResponse.statusCode()).thenReturn(200);
+        when(mockHttpResponse.body())
+                .thenReturn(Json.toJson(
+                        new ModelGatewayImageResponse(0, data, "opaque", "png", "high", "1024x1024", usage)));
+        when(mockHttpClient.send(mockHttpRequest.capture(), any(BodyHandler.class)))
+                .thenReturn(mockHttpResponse);
+
+        try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mockHttpClient);
+
+            var imageModel = WatsonxGatewayImageModel.builder()
+                    .baseUrl(CloudRegion.FRANKFURT)
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key-test")
+                    .version("my-version")
+                    .background(Background.OPAQUE)
+                    .moderation(Moderation.LOW)
+                    .outputCompression(50)
+                    .outputFormat(OutputFormat.PNG)
+                    .quality(Quality.HIGH)
+                    .responseFormat(ResponseFormat.B64_JSON)
+                    .size(Size.SIZE_1024X1024)
+                    .style(Style.VIVID)
+                    .user("my-user")
+                    .logRequests(true)
+                    .logResponses(true)
+                    .authenticator(mockAuthenticatorProvider)
+                    .timeout(Duration.ofSeconds(10))
+                    .build();
+
+            var response = imageModel.generate("A futuristic city at sunset");
+
+            var payload = Json.fromJson(
+                    HttpUtils.bodyPublisherToString(mockHttpRequest), ModelGatewayImageGenerationRequest.class);
+
+            assertEquals("gpt-image-1", payload.model());
+            assertEquals("A futuristic city at sunset", payload.prompt());
+            assertEquals("opaque", payload.background());
+            assertEquals("low", payload.moderation());
+            assertNull(payload.n());
+            assertEquals(50, payload.outputCompression());
+            assertEquals("png", payload.outputFormat());
+            assertEquals("high", payload.quality());
+            assertEquals("b64_json", payload.responseFormat());
+            assertEquals("1024x1024", payload.size());
+            assertEquals("vivid", payload.style());
+            assertEquals("my-user", payload.user());
+
+            var serviceField =
+                    assertDoesNotThrow(() -> imageModel.getClass().getDeclaredField("modelGatewayImageService"));
+            serviceField.setAccessible(true);
+            var service = assertDoesNotThrow(() -> serviceField.get(imageModel));
+
+            assertInstanceOf(ModelGatewayImageService.class, service);
+            assertEquals("gpt-image-1", imageModel.modelName());
+
+            var image = response.content();
+            assertNull(image.url());
+            assertEquals("aGVsbG8=", image.base64Data());
+            assertEquals("image/png", image.mimeType());
+            assertEquals("A revised prompt", image.revisedPrompt());
+            assertEquals(10, response.tokenUsage().inputTokenCount());
+            assertEquals(20, response.tokenUsage().outputTokenCount());
+            assertEquals(30, response.tokenUsage().totalTokenCount());
+
+            assertDoesNotThrow(() -> WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key")
+                    .build());
+        }
+    }
+
+    @Test
+    void should_generate_more_than_one_image() {
+
+        var data = List.of(new ImageData("https://test.com/1.png", null, null), new ImageData(null, "aGVsbG8=", null));
+
+        when(mockModelGatewayImageService.generate(any(String.class), parametersCaptor.capture()))
+                .thenReturn(new ModelGatewayImageResponse(0, data, null, null, null, null, null));
+
+        withModelGatewayImageServiceMock(() -> {
+            ImageModel imageModel = WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key")
+                    .size(Size.SIZE_1024X1024)
+                    .user("my-user")
+                    .build();
+
+            var response = imageModel.generate("A futuristic city at sunset", 2);
+            var parameters = parametersCaptor.getValue();
+
+            assertEquals(2, parameters.n());
+            assertEquals("1024x1024", parameters.size());
+            assertEquals("my-user", parameters.user());
+
+            assertEquals(2, response.content().size());
+            assertEquals(
+                    URI.create("https://test.com/1.png"),
+                    response.content().get(0).url());
+            assertNull(response.content().get(0).base64Data());
+            assertNull(response.content().get(0).mimeType());
+            assertEquals("aGVsbG8=", response.content().get(1).base64Data());
+            assertNull(response.tokenUsage());
+        });
+    }
+
+    @Test
+    void should_return_the_first_image_when_the_model_generates_more_than_one() {
+
+        var data = List.of(new ImageData(null, "Zmlyc3Q=", null), new ImageData(null, "c2Vjb25k", null));
+
+        when(mockModelGatewayImageService.generate(any(String.class), any()))
+                .thenReturn(new ModelGatewayImageResponse(0, data, null, "jpeg", null, null, null));
+
+        withModelGatewayImageServiceMock(() -> {
+            ImageModel imageModel = WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key")
+                    .build();
+
+            var response = imageModel.generate("A futuristic city at sunset");
+
+            assertEquals("Zmlyc3Q=", response.content().base64Data());
+            assertEquals("image/jpeg", response.content().mimeType());
+        });
+    }
+
+    @Test
+    void should_override_the_builder_parameters_with_the_given_parameters() {
+
+        var data = List.of(new ImageData(null, "aGVsbG8=", null));
+
+        var parameters = ModelGatewayImageParameters.builder()
+                .n(1)
+                .size(Size.SIZE_512X512)
+                .quality(Quality.LOW)
+                .build();
+
+        when(mockModelGatewayImageService.generate("A futuristic city at sunset", parameters))
+                .thenReturn(new ModelGatewayImageResponse(0, data, null, "png", null, null, null));
+
+        withModelGatewayImageServiceMock(() -> {
+            var imageModel = WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key")
+                    .size(Size.SIZE_1024X1024)
+                    .quality(Quality.HIGH)
+                    .user("my-user")
+                    .build();
+
+            var response = imageModel.generate("A futuristic city at sunset", parameters);
+
+            assertEquals(1, response.content().size());
+            assertEquals("aGVsbG8=", response.content().get(0).base64Data());
+        });
+    }
+
+    @Test
+    void should_use_the_builder_parameters_when_no_parameters_are_given() {
+
+        var data = List.of(new ImageData(null, "aGVsbG8=", null));
+
+        when(mockModelGatewayImageService.generate(any(String.class), parametersCaptor.capture()))
+                .thenReturn(new ModelGatewayImageResponse(0, data, null, null, null, null, null));
+
+        withModelGatewayImageServiceMock(() -> {
+            var imageModel = WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key")
+                    .background("opaque")
+                    .moderation("low")
+                    .outputFormat("webp")
+                    .quality("medium")
+                    .responseFormat("b64_json")
+                    .size("1536x1024")
+                    .style("natural")
+                    .outputCompression(80)
+                    .user("my-user")
+                    .build();
+
+            imageModel.generate("A futuristic city at sunset", (ModelGatewayImageParameters) null);
+            var parameters = parametersCaptor.getValue();
+
+            assertEquals("opaque", parameters.background());
+            assertEquals("low", parameters.moderation());
+            assertEquals("webp", parameters.outputFormat());
+            assertEquals("medium", parameters.quality());
+            assertEquals("b64_json", parameters.responseFormat());
+            assertEquals("1536x1024", parameters.size());
+            assertEquals("natural", parameters.style());
+            assertEquals(80, parameters.outputCompression());
+            assertEquals("my-user", parameters.user());
+            assertNull(parameters.n());
+        });
+    }
+
+    @Test
+    void should_not_support_the_image_editing() {
+
+        withModelGatewayImageServiceMock(() -> {
+            ImageModel imageModel = WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key")
+                    .build();
+
+            var image = Image.builder().base64Data("aGVsbG8=").build();
+
+            assertThrows(IllegalArgumentException.class, () -> imageModel.edit(image, "Make it brighter"));
+            assertThrows(IllegalArgumentException.class, () -> imageModel.edit(image, image, "Make it brighter"));
+        });
+    }
+
+    @Test
+    void should_map_the_exceptions_of_the_service() {
+
+        when(mockModelGatewayImageService.generate(any(String.class), any())).thenThrow(new WatsonxException(500));
+
+        withModelGatewayImageServiceMock(() -> {
+            ImageModel imageModel = WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .apiKey("api-key")
+                    .build();
+
+            assertThrows(InternalServerException.class, () -> imageModel.generate("A futuristic city at sunset"));
+        });
+    }
+
+    @Test
+    void should_authenticate_with_an_authenticator_instead_of_an_api_key() {
+
+        var authenticator = mock(IBMCloudAuthenticator.class);
+
+        withModelGatewayImageServiceMock(() -> {
+            assertDoesNotThrow(() -> WatsonxGatewayImageModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("gpt-image-1")
+                    .authenticator(authenticator)
+                    .build());
+
+            verify(mockModelGatewayImageServiceBuilder).authenticator(authenticator);
+            verify(mockModelGatewayImageServiceBuilder, never()).apiKey(any());
+        });
+    }
+
+    private void withModelGatewayImageServiceMock(Runnable action) {
+        try (MockedStatic<ModelGatewayImageService> mockedStatic = mockStatic(ModelGatewayImageService.class)) {
+            mockedStatic.when(ModelGatewayImageService::builder).thenReturn(mockModelGatewayImageServiceBuilder);
+            action.run();
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
@@ -24,11 +24,11 @@ import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.FunctionCall;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ReasoningEffort;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatParameters.ServiceTier;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRequest;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatResponse;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ReasoningEffort;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayParameters.ServiceTier;
-import com.ibm.watsonx.ai.gateway.chat.ModelGatewayService;
+import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatService;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.ContentFilteredException;
@@ -67,10 +67,10 @@ import org.mockito.quality.Strictness;
 public class WatsonxGatewayStreamingChatModelTest {
 
     @Mock
-    ModelGatewayService mockModelGatewayService;
+    ModelGatewayChatService mockModelGatewayChatService;
 
     @Mock
-    ModelGatewayService.Builder mockModelGatewayServiceBuilder;
+    ModelGatewayChatService.Builder mockModelGatewayChatServiceBuilder;
 
     @Captor
     ArgumentCaptor<ModelGatewayChatRequest> chatRequestCaptor;
@@ -80,17 +80,17 @@ public class WatsonxGatewayStreamingChatModelTest {
     @BeforeEach
     void setUp() {
 
-        when(mockModelGatewayServiceBuilder.modelId(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.timeout(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.version(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.logRequests(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.logResponses(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.authenticator(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.httpClient(any())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockModelGatewayServiceBuilder);
-        when(mockModelGatewayServiceBuilder.build()).thenReturn(mockModelGatewayService);
+        when(mockModelGatewayChatServiceBuilder.modelId(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.timeout(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.version(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.logRequests(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.logResponses(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.authenticator(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.apiKey(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.httpClient(any())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockModelGatewayChatServiceBuilder);
+        when(mockModelGatewayChatServiceBuilder.build()).thenReturn(mockModelGatewayChatService);
 
         var chatUsage = new ChatUsage(10, 10, 20);
         chatResponse = ModelGatewayChatResponse.builder()
@@ -122,11 +122,11 @@ public class WatsonxGatewayStreamingChatModelTest {
         var defaultRequestParameters = assertInstanceOf(
                 WatsonxGatewayChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
 
-        var modelGatewayServiceField = assertDoesNotThrow(
-                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("modelGatewayService"));
-        var modelGatewayService = assertDoesNotThrow(() -> modelGatewayServiceField.get(streamingChatModel));
+        var modelGatewayChatServiceField = assertDoesNotThrow(
+                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("modelGatewayChatService"));
+        var modelGatewayChatService = assertDoesNotThrow(() -> modelGatewayChatServiceField.get(streamingChatModel));
 
-        assertInstanceOf(ModelGatewayService.class, modelGatewayService);
+        assertInstanceOf(ModelGatewayChatService.class, modelGatewayChatService);
         assertEquals(ModelProvider.WATSONX, streamingChatModel.provider());
         assertEquals("gpt-4o", defaultRequestParameters.modelName());
         assertNull(defaultRequestParameters.serviceTier());
@@ -150,10 +150,10 @@ public class WatsonxGatewayStreamingChatModelTest {
 
                     return CompletableFuture.completedFuture(null);
                 })
-                .when(mockModelGatewayService)
+                .when(mockModelGatewayChatService)
                 .chatStreaming(chatRequestCaptor.capture(), any());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -222,10 +222,10 @@ public class WatsonxGatewayStreamingChatModelTest {
 
                     return CompletableFuture.completedFuture(null);
                 })
-                .when(mockModelGatewayService)
+                .when(mockModelGatewayChatService)
                 .chatStreaming(chatRequestCaptor.capture(), any());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -282,10 +282,10 @@ public class WatsonxGatewayStreamingChatModelTest {
                     handler.onCompleteResponse(chatResponse.build());
                     return CompletableFuture.completedFuture(null);
                 })
-                .when(mockModelGatewayService)
+                .when(mockModelGatewayChatService)
                 .chatStreaming(chatRequestCaptor.capture(), any());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             StreamingChatModel streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -383,10 +383,10 @@ public class WatsonxGatewayStreamingChatModelTest {
                     handler.onCompleteResponse(chatResponse.build());
                     return CompletableFuture.completedFuture(null);
                 })
-                .when(mockModelGatewayService)
+                .when(mockModelGatewayChatService)
                 .chatStreaming(chatRequestCaptor.capture(), any());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -440,10 +440,10 @@ public class WatsonxGatewayStreamingChatModelTest {
                     handler.onError(new Exception("test"));
                     return CompletableFuture.completedFuture(null);
                 })
-                .when(mockModelGatewayService)
+                .when(mockModelGatewayChatService)
                 .chatStreaming(chatRequestCaptor.capture(), any());
 
-        withModelGatewayServiceMock(() -> {
+        withModelGatewayChatServiceMock(() -> {
             var streamingChatModel = WatsonxGatewayStreamingChatModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("gpt-4o")
@@ -529,9 +529,9 @@ public class WatsonxGatewayStreamingChatModelTest {
         assertTrue(streamingChatModel.supportedCapabilities().contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
     }
 
-    private void withModelGatewayServiceMock(Runnable action) {
-        try (MockedStatic<ModelGatewayService> mockedStatic = mockStatic(ModelGatewayService.class)) {
-            mockedStatic.when(ModelGatewayService::builder).thenReturn(mockModelGatewayServiceBuilder);
+    private void withModelGatewayChatServiceMock(Runnable action) {
+        try (MockedStatic<ModelGatewayChatService> mockedStatic = mockStatic(ModelGatewayChatService.class)) {
+            mockedStatic.when(ModelGatewayChatService::builder).thenReturn(mockModelGatewayChatServiceBuilder);
             action.run();
         }
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxGatewayStreamingChatModelTest.java
@@ -176,11 +176,11 @@ public class WatsonxGatewayStreamingChatModelTest {
                 public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
                     var metadata = (WatsonxChatResponseMetadata) completeResponse.metadata();
                     assertEquals("Hello World", completeResponse.aiMessage().text());
-                    assertEquals("auto", metadata.getServiceTier());
-                    assertEquals("fp", metadata.getSystemFingerprint());
-                    assertEquals(true, metadata.getCached());
-                    assertEquals("modelVersion", metadata.getModelVersion());
-                    assertEquals(1L, metadata.getCreated());
+                    assertEquals("auto", metadata.serviceTier());
+                    assertEquals("fp", metadata.systemFingerprint());
+                    assertEquals(true, metadata.cached());
+                    assertEquals("modelVersion", metadata.modelVersion());
+                    assertEquals(1L, metadata.created());
                     latch.countDown();
                 }
 
@@ -317,11 +317,11 @@ public class WatsonxGatewayStreamingChatModelTest {
                     assertTrue(completeResponse.aiMessage().hasToolExecutionRequests());
                     assertEquals("id", completeResponse.id());
                     assertEquals("model", completeResponse.modelName());
-                    assertEquals("modelVersion", metadata.getModelVersion());
-                    assertEquals(1L, metadata.getCreated());
-                    assertEquals("auto", metadata.getServiceTier());
-                    assertEquals("fp", metadata.getSystemFingerprint());
-                    assertEquals(true, metadata.getCached());
+                    assertEquals("modelVersion", metadata.modelVersion());
+                    assertEquals(1L, metadata.created());
+                    assertEquals("auto", metadata.serviceTier());
+                    assertEquals("fp", metadata.systemFingerprint());
+                    assertEquals(true, metadata.cached());
                     assertEquals(FinishReason.TOOL_EXECUTION, completeResponse.finishReason());
                     assertEquals(
                             1,

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.watsonx;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -42,9 +43,12 @@ import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.PartialResponseContext;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.FinishReason;
 import java.net.URI;
 import java.util.ArrayList;
@@ -53,6 +57,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -894,6 +899,111 @@ public class WatsonxStreamingChatModelTest {
 
         assertEquals(1, chatModel.supportedCapabilities().size());
         assertTrue(chatModel.supportedCapabilities().contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
+    }
+
+    @Test
+    void should_cancel_the_streaming() {
+
+        var streamingFuture = new CompletableFuture<ChatResponse>();
+        var chatHandler = new AtomicReference<ChatHandler>();
+
+        doAnswer(invocation -> {
+                    chatHandler.set(invocation.getArgument(1));
+                    return streamingFuture;
+                })
+                .when(mockChatService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withChatServiceMock(() -> {
+            var streamingChatModel = WatsonxStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("projectId")
+                    .apiKey("api-key")
+                    .build();
+
+            var streamingHandles = new ArrayList<StreamingHandle>();
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(PartialResponse partialResponse, PartialResponseContext context) {
+                    streamingHandles.add(context.streamingHandle());
+                    assertFalse(context.streamingHandle().isCancelled());
+                    context.streamingHandle().cancel();
+                }
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    fail("Unexpected complete response");
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+            chatHandler.get().onPartialResponse("Hello", null);
+
+            assertEquals(1, streamingHandles.size());
+            var streamingHandle = streamingHandles.get(0);
+            assertTrue(streamingHandle.isCancelled());
+            assertTrue(streamingFuture.isCancelled());
+
+            // Cancelling an already cancelled streaming does nothing
+            assertDoesNotThrow(streamingHandle::cancel);
+            assertTrue(streamingHandle.isCancelled());
+        });
+    }
+
+    @Test
+    void should_cancel_the_streaming_when_the_partial_response_arrives_before_the_streaming_future() {
+
+        var streamingFuture = new CompletableFuture<ChatResponse>();
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+                    handler.onPartialResponse("Hello", null);
+                    return streamingFuture;
+                })
+                .when(mockChatService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withChatServiceMock(() -> {
+            var streamingChatModel = WatsonxStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("projectId")
+                    .apiKey("api-key")
+                    .build();
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(PartialResponse partialResponse, PartialResponseContext context) {
+                    context.streamingHandle().cancel();
+                }
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    fail("Unexpected complete response");
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+            assertTrue(streamingFuture.isCancelled());
+        });
     }
 
     private void withChatServiceMock(Runnable action) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -17,10 +18,17 @@ import static org.mockito.Mockito.when;
 
 import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.chat.ChatHandler;
+import com.ibm.watsonx.ai.chat.ChatModeration;
+import com.ibm.watsonx.ai.chat.ChatModeration.InputRanges;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.ChatService;
-import com.ibm.watsonx.ai.chat.EmptyChatResponseException;
 import com.ibm.watsonx.ai.chat.TextChatResponse;
+import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionEntry;
+import com.ibm.watsonx.ai.chat.TextChatResponse.DetectionResult;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult.Position;
+import com.ibm.watsonx.ai.chat.exception.EmptyChatResponseException;
+import com.ibm.watsonx.ai.chat.exception.ModerationException;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
@@ -53,6 +61,7 @@ import dev.langchain4j.model.output.FinishReason;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -693,8 +702,8 @@ public class WatsonxStreamingChatModelTest {
                     assertTrue(completeResponse.aiMessage().hasToolExecutionRequests());
                     assertEquals("id", completeResponse.id());
                     assertEquals("modelId", completeResponse.modelName());
-                    assertEquals("modelVersion", metadata.getModelVersion());
-                    assertEquals(1L, metadata.getCreated());
+                    assertEquals("modelVersion", metadata.modelVersion());
+                    assertEquals(1L, metadata.created());
                     assertEquals(FinishReason.TOOL_EXECUTION, completeResponse.finishReason());
                     assertEquals(10, completeResponse.tokenUsage().inputTokenCount());
                     assertEquals(10, completeResponse.tokenUsage().outputTokenCount());
@@ -1003,6 +1012,154 @@ public class WatsonxStreamingChatModelTest {
 
             streamingChatModel.chat(chatRequest, streamingHandler);
             assertTrue(streamingFuture.isCancelled());
+        });
+    }
+
+    @Test
+    void should_do_chat_with_inline_moderation() {
+
+        var moderation = ChatModeration.builder()
+                .pii(p -> p.output(true))
+                .inputRanges(List.of(InputRanges.of(0, 10)))
+                .build();
+
+        var moderationResult = new ModerationResult(0.98f, false, new Position(11, 23), "PhoneNumber", "555-123-4567");
+        var detectionEntry = new DetectionEntry(
+                0,
+                List.of(new DetectionResult("en_syntax_rbr_pii", "pii", "PhoneNumber", 0.98, "555-123-4567", 11, 23)));
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+                    handler.onPartialResponse("Call me at 555-123-4567", null);
+
+                    var resultMessage =
+                            new ResultMessage(AssistantMessage.ROLE, "Call me at 555-123-4567", null, null, null);
+                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+                    chatResponse
+                            .choices(List.of(resultChoice))
+                            .moderations(Map.of("pii", List.of(moderationResult)))
+                            .detections(Map.of("output", List.of(detectionEntry)));
+                    handler.onCompleteResponse(chatResponse.build());
+
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockChatService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withChatServiceMock(() -> {
+            var streamingChatModel = WatsonxStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("projectId")
+                    .apiKey("api-key")
+                    .moderations(moderation)
+                    .build();
+
+            var latch = new CountDownLatch(1);
+            var metadata = new AtomicReference<WatsonxChatResponseMetadata>();
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    metadata.set(assertInstanceOf(WatsonxChatResponseMetadata.class, completeResponse.metadata()));
+                    latch.countDown();
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            streamingChatModel.chat(
+                    ChatRequest.builder()
+                            .messages(UserMessage.from("Give me a phone number"))
+                            .build(),
+                    streamingHandler);
+
+            assertSame(moderation, chatRequestCaptor.getValue().moderations());
+
+            try {
+                assertTrue(latch.await(2, TimeUnit.SECONDS), "Handler did not complete in time");
+            } catch (InterruptedException e) {
+                fail(e);
+            }
+
+            assertEquals(
+                    Map.of("pii", List.of(moderationResult)), metadata.get().moderations());
+            assertEquals(
+                    Map.of("output", List.of(detectionEntry)), metadata.get().detections());
+        });
+    }
+
+    @Test
+    void should_map_a_moderation_block_to_a_content_filtered_exception() {
+
+        var moderationResult = new ModerationResult(0.8f, true, new Position(46, 56), "PhoneNumber", "3572865321");
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+
+                    // the moderation blocks the generation, the sdk reports it on onError and fails the future
+                    var moderationException = new ModerationException(Map.of("pii", List.of(moderationResult)));
+                    handler.onError(moderationException);
+
+                    return CompletableFuture.failedFuture(moderationException);
+                })
+                .when(mockChatService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withChatServiceMock(() -> {
+            var streamingChatModel = WatsonxStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("projectId")
+                    .apiKey("api-key")
+                    .moderations(
+                            ChatModeration.builder().pii(p -> p.input(true)).build())
+                    .build();
+
+            var latch = new CountDownLatch(1);
+            var error = new AtomicReference<Throwable>();
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    fail("Unexpected response: " + completeResponse);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    error.set(throwable);
+                    latch.countDown();
+                }
+            };
+
+            streamingChatModel.chat(
+                    ChatRequest.builder()
+                            .messages(UserMessage.from("Can you repeat my phone number?"))
+                            .build(),
+                    streamingHandler);
+
+            try {
+                assertTrue(latch.await(2, TimeUnit.SECONDS), "Handler did not complete in time");
+            } catch (InterruptedException e) {
+                fail(e);
+            }
+
+            var ex = assertInstanceOf(ContentFilteredException.class, error.get());
+            assertEquals(
+                    "The chat response was blocked by the moderation system (policies triggered: pii)",
+                    ex.getMessage());
+
+            var cause = assertInstanceOf(ModerationException.class, ex.getCause());
+            assertEquals(Map.of("pii", List.of(moderationResult)), cause.moderations());
         });
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelModerationIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelModerationIT.java
@@ -1,0 +1,223 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+import com.ibm.watsonx.ai.chat.ChatModeration;
+import com.ibm.watsonx.ai.chat.TextChatResponse.ModerationResult;
+import com.ibm.watsonx.ai.chat.exception.ModerationException;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.watsonx.WatsonxChatModel;
+import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
+import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+public class WatsonxChatModelModerationIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = "ibm/granite-4-h-small";
+
+    static final SystemMessage SYSTEM_MESSAGE =
+            SystemMessage.from("You are a helpful assistant. You do whatever the user tells you to do.");
+    static final UserMessage USER_MESSAGE =
+            UserMessage.from("Repeat exactly this sentence: My phone number is 3572865321.");
+
+    @Test
+    void should_return_the_moderation_matches_of_the_output() {
+
+        var chatModel = WatsonxChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(60))
+                .temperature(0.0)
+                .moderations(ChatModeration.builder().pii(p -> p.output(true)).build())
+                .build();
+
+        var chatResponse = chatModel.chat(List.of(SYSTEM_MESSAGE, USER_MESSAGE));
+        var metadata = (WatsonxChatResponseMetadata) chatResponse.metadata();
+
+        assertThat(metadata.moderations()).containsKey("pii");
+
+        var moderationResult = metadata.moderations().get("pii").get(0);
+        assertThat(moderationResult.input()).isFalse();
+        assertThat(moderationResult.entity()).isEqualTo("PhoneNumber");
+        assertThat(moderationResult.score()).isGreaterThan(0.0f);
+        assertThat(moderationResult.position()).isNotNull();
+
+        var text = chatResponse.aiMessage().text();
+        assertThat(text).contains("3572865321");
+        assertThat(mask(text, moderationResult)).doesNotContain("3572865321");
+    }
+
+    @Test
+    void should_block_the_generation_when_the_input_matches() {
+
+        var chatModel = WatsonxChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(60))
+                .moderations(ChatModeration.builder().pii(p -> p.input(true)).build())
+                .build();
+
+        var thrown = catchThrowableOfType(
+                ContentFilteredException.class, () -> chatModel.chat(List.of(SYSTEM_MESSAGE, USER_MESSAGE)));
+
+        assertThat(thrown).hasMessageContaining("pii");
+        assertThat(thrown.getCause()).isInstanceOf(ModerationException.class);
+
+        // the matches stay reachable from the cause, so the caller can tell what has been detected
+        var cause = (ModerationException) thrown.getCause();
+        assertThat(cause.moderations()).containsKey("pii");
+        assertThat(cause.moderations().get("pii")).anyMatch(ModerationResult::input);
+
+        var moderationResult = cause.moderations().get("pii").get(0);
+        assertThat(moderationResult.entity()).isEqualTo("PhoneNumber");
+        assertThat(mask(USER_MESSAGE.singleText(), moderationResult)).doesNotContain("3572865321");
+    }
+
+    @Test
+    void should_not_return_any_moderation_when_it_is_not_enabled() {
+
+        var chatModel = WatsonxChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(60))
+                .build();
+
+        var chatResponse = chatModel.chat(List.of(SYSTEM_MESSAGE, USER_MESSAGE));
+        var metadata = (WatsonxChatResponseMetadata) chatResponse.metadata();
+
+        assertThat(metadata.moderations()).isNull();
+        assertThat(metadata.detections()).isNull();
+    }
+
+    @Test
+    void should_enable_the_moderation_with_the_request_parameters() {
+
+        var chatModel = WatsonxChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(60))
+                .build();
+
+        var chatRequest = ChatRequest.builder()
+                .messages(SYSTEM_MESSAGE, USER_MESSAGE)
+                .parameters(WatsonxChatRequestParameters.builder()
+                        .moderations(
+                                ChatModeration.builder().pii(p -> p.input(true)).build())
+                        .build())
+                .build();
+
+        var thrown = catchThrowableOfType(ContentFilteredException.class, () -> chatModel.chat(chatRequest));
+        assertThat(thrown).hasMessageContaining("pii");
+    }
+
+    @Test
+    void should_return_the_moderation_matches_when_streaming() throws Exception {
+
+        var streamingChatModel = WatsonxStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(60))
+                .temperature(0.0)
+                .moderations(ChatModeration.builder().pii(p -> p.output(true)).build())
+                .build();
+
+        var future = new CompletableFuture<ChatResponse>();
+
+        streamingChatModel.chat(List.of(SYSTEM_MESSAGE, USER_MESSAGE), new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        var chatResponse = future.get(60, TimeUnit.SECONDS);
+        var metadata = (WatsonxChatResponseMetadata) chatResponse.metadata();
+
+        assertThat(metadata.moderations()).containsKey("pii");
+        assertThat(metadata.moderations().get("pii")).anyMatch(result -> !result.input());
+    }
+
+    @Test
+    void should_block_the_generation_when_the_input_matches_while_streaming() throws Exception {
+
+        var streamingChatModel = WatsonxStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName(MODEL)
+                .timeout(Duration.ofSeconds(60))
+                .moderations(ChatModeration.builder().pii(p -> p.input(true)).build())
+                .build();
+
+        var future = new CompletableFuture<ChatResponse>();
+
+        streamingChatModel.chat(List.of(SYSTEM_MESSAGE, USER_MESSAGE), new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        var thrown = catchThrowableOfType(ExecutionException.class, () -> future.get(60, TimeUnit.SECONDS));
+
+        assertThat(thrown.getCause())
+                .isInstanceOf(ContentFilteredException.class)
+                .hasMessageContaining("pii");
+        assertThat(thrown.getCause().getCause()).isInstanceOf(ModerationException.class);
+
+        var cause = (ModerationException) thrown.getCause().getCause();
+        assertThat(cause.moderations().get("pii")).anyMatch(ModerationResult::input);
+    }
+
+    private static String mask(String text, ModerationResult result) {
+        var position = result.position();
+        return text.substring(0, position.start())
+                + "*".repeat(position.end() - position.start())
+                + text.substring(position.end());
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxDeploymentStreamingChatModelIT.java
@@ -89,12 +89,6 @@ public class WatsonxDeploymentStreamingChatModelIT extends AbstractStreamingChat
     }
 
     @Override
-    protected boolean supportsStreamingCancellation() {
-        // The watsonx models do not expose a StreamingHandle that can stop an ongoing stream
-        return false;
-    }
-
-    @Override
     protected boolean supportsToolsAndJsonResponseFormatWithSchema() {
         // None of the deployed models can combine the two features. The reasoning one rejects tools without a
         // description, the others answer with the requested JSON instead of calling the tool

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxEmbeddingModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxEmbeddingModelIT.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.model.watsonx.it;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.common.AbstractEmbeddingModelIT;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
+import dev.langchain4j.model.watsonx.WatsonxEmbeddingModel;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_EMBEDDING_MODEL", matches = ".+")
+public class WatsonxEmbeddingModelIT extends AbstractEmbeddingModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_EMBEDDING_MODEL");
+
+    @Override
+    protected List<EmbeddingModel> models() {
+        return List.of(createEmbeddingModel(MODEL).build());
+    }
+
+    @Override
+    protected EmbeddingModel modelWith(EmbeddingModelListener listener) {
+        return createEmbeddingModel(MODEL).listeners(List.of(listener)).build();
+    }
+
+    @Override
+    protected EmbeddingModel failingModelWith(EmbeddingModelListener listener) {
+        return createEmbeddingModel("invalid-model")
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected boolean supportsInputTypeParameter() {
+        // The watsonx.ai embeddings endpoint has no input type, a query and a document are embedded the same way
+        return false;
+    }
+
+    @Override
+    protected boolean supportsDimensionsParameter() {
+        // The number of dimensions is fixed by the model, the endpoint does not accept a dimensions value
+        return false;
+    }
+
+    @Override
+    protected boolean supportsImageInput() {
+        // The watsonx.ai embeddings endpoint accepts text only
+        return false;
+    }
+
+    private WatsonxEmbeddingModel.Builder createEmbeddingModel(String modelName) {
+        return WatsonxEmbeddingModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName(modelName)
+                .timeout(Duration.ofSeconds(60));
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayEmbeddingModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayEmbeddingModelIT.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.model.watsonx.it;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.common.AbstractEmbeddingModelIT;
+import dev.langchain4j.model.embedding.listener.EmbeddingModelListener;
+import dev.langchain4j.model.watsonx.WatsonxGatewayEmbeddingModel;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_EMBEDDING_MODEL", matches = ".+")
+public class WatsonxGatewayEmbeddingModelIT extends AbstractEmbeddingModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_GATEWAY_EMBEDDING_MODEL");
+
+    @Override
+    protected List<EmbeddingModel> models() {
+        return List.of(createEmbeddingModel(MODEL).build());
+    }
+
+    @Override
+    protected EmbeddingModel modelWith(EmbeddingModelListener listener) {
+        return createEmbeddingModel(MODEL).listeners(List.of(listener)).build();
+    }
+
+    @Override
+    protected EmbeddingModel failingModelWith(EmbeddingModelListener listener) {
+        return createEmbeddingModel("invalid-model")
+                .listeners(List.of(listener))
+                .build();
+    }
+
+    @Override
+    protected boolean supportsInputTypeParameter() {
+        // The gateway embeddings endpoint is OpenAI-compatible and has no input type
+        return false;
+    }
+
+    @Override
+    protected boolean supportsImageInput() {
+        // The gateway embeddings endpoint accepts text only
+        return false;
+    }
+
+    private WatsonxGatewayEmbeddingModel.Builder createEmbeddingModel(String modelName) {
+        return WatsonxGatewayEmbeddingModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .modelName(modelName)
+                .timeout(Duration.ofSeconds(60));
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayImageModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayImageModelIT.java
@@ -1,0 +1,104 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.OutputFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Quality;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Size;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.exception.InvalidRequestException;
+import dev.langchain4j.model.watsonx.WatsonxGatewayImageModel;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GATEWAY_IMAGE_MODEL", matches = ".+")
+public class WatsonxGatewayImageModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_GATEWAY_IMAGE_MODEL");
+
+    static final WatsonxGatewayImageModel model = WatsonxGatewayImageModel.builder()
+            .baseUrl(URL)
+            .apiKey(API_KEY)
+            .modelName(MODEL)
+            .size(Size.SIZE_1024X1024)
+            .quality(Quality.LOW)
+            .build();
+
+    @Test
+    void should_generate_an_image() {
+
+        var response = model.generate("A red cube on a white background");
+        var image = response.content();
+
+        assertEquals(MODEL, model.modelName());
+        assertNotNull(assertDecodableBase64Data(image));
+    }
+
+    @Test
+    void should_generate_more_than_one_image() {
+
+        var response = model.generate("A blue sphere on a white background", 2);
+
+        assertEquals(2, response.content().size());
+        response.content().forEach(this::assertDecodableBase64Data);
+    }
+
+    @Test
+    void should_generate_an_image_with_the_given_parameters() {
+
+        var response = model.generate(
+                "A green pyramid on a white background",
+                ModelGatewayImageParameters.builder()
+                        .size(Size.SIZE_1024X1024)
+                        .quality(Quality.LOW)
+                        .outputFormat(OutputFormat.PNG)
+                        .n(1)
+                        .build());
+
+        var image = response.content().get(0);
+
+        assertEquals(1, response.content().size());
+        assertEquals("image/png", image.mimeType());
+        assertDecodableBase64Data(image);
+    }
+
+    @Test
+    void should_fail_when_the_size_is_not_supported() {
+
+        var parameters = ModelGatewayImageParameters.builder().size("123x456").build();
+
+        assertThrows(
+                InvalidRequestException.class, () -> model.generate("A yellow cone on a white background", parameters));
+    }
+
+    @Test
+    void should_not_support_the_image_editing() {
+
+        var image = Image.builder().base64Data("aGVsbG8=").mimeType("image/png").build();
+
+        assertThrows(IllegalArgumentException.class, () -> model.edit(image, "Make it brighter"));
+        assertThrows(IllegalArgumentException.class, () -> model.edit(image, image, "Make it brighter"));
+    }
+
+    private byte[] assertDecodableBase64Data(Image image) {
+
+        // The gpt-image-1 model always answers with Base64 data, it does not support the url response format.
+        assertNull(image.url());
+        assertNotNull(image.base64Data());
+
+        var bytes = Base64.getDecoder().decode(image.base64Data());
+        assertTrue(bytes.length > 0);
+
+        return bytes;
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxGatewayStreamingChatModelIT.java
@@ -84,12 +84,6 @@ public class WatsonxGatewayStreamingChatModelIT extends AbstractStreamingChatMod
     }
 
     @Override
-    protected boolean supportsStreamingCancellation() {
-        // The watsonx models do not expose a StreamingHandle that can stop an ongoing stream
-        return false;
-    }
-
-    @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id) {
         verifyToolCall(handler, io, 0, id, "getWeather", "{\"city\": \"Munich\"}");
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxScoringModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxScoringModelIT.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ibm.watsonx.ai.rerank.RerankParameters;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.watsonx.WatsonxScoringModel;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_RERANK_MODEL", matches = ".+")
+public class WatsonxScoringModelIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
+    static final String URL = System.getenv("WATSONX_URL");
+    static final String MODEL = System.getenv("WATSONX_RERANK_MODEL");
+
+    static final WatsonxScoringModel model = WatsonxScoringModel.builder()
+            .baseUrl(URL)
+            .apiKey(API_KEY)
+            .projectId(PROJECT_ID)
+            .modelName(MODEL)
+            .build();
+
+    @Test
+    void should_score_single_text() {
+
+        var response =
+                model.score("Water boils at 100 degrees Celsius at sea level.", "At what temperature does water boil?");
+
+        assertTrue(response.content() > 0.0);
+        assertTrue(response.tokenUsage().inputTokenCount() > 0);
+        assertNull(response.finishReason());
+    }
+
+    @Test
+    void should_score_all_segments_in_the_order_of_the_input() {
+
+        var query = "Which planet is the closest to the Sun?";
+        var segments = List.of(
+                TextSegment.from("Bees pollinate flowers while collecting nectar."),
+                TextSegment.from("Mercury is the planet closest to the Sun."),
+                TextSegment.from("The violin has four strings tuned in fifths."));
+
+        var response = model.scoreAll(segments, query);
+        var scores = response.content();
+
+        assertEquals(3, scores.size());
+        assertTrue(scores.get(1) > scores.get(0));
+        assertTrue(scores.get(1) > scores.get(2));
+        assertTrue(response.tokenUsage().inputTokenCount() > 0);
+        assertNull(response.finishReason());
+    }
+
+    @Test
+    void should_score_all_segments_with_rerank_parameters() {
+
+        var query = "Which planet is the closest to the Sun?";
+        var segments = List.of(
+                TextSegment.from("Mercury is the planet closest to the Sun, orbiting it every 88 Earth days."),
+                TextSegment.from("Neptune is the farthest planet from the Sun, orbiting it every 165 Earth years."));
+
+        var response = model.scoreAll(segments, query);
+        var truncatedResponse = model.scoreAll(
+                segments,
+                query,
+                RerankParameters.builder().truncateInputTokens(4).build());
+
+        assertEquals(2, truncatedResponse.content().size());
+        assertTrue(truncatedResponse.tokenUsage().inputTokenCount()
+                < response.tokenUsage().inputTokenCount());
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
@@ -82,12 +82,6 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
-    protected boolean supportsStreamingCancellation() {
-        // The watsonx models do not expose a StreamingHandle that can stop an ongoing stream
-        return false;
-    }
-
-    @Override
     protected boolean supportsToolsAndJsonResponseFormatWithSchema() {
         // None of the models available in the project can combine the two features. They either answer with the
         // requested JSON instead of calling the tool, or return a "tool_calls" finish reason without any tool call


### PR DESCRIPTION
## Change

This PR extends the `langchain4j-watsonx` module with four new capabilities: streaming cancellation, embedding listeners, a new Model Gateway embedding model, a new Model Gateway image model, and inline chat moderation for foundation models. It also includes several minor breaking changes to align the API with the rest of LangChain4j.

### New features

#### 1. Streaming cancellation via `WatsonxStreamingHandle`

All three streaming chat models (`WatsonxStreamingChatModel`, `WatsonxDeploymentStreamingChatModel`, `WatsonxGatewayStreamingChatModel`) now implement the `StreamingHandle` contract. Calling `cancel()` on the handle propagates the cancellation to the underlying SDK future, so the in-flight HTTP stream is aborted immediately.

#### 2. `EmbeddingModelListener` support on `WatsonxEmbeddingModel`

`WatsonxEmbeddingModel` now implements `EmbeddingModel.listeners()` and routes all embedding calls through `doEmbed(EmbeddingRequest)`, so registered listeners are notified before and after every request.

#### 3. `WatsonxGatewayEmbeddingModel`

New `EmbeddingModel` implementation backed by the `ModelGatewayEmbeddingService` of the watsonx.ai SDK. It targets the watsonx.ai Model Gateway and supports the same `EmbeddingModelListener` hooks and `EmbeddingRequestParameters` overrides as the foundation-model counterpart.

```java
EmbeddingModel embeddingModel = WatsonxGatewayEmbeddingModel.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .modelName("text-embedding-3-small")
    .build();
```

#### 4. `WatsonxGatewayImageModel`

New `ImageModel` implementation backed by the `ModelGatewayImageService`. It supports single-image generation and the full set of SDK image parameters (`size`, `quality`, `style`, `responseFormat`, `outputFormat`, `outputCompression`, `background`, `moderation`, `user`).

```java
ImageModel imageModel = WatsonxGatewayImageModel.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .modelName("gpt-image-1")
    .build();

Image image = imageModel.generate("A futuristic city at sunset").content();
```

#### 5. Inline chat moderation for foundation model chat

`WatsonxChatModel` and `WatsonxStreamingChatModel` now accept a `moderations(ChatModeration)` setting, both on their builders and as a per-request override in `WatsonxChatRequestParameters`. The moderation results returned by the API are exposed on the new `moderations()` and `detections()` accessors of `WatsonxChatResponseMetadata`.

```java
ChatModel model = WatsonxChatModel.builder()
    .baseUrl(CloudRegion.FRANKFURT)
    .apiKey(System.getenv("WATSONX_API_KEY"))
    .projectId(System.getenv("WATSONX_PROJECT_ID"))
    .modelName("ibm/granite-4-h-small")
    .moderations(
             ChatModeration.builder()
                  .pii(p -> p.output(true))
                  .hap(h -> h.output(0.8f))
                  .build()
    ).build();
```

---

## Breaking changes

#### 1. `WatsonxEmbeddingModel.embedAll(List<TextSegment>)` removed

The override is gone; the method is still callable through the default implementation inherited from `EmbeddingModel`, which now routes via `doEmbed(EmbeddingRequest)` to fire listeners.

#### 2. `WatsonxChatResponseMetadata` accessor renames

The five getter-style accessors were renamed to follow the fluent naming used by every other provider metadata class in LangChain4j:

| Before | After |
|---|---|
| `getCreated()` | `created()` |
| `getModelVersion()` | `modelVersion()` |
| `getServiceTier()` | `serviceTier()` |
| `getSystemFingerprint()` | `systemFingerprint()` |
| `getCached()` | `cached()` |

#### 3. SDK rename: `ModelGatewayParameters` → `ModelGatewayChatParameters`

The watsonx.ai SDK renamed its inner parameter types (`Cache`, `Router`, `ReasoningEffort`, `ServiceTier`) from `ModelGatewayParameters.*` to `ModelGatewayChatParameters.*`.

---

## General checklist
- [ ] There are no breaking changes (API, behaviour) <!-- see the "Breaking changes" section above; the module is in beta -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A, there is no watsonx Spring Boot starter -->