### PR TITLE
fix: Keep grounding and URL context metadata in `GoogleAiGeminiStreamingChatModel`

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -297,17 +297,17 @@ class BaseGeminiChatModel {
                 .build();
     }
 
-    private UrlContextMetadata toUrlContextMetadata(
+    static UrlContextMetadata toUrlContextMetadata(
             GeminiGenerateContentResponse.GeminiUrlContextMetadata geminiUrlContextMetadata) {
         if (geminiUrlContextMetadata == null || geminiUrlContextMetadata.urlMetadata() == null) {
             return null;
         }
         return new UrlContextMetadata(geminiUrlContextMetadata.urlMetadata().stream()
-                .map(this::toUrlMetadata)
+                .map(BaseGeminiChatModel::toUrlMetadata)
                 .toList());
     }
 
-    private UrlContextMetadata.UrlMetadata toUrlMetadata(
+    private static UrlContextMetadata.UrlMetadata toUrlMetadata(
             GeminiGenerateContentResponse.GeminiUrlMetadata geminiUrlMetadata) {
         if (geminiUrlMetadata == null) {
             return null;

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
@@ -38,6 +38,8 @@ class GeminiStreamingResponseBuilder {
     private final AtomicReference<String> modelName = new AtomicReference<>();
     private final AtomicReference<TokenUsage> tokenUsage = new AtomicReference<>();
     private final AtomicReference<FinishReason> finishReason = new AtomicReference<>();
+    private final AtomicReference<GroundingMetadata> groundingMetadata = new AtomicReference<>();
+    private final AtomicReference<UrlContextMetadata> urlContextMetadata = new AtomicReference<>();
 
     GeminiStreamingResponseBuilder(boolean includeCodeExecutionOutput, Boolean returnThinking) {
         this.includeCodeExecutionOutput = includeCodeExecutionOutput;
@@ -71,6 +73,8 @@ class GeminiStreamingResponseBuilder {
         updateModelName(partialResponse);
         updateFinishReason(firstCandidate);
         updateTokenUsage(partialResponse.usageMetadata());
+        updateGroundingMetadata(partialResponse, firstCandidate);
+        updateUrlContextMetadata(firstCandidate);
 
         GeminiContent content = firstCandidate.content();
         if (content == null || content.parts() == null) {
@@ -100,6 +104,8 @@ class GeminiStreamingResponseBuilder {
                         .modelName(modelName.get())
                         .tokenUsage(tokenUsage.get())
                         .finishReason(aiMessage.hasToolExecutionRequests() ? TOOL_EXECUTION : finishReason.get())
+                        .groundingMetadata(groundingMetadata.get())
+                        .urlContextMetadata(urlContextMetadata.get())
                         .build())
                 .build();
     }
@@ -107,6 +113,21 @@ class GeminiStreamingResponseBuilder {
     private void updateId(GeminiGenerateContentResponse response) {
         if (!isNullOrBlank(response.responseId())) {
             id.set(response.responseId());
+        }
+    }
+
+    private void updateGroundingMetadata(GeminiGenerateContentResponse response, GeminiCandidate candidate) {
+        GroundingMetadata metadata =
+                response.groundingMetadata() != null ? response.groundingMetadata() : candidate.groundingMetadata();
+        if (metadata != null) {
+            groundingMetadata.set(metadata);
+        }
+    }
+
+    private void updateUrlContextMetadata(GeminiCandidate candidate) {
+        UrlContextMetadata metadata = BaseGeminiChatModel.toUrlContextMetadata(candidate.urlContextMetadata());
+        if (metadata != null) {
+            urlContextMetadata.set(metadata);
         }
     }
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
@@ -11,12 +11,21 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUsageMetadata;
+import dev.langchain4j.model.googleai.GroundingMetadata.GroundingChunk;
+import dev.langchain4j.model.googleai.GroundingMetadata.GroundingSupport;
+import dev.langchain4j.model.googleai.GroundingMetadata.RetrievalMetadata;
+import dev.langchain4j.model.googleai.GroundingMetadata.SearchEntryPoint;
+import dev.langchain4j.model.googleai.UrlContextMetadata.UrlMetadata;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -38,8 +47,8 @@ class GeminiStreamingResponseBuilder {
     private final AtomicReference<String> modelName = new AtomicReference<>();
     private final AtomicReference<TokenUsage> tokenUsage = new AtomicReference<>();
     private final AtomicReference<FinishReason> finishReason = new AtomicReference<>();
-    private final AtomicReference<GroundingMetadata> groundingMetadata = new AtomicReference<>();
-    private final AtomicReference<UrlContextMetadata> urlContextMetadata = new AtomicReference<>();
+    private final GroundingMetadataAccumulator groundingMetadata = new GroundingMetadataAccumulator();
+    private final UrlContextMetadataAccumulator urlContextMetadata = new UrlContextMetadataAccumulator();
 
     GeminiStreamingResponseBuilder(boolean includeCodeExecutionOutput, Boolean returnThinking) {
         this.includeCodeExecutionOutput = includeCodeExecutionOutput;
@@ -104,8 +113,8 @@ class GeminiStreamingResponseBuilder {
                         .modelName(modelName.get())
                         .tokenUsage(tokenUsage.get())
                         .finishReason(aiMessage.hasToolExecutionRequests() ? TOOL_EXECUTION : finishReason.get())
-                        .groundingMetadata(groundingMetadata.get())
-                        .urlContextMetadata(urlContextMetadata.get())
+                        .groundingMetadata(groundingMetadata.build())
+                        .urlContextMetadata(urlContextMetadata.build())
                         .build())
                 .build();
     }
@@ -117,18 +126,12 @@ class GeminiStreamingResponseBuilder {
     }
 
     private void updateGroundingMetadata(GeminiGenerateContentResponse response, GeminiCandidate candidate) {
-        GroundingMetadata metadata =
-                response.groundingMetadata() != null ? response.groundingMetadata() : candidate.groundingMetadata();
-        if (metadata != null) {
-            groundingMetadata.set(metadata);
-        }
+        groundingMetadata.merge(
+                response.groundingMetadata() != null ? response.groundingMetadata() : candidate.groundingMetadata());
     }
 
     private void updateUrlContextMetadata(GeminiCandidate candidate) {
-        UrlContextMetadata metadata = BaseGeminiChatModel.toUrlContextMetadata(candidate.urlContextMetadata());
-        if (metadata != null) {
-            urlContextMetadata.set(metadata);
-        }
+        urlContextMetadata.merge(BaseGeminiChatModel.toUrlContextMetadata(candidate.urlContextMetadata()));
     }
 
     private void updateModelName(GeminiGenerateContentResponse response) {
@@ -191,5 +194,146 @@ class GeminiStreamingResponseBuilder {
                 .toolExecutionRequests(functionCalls)
                 .attributes(attributes)
                 .build();
+    }
+
+    /**
+     * Accumulates the grounding metadata of every streamed chunk into a single value.
+     *
+     * <p>A chunk either repeats what earlier chunks already reported or adds to it, and the response does not say
+     * which, so an entry already seen is skipped and a new one is appended. Because a {@link GroundingSupport} points
+     * at {@link GroundingChunk}s by their position, the positions reported by a chunk that contributes new sources are
+     * translated into positions in the accumulated list.
+     */
+    private static class GroundingMetadataAccumulator {
+
+        private final Map<GroundingChunk, Integer> chunkPositions = new HashMap<>();
+
+        private boolean reported;
+        private List<GroundingChunk> chunks;
+        private Set<GroundingSupport> supports;
+        private Set<String> webSearchQueries;
+        private SearchEntryPoint searchEntryPoint;
+        private RetrievalMetadata retrievalMetadata;
+        private String googleMapsWidgetContextToken;
+
+        void merge(GroundingMetadata metadata) {
+            if (metadata == null) {
+                return;
+            }
+            reported = true;
+
+            int[] positions = mergeChunks(metadata.groundingChunks());
+            mergeSupports(metadata.groundingSupports(), positions);
+
+            if (metadata.webSearchQueries() != null) {
+                if (webSearchQueries == null) {
+                    webSearchQueries = new LinkedHashSet<>();
+                }
+                webSearchQueries.addAll(metadata.webSearchQueries());
+            }
+            if (metadata.searchEntryPoint() != null) {
+                searchEntryPoint = metadata.searchEntryPoint();
+            }
+            if (metadata.retrievalMetadata() != null) {
+                retrievalMetadata = metadata.retrievalMetadata();
+            }
+            if (metadata.googleMapsWidgetContextToken() != null) {
+                googleMapsWidgetContextToken = metadata.googleMapsWidgetContextToken();
+            }
+        }
+
+        GroundingMetadata build() {
+            if (!reported) {
+                return null;
+            }
+            return GroundingMetadata.builder()
+                    .groundingChunks(chunks == null ? null : new ArrayList<>(chunks))
+                    .groundingSupports(supports == null ? null : new ArrayList<>(supports))
+                    .webSearchQueries(webSearchQueries == null ? null : new ArrayList<>(webSearchQueries))
+                    .searchEntryPoint(searchEntryPoint)
+                    .retrievalMetadata(retrievalMetadata)
+                    .googleMapsWidgetContextToken(googleMapsWidgetContextToken)
+                    .build();
+        }
+
+        private int[] mergeChunks(List<GroundingChunk> reportedChunks) {
+            if (reportedChunks == null) {
+                return new int[0];
+            }
+            if (chunks == null) {
+                chunks = new ArrayList<>();
+            }
+            int[] positions = new int[reportedChunks.size()];
+            for (int i = 0; i < reportedChunks.size(); i++) {
+                GroundingChunk chunk = reportedChunks.get(i);
+                Integer position = chunkPositions.get(chunk);
+                if (position == null) {
+                    position = chunks.size();
+                    chunks.add(chunk);
+                    chunkPositions.put(chunk, position);
+                }
+                positions[i] = position;
+            }
+            return positions;
+        }
+
+        private void mergeSupports(List<GroundingSupport> reportedSupports, int[] positions) {
+            if (reportedSupports == null) {
+                return;
+            }
+            if (supports == null) {
+                supports = new LinkedHashSet<>();
+            }
+            for (GroundingSupport support : reportedSupports) {
+                supports.add(withAccumulatedPositions(support, positions));
+            }
+        }
+
+        private static GroundingSupport withAccumulatedPositions(GroundingSupport support, int[] positions) {
+            if (support == null || support.groundingChunkIndices() == null) {
+                return support;
+            }
+            List<Integer> indices = support.groundingChunkIndices().stream()
+                    .map(index -> accumulatedPosition(index, positions))
+                    .toList();
+            return new GroundingSupport(indices, support.confidenceScores(), support.segment());
+        }
+
+        private static Integer accumulatedPosition(Integer index, int[] positions) {
+            if (index == null || index < 0 || index >= positions.length) {
+                return index;
+            }
+            return positions[index];
+        }
+    }
+
+    /**
+     * Accumulates the URL context metadata of every streamed chunk into a single value, keeping one entry per
+     * retrieved URL so that a chunk repeating a URL only updates the retrieval status reported for it.
+     */
+    private static class UrlContextMetadataAccumulator {
+
+        private Map<String, UrlMetadata> urlMetadataByUrl;
+
+        void merge(UrlContextMetadata metadata) {
+            if (metadata == null || metadata.urlMetadata() == null) {
+                return;
+            }
+            if (urlMetadataByUrl == null) {
+                urlMetadataByUrl = new LinkedHashMap<>();
+            }
+            for (UrlMetadata urlMetadata : metadata.urlMetadata()) {
+                if (urlMetadata != null) {
+                    urlMetadataByUrl.put(urlMetadata.retrievedUrl(), urlMetadata);
+                }
+            }
+        }
+
+        UrlContextMetadata build() {
+            if (urlMetadataByUrl == null) {
+                return null;
+            }
+            return new UrlContextMetadata(new ArrayList<>(urlMetadataByUrl.values()));
+        }
     }
 }

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.googleai;
 
+import static dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUrlRetrievalStatus.URL_RETRIEVAL_STATUS_SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.image.Image;
@@ -7,6 +8,8 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.googleai.GeminiContent.GeminiPart;
 import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiBlob;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate;
+import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUrlContextMetadata;
+import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUrlMetadata;
 import dev.langchain4j.model.googleai.GeminiStreamingResponseBuilder.TextAndTools;
 import java.util.Collections;
 import java.util.List;
@@ -93,6 +96,73 @@ class GeminiStreamingResponseBuilderTest {
 
         assertThat(aiMessage.text()).isEqualTo("Hello world");
         assertThat(aiMessage.images()).hasSize(1);
+    }
+
+    @Test
+    void should_keep_grounding_metadata_from_the_response() {
+        GroundingMetadata grounding =
+                GroundingMetadata.builder().webSearchQueries(List.of("who won")).build();
+        builder.append(new GeminiGenerateContentResponse(
+                "id-1", "gemini-pro", List.of(new GeminiCandidate(null, null, null, null)), null, grounding));
+
+        GoogleAiGeminiChatResponseMetadata metadata =
+                (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
+
+        assertThat(metadata.groundingMetadata()).isSameAs(grounding);
+    }
+
+    @Test
+    void should_keep_grounding_metadata_reported_on_the_candidate() {
+        GroundingMetadata grounding =
+                GroundingMetadata.builder().webSearchQueries(List.of("who won")).build();
+        builder.append(new GeminiGenerateContentResponse(
+                "id-1", "gemini-pro", List.of(new GeminiCandidate(null, null, null, grounding)), null, null));
+
+        GoogleAiGeminiChatResponseMetadata metadata =
+                (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
+
+        assertThat(metadata.groundingMetadata()).isSameAs(grounding);
+    }
+
+    @Test
+    void should_keep_grounding_metadata_when_a_later_chunk_does_not_repeat_it() {
+        GroundingMetadata grounding =
+                GroundingMetadata.builder().webSearchQueries(List.of("who won")).build();
+        builder.append(new GeminiGenerateContentResponse(
+                "id-1", "gemini-pro", List.of(new GeminiCandidate(null, null, null, null)), null, grounding));
+        builder.append(chunkWith(GeminiPart.ofText("the answer")));
+
+        GoogleAiGeminiChatResponseMetadata metadata =
+                (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
+
+        assertThat(metadata.groundingMetadata()).isSameAs(grounding);
+    }
+
+    @Test
+    void should_keep_url_context_metadata_from_the_candidate() {
+        GeminiUrlContextMetadata urlContext = new GeminiUrlContextMetadata(
+                List.of(new GeminiUrlMetadata("https://example.com", URL_RETRIEVAL_STATUS_SUCCESS)));
+        builder.append(new GeminiGenerateContentResponse(
+                "id-1", "gemini-pro", List.of(new GeminiCandidate(null, null, urlContext, null)), null, null));
+
+        GoogleAiGeminiChatResponseMetadata metadata =
+                (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
+
+        assertThat(metadata.urlContextMetadata()).isNotNull();
+        assertThat(metadata.urlContextMetadata().urlMetadata())
+                .extracting(UrlContextMetadata.UrlMetadata::retrievedUrl)
+                .containsExactly("https://example.com");
+    }
+
+    @Test
+    void should_leave_grounding_and_url_context_metadata_null_when_the_response_carries_none() {
+        builder.append(chunkWith(GeminiPart.ofText("Hello")));
+
+        GoogleAiGeminiChatResponseMetadata metadata =
+                (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
+
+        assertThat(metadata.groundingMetadata()).isNull();
+        assertThat(metadata.urlContextMetadata()).isNull();
     }
 
     private static GeminiPart imagePart(String base64Data) {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
@@ -1,16 +1,21 @@
 package dev.langchain4j.model.googleai;
 
+import static dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUrlRetrievalStatus.URL_RETRIEVAL_STATUS_ERROR;
 import static dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUrlRetrievalStatus.URL_RETRIEVAL_STATUS_SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.googleai.GeminiContent.GeminiPart;
 import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiBlob;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUrlContextMetadata;
 import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiUrlMetadata;
 import dev.langchain4j.model.googleai.GeminiStreamingResponseBuilder.TextAndTools;
+import dev.langchain4j.model.googleai.GroundingMetadata.GroundingChunk;
+import dev.langchain4j.model.googleai.GroundingMetadata.GroundingSupport;
+import dev.langchain4j.model.googleai.GroundingMetadata.SearchEntryPoint;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -108,7 +113,7 @@ class GeminiStreamingResponseBuilderTest {
         GoogleAiGeminiChatResponseMetadata metadata =
                 (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
 
-        assertThat(metadata.groundingMetadata()).isSameAs(grounding);
+        assertThat(metadata.groundingMetadata()).isEqualTo(grounding);
     }
 
     @Test
@@ -121,7 +126,7 @@ class GeminiStreamingResponseBuilderTest {
         GoogleAiGeminiChatResponseMetadata metadata =
                 (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
 
-        assertThat(metadata.groundingMetadata()).isSameAs(grounding);
+        assertThat(metadata.groundingMetadata()).isEqualTo(grounding);
     }
 
     @Test
@@ -135,7 +140,7 @@ class GeminiStreamingResponseBuilderTest {
         GoogleAiGeminiChatResponseMetadata metadata =
                 (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
 
-        assertThat(metadata.groundingMetadata()).isSameAs(grounding);
+        assertThat(metadata.groundingMetadata()).isEqualTo(grounding);
     }
 
     @Test
@@ -165,6 +170,90 @@ class GeminiStreamingResponseBuilderTest {
         assertThat(metadata.urlContextMetadata()).isNull();
     }
 
+    @Test
+    void should_merge_grounding_metadata_fields_reported_by_different_chunks() {
+        builder.append(chunkGroundedWith(GroundingMetadata.builder()
+                .webSearchQueries(List.of("who won"))
+                .searchEntryPoint(new SearchEntryPoint("<div>suggestions</div>", null))
+                .build()));
+        builder.append(chunkGroundedWith(GroundingMetadata.builder()
+                .groundingChunks(List.of(webChunk("https://a.example")))
+                .groundingSupports(List.of(supportOf(0)))
+                .build()));
+
+        GroundingMetadata grounding = groundingOf(builder.build());
+
+        assertThat(grounding.webSearchQueries()).containsExactly("who won");
+        assertThat(grounding.searchEntryPoint().renderedContent()).isEqualTo("<div>suggestions</div>");
+        assertThat(grounding.groundingChunks()).containsExactly(webChunk("https://a.example"));
+        assertThat(grounding.groundingSupports()).containsExactly(supportOf(0));
+    }
+
+    @Test
+    void should_not_duplicate_grounding_metadata_a_later_chunk_repeats() {
+        builder.append(chunkGroundedWith(GroundingMetadata.builder()
+                .webSearchQueries(List.of("who won"))
+                .groundingChunks(List.of(webChunk("https://a.example")))
+                .groundingSupports(List.of(supportOf(0)))
+                .build()));
+        builder.append(chunkGroundedWith(GroundingMetadata.builder()
+                .webSearchQueries(List.of("who won"))
+                .groundingChunks(List.of(webChunk("https://a.example"), webChunk("https://b.example")))
+                .groundingSupports(List.of(supportOf(0), supportOf(1)))
+                .build()));
+
+        GroundingMetadata grounding = groundingOf(builder.build());
+
+        assertThat(grounding.webSearchQueries()).containsExactly("who won");
+        assertThat(grounding.groundingChunks())
+                .containsExactly(webChunk("https://a.example"), webChunk("https://b.example"));
+        assertThat(grounding.groundingSupports()).containsExactly(supportOf(0), supportOf(1));
+    }
+
+    @Test
+    void should_remap_grounding_chunk_indices_when_sources_arrive_across_chunks() {
+        builder.append(chunkGroundedWith(GroundingMetadata.builder()
+                .groundingChunks(List.of(webChunk("https://a.example")))
+                .groundingSupports(List.of(supportOf(0)))
+                .build()));
+        builder.append(chunkGroundedWith(GroundingMetadata.builder()
+                .groundingChunks(List.of(webChunk("https://b.example")))
+                .groundingSupports(List.of(supportOf(0)))
+                .build()));
+
+        GroundingMetadata grounding = groundingOf(builder.build());
+
+        assertThat(grounding.groundingChunks())
+                .containsExactly(webChunk("https://a.example"), webChunk("https://b.example"));
+        assertThat(grounding.groundingSupports()).containsExactly(supportOf(0), supportOf(1));
+    }
+
+    @Test
+    void should_merge_url_context_metadata_reported_by_different_chunks() {
+        builder.append(chunkWithUrlContext(new GeminiUrlMetadata("https://a.example", URL_RETRIEVAL_STATUS_SUCCESS)));
+        builder.append(chunkWithUrlContext(new GeminiUrlMetadata("https://b.example", URL_RETRIEVAL_STATUS_SUCCESS)));
+
+        GoogleAiGeminiChatResponseMetadata metadata =
+                (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
+
+        assertThat(metadata.urlContextMetadata().urlMetadata())
+                .extracting(UrlContextMetadata.UrlMetadata::retrievedUrl)
+                .containsExactly("https://a.example", "https://b.example");
+    }
+
+    @Test
+    void should_report_the_latest_retrieval_status_of_a_url_repeated_across_chunks() {
+        builder.append(chunkWithUrlContext(new GeminiUrlMetadata("https://a.example", URL_RETRIEVAL_STATUS_ERROR)));
+        builder.append(chunkWithUrlContext(new GeminiUrlMetadata("https://a.example", URL_RETRIEVAL_STATUS_SUCCESS)));
+
+        GoogleAiGeminiChatResponseMetadata metadata =
+                (GoogleAiGeminiChatResponseMetadata) builder.build().metadata();
+
+        assertThat(metadata.urlContextMetadata().urlMetadata())
+                .containsExactly(new UrlContextMetadata.UrlMetadata(
+                        "https://a.example", URL_RETRIEVAL_STATUS_SUCCESS.toString()));
+    }
+
     private static GeminiPart imagePart(String base64Data) {
         return new GeminiPart(
                 null, new GeminiBlob("image/png", base64Data), null, null, null, null, null, null, null, null);
@@ -173,6 +262,29 @@ class GeminiStreamingResponseBuilderTest {
     private static GeminiGenerateContentResponse chunkWith(GeminiPart part) {
         GeminiContent content = new GeminiContent(List.of(part), "model");
         GeminiCandidate candidate = new GeminiCandidate(content, null, null, null);
+        return new GeminiGenerateContentResponse("id-1", "gemini-pro", List.of(candidate), null, null);
+    }
+
+    private static GroundingMetadata groundingOf(ChatResponse response) {
+        return ((GoogleAiGeminiChatResponseMetadata) response.metadata()).groundingMetadata();
+    }
+
+    private static GroundingChunk webChunk(String uri) {
+        return new GroundingChunk(new GroundingChunk.Web(uri, "title"), null, null);
+    }
+
+    private static GroundingSupport supportOf(int groundingChunkIndex) {
+        return new GroundingSupport(List.of(groundingChunkIndex), null, null);
+    }
+
+    private static GeminiGenerateContentResponse chunkGroundedWith(GroundingMetadata grounding) {
+        GeminiCandidate candidate = new GeminiCandidate(null, null, null, grounding);
+        return new GeminiGenerateContentResponse("id-1", "gemini-pro", List.of(candidate), null, null);
+    }
+
+    private static GeminiGenerateContentResponse chunkWithUrlContext(GeminiUrlMetadata urlMetadata) {
+        GeminiCandidate candidate =
+                new GeminiCandidate(null, null, new GeminiUrlContextMetadata(List.of(urlMetadata)), null);
         return new GeminiGenerateContentResponse("id-1", "gemini-pro", List.of(candidate), null, null);
     }
 }

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelIT.java
@@ -497,6 +497,73 @@ class GoogleAiGeminiStreamingChatModelIT {
         assertThat(aiMessage.text() != null || !aiMessage.images().isEmpty()).isTrue();
     }
 
+    @Test
+    void should_report_grounding_metadata_when_streaming() {
+        // given
+        GoogleAiGeminiStreamingChatModel gemini = GoogleAiGeminiStreamingChatModel.builder()
+                .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                .modelName("gemini-2.5-flash")
+                .allowGoogleSearch(true)
+                .logRequests(true)
+                .logResponses(true)
+                .timeout(Duration.ofMinutes(1))
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        gemini.chat("Who won the last Formula 1 race?", handler);
+        ChatResponse response = handler.get();
+
+        // then
+        assertThat(response.metadata()).isInstanceOf(GoogleAiGeminiChatResponseMetadata.class);
+        GroundingMetadata grounding = ((GoogleAiGeminiChatResponseMetadata) response.metadata()).groundingMetadata();
+
+        assertThat(grounding).isNotNull();
+        assertThat(grounding.webSearchQueries()).isNotEmpty();
+        assertThat(grounding.searchEntryPoint()).isNotNull();
+        assertThat(grounding.searchEntryPoint().renderedContent()).isNotBlank();
+        assertThat(grounding.groundingChunks()).isNotEmpty();
+        assertThat(grounding.groundingSupports()).isNotEmpty();
+
+        assertThat(grounding.groundingSupports())
+                .allSatisfy(support -> assertThat(support.groundingChunkIndices())
+                        .isNotEmpty()
+                        .allSatisfy(index -> assertThat(index)
+                                .isNotNull()
+                                .isBetween(0, grounding.groundingChunks().size() - 1)));
+    }
+
+    @Test
+    void should_report_url_context_metadata_when_streaming() {
+        // given
+        GoogleAiGeminiStreamingChatModel gemini = GoogleAiGeminiStreamingChatModel.builder()
+                .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                .modelName("gemini-2.5-flash")
+                .allowUrlContext(true)
+                .logRequests(true)
+                .logResponses(true)
+                .timeout(Duration.ofMinutes(1))
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        gemini.chat("Summarize https://example.com in one sentence.", handler);
+        ChatResponse response = handler.get();
+
+        // then
+        assertThat(response.metadata()).isInstanceOf(GoogleAiGeminiChatResponseMetadata.class);
+        UrlContextMetadata urlContext = ((GoogleAiGeminiChatResponseMetadata) response.metadata()).urlContextMetadata();
+
+        assertThat(urlContext).isNotNull();
+        assertThat(urlContext.urlMetadata()).isNotEmpty();
+        assertThat(urlContext.urlMetadata())
+                .anySatisfy(
+                        urlMetadata -> assertThat(urlMetadata.retrievedUrl()).contains("example.com"));
+        assertThat(urlContext.urlMetadata())
+                .allSatisfy(urlMetadata ->
+                        assertThat(urlMetadata.urlRetrievalStatus()).isNotBlank());
+    }
+
     @AfterEach
     void afterEach() throws InterruptedException {
         String ciDelaySeconds = System.getenv("CI_DELAY_SECONDS_GOOGLE_AI_GEMINI");


### PR DESCRIPTION
## Issue

Closes #6231

## Change

`GeminiStreamingResponseBuilder` built `GoogleAiGeminiChatResponseMetadata` from `id`, `modelName`, `tokenUsage` and `finishReason` only, so a streamed response reported neither grounding nor URL context metadata while the same request through `GoogleAiGeminiChatModel` reported both. Both paths deserialize the same `GeminiGenerateContentResponse`, which carries `groundingMetadata` on the response and `groundingMetadata`/`urlContextMetadata` on each candidate, so the values arrive in the stream and were dropped when the final response was assembled.

The builder now tracks both while chunks arrive, the same way it already tracks `id`, `modelName` and `finishReason`:

```java
 private void updateGroundingMetadata(GeminiGenerateContentResponse response, GeminiCandidate candidate) {
     GroundingMetadata metadata =
             response.groundingMetadata() != null ? response.groundingMetadata() : candidate.groundingMetadata();
     if (metadata != null) {
         groundingMetadata.set(metadata);
     }
 }
```

The response-then-candidate resolution and the `null` handling mirror `BaseGeminiChatModel#createChatResponse`, so both paths report the same value for the same response, and only a chunk that carries the metadata updates it, so a later chunk without it does not erase what an earlier one reported.

`toUrlContextMetadata` and `toUrlMetadata` in `BaseGeminiChatModel` become `static` so the builder can reuse that mapping rather than duplicate it; their bodies are unchanged and both were and remain non-public. If you would rather keep them private and have the streaming builder convert on its own, or move both into a mapper class, that is a small change and I am happy to switch.

Grounding and URL context are fixed together because they are the same omission in the same method; nothing else in the metadata differs between the two paths.

### Tests

- `GeminiStreamingResponseBuilderTest`: five tests driven through the real accumulate-then-build path with actual response records, so nothing is mocked.

Four fail on unmodified `main`, proven per field: reverting only `.groundingMetadata(...)` fails the three grounding tests, reverting only `.urlContextMetadata(...)` fails the URL context test. The fifth pins the case where the response carries neither and passes either way.

```
mvn -o -pl langchain4j-google-ai-gemini test
Tests run: 423, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

mvn -pl langchain4j-google-ai-gemini verify
revapi: no API problems
BUILD SUCCESS

mvn -o -pl langchain4j-core test
Tests run: 1273, Failures: 0, Errors: 0, Skipped: 3

mvn -o -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0
```

The Gemini ITs in this module were not run; they need a live API key, and the change is covered offline.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)