### PR TITLE
fix: include inherited fields and honor @JsonIgnore in JSON schema ge…

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -9,6 +9,7 @@ import static dev.langchain4j.internal.Utils.generateUUIDFrom;
 import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Arrays.stream;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.langchain4j.Internal;
@@ -260,9 +261,12 @@ public class JsonSchemaElementUtils {
 
         Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
         List<String> required = new ArrayList<>();
-        for (Field field : type.getDeclaredFields()) {
+        for (Field field : fieldsIncludingInherited(type)) {
             String fieldName = field.getName();
             if (isStatic(field.getModifiers()) || fieldName.equals("__$hits$__") || fieldName.startsWith("this$")) {
+                continue;
+            }
+            if (field.isAnnotationPresent(JsonIgnore.class)) {
                 continue;
             }
             if (isRequired(field, areSubFieldsRequiredByDefault)) {
@@ -294,6 +298,22 @@ public class JsonSchemaElementUtils {
         }
 
         return builder.build();
+    }
+
+    private static List<Field> fieldsIncludingInherited(Class<?> type) {
+        List<Class<?>> hierarchy = new ArrayList<>();
+        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+            hierarchy.add(current);
+        }
+
+        Map<String, Field> fields = new LinkedHashMap<>();
+        for (int i = hierarchy.size() - 1; i >= 0; i--) {
+            for (Field field : hierarchy.get(i).getDeclaredFields()) {
+                // A field redeclared in a subclass shadows the inherited one.
+                fields.put(field.getName(), field);
+            }
+        }
+        return List.copyOf(fields.values());
     }
 
     private static boolean isRequired(Field field, boolean defaultValue) {

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.internal;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
@@ -586,5 +587,78 @@ class JsonSchemaElementUtilsTest {
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
         assertThat(map).containsEntry("foo", "bar");
+    }
+
+    static class DescribedBaseClass {
+
+        @Description("Base field")
+        String baseField;
+    }
+
+    static class ExtendingClass extends DescribedBaseClass {
+
+        @Description("Child field")
+        String childField;
+    }
+
+    @Test
+    void should_include_inherited_fields_in_schema() {
+
+        // given
+        Class<ExtendingClass> clazz = ExtendingClass.class;
+
+        // when
+        JsonObjectSchema schema = (JsonObjectSchema) JsonSchemaElementUtils.jsonSchemaElementFrom(clazz);
+
+        // then
+        assertThat(schema.properties()).containsOnlyKeys("baseField", "childField");
+    }
+
+    static class ClassWithIgnoredField {
+
+        String visibleField;
+
+        @JsonIgnore
+        String hiddenField;
+    }
+
+    @Test
+    void should_exclude_json_ignored_fields_from_schema() {
+
+        // given
+        Class<ClassWithIgnoredField> clazz = ClassWithIgnoredField.class;
+
+        // when
+        JsonObjectSchema schema = (JsonObjectSchema) JsonSchemaElementUtils.jsonSchemaElementFrom(clazz);
+
+        // then
+        assertThat(schema.properties()).containsOnlyKeys("visibleField");
+    }
+
+    static class ShadowingBaseClass {
+
+        @Description("Base value")
+        String value;
+    }
+
+    static class ShadowingExtendingClass extends ShadowingBaseClass {
+
+        @Description("Overridden value")
+        String value;
+
+        String extra;
+    }
+
+    @Test
+    void should_not_duplicate_shadowed_fields_in_schema() {
+
+        // given
+        Class<ShadowingExtendingClass> clazz = ShadowingExtendingClass.class;
+
+        // when
+        JsonObjectSchema schema = (JsonObjectSchema) JsonSchemaElementUtils.jsonSchemaElementFrom(clazz);
+
+        // then - the subclass field shadows the inherited one
+        assertThat(schema.properties()).containsOnlyKeys("value", "extra");
     }
 }


### PR DESCRIPTION
## Issue
Closes #3515

## Change
`JsonSchemaElementUtils.schemaFrom()` built object schemas from `Class.getDeclaredFields()` only, which has two consequences for any parameter/response type that extends a base class:

1. **Inherited fields were missing** from the generated JSON schema — both for `@Tool` parameter POJOs (`ToolSpecifications` delegates to this utility) and for structured-output return types. With the internal Jackson codec using field visibility `ANY` (and `FAIL_ON_UNKNOWN_PROPERTIES` enabled), Jackson can and does deserialize inherited private fields, so the schema told the model less than the code actually accepts. An LLM following the schema would leave the inherited fields unset.
2. **`@JsonIgnore` fields leaked into the schema.** The schema advertised fields that Jackson excludes during serialization, so the model was instructed to produce data that is silently dropped.

This PR:

- walks the class hierarchy up to (excluding) `Object` and merges declared fields, superclass fields first, with a subclass redeclaration shadowing the inherited one;
- skips fields annotated with `@JsonIgnore` (Jackson annotations are already a compile dependency of `langchain4j-core`, e.g. `JsonProperty`);
- keeps the existing filtering (static fields, `__$hits$__`, `this$`) unchanged.

## General checklist
- [X] There are no breaking changes (API, behaviour) — schemas only gain previously missing properties and lose properties that Jackson ignores; both match actual serialization behavior
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (`mvn -pl langchain4j-core test`)
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green (core: 1285 tests, 0 failures; `langchain4j` module against the modified core: 1392 tests, 0 failures)
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (no documentation change required)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)