### PR TITLE
MCP: Support dynamic tool refresh in McpToolProvider

### DIFF
--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -205,6 +205,23 @@ In order to allow applications to connect or disconnect from MCP servers at
 runtime, it is also possible to dynamically add and remove clients and filters 
 to an existing `McpToolProvider` instance.
 
+By default, the provider is evaluated once per AI Service invocation. If an MCP
+tool changes the provider's filters and newly enabled tools must be available to
+the LLM during the same tool execution loop, enable dynamic mode:
+
+```java
+McpToolProvider toolProvider = McpToolProvider.builder()
+    .mcpClients(mcpClient)
+    .filter((client, tool) -> isToolEnabled(tool.name()))
+    .dynamic(true)
+    .build();
+```
+
+In dynamic mode, the provider is evaluated before every LLM call in the tool
+execution loop. Newly enabled tools are added to the available tools. Tools that
+were already exposed remain available for the rest of that AI Service invocation.
+Dynamic mode can therefore result in additional `listTools()` calls to MCP servers.
+
 To bind a tool provider to an AI service, simply use the `toolProvider` method
 of an AI service builder:
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
@@ -47,6 +47,7 @@ public class McpToolProvider implements ToolProvider {
     private final AtomicReference<BiFunction<McpClient, ToolSpecification, ToolSpecification>> toolSpecificationMapper;
     private final Set<String> alwaysVisibleToolNames;
     private final boolean returnToolResultAttributes;
+    private final boolean dynamic;
 
     private McpToolProvider(Builder builder) {
         this.mcpClients = new CopyOnWriteArrayList<>(builder.mcpClients);
@@ -58,6 +59,7 @@ public class McpToolProvider implements ToolProvider {
         this.toolSpecificationMapper = new AtomicReference<>(builder.toolSpecificationMapper);
         this.alwaysVisibleToolNames = copy(builder.alwaysVisibleToolNames);
         this.returnToolResultAttributes = Utils.getOrDefault(builder.returnToolResultAttributes, false);
+        this.dynamic = Utils.getOrDefault(builder.dynamic, false);
     }
 
     protected McpToolProvider(
@@ -77,6 +79,7 @@ public class McpToolProvider implements ToolProvider {
         this.toolSpecificationMapper = new AtomicReference<>(toolSpecificationMapper);
         this.alwaysVisibleToolNames = Set.of();
         this.returnToolResultAttributes = false;
+        this.dynamic = false;
     }
 
     /**
@@ -151,6 +154,11 @@ public class McpToolProvider implements ToolProvider {
     @Override
     public ToolProviderResult provideTools(ToolProviderRequest request) {
         return provideTools(request, mcpToolsFilter.get());
+    }
+
+    @Override
+    public boolean isDynamic() {
+        return dynamic;
     }
 
     protected ToolProviderResult provideTools(
@@ -246,6 +254,7 @@ public class McpToolProvider implements ToolProvider {
         private BiFunction<McpClient, ToolSpecification, ToolSpecification> toolSpecificationMapper;
         private Set<String> alwaysVisibleToolNames;
         private Boolean returnToolResultAttributes;
+        private Boolean dynamic;
 
         /**
          * The list of MCP clients to use for retrieving tools.
@@ -396,6 +405,20 @@ public class McpToolProvider implements ToolProvider {
          */
         public McpToolProvider.Builder returnToolResultAttributes(Boolean returnToolResultAttributes) {
             this.returnToolResultAttributes = returnToolResultAttributes;
+            return this;
+        }
+
+        /**
+         * Controls whether this provider is re-evaluated before every LLM call in the tool execution loop.
+         * This allows filter changes made during a tool execution to make newly enabled tools available
+         * in the next request to the LLM. Tools already exposed remain available for the rest of the invocation.
+         * <p>
+         * Default: {@code false}.
+         *
+         * @since 1.20.0
+         */
+        public McpToolProvider.Builder dynamic(boolean dynamic) {
+            this.dynamic = dynamic;
             return this;
         }
 

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/McpToolProviderTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/McpToolProviderTest.java
@@ -1,21 +1,31 @@
 package dev.langchain4j.mcp;
 
+import static dev.langchain4j.agent.tool.SearchBehavior.ALWAYS_VISIBLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.Map;
-
-import static dev.langchain4j.agent.tool.SearchBehavior.ALWAYS_VISIBLE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class McpToolProviderTest {
 
@@ -23,16 +33,16 @@ class McpToolProviderTest {
 
     @BeforeEach
     void setUp() {
-        when(mcpClient.listTools()).thenReturn(List.of(
-                ToolSpecification.builder()
-                        .name("tool_1")
-                        .metadata(Map.of("one", 1))
-                        .build(),
-                ToolSpecification.builder()
-                        .name("tool_2")
-                        .metadata(Map.of("two", 2))
-                        .build()
-        ));
+        when(mcpClient.listTools())
+                .thenReturn(List.of(
+                        ToolSpecification.builder()
+                                .name("tool_1")
+                                .metadata(Map.of("one", 1))
+                                .build(),
+                        ToolSpecification.builder()
+                                .name("tool_2")
+                                .metadata(Map.of("two", 2))
+                                .build()));
     }
 
     @Test
@@ -58,8 +68,7 @@ class McpToolProviderTest {
                         ToolSpecification.builder()
                                 .name("tool_2")
                                 .metadata(Map.of("two", 2))
-                                .build()
-                );
+                                .build());
     }
 
     @Test
@@ -86,8 +95,70 @@ class McpToolProviderTest {
                         ToolSpecification.builder()
                                 .name("my_tool_2")
                                 .metadata(Map.of("two", 2))
-                                .build()
-                );
+                                .build());
+    }
+
+    @Test
+    void should_be_static_by_default() {
+        McpToolProvider toolProvider =
+                McpToolProvider.builder().mcpClients(mcpClient).build();
+
+        assertThat(toolProvider.isDynamic()).isFalse();
+    }
+
+    @Test
+    void should_reapply_filter_between_tool_execution_rounds_when_dynamic() {
+        // given
+        ToolSpecification searchTools =
+                ToolSpecification.builder().name("searchTools").build();
+        ToolSpecification getWeather =
+                ToolSpecification.builder().name("getWeather").build();
+        when(mcpClient.listTools()).thenReturn(List.of(searchTools, getWeather));
+
+        AtomicBoolean weatherToolEnabled = new AtomicBoolean();
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class), any(InvocationContext.class)))
+                .thenAnswer(invocation -> {
+                    weatherToolEnabled.set(true);
+                    return ToolExecutionResult.builder()
+                            .resultText("getWeather enabled")
+                            .build();
+                });
+
+        AtomicInteger chatCallCount = new AtomicInteger();
+        ChatModel chatModel = ChatModelMock.thatResponds(request -> {
+            if (chatCallCount.getAndIncrement() == 0) {
+                assertThat(request.toolSpecifications())
+                        .extracting(ToolSpecification::name)
+                        .containsExactly("searchTools");
+                return AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name("searchTools")
+                        .arguments("{}")
+                        .build());
+            }
+            assertThat(request.toolSpecifications())
+                    .extracting(ToolSpecification::name)
+                    .containsExactly("searchTools", "getWeather");
+            return AiMessage.from("The weather tool is now available");
+        });
+
+        McpToolProvider toolProvider = McpToolProvider.builder()
+                .mcpClients(mcpClient)
+                .filter((client, tool) -> tool.name().equals("searchTools") || weatherToolEnabled.get())
+                .dynamic(true)
+                .build();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .toolProvider(toolProvider)
+                .build();
+
+        // when
+        String answer = assistant.chat("Find a tool that can check the weather");
+
+        // then
+        assertThat(answer).isEqualTo("The weather tool is now available");
+        assertThat(toolProvider.isDynamic()).isTrue();
+        verify(mcpClient, times(2)).listTools();
     }
 
     private static ToolProviderRequest toolProviderRequest() {
@@ -95,5 +166,9 @@ class McpToolProviderTest {
                 .invocationContext(InvocationContext.builder().build())
                 .userMessage(UserMessage.from("does not matter"))
                 .build();
+    }
+
+    private interface Assistant {
+        String chat(String userMessage);
     }
 }


### PR DESCRIPTION
## Issue

Closes #4455

## Change

- Add an opt-in `dynamic` mode to `McpToolProvider`.
- Re-evaluate the provider before each LLM call in the tool execution loop, allowing filters changed by an MCP tool to expose newly enabled tools during the same AI Service invocation.
- Keep the existing static behavior as the default to avoid extra `listTools()` calls and preserve backward compatibility.
- Add regression coverage for the default static mode and a two-round tool execution where the first tool enables the second.
- Document dynamic mode, its additive behavior, and its MCP request overhead.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (not applicable for this focused bug fix)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (not applicable)

## Verification

`./mvnw -pl langchain4j-mcp test -DskipITs`

Tests run: 206, Failures: 0, Errors: 0, Skipped: 1.

## Checklist for adding new maven module

- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml` (not applicable)

## Checklist for adding new embedding store integration

- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT` (not applicable)
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT` (not applicable)

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j (not applicable)
