### PR TITLE
fix(mcp): clean up timed-out multi-round-trip retries

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -617,7 +617,11 @@ public class DefaultMcpClient implements McpClient {
             McpCallContext retryContext = new McpCallContext(invocationContext, retryOperation);
             applyMeta(retryOperation, retryContext);
             CompletableFuture<JsonNode> resultFuture = executeViaTransport(retryContext);
-            result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            try {
+                result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException timeout) {
+                throw new McpOperationTimeoutException(retryOperationId, resultFuture, timeout);
+            }
             pendingOperations.remove(retryOperationId);
             parsed = multiRoundTripResult(result);
             retryCount++;
@@ -627,6 +631,39 @@ public class DefaultMcpClient implements McpClient {
             throw new RuntimeException("Unexpected resultType for " + operationName + ": " + resultType);
         }
         return result;
+    }
+
+    private void cancelTimedOutOperation(
+            TimeoutException timeout, long operationId, CompletableFuture<JsonNode> resultFuture) {
+        long timedOutOperationId = operationId;
+        CompletableFuture<JsonNode> timedOutResultFuture = resultFuture;
+        if (timeout instanceof McpOperationTimeoutException operationTimeout) {
+            timedOutOperationId = operationTimeout.operationId;
+            timedOutResultFuture = operationTimeout.resultFuture;
+        }
+        if (timedOutResultFuture != null) {
+            timedOutResultFuture.cancel(true);
+        }
+        pendingOperations.remove(timedOutOperationId);
+        if (shouldSendCancellationNotification()) {
+            McpCancellationNotification cancellation = new McpCancellationNotification(timedOutOperationId, "Timeout");
+            applyMeta(cancellation, null);
+            transport.sendMessage(cancellation);
+        }
+    }
+
+    private static class McpOperationTimeoutException extends TimeoutException {
+
+        private final long operationId;
+        private final CompletableFuture<JsonNode> resultFuture;
+
+        private McpOperationTimeoutException(
+                long operationId, CompletableFuture<JsonNode> resultFuture, TimeoutException cause) {
+            super(cause.getMessage());
+            this.operationId = operationId;
+            this.resultFuture = resultFuture;
+            initCause(cause);
+        }
     }
 
     @Override
@@ -716,14 +753,7 @@ public class DefaultMcpClient implements McpClient {
                     "tools/call");
         } catch (TimeoutException timeout) {
             notifyListeners(l -> l.onExecuteToolError(context, timeout));
-            if (resultFuture != null) {
-                resultFuture.cancel(true);
-            }
-            if (shouldSendCancellationNotification()) {
-                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
-                applyMeta(cancellation, null);
-                transport.sendMessage(cancellation);
-            }
+            cancelTimedOutOperation(timeout, operationId, resultFuture);
             // built on demand, not once at construction: a custom converter must not be invoked
             // for a tool call that never happened
             return toolResultConverter.convert(
@@ -810,14 +840,7 @@ public class DefaultMcpClient implements McpClient {
             return resourceResult;
         } catch (TimeoutException timeout) {
             notifyListeners(l -> l.onResourceGetError(context, timeout));
-            if (resultFuture != null) {
-                resultFuture.cancel(true);
-            }
-            if (shouldSendCancellationNotification()) {
-                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
-                applyMeta(cancellation, null);
-                transport.sendMessage(cancellation);
-            }
+            cancelTimedOutOperation(timeout, operationId, resultFuture);
             throw new RuntimeException(timeout);
         } catch (ExecutionException e) {
             notifyListeners(l -> l.onResourceGetError(context, e));
@@ -873,14 +896,7 @@ public class DefaultMcpClient implements McpClient {
             return promptResult;
         } catch (TimeoutException timeout) {
             notifyListeners(l -> l.onPromptGetError(context, timeout));
-            if (resultFuture != null) {
-                resultFuture.cancel(true);
-            }
-            if (shouldSendCancellationNotification()) {
-                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
-                applyMeta(cancellation, null);
-                transport.sendMessage(cancellation);
-            }
+            cancelTimedOutOperation(timeout, operationId, resultFuture);
             throw new RuntimeException(timeout);
         } catch (ExecutionException e) {
             notifyListeners(l -> l.onPromptGetError(context, e));

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -728,25 +728,29 @@ public class DefaultMcpClientTest {
                 .subscribeToResourceListChanges(false)
                 .build();
 
-        client.executeTool(
-                ToolExecutionRequest.builder().name("test").arguments("{}").build());
+        try {
+            client.executeTool(
+                    ToolExecutionRequest.builder().name("test").arguments("{}").build());
 
-        ArgumentCaptor<McpCallContext> requestCaptor = ArgumentCaptor.forClass(McpCallContext.class);
-        verify(transport, times(3)).sendRequest(requestCaptor.capture());
-        Long retryRequestId =
-                ((McpClientRequest) requestCaptor.getAllValues().get(2).message()).getId();
+            ArgumentCaptor<McpCallContext> requestCaptor = ArgumentCaptor.forClass(McpCallContext.class);
+            verify(transport, times(3)).sendRequest(requestCaptor.capture());
+            Long retryRequestId =
+                    ((McpClientRequest) requestCaptor.getAllValues().get(2).message()).getId();
 
-        java.lang.reflect.Field pendingOperationsField = DefaultMcpClient.class.getDeclaredField("pendingOperations");
-        pendingOperationsField.setAccessible(true);
-        Map<?, ?> pendingOperations = (Map<?, ?>) pendingOperationsField.get(client);
-        assertThat(pendingOperations.containsKey(retryRequestId)).isFalse();
-        assertThat(retryNeverCompletes.isCancelled()).isTrue();
+            java.lang.reflect.Field pendingOperationsField = DefaultMcpClient.class.getDeclaredField("pendingOperations");
+            pendingOperationsField.setAccessible(true);
+            Map<?, ?> pendingOperations = (Map<?, ?>) pendingOperationsField.get(client);
+            assertThat(pendingOperations.containsKey(retryRequestId)).isFalse();
+            assertThat(retryNeverCompletes.isCancelled()).isTrue();
 
-        ArgumentCaptor<McpClientMessage> cancellationCaptor = ArgumentCaptor.forClass(McpClientMessage.class);
-        verify(transport).sendMessage(cancellationCaptor.capture());
-        McpCancellationNotification cancellation = (McpCancellationNotification) cancellationCaptor.getValue();
-        McpCancellationParams params = (McpCancellationParams) cancellation.getParams();
-        assertThat(params.getRequestId()).isEqualTo(retryRequestId);
+            ArgumentCaptor<McpClientMessage> cancellationCaptor = ArgumentCaptor.forClass(McpClientMessage.class);
+            verify(transport).sendMessage(cancellationCaptor.capture());
+            McpCancellationNotification cancellation = (McpCancellationNotification) cancellationCaptor.getValue();
+            McpCancellationParams params = (McpCancellationParams) cancellation.getParams();
+            assertThat(params.getRequestId()).isEqualTo(retryRequestId);
+        } finally {
+            client.close();
+        }
     }
 
     @Test

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -24,6 +24,8 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpCancellationNotification;
+import dev.langchain4j.mcp.protocol.McpCancellationParams;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpClientRequest;
 import dev.langchain4j.mcp.protocol.McpListToolsParams;
@@ -697,6 +699,54 @@ public class DefaultMcpClientTest {
 
         // 4 calls: discover, first tool call, retry
         verify(transport, times(3)).executeOperationWithResponse(any(McpCallContext.class));
+    }
+
+    @Test
+    public void mrtr_retry_timeout_cancels_retry_request_and_notifies_server() throws Exception {
+        McpTransport transport = getModernStdioTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+        CompletableFuture<String> retryNeverCompletes = new CompletableFuture<>();
+
+        when(transport.sendRequest(any(McpCallContext.class)))
+                .thenReturn(
+                        CompletableFuture.completedFuture(getDiscoverResult().toString()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        buildInputRequiredResponse(true, false).toString()))
+                .thenAnswer(invocation -> {
+                    McpCallContext retryContext = invocation.getArgument(0);
+                    Long retryRequestId = retryContext.message().getId();
+                    handlerRef.get().expectResponse(retryRequestId, retryNeverCompletes);
+                    return retryNeverCompletes;
+                });
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .toolExecutionTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        client.executeTool(
+                ToolExecutionRequest.builder().name("test").arguments("{}").build());
+
+        ArgumentCaptor<McpCallContext> requestCaptor = ArgumentCaptor.forClass(McpCallContext.class);
+        verify(transport, times(3)).sendRequest(requestCaptor.capture());
+        Long retryRequestId =
+                ((McpClientRequest) requestCaptor.getAllValues().get(2).message()).getId();
+
+        java.lang.reflect.Field pendingOperationsField = DefaultMcpClient.class.getDeclaredField("pendingOperations");
+        pendingOperationsField.setAccessible(true);
+        Map<?, ?> pendingOperations = (Map<?, ?>) pendingOperationsField.get(client);
+        assertThat(pendingOperations.containsKey(retryRequestId)).isFalse();
+        assertThat(retryNeverCompletes.isCancelled()).isTrue();
+
+        ArgumentCaptor<McpClientMessage> cancellationCaptor = ArgumentCaptor.forClass(McpClientMessage.class);
+        verify(transport).sendMessage(cancellationCaptor.capture());
+        McpCancellationNotification cancellation = (McpCancellationNotification) cancellationCaptor.getValue();
+        McpCancellationParams params = (McpCancellationParams) cancellation.getParams();
+        assertThat(params.getRequestId()).isEqualTo(retryRequestId);
     }
 
     @Test

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -737,7 +737,8 @@ public class DefaultMcpClientTest {
             Long retryRequestId =
                     ((McpClientRequest) requestCaptor.getAllValues().get(2).message()).getId();
 
-            java.lang.reflect.Field pendingOperationsField = DefaultMcpClient.class.getDeclaredField("pendingOperations");
+            java.lang.reflect.Field pendingOperationsField =
+                    DefaultMcpClient.class.getDeclaredField("pendingOperations");
             pendingOperationsField.setAccessible(true);
             Map<?, ?> pendingOperations = (Map<?, ?>) pendingOperationsField.get(client);
             assertThat(pendingOperations.containsKey(retryRequestId)).isFalse();


### PR DESCRIPTION
## Issue

Closes #6238

## Change

Preserve the active retry request ID and Future when an MCP multi-round-trip operation times out.

Timeout cleanup now:

- Cancels the active retry Future.
- Removes the retry request from `pendingOperations`.
- Sends `notifications/cancelled` with the retry request ID.

This is a focused follow-up to #6175 and only addresses the `input_required` retry-timeout path used by `tools/call`, `resources/read`, and `prompts/get`.

A regression test verifies the retry Future, pending-operation cleanup, and cancellation request ID.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all tests in the changed `langchain4j-mcp` module, and they are green
- [ ] I have manually run all tests in the core and main modules
- [x] Documentation is not required for this internal lifecycle bug fix
- [x] An examples-repository change is not applicable
- [x] Spring Boot starter changes are not applicable

## Validation

- `.\mvnw.cmd -pl langchain4j-mcp test`: 209 passed, 1 skipped
- `.\mvnw.cmd spotless:check -pl langchain4j-mcp`
- `git diff --check`