### PR TITLE
fix: forward image detailLevel in Azure OpenAI chat requests

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
@@ -30,6 +30,7 @@ import com.azure.ai.openai.models.ChatCompletionsToolDefinition;
 import com.azure.ai.openai.models.ChatCompletionsToolSelection;
 import com.azure.ai.openai.models.ChatCompletionsToolSelectionPreset;
 import com.azure.ai.openai.models.ChatMessageImageContentItem;
+import com.azure.ai.openai.models.ChatMessageImageDetailLevel;
 import com.azure.ai.openai.models.ChatMessageImageUrl;
 import com.azure.ai.openai.models.ChatMessageTextContentItem;
 import com.azure.ai.openai.models.ChatRequestAssistantMessage;
@@ -283,6 +284,7 @@ class InternalAzureOpenAiHelper {
                             } else if (content instanceof ImageContent imageContent) {
                                 String imageUrlString = toImageUrl(imageContent.image());
                                 ChatMessageImageUrl imageUrl = new ChatMessageImageUrl(imageUrlString);
+                                imageUrl.setDetail(toImageDetail(imageContent.detailLevel()));
                                 return new ChatMessageImageContentItem(imageUrl);
                             } else {
                                 throw new IllegalArgumentException("Unsupported content type: " + content.type());
@@ -314,6 +316,18 @@ class InternalAzureOpenAiHelper {
             return image.url().toString();
         }
         return String.format("data:%s;base64,%s", image.mimeType(), image.base64Data());
+    }
+
+    private static ChatMessageImageDetailLevel toImageDetail(ImageContent.DetailLevel detailLevel) {
+        if (detailLevel == null) {
+            return null;
+        }
+        return switch (detailLevel) {
+            case LOW -> ChatMessageImageDetailLevel.LOW;
+            case HIGH -> ChatMessageImageDetailLevel.HIGH;
+            case AUTO -> ChatMessageImageDetailLevel.AUTO;
+            default -> throw new UnsupportedFeatureException("Unsupported detail level: " + detailLevel);
+        };
     }
 
     private static List<ChatCompletionsToolCall> toolExecutionRequestsFrom(ChatMessage message) {

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
@@ -30,7 +30,9 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.ImageContent.DetailLevel;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.output.FinishReason;
 import java.io.IOException;
 import java.time.Duration;
@@ -297,6 +299,91 @@ class InternalAzureOpenAiHelperTest {
                 .contains("url")
                 .doesNotContain("data:image")
                 .doesNotContain("base64");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardImageDetailLevelLow() {
+        // Given
+        ImageContent imageContent = ImageContent.from("https://example.com/low-res.png", DetailLevel.LOW);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then - the detail level must not be silently dropped
+        assertThat(openAiMessages).hasSize(1);
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        assertThat(requestMessage.getContent().toString())
+                .containsIgnoringCase("\"detail\"")
+                .containsIgnoringCase("low");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardImageDetailLevelHigh() {
+        // Given
+        ImageContent imageContent = ImageContent.from("https://example.com/image.png", DetailLevel.HIGH);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then - the detail level must not be silently dropped
+        assertThat(openAiMessages).hasSize(1);
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        assertThat(requestMessage.getContent().toString())
+                .containsIgnoringCase("\"detail\"")
+                .containsIgnoringCase("high");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardImageDetailLevelAuto() {
+        // Given
+        ImageContent imageContent = ImageContent.from("https://example.com/image.png", DetailLevel.AUTO);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then - the detail level must not be silently dropped
+        assertThat(openAiMessages).hasSize(1);
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        assertThat(requestMessage.getContent().toString())
+                .containsIgnoringCase("\"detail\"")
+                .containsIgnoringCase("auto");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardDefaultImageDetailLevel() {
+        // Given - ImageContent.from(url) defaults to DetailLevel.LOW
+        ImageContent imageContent = ImageContent.from("https://example.com/image.png");
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then - even the implicit LOW detail must not be silently dropped
+        assertThat(openAiMessages).hasSize(1);
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        assertThat(requestMessage.getContent().toString())
+                .containsIgnoringCase("\"detail\"")
+                .containsIgnoringCase("low");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldThrowOnUnsupportedImageDetailLevel() {
+        // Given
+        ImageContent imageContent = ImageContent.from("https://example.com/image.png", DetailLevel.MEDIUM);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When + Then - fail loudly instead of silently dropping the value
+        assertThatThrownBy(() -> InternalAzureOpenAiHelper.toOpenAiMessages(messages))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("Unsupported detail level");
     }
 
     @Test


### PR DESCRIPTION
## Issue
Closes #5508

## Change
`InternalAzureOpenAiHelper.toOpenAiMessage()` built `ChatMessageImageUrl` from the URL only and never called `setDetail(...)`, so the user-specified image detail level was silently dropped and Azure always applied its server default.

This PR maps `ImageContent.DetailLevel` to the Azure SDK `ChatMessageImageDetailLevel` and forwards it in the request:

- `LOW` / `HIGH` / `AUTO` are forwarded as-is.
- A `null` detail level is not sent.
- Unsupported values (`MEDIUM`, `ULTRA_HIGH`) now throw `UnsupportedFeatureException` instead of being silently lost — the same approach the sibling `langchain4j-open-ai` module uses in `OpenAiUtils.toDetail(...)`.

This also makes the request consistent with `AzureOpenAiTokenCountEstimator.estimateImageTokens()`, which is already detail-aware (so token estimation and the actual request no longer disagree).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (`mvn -pl langchain4j-azure-open-ai test`: 72 tests, 0 failures)
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (no documentation change required — the behavior now matches the documented `DetailLevel` semantics)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)