### PR TITLE
fix(deps): align HttpCore with HttpClient 5.6.3

### DIFF
--- a/http-clients/langchain4j-http-client-apache/pom.xml
+++ b/http-clients/langchain4j-http-client-apache/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.6.1</version>
+            <version>5.6.3</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.3</version>
+                <version>5.6.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -40,6 +40,11 @@
                 <artifactId>httpclient5</artifactId>
                 <version>5.6.3</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>5.4.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -81,7 +86,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
 
         <!-- test dependencies -->
 


### PR DESCRIPTION
## Issue

Relates to #6048

## Change

Manage `httpcore5` at 5.4.3 in the OpenSearch module, matching the version required
by `httpclient5:5.6.3`. This resolves the Maven dependency-convergence failure
between HttpClient and `opensearch-java`.

The repository formatter also removes the extra blank line it reported in the same
POM.

## Verification

- `mvn -ntp -pl langchain4j-opensearch -am test` on JDK 21: all six affected
  reactor modules passed.
- `mvn -ntp -pl langchain4j-opensearch -am dependency:tree -Dincludes=org.apache.httpcomponents.core5:httpcore5`:
  resolves `httpclient5:5.6.3 -> httpcore5:5.4.3`.
- `mvn -ntp -f langchain4j-opensearch/pom.xml -Pspotless com.diffplug.spotless:spotless-maven-plugin:2.44.4:check`.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change (not applicable to this dependency-management-only fix)
- [ ] The tests cover both positive and negative cases (not applicable)
- [ ] I have manually run all the unit and integration tests in the module I have changed (the affected `test` lifecycle passed; external-service integration tests were not run)
- [ ] I have manually run all the unit and integration tests in the core and main modules (core passed in the affected reactor; the main module was not part of it)
- [ ] I have added/updated the documentation (not applicable)
- [ ] I have added an example in the examples repo (not applicable)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)

## Checklist for adding new maven module

- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml` (not applicable)

## Checklist for adding new embedding store integration

- [ ] I have added the required integration tests (not applicable)

## Checklist for changing existing embedding store integration

- [ ] I have manually verified persisted data compatibility (not applicable)
