### PR TITLE
fix: include inherited fields in PojoOutputParser format instructions

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -23,6 +23,7 @@ import dev.langchain4j.model.output.structured.Description;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -49,14 +50,15 @@ class PojoOutputParser<T> implements OutputParser<T> {
         try {
             if (isPolymorphic(type)) {
                 return extractAndParseJson(text, json -> {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> map = Json.fromJson(json, Map.class);
-                    if (map != null && map.size() == 1 && map.containsKey("value")) {
-                        return Json.fromJson(Json.toJson(map.get("value")), type);
-                    } else {
-                        return Json.fromJson(json, type);
-                    }
-                }).value();
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> map = Json.fromJson(json, Map.class);
+                            if (map != null && map.size() == 1 && map.containsKey("value")) {
+                                return Json.fromJson(Json.toJson(map.get("value")), type);
+                            } else {
+                                return Json.fromJson(json, type);
+                            }
+                        })
+                        .value();
             } else {
                 return extractAndParseJson(text, type).value();
             }
@@ -101,7 +103,7 @@ class PojoOutputParser<T> implements OutputParser<T> {
         StringBuilder jsonSchema = new StringBuilder();
 
         jsonSchema.append("{\n");
-        for (Field field : type.getDeclaredFields()) {
+        for (Field field : fieldsIncludingInherited(type)) {
             String name = field.getName();
             if (name.equals("__$hits$__") || java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
                 // Skip coverage instrumentation field.
@@ -116,6 +118,22 @@ class PojoOutputParser<T> implements OutputParser<T> {
         }
         jsonSchema.append("}");
         return jsonSchema.toString();
+    }
+
+    private static List<Field> fieldsIncludingInherited(Class<?> type) {
+        List<Class<?>> hierarchy = new ArrayList<>();
+        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+            hierarchy.add(current);
+        }
+
+        Map<String, Field> fields = new LinkedHashMap<>();
+        for (int i = hierarchy.size() - 1; i >= 0; i--) {
+            for (Field field : hierarchy.get(i).getDeclaredFields()) {
+                // A field redeclared in a subclass shadows the inherited one.
+                fields.put(field.getName(), field);
+            }
+        }
+        return List.copyOf(fields.values());
     }
 
     private static String descriptionFor(Field field, Set<Class<?>> visited) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PojoOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PojoOutputParserTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.service.output;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.model.output.structured.Description;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -57,5 +58,119 @@ class PojoOutputParserTest {
 
         // then
         assertThat(formatInstructions).contains("array of enum, must be one of [OPEN, CLOSED]");
+    }
+
+    @Test
+    void should_include_inherited_fields_in_format_instructions() {
+
+        // given
+        PojoOutputParser<ChildDto> parser = new PojoOutputParser<>(ChildDto.class);
+
+        // when
+        String formatInstructions = parser.formatInstructions();
+
+        // then
+        assertThat(formatInstructions)
+                .contains("Request status")
+                .contains("\"status\"")
+                .contains("\"message\"")
+                .contains("The answer")
+                .contains("\"answer\"");
+        assertThat(formatInstructions.indexOf("\"status\"")).isLessThan(formatInstructions.indexOf("\"answer\""));
+    }
+
+    @Test
+    void should_not_fail_for_pojo_with_only_inherited_fields() {
+
+        // given - before the fix this threw IllegalConfigurationException: Illegal method return type
+        PojoOutputParser<OnlyInheritedFieldsDto> parser = new PojoOutputParser<>(OnlyInheritedFieldsDto.class);
+
+        // when
+        String formatInstructions = parser.formatInstructions();
+
+        // then
+        assertThat(formatInstructions).contains("\"status\"").contains("\"message\"");
+    }
+
+    @Test
+    void should_parse_json_with_inherited_fields() {
+
+        // given
+        PojoOutputParser<ChildDto> parser = new PojoOutputParser<>(ChildDto.class);
+
+        // when
+        ChildDto dto = parser.parse("{\"status\":\"SUCCESS\",\"message\":\"all good\",\"answer\":\"42\"}");
+
+        // then
+        assertThat(dto.getStatus()).isEqualTo("SUCCESS");
+        assertThat(dto.getMessage()).isEqualTo("all good");
+        assertThat(dto.getAnswer()).isEqualTo("42");
+    }
+
+    @Test
+    void should_not_duplicate_shadowed_fields() {
+
+        // given
+        PojoOutputParser<ShadowingChildDto> parser = new PojoOutputParser<>(ShadowingChildDto.class);
+
+        // when
+        String formatInstructions = parser.formatInstructions();
+
+        // then - the subclass field shadows the inherited one and appears exactly once
+        assertThat(countOccurrences(formatInstructions, "\"value\"")).isEqualTo(1);
+        assertThat(formatInstructions).contains("Overridden description").contains("\"extra\"");
+    }
+
+    private static int countOccurrences(String text, String substring) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(substring, index)) != -1) {
+            count++;
+            index += substring.length();
+        }
+        return count;
+    }
+
+    static class BaseDto {
+
+        @Description("Request status - SUCCESS OR ERROR")
+        private String status;
+
+        @Description("Descriptive message in case of error, success or other information")
+        private String message;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    static class ChildDto extends BaseDto {
+
+        @Description("The answer to the question")
+        private String answer;
+
+        public String getAnswer() {
+            return answer;
+        }
+    }
+
+    static class OnlyInheritedFieldsDto extends BaseDto {}
+
+    static class ShadowingBaseDto {
+
+        @Description("Base description")
+        private String value;
+    }
+
+    static class ShadowingChildDto extends ShadowingBaseDto {
+
+        @Description("Overridden description")
+        private String value;
+
+        private String extra;
     }
 }


### PR DESCRIPTION
## Issue
Closes #3186

## Change
`PojoOutputParser.jsonStructure()` used `Class.getDeclaredFields()`, which only returns fields declared by the class itself. For a response type extending a base class, inherited fields were missing from the JSON format instructions, and a type with no declared fields of its own even failed validation with `Illegal method return type` (`IllegalConfigurationException`) — as reported in the issue.

This PR walks the class hierarchy up to (excluding) `Object` and merges declared fields:

- superclass fields come first, then the subclass's own fields;
- a field redeclared in a subclass shadows the inherited one (no duplicates);
- the existing per-field filtering (static fields, JaCoCo's `__$hits$__`) is unchanged.

`parse()` already handles inherited private fields correctly (the internal Jackson codec uses field visibility `ANY`, and `FAIL_ON_UNKNOWN_PROPERTIES` is enabled), so the format instructions now match what `parse()` actually accepts.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (`mvn -pl langchain4j test`: 1396 tests, 0 failures)
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green (untouched by this PR; `langchain4j` module verified above)
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (no documentation change required)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)