### PR TITLE
fix(elasticsearch): align RRF rank window with max results

### DIFF
--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybrid.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybrid.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ElasticsearchConfigurationHybrid implements ElasticsearchConfiguration {
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchConfigurationHybrid.class);
+    private static final int DEFAULT_RRF_RANK_WINDOW_SIZE = 10;
     private final Integer numCandidates;
     private final boolean includeVectorResponse;
 
@@ -127,9 +128,13 @@ public class ElasticsearchConfigurationHybrid implements ElasticsearchConfigurat
                             return new SourceConfig.Builder().filter(f -> f);
                         })
                         .index(indexName)
-                        .retriever(r -> r.rrf(rf -> rf.retrievers(List.of(
-                                RRFRetrieverEntry.of(rre -> rre.retriever(rt -> rt.standard(standard))),
-                                RRFRetrieverEntry.of(rre -> rre.retriever(rt -> rt.knn(knn)))))))
+                        .retriever(r -> r.rrf(rf -> rf
+                                // Elasticsearch requires rank_window_size to be at least as large as size.
+                                .rankWindowSize(
+                                        Math.max(DEFAULT_RRF_RANK_WINDOW_SIZE, embeddingSearchRequest.maxResults()))
+                                .retrievers(List.of(
+                                        RRFRetrieverEntry.of(rre -> rre.retriever(rt -> rt.standard(standard))),
+                                        RRFRetrieverEntry.of(rre -> rre.retriever(rt -> rt.knn(knn)))))))
                         .size(embeddingSearchRequest.maxResults())
                         .minScore(embeddingSearchRequest.minScore()),
                 Document.class);

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybridTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybridTest.java
@@ -38,6 +38,7 @@ class ElasticsearchConfigurationHybridTest {
 
         assertThat(transport.capturedRequest).isNotNull();
         assertThat(transport.capturedRequest.retriever().rrf().retrievers()).hasSize(2);
+        assertThat(transport.capturedRequest.retriever().rrf().rankWindowSize()).isEqualTo(10);
 
         var standardRetriever = transport
                 .capturedRequest
@@ -62,6 +63,24 @@ class ElasticsearchConfigurationHybridTest {
         assertThat(knnRetriever.filter()).hasSize(1);
         assertThat(knnRetriever.filter().get(0))
                 .isEqualTo(standardRetriever.filter().get(0));
+    }
+
+    @Test
+    void should_set_rrf_rank_window_to_requested_max_results() throws IOException {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchClient client = new ElasticsearchClient(transport);
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(Embedding.from(new float[] {0.1f, 0.2f}))
+                .maxResults(20)
+                .build();
+
+        ElasticsearchConfigurationHybrid.builder()
+                .build()
+                .hybridSearch(client, "movies", searchRequest, "movies about space battles");
+
+        assertThat(transport.capturedRequest).isNotNull();
+        assertThat(transport.capturedRequest.size()).isEqualTo(20);
+        assertThat(transport.capturedRequest.retriever().rrf().rankWindowSize()).isEqualTo(20);
     }
 
     private static class CapturingTransport implements ElasticsearchTransport {


### PR DESCRIPTION
## Summary

- align Elasticsearch RRF `rank_window_size` with the requested `maxResults`
- preserve the default RRF rank window of 10 for smaller result requests
- add regression coverage for hybrid searches requesting more than 10 results

## Problem

`ElasticsearchConfigurationHybrid` forwards `maxResults` as the search request `size`,
but leaves the RRF `rank_window_size` unset.

Elasticsearch defaults `rank_window_size` to 10 and requires it to be greater than
or equal to the search request `size`. As a result, hybrid searches with
`maxResults > 10` can be rejected by Elasticsearch.

## Test Plan

- `./mvnw -pl langchain4j-elasticsearch -Dtest=ElasticsearchConfigurationHybridTest test`
- `./mvnw -pl langchain4j-elasticsearch spotless:check`
- `git diff --check`