### PR TITLE
fix: Map `cacheDiagnostics` in `AnthropicBatchChatModel`

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.anthropic.InternalAnthropicHelper.validate;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAiMessage;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toCacheDiagnostics;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toFinishReason;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toTokenUsage;
 import static java.util.Arrays.asList;
@@ -246,6 +247,7 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
                 .modelName(response.model)
                 .tokenUsage(toTokenUsage(response.usage))
                 .finishReason(toFinishReason(response.stopReason))
+                .cacheDiagnostics(toCacheDiagnostics(response.diagnostics))
                 .build();
         return ChatResponse.builder()
                 .aiMessage(toAiMessage(response.content, returnThinking, returnServerToolResults))

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModelTest.java
@@ -67,6 +67,14 @@ class AnthropicBatchChatModelTest {
                     + "\"model\":\"claude-haiku-4-5-20251001\",\"stop_reason\":\"end_turn\","
                     + "\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}}\n";
 
+    private static final String DIAGNOSTICS_RESULTS_JSONL =
+            "{\"custom_id\":\"request-0\",\"result\":{\"type\":\"succeeded\",\"message\":{\"id\":\"msg_0\","
+                    + "\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"A\"}],"
+                    + "\"model\":\"claude-haiku-4-5-20251001\",\"stop_reason\":\"end_turn\","
+                    + "\"usage\":{\"input_tokens\":5,\"output_tokens\":1},"
+                    + "\"diagnostics\":{\"cache_miss_reason\":{\"type\":\"system_changed\","
+                    + "\"cache_missed_input_tokens\":41850}}}}}\n";
+
     private static final String CANCELED_RESULTS_JSONL =
             "{\"custom_id\":\"request-0\",\"result\":{\"type\":\"canceled\"}}\n";
 
@@ -105,6 +113,8 @@ class AnthropicBatchChatModelTest {
                     responseBody = CANCELED_RESULTS_JSONL;
                 } else if (path.contains("msgbatch_thinking")) {
                     responseBody = THINKING_RESULTS_JSONL;
+                } else if (path.contains("msgbatch_diagnostics")) {
+                    responseBody = DIAGNOSTICS_RESULTS_JSONL;
                 } else {
                     responseBody = RESULTS_JSONL;
                 }
@@ -236,6 +246,26 @@ class AnthropicBatchChatModelTest {
         AiMessage aiMessage = response.results().get(0).response().aiMessage();
         assertThat(aiMessage.text()).isEqualTo("Paris");
         assertThat(aiMessage.thinking()).isNull();
+    }
+
+    @Test
+    void retrieve_maps_cache_diagnostics_from_the_result_message() {
+        BatchResponse<ChatResponse> response = model().retrieve("msgbatch_diagnostics");
+
+        AnthropicChatResponseMetadata metadata = (AnthropicChatResponseMetadata)
+                response.results().get(0).response().metadata();
+        assertThat(metadata.cacheDiagnostics()).isNotNull();
+        assertThat(metadata.cacheDiagnostics().cacheMissReasonType()).isEqualTo("system_changed");
+        assertThat(metadata.cacheDiagnostics().cacheMissedInputTokens()).isEqualTo(41850);
+    }
+
+    @Test
+    void retrieve_maps_absent_cache_diagnostics_to_null() {
+        BatchResponse<ChatResponse> response = model().retrieve("msgbatch_1");
+
+        AnthropicChatResponseMetadata metadata = (AnthropicChatResponseMetadata)
+                response.results().get(0).response().metadata();
+        assertThat(metadata.cacheDiagnostics()).isNull();
     }
 
     @Test


### PR DESCRIPTION

## Issue

Closes #6233

## Change

`AnthropicBatchChatModel` forwards `returnCacheDiagnostics` and `previousMessageId` into every batch request, and each succeeded result is deserialized into `AnthropicCreateMessageResponse`, which carries the `diagnostics` the API returns. `toChatResponse` then built the metadata from `id`, `modelName`, `tokenUsage` and `finishReason` only, so the diagnostics were dropped.

The fix is the mapping line the other two paths already use:

```java
 AnthropicChatResponseMetadata metadata = AnthropicChatResponseMetadata.builder()
         .id(response.id)
         .modelName(response.model)
         .tokenUsage(toTokenUsage(response.usage))
         .finishReason(toFinishReason(response.stopReason))
+        .cacheDiagnostics(toCacheDiagnostics(response.diagnostics))
         .build();
```

The module builds `AnthropicChatResponseMetadata` from an Anthropic response in three places, and the other two already map this field: `AnthropicChatModel#createChatResponse` and the streaming `createMetadata` in `DefaultAnthropicClient`. `toCacheDiagnostics` is already `public static` on `AnthropicMapper` and returns `null` for a `null` argument, so no visibility was widened and responses without diagnostics keep reporting `null`. Nothing else changed: no new public API, no change to the request path.

### Tests

- `AnthropicBatchChatModelTest`: two tests driven through the real batch retrieval path against the class's existing canned `HttpServer`, so the real JSONL and JSON parsing runs. The fixture uses the same wire shape and values as the existing streaming test for this feature, `DefaultAnthropicClientTest#shouldIncludeCacheDiagnosticsFromMessageStartEvent`.

The first fails on unmodified `main`; the second pins the absent-diagnostics case and passes either way.

```
mvn -o -pl langchain4j-anthropic test
Tests run: 191, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

mvn -o -pl langchain4j-core test
Tests run: 1273, Failures: 0, Errors: 0, Skipped: 3
BUILD SUCCESS

mvn -o -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

`AnthropicCacheDiagnosticsIT` and the other Anthropic ITs were not run; they need a live API key and the `cache-diagnosis-2026-04-07` beta, and this change is covered offline.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
