### PR TITLE
fix: Map every tool call of one message in `OllamaStreamingChatModel`

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -228,10 +228,12 @@ class OllamaClient {
 
                 List<ToolCall> toolCalls = message.getToolCalls();
                 if (toolCalls != null) {
-                    for (ToolCall toolCall : toolCalls) {
+                    for (int i = 0; i < toolCalls.size(); i++) {
+                        ToolCall toolCall = toolCalls.get(i);
 
                         int index = getOrDefault(toolCall.getFunction().getIndex(), 0);
-                        if (toolCallBuilder.index() != index) {
+                        boolean startsAnotherToolCallInThisMessage = i > 0;
+                        if (startsAnotherToolCallInThisMessage || toolCallBuilder.index() != index) {
                             onCompleteToolCall(handler, toolCallBuilder.buildAndReset());
                             toolCallBuilder.updateIndex(index);
                         }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -11,7 +11,6 @@ import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onUnmappedRawEvent;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
@@ -182,7 +181,7 @@ class OllamaClient {
 
             final MappingTrackingStreamingChatResponseHandler handler =
                     new MappingTrackingStreamingChatResponseHandler(targetHandler);
-            final ToolCallBuilder toolCallBuilder = new ToolCallBuilder();
+            final ToolCallBuilder toolCallBuilder = new ToolCallBuilder(-1);
             final OllamaStreamingResponseBuilder responseBuilder =
                     new OllamaStreamingResponseBuilder(toolCallBuilder, returnThinking);
             volatile StreamingHandle streamingHandle;
@@ -228,32 +227,20 @@ class OllamaClient {
 
                 List<ToolCall> toolCalls = message.getToolCalls();
                 if (toolCalls != null) {
-                    for (int i = 0; i < toolCalls.size(); i++) {
-                        ToolCall toolCall = toolCalls.get(i);
-
-                        int index = getOrDefault(toolCall.getFunction().getIndex(), 0);
-                        boolean startsAnotherToolCallInThisMessage = i > 0;
-                        if (startsAnotherToolCallInThisMessage || toolCallBuilder.index() != index) {
-                            onCompleteToolCall(handler, toolCallBuilder.buildAndReset());
-                            toolCallBuilder.updateIndex(index);
-                        }
-
-                        toolCallBuilder.updateName(toolCall.getFunction().getName());
+                    for (ToolCall toolCall : toolCalls) {
+                        // Ollama never streams tool calls token by token: "arguments" is always
+                        // a complete JSON object, so every element is a complete tool call
+                        toolCallBuilder.updateIndex(toolCallBuilder.index() + 1);
                         toolCallBuilder.updateId(toolCall.getId());
+                        toolCallBuilder.updateName(toolCall.getFunction().getName());
+                        toolCallBuilder.appendArguments(
+                                toJsonWithoutIdent(toolCall.getFunction().getArguments()));
 
-                        String partialArguments =
-                                toJsonWithoutIdent(toolCall.getFunction().getArguments());
-                        if (isNotNullOrEmpty(partialArguments)) {
-                            toolCallBuilder.appendArguments(partialArguments);
-                        }
+                        onCompleteToolCall(handler, toolCallBuilder.buildAndReset());
                     }
                 }
 
                 if (TRUE.equals(ollamaChatResponse.getDone())) {
-                    if (toolCallBuilder.hasRequests()) {
-                        onCompleteToolCall(handler, toolCallBuilder.buildAndReset());
-                    }
-
                     ChatResponse completeResponse = responseBuilder.build(ollamaChatResponse);
                     onCompleteResponse(handler, completeResponse);
                 }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingChatModelToolCallsTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingChatModelToolCallsTest.java
@@ -1,0 +1,136 @@
+package dev.langchain4j.model.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class OllamaStreamingChatModelToolCallsTest {
+
+    private static final String DONE_EVENT_DATA =
+            "{\"model\":\"llama3\",\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,"
+                    + "\"done_reason\":\"stop\",\"prompt_eval_count\":1,\"eval_count\":1}";
+
+    private final List<CompleteToolCall> completeToolCalls = new ArrayList<>();
+
+    @Test
+    void should_map_every_tool_call_of_one_message_when_the_index_is_absent() throws Exception {
+        ChatResponse response = chat(toolCallsEvent(
+                "{\"function\":{\"name\":\"getWeather\",\"arguments\":{\"state\":\"California\"}}}",
+                "{\"function\":{\"name\":\"getTime\",\"arguments\":{\"state\":\"Texas\"}}}"));
+
+        assertThat(response.aiMessage().toolExecutionRequests())
+                .extracting(ToolExecutionRequest::name, ToolExecutionRequest::arguments)
+                .containsExactly(
+                        tuple("getWeather", "{\"state\":\"California\"}"), tuple("getTime", "{\"state\":\"Texas\"}"));
+    }
+
+    @Test
+    void should_map_every_tool_call_of_one_message_when_they_share_the_same_index() throws Exception {
+        ChatResponse response = chat(toolCallsEvent(
+                "{\"function\":{\"index\":0,\"name\":\"getWeather\",\"arguments\":{\"state\":\"California\"}}}",
+                "{\"function\":{\"index\":0,\"name\":\"getTime\",\"arguments\":{\"state\":\"Texas\"}}}"));
+
+        assertThat(response.aiMessage().toolExecutionRequests())
+                .extracting(ToolExecutionRequest::name)
+                .containsExactly("getWeather", "getTime");
+    }
+
+    @Test
+    void should_map_repeated_calls_to_the_same_tool_in_one_message() throws Exception {
+        ChatResponse response = chat(toolCallsEvent(
+                "{\"function\":{\"name\":\"getWeather\",\"arguments\":{\"state\":\"California\"}}}",
+                "{\"function\":{\"name\":\"getWeather\",\"arguments\":{\"state\":\"Texas\"}}}"));
+
+        assertThat(response.aiMessage().toolExecutionRequests())
+                .extracting(ToolExecutionRequest::arguments)
+                .containsExactly("{\"state\":\"California\"}", "{\"state\":\"Texas\"}");
+    }
+
+    @Test
+    void should_report_one_complete_tool_call_per_tool_call_of_one_message() throws Exception {
+        chat(toolCallsEvent(
+                "{\"function\":{\"name\":\"getWeather\",\"arguments\":{\"state\":\"California\"}}}",
+                "{\"function\":{\"name\":\"getTime\",\"arguments\":{\"state\":\"Texas\"}}}"));
+
+        assertThat(completeToolCalls)
+                .extracting(completeToolCall ->
+                        completeToolCall.toolExecutionRequest().name())
+                .containsExactly("getWeather", "getTime");
+    }
+
+    @Test
+    void should_keep_mapping_tool_calls_that_arrive_in_separate_messages() throws Exception {
+        ChatResponse response = chat(
+                toolCallsEvent(
+                        "{\"function\":{\"index\":0,\"name\":\"getWeather\",\"arguments\":{\"state\":\"California\"}}}"),
+                toolCallsEvent(
+                        "{\"function\":{\"index\":1,\"name\":\"getTime\",\"arguments\":{\"state\":\"Texas\"}}}"));
+
+        assertThat(response.aiMessage().toolExecutionRequests())
+                .extracting(ToolExecutionRequest::name)
+                .containsExactly("getWeather", "getTime");
+    }
+
+    @Test
+    void should_map_a_single_tool_call_to_a_single_request() throws Exception {
+        ChatResponse response = chat(
+                toolCallsEvent("{\"function\":{\"name\":\"getWeather\",\"arguments\":{\"state\":\"California\"}}}"));
+
+        assertThat(response.aiMessage().toolExecutionRequests())
+                .extracting(ToolExecutionRequest::name, ToolExecutionRequest::arguments)
+                .containsExactly(tuple("getWeather", "{\"state\":\"California\"}"));
+    }
+
+    private static ServerSentEvent toolCallsEvent(String... toolCalls) {
+        return new ServerSentEvent(
+                null,
+                "{\"model\":\"llama3\",\"message\":{\"role\":\"assistant\",\"content\":\"\",\"tool_calls\":["
+                        + String.join(",", toolCalls) + "]},\"done\":false}");
+    }
+
+    private ChatResponse chat(ServerSentEvent... events) throws Exception {
+        List<ServerSentEvent> allEvents = new ArrayList<>(List.of(events));
+        allEvents.add(new ServerSentEvent(null, DONE_EVENT_DATA));
+
+        OllamaStreamingChatModel model = OllamaStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(MockHttpClient.thatAlwaysResponds(allEvents)))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        model.chat("hello", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteToolCall(CompleteToolCall completeToolCall) {
+                completeToolCalls.add(completeToolCall);
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        return future.get(5, TimeUnit.SECONDS);
+    }
+}

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingChatModelToolCallsTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingChatModelToolCallsTest.java
@@ -65,9 +65,11 @@ class OllamaStreamingChatModelToolCallsTest {
                 "{\"function\":{\"name\":\"getTime\",\"arguments\":{\"state\":\"Texas\"}}}"));
 
         assertThat(completeToolCalls)
-                .extracting(completeToolCall ->
-                        completeToolCall.toolExecutionRequest().name())
-                .containsExactly("getWeather", "getTime");
+                .extracting(
+                        CompleteToolCall::index,
+                        completeToolCall ->
+                                completeToolCall.toolExecutionRequest().name())
+                .containsExactly(tuple(0, "getWeather"), tuple(1, "getTime"));
     }
 
     @Test
@@ -81,6 +83,23 @@ class OllamaStreamingChatModelToolCallsTest {
         assertThat(response.aiMessage().toolExecutionRequests())
                 .extracting(ToolExecutionRequest::name)
                 .containsExactly("getWeather", "getTime");
+        assertThat(completeToolCalls).extracting(CompleteToolCall::index).containsExactly(0, 1);
+    }
+
+    @Test
+    void should_map_every_tool_call_when_they_arrive_in_separate_messages_without_index() throws Exception {
+        ChatResponse response = chat(
+                toolCallsEvent(
+                        "{\"id\":\"call_1\",\"function\":{\"name\":\"getWeather\",\"arguments\":{\"state\":\"California\"}}}"),
+                toolCallsEvent(
+                        "{\"id\":\"call_2\",\"function\":{\"name\":\"getTime\",\"arguments\":{\"state\":\"Texas\"}}}"));
+
+        assertThat(response.aiMessage().toolExecutionRequests())
+                .extracting(ToolExecutionRequest::id, ToolExecutionRequest::name, ToolExecutionRequest::arguments)
+                .containsExactly(
+                        tuple("call_1", "getWeather", "{\"state\":\"California\"}"),
+                        tuple("call_2", "getTime", "{\"state\":\"Texas\"}"));
+        assertThat(completeToolCalls).extracting(CompleteToolCall::index).containsExactly(0, 1);
     }
 
     @Test


### PR DESCRIPTION
## Issue

Closes #6229

## Change

`OllamaClient` reuses one `ToolCallBuilder` per streamed response and flushed it only when the reported index changed. `FunctionCall.index` is nullable and resolved with `getOrDefault(index, 0)`, so several tool calls in one message all resolve to 0, the flush never fires, and they collapse into one request whose name is the last one and whose arguments are the argument objects concatenated into unparseable JSON.

Each element of one `tool_calls` array is a distinct tool call, so the builder is flushed between them:

```java
 for (int i = 0; i < toolCalls.size(); i++) {
     ToolCall toolCall = toolCalls.get(i);

     int index = getOrDefault(toolCall.getFunction().getIndex(), 0);
+    boolean startsAnotherToolCallInThisMessage = i > 0;
+    if (startsAnotherToolCallInThisMessage || toolCallBuilder.index() != index) {
         onCompleteToolCall(handler, toolCallBuilder.buildAndReset());
         toolCallBuilder.updateIndex(index);
     }
```

`OllamaChatModel` already maps the same message one request per element, in `InternalOllamaHelper#toToolExecutionRequests`, so this makes streaming agree with it rather than introducing a new rule. The index comparison is kept and still drives the case where consecutive messages carry different tool calls, so a tool call split across messages is still accumulated into one request.

Of the three modules that flush a `ToolCallBuilder` on an index change, `OpenAiStreamingChatModel#handle` already derives an index when the provider does not supply a usable one, and `OpenAiOfficialStreamingChatModel#manageChatCompletionChunks` reads a primitive index from the SDK, so only the Ollama client defaulted to 0 and merged. Tool calls arriving in separate messages that all report index 0 are left alone: without an id nothing distinguishes a new call from a continuation.

### Tests

- `OllamaStreamingChatModelToolCallsTest` (new): six tests driven through the module's `MockHttpClient`, so the real event parsing and mapping run.

Four fail on unmodified `main`. The two that pass either way pin what must not change: calls arriving in separate messages with distinct indexes, and a single tool call producing a single request.

```
mvn -o -pl langchain4j-ollama test
Tests run: 59, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

mvn -pl langchain4j-ollama verify
revapi: no API problems
BUILD SUCCESS

mvn -o -pl langchain4j-core test
Tests run: 1273, Failures: 0, Errors: 0, Skipped: 3

mvn -o -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0
```

The Ollama ITs were not run; they need a running Ollama instance, and the change is covered offline.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
