### PR TITLE
fix(mcp): make log level parsing locale-independent

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLogLevel.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLogLevel.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.mcp.client.logging;
 
+import java.util.Locale;
+
 /**
  * Log level of an MCP log message.
  */
@@ -18,7 +20,7 @@ public enum McpLogLevel {
             return null;
         }
         try {
-            return valueOf(val.toUpperCase());
+            return valueOf(val.toUpperCase(Locale.ROOT));
         } catch (Exception e) {
             return null;
         }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/logging/McpLogLevelTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/logging/McpLogLevelTest.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.mcp.client.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * and single-threaded to avoid races with the otherwise parallel test suite.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class McpLogLevelTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ"})
+    void should_parse_log_level_independently_of_default_locale(String languageTag) {
+        withDefaultLocale(
+                languageTag, () -> assertThat(McpLogLevel.from("info")).isEqualTo(McpLogLevel.INFO));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "unknown"})
+    void should_return_null_for_invalid_value(String value) {
+        assertThat(McpLogLevel.from(value)).isNull();
+    }
+
+    private static void withDefaultLocale(String languageTag, Runnable action) {
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
+            action.run();
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6228

## Change

`McpLogLevel.from(String)` used the JVM default locale when uppercasing protocol values. Under Turkish or Azerbaijani locales, `"info"` becomes `"İNFO"`, causing enum parsing to fail and return `null`.

Use `Locale.ROOT` for locale-independent parsing. Add isolated regression tests for `tr-TR` and `az-AZ`, together with null, empty, blank, and unknown inputs. The locale-mutating tests use `@Isolated` and `SAME_THREAD`, and always restore the previous default locale.

## General checklist

- [X] There are no breaking changes (API, behaviour)
    - No API change; valid MCP log levels now parse consistently across JVM locales.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
    - `./mvnw -pl langchain4j-mcp -am test` → 210 MCP tests, `BUILD SUCCESS` (JDK 17).
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
    - `./mvnw -DembeddingsSkipDownload -T8C test javadoc:aggregate` → 110 reactor modules, `BUILD SUCCESS` (JDK 17).
    - `./mvnw -Pspotless validate` → 110 reactor modules, `BUILD SUCCESS` (JDK 17).
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
    - N/A — internal behaviour fix; no documented API changed.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
    - N/A — not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
    - N/A — no starter impact.
