### PR TITLE
feat(agentic): preserve agent argument descriptions

### DIFF
--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
@@ -45,6 +45,7 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
     private InternalAgent parent;
 
     private String[] inputKeys;
+    private Map<String, String> inputDescriptions = Map.of();
     private String outputKey;
     private boolean async;
 
@@ -92,9 +93,18 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
         this.name = toolSpec.name();
         this.agentId = this.name;
         this.description = toolSpec.description();
+        JsonObjectSchema params = toolSpec.parameters();
+        if (params != null && params.properties() != null) {
+            Map<String, String> descriptions = new HashMap<>();
+            params.properties().forEach((key, schema) -> {
+                if (schema != null && schema.description() != null && !schema.description().isBlank()) {
+                    descriptions.put(key, schema.description());
+                }
+            });
+            this.inputDescriptions = Map.copyOf(descriptions);
+        }
 
         if (agentServiceClass == UntypedAgent.class && inputKeys == null) {
-            JsonObjectSchema params = toolSpec.parameters();
             if (params != null && params.properties() != null) {
                 this.inputKeys = params.properties().keySet().toArray(new String[0]);
             } else {
@@ -139,6 +149,7 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
                 case "toolName" -> name;
                 case "toolDescription" -> description;
                 case "inputKeys" -> inputKeys;
+                case "inputDescriptions" -> inputDescriptions;
                 default ->
                         throw new UnsupportedOperationException(
                                 "Unknown method on McpClientInstance class: " + method.getName());

--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.agentic.mcp;
 
+import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agentic.UntypedAgent;
 import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.InternalAgent;
@@ -10,8 +14,6 @@ import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemConfigurationException;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 import dev.langchain4j.agentic.planner.Planner;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -26,8 +28,6 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
 
 public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, InternalAgent, InvocationHandler {
 
@@ -97,7 +97,9 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
         if (params != null && params.properties() != null) {
             Map<String, String> descriptions = new HashMap<>();
             params.properties().forEach((key, schema) -> {
-                if (schema != null && schema.description() != null && !schema.description().isBlank()) {
+                if (schema != null
+                        && schema.description() != null
+                        && !schema.description().isBlank()) {
                     descriptions.put(key, schema.description());
                 }
             });
@@ -113,8 +115,7 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
         }
 
         Object agent = Proxy.newProxyInstance(
-                agentServiceClass.getClassLoader(),
-                new Class<?>[] {agentServiceClass, McpClientInstance.class}, this);
+                agentServiceClass.getClassLoader(), new Class<?>[] {agentServiceClass, McpClientInstance.class}, this);
 
         return (T) agent;
     }
@@ -126,16 +127,16 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
                 return tools.get(0);
             }
             throw new AgenticSystemConfigurationException(
-                    "Tool name is required when there is more than one tool available: " +
-                            tools.stream().map(ToolSpecification::name).toList());
+                    "Tool name is required when there is more than one tool available: "
+                            + tools.stream().map(ToolSpecification::name).toList());
         }
 
         return tools.stream()
                 .filter(t -> toolName == null || t.name().equals(toolName))
                 .findFirst()
-                .orElseThrow(() -> new AgenticSystemConfigurationException(
-                        "Tool '" + toolName + "' not found. Available tools: " +
-                                tools.stream().map(ToolSpecification::name).toList()));
+                .orElseThrow(() ->
+                        new AgenticSystemConfigurationException("Tool '" + toolName + "' not found. Available tools: "
+                                + tools.stream().map(ToolSpecification::name).toList()));
     }
 
     @Override
@@ -151,8 +152,8 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
                 case "inputKeys" -> inputKeys;
                 case "inputDescriptions" -> inputDescriptions;
                 default ->
-                        throw new UnsupportedOperationException(
-                                "Unknown method on McpClientInstance class: " + method.getName());
+                    throw new UnsupportedOperationException(
+                            "Unknown method on McpClientInstance class: " + method.getName());
             };
         }
 

--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientAgentInvoker.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientAgentInvoker.java
@@ -24,6 +24,7 @@ public class McpClientAgentInvoker implements AgentInvoker {
 
     private String agentId;
     private final String[] inputKeys;
+    private final Map<String, String> inputDescriptions;
 
     private final McpClientInstance mcpClientInstance;
 
@@ -40,6 +41,7 @@ public class McpClientAgentInvoker implements AgentInvoker {
         this.toolDescription = mcpClientInstance.toolDescription();
         this.agentId = name();
         this.inputKeys = inputKeys(mcpClientInstance);
+        this.inputDescriptions = mcpClientInstance.inputDescriptions();
     }
 
     private String[] inputKeys(McpClientInstance mcpClientInstance) {
@@ -98,7 +100,7 @@ public class McpClientAgentInvoker implements AgentInvoker {
     @Override
     public List<AgentArgument> arguments() {
         return Stream.of(inputKeys)
-                .map(input -> new AgentArgument(Object.class, input))
+                .map(input -> new AgentArgument(Object.class, input, null, false, inputDescriptions.get(input)))
                 .toList();
     }
 

--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientInstance.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientInstance.java
@@ -1,10 +1,16 @@
 package dev.langchain4j.agentic.mcp;
 
 import dev.langchain4j.agentic.internal.InternalAgent;
+import java.util.Map;
 
 public interface McpClientInstance extends InternalAgent {
 
     String[] inputKeys();
+
+    /** Descriptions published by the MCP tool for each input key. */
+    default Map<String, String> inputDescriptions() {
+        return Map.of();
+    }
 
     String toolName();
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
@@ -20,6 +20,7 @@ import dev.langchain4j.agentic.planner.AgenticSystemConfigurationException;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.internal.Json;
@@ -199,8 +200,10 @@ public class AgentUtil {
             Parameter parameter, Map<String, Object> defaultValues, Set<String> optionalArgs) {
         String argName = parameterName(parameter);
         Object defaultValue = defaultValues.getOrDefault(argName, parameterDefaultValue(parameter));
+        P p = parameter.getAnnotation(P.class);
+        String description = p == null ? null : (isNullOrBlank(p.description()) ? p.value() : p.description());
         return new AgentArgument(
-                parameter.getParameterizedType(), argName, defaultValue, optionalArgs.contains(argName));
+                parameter.getParameterizedType(), argName, defaultValue, optionalArgs.contains(argName), description);
     }
 
     private static String parameterName(Parameter p) {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
@@ -207,6 +207,10 @@ public class AgentUtil {
     }
 
     private static String parameterName(Parameter p) {
+        P annotation = p.getAnnotation(P.class);
+        if (annotation != null && !annotation.name().isBlank()) {
+            return annotation.name();
+        }
         if (p.getAnnotation(MemoryId.class) != null) {
             return MEMORY_ID_ARG_NAME;
         }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
@@ -7,6 +7,7 @@ import static dev.langchain4j.internal.Utils.getAnnotatedMethod;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.service.TypeUtils.isImageType;
 
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.UntypedAgent;
@@ -20,7 +21,6 @@ import dev.langchain4j.agentic.planner.AgenticSystemConfigurationException;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
-import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.internal.Json;

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentArgument.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentArgument.java
@@ -3,8 +3,7 @@ package dev.langchain4j.agentic.planner;
 import dev.langchain4j.agentic.internal.AgentUtil;
 import java.lang.reflect.Type;
 
-public record AgentArgument(
-        Type type, String name, Object defaultValue, boolean isOptional, String description) {
+public record AgentArgument(Type type, String name, Object defaultValue, boolean isOptional, String description) {
 
     public AgentArgument(Type type, String name, Object defaultValue, boolean isOptional) {
         this(type, name, defaultValue, isOptional, null);

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentArgument.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentArgument.java
@@ -3,7 +3,12 @@ package dev.langchain4j.agentic.planner;
 import dev.langchain4j.agentic.internal.AgentUtil;
 import java.lang.reflect.Type;
 
-public record AgentArgument(Type type, String name, Object defaultValue, boolean isOptional) {
+public record AgentArgument(
+        Type type, String name, Object defaultValue, boolean isOptional, String description) {
+
+    public AgentArgument(Type type, String name, Object defaultValue, boolean isOptional) {
+        this(type, name, defaultValue, isOptional, null);
+    }
 
     public AgentArgument(Type type, String name) {
         this(type, name, null);

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
@@ -115,6 +115,10 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
     }
 
     private static String argumentDescription(AgentArgument arg) {
+        String description = arg.description();
+        if (description != null && !description.isBlank()) {
+            return argumentDescription(arg.rawType(), arg.name()) + " - " + description;
+        }
         return argumentDescription(arg.rawType(), arg.name());
     }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
@@ -2,7 +2,6 @@ package dev.langchain4j.agentic;
 
 import static dev.langchain4j.agentic.Models.baseModel;
 import static dev.langchain4j.agentic.Models.plannerModel;
-import static dev.langchain4j.agentic.observability.HtmlReportGenerator.generateReport;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
@@ -18,14 +17,14 @@ import dev.langchain4j.agent.tool.CompensateFor;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agentic.Agents.ColorExpert;
+import dev.langchain4j.agentic.Agents.ColorMixerExpert;
 import dev.langchain4j.agentic.Agents.LegalExpert;
 import dev.langchain4j.agentic.Agents.LoanApplicationEvaluator;
 import dev.langchain4j.agentic.Agents.LoanApplicationExtractor;
 import dev.langchain4j.agentic.Agents.MedicalExpert;
 import dev.langchain4j.agentic.Agents.RouterAgent;
 import dev.langchain4j.agentic.Agents.TechnicalExpert;
-import dev.langchain4j.agentic.Agents.ColorExpert;
-import dev.langchain4j.agentic.Agents.ColorMixerExpert;
 import dev.langchain4j.agentic.declarative.Output;
 import dev.langchain4j.agentic.observability.AfterAgentToolExecution;
 import dev.langchain4j.agentic.observability.AgentInvocation;
@@ -35,8 +34,6 @@ import dev.langchain4j.agentic.observability.AgentResponse;
 import dev.langchain4j.agentic.observability.BeforeAgentToolExecution;
 import dev.langchain4j.agentic.observability.MonitoredAgent;
 import dev.langchain4j.agentic.observability.MonitoredExecution;
-import dev.langchain4j.agentic.scope.AgenticScope;
-import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.agentic.supervisor.SupervisorAgent;
@@ -48,14 +45,16 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
+import dev.langchain4j.service.tool.ToolExecution;
+import dev.langchain4j.service.tool.ToolExecutor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,7 +62,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import dev.langchain4j.service.tool.ToolExecutor;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -95,8 +93,7 @@ public class SupervisorAgentIT {
 
     public interface RequestClassifierAgent {
 
-        @UserMessage(
-                """
+        @UserMessage("""
             Categorize the user request returning only one word among 'legal', 'medical' or 'technical',
             and nothing else, avoiding any explanation.
 
@@ -169,8 +166,7 @@ public class SupervisorAgentIT {
 
     public interface BankerAgent {
 
-        @UserMessage(
-                """
+        @UserMessage("""
             You are a banker that executes user request crediting or withdrawing US dollars (USD) from an account,
             using the tools provided and returning the final balance.
 
@@ -180,12 +176,10 @@ public class SupervisorAgentIT {
     }
 
     public interface WithdrawAgent {
-        @SystemMessage(
-                """
+        @SystemMessage("""
             You are a banker that can only withdraw US dollars (USD) from a user account.
             """)
-        @UserMessage(
-                """
+        @UserMessage("""
             Withdraw {{amountInUSD}} USD from {{withdrawUser}}'s account and return the new balance.
             """)
         @Agent("A banker that withdraw USD from an account")
@@ -193,12 +187,10 @@ public class SupervisorAgentIT {
     }
 
     public interface CreditAgent {
-        @SystemMessage(
-                """
+        @SystemMessage("""
             You are a banker that can only credit US dollars (USD) to a user account.
             """)
-        @UserMessage(
-                """
+        @UserMessage("""
             Credit {{amountInUSD}} USD to {{creditUser}}'s account and return the new balance.
             """)
         @Agent("A banker that credit USD to an account")
@@ -353,13 +345,15 @@ public class SupervisorAgentIT {
                 .compensateOnError(compensating)
                 .build();
 
-        String result = bankSupervisor.execute("1", "Credit 100 USD to Georgios' account and after withdraw them from Mario's one");
+        String result = bankSupervisor.execute(
+                "1", "Credit 100 USD to Georgios' account and after withdraw them from Mario's one");
         System.out.println(result);
 
         assertThat(bankTool.getBalance("Mario")).isEqualTo(50.0);
         assertThat(bankTool.getBalance("Georgios")).isEqualTo(1100.0);
 
-        result = bankSupervisor.execute("1", "Credit 100 USD to Georgios' account and after withdraw them from Mario's one");
+        result = bankSupervisor.execute(
+                "1", "Credit 100 USD to Georgios' account and after withdraw them from Mario's one");
         System.out.println(result);
 
         assertThat(bankTool.getBalance("Mario")).isEqualTo(50.0);
@@ -367,8 +361,7 @@ public class SupervisorAgentIT {
     }
 
     public interface ExchangeAgent {
-        @UserMessage(
-                """
+        @UserMessage("""
             You are an operator exchanging money in different currencies.
             Use the tool to exchange {{amount}} {{originalCurrency}} into {{targetCurrency}}
             returning only the final amount provided by the tool as it is and nothing else.
@@ -516,12 +509,22 @@ public class SupervisorAgentIT {
                 .listener(new AgentListener() {
                     @Override
                     public void afterAgentToolExecution(AfterAgentToolExecution afterAgentToolExecution) {
-                        toolResults.put(afterAgentToolExecution.toolExecution().request().name(), (Double) afterAgentToolExecution.toolExecution().resultObject());
+                        toolResults.put(
+                                afterAgentToolExecution
+                                        .toolExecution()
+                                        .request()
+                                        .name(),
+                                (Double) afterAgentToolExecution.toolExecution().resultObject());
                     }
 
                     @Override
                     public void beforeAgentToolExecution(BeforeAgentToolExecution beforeAgentToolExecution) {
-                        toolCalls.put(beforeAgentToolExecution.agentInstance().agentId(), beforeAgentToolExecution.toolExecution().request().name());
+                        toolCalls.put(
+                                beforeAgentToolExecution.agentInstance().agentId(),
+                                beforeAgentToolExecution
+                                        .toolExecution()
+                                        .request()
+                                        .name());
                     }
 
                     @Override
@@ -542,14 +545,14 @@ public class SupervisorAgentIT {
         assertThat(toolCalls).hasSize(fullyAI ? 3 : 2);
         assertThat(toolResults).hasSize(fullyAI ? 3 : 2);
 
-        assertThat(toolCalls).containsEntry(((AgentInstance)creditAgent).agentId(), "credit");
-        assertThat(toolCalls).containsEntry(((AgentInstance)withdrawAgent).agentId(), "withdraw");
+        assertThat(toolCalls).containsEntry(((AgentInstance) creditAgent).agentId(), "credit");
+        assertThat(toolCalls).containsEntry(((AgentInstance) withdrawAgent).agentId(), "withdraw");
 
         assertThat(toolResults.get("credit")).isCloseTo(1115.0, offset(0.1));
         assertThat(toolResults.get("withdraw")).isCloseTo(885.0, offset(0.1));
 
         if (fullyAI) {
-            assertThat(toolCalls).containsEntry(((AgentInstance)exchangeAgent).agentId(), "exchange");
+            assertThat(toolCalls).containsEntry(((AgentInstance) exchangeAgent).agentId(), "exchange");
             assertThat(toolResults.get("exchange")).isCloseTo(115.0, offset(0.1));
         }
     }
@@ -569,31 +572,39 @@ public class SupervisorAgentIT {
                     @Override
                     public void beforeAgentToolExecution(BeforeAgentToolExecution beforeAgentToolExecution) {
                         assertThat(beforeWithdrawTool.get()).isNull();
-                        beforeWithdrawTool.set("before " + beforeAgentToolExecution.toolExecution().request().name() +
-                                " on agent " + beforeAgentToolExecution.agentInstance().agentId());
+                        beforeWithdrawTool.set("before "
+                                + beforeAgentToolExecution
+                                        .toolExecution()
+                                        .request()
+                                        .name() + " on agent "
+                                + beforeAgentToolExecution.agentInstance().agentId());
                     }
 
                     @Override
                     public void afterAgentToolExecution(AfterAgentToolExecution afterAgentToolExecution) {
                         assertThat(afterWithdrawTool.get()).isNull();
-                        afterWithdrawTool.set("after " + afterAgentToolExecution.toolExecution().request().name() +
-                                " on agent " + afterAgentToolExecution.agentInstance().agentId());
+                        afterWithdrawTool.set("after "
+                                + afterAgentToolExecution
+                                        .toolExecution()
+                                        .request()
+                                        .name() + " on agent "
+                                + afterAgentToolExecution.agentInstance().agentId());
                     }
                 })
                 .tools(bankTool)
                 .build();
 
-        CreditAgent creditAgent  = AgenticServices.agentBuilder(CreditAgent.class)
+        CreditAgent creditAgent = AgenticServices.agentBuilder(CreditAgent.class)
                 .chatModel(baseModel())
                 .tools(bankTool)
                 .build();
 
         ExchangeAgent exchangeAgent = AgenticServices.agentBuilder(ExchangeAgent.class)
-                    .chatModel(baseModel())
-                    .description(
-                            "A money exchanger that converts a given amount of money from the original to the target currency")
-                    .tools(new ExchangeTool())
-                    .build();
+                .chatModel(baseModel())
+                .description(
+                        "A money exchanger that converts a given amount of money from the original to the target currency")
+                .tools(new ExchangeTool())
+                .build();
 
         List<String> invokedAgents = new ArrayList<>();
         Map<String, String> toolCalls = new HashMap<>();
@@ -607,8 +618,15 @@ public class SupervisorAgentIT {
                 .listener(new AgentListener() {
                     @Override
                     public void beforeAgentToolExecution(BeforeAgentToolExecution beforeAgentToolExecution) {
-                        assertThat(toolCalls).doesNotContainKey(beforeAgentToolExecution.agentInstance().agentId());
-                        toolCalls.put(beforeAgentToolExecution.agentInstance().agentId(), beforeAgentToolExecution.toolExecution().request().name());
+                        assertThat(toolCalls)
+                                .doesNotContainKey(
+                                        beforeAgentToolExecution.agentInstance().agentId());
+                        toolCalls.put(
+                                beforeAgentToolExecution.agentInstance().agentId(),
+                                beforeAgentToolExecution
+                                        .toolExecution()
+                                        .request()
+                                        .name());
                     }
 
                     @Override
@@ -628,8 +646,17 @@ public class SupervisorAgentIT {
 
                     @Override
                     public void afterAgentToolExecution(AfterAgentToolExecution afterAgentToolExecution) {
-                        assertThat(toolResults).doesNotContainKey(afterAgentToolExecution.toolExecution().request().name());
-                        toolResults.put(afterAgentToolExecution.toolExecution().request().name(), (Double) afterAgentToolExecution.toolExecution().resultObject());
+                        assertThat(toolResults)
+                                .doesNotContainKey(afterAgentToolExecution
+                                        .toolExecution()
+                                        .request()
+                                        .name());
+                        toolResults.put(
+                                afterAgentToolExecution
+                                        .toolExecution()
+                                        .request()
+                                        .name(),
+                                (Double) afterAgentToolExecution.toolExecution().resultObject());
                     }
 
                     @Override
@@ -639,7 +666,8 @@ public class SupervisorAgentIT {
                 })
                 .build();
 
-        ResultWithAgenticScope<String> result = sequence.invokeWithAgenticScope("Transfer 100 EUR from Mario's account to Georgios' one");
+        ResultWithAgenticScope<String> result =
+                sequence.invokeWithAgenticScope("Transfer 100 EUR from Mario's account to Georgios' one");
         System.out.println(result.result());
 
         assertThat(bankTool.getBalance("Mario")).isEqualTo(885.0);
@@ -647,18 +675,25 @@ public class SupervisorAgentIT {
 
         assertThat(result.agenticScope().readState("exchange", 0.0)).isCloseTo(115.0, offset(0.1));
 
-        assertThat(beforeWithdrawTool.get()).isEqualTo("before withdraw on agent " + ((AgentInstance)withdrawAgent).agentId());
-        assertThat(afterWithdrawTool.get()).isEqualTo("after withdraw on agent " + ((AgentInstance)withdrawAgent).agentId());
+        assertThat(beforeWithdrawTool.get())
+                .isEqualTo("before withdraw on agent " + ((AgentInstance) withdrawAgent).agentId());
+        assertThat(afterWithdrawTool.get())
+                .isEqualTo("after withdraw on agent " + ((AgentInstance) withdrawAgent).agentId());
 
-        assertThat(invokedAgents).hasSize(5)
-                .containsExactlyInAnyOrder(((AgentInstance)exchangeAgent).agentId(),
-                ((AgentInstance)creditAgent).agentId(), ((AgentInstance)withdrawAgent).agentId(),
-                ((AgentInstance)sequence).agentId(), ((AgentInstance)bankSupervisor).agentId());
+        assertThat(invokedAgents)
+                .hasSize(5)
+                .containsExactlyInAnyOrder(
+                        ((AgentInstance) exchangeAgent).agentId(),
+                        ((AgentInstance) creditAgent).agentId(),
+                        ((AgentInstance) withdrawAgent).agentId(),
+                        ((AgentInstance) sequence).agentId(),
+                        ((AgentInstance) bankSupervisor).agentId());
 
-        assertThat(toolCalls).hasSize(3)
-                .containsEntry(((AgentInstance)exchangeAgent).agentId(), "exchange")
-                .containsEntry(((AgentInstance)creditAgent).agentId(), "credit")
-                .containsEntry(((AgentInstance)withdrawAgent).agentId(), "withdraw");
+        assertThat(toolCalls)
+                .hasSize(3)
+                .containsEntry(((AgentInstance) exchangeAgent).agentId(), "exchange")
+                .containsEntry(((AgentInstance) creditAgent).agentId(), "credit")
+                .containsEntry(((AgentInstance) withdrawAgent).agentId(), "withdraw");
 
         assertThat(toolResults).hasSize(3);
         assertThat(toolResults.get("exchange")).isCloseTo(115.0, offset(0.1));
@@ -674,9 +709,10 @@ public class SupervisorAgentIT {
         TransactionDetails execute(@V("request") String request);
 
         @Output
-        static TransactionDetails output(@V("withdrawUser") String withdrawUser,
-                                         @V("creditUser") String creditUser,
-                                         @V("amountInUSD") double amountInUSD) {
+        static TransactionDetails output(
+                @V("withdrawUser") String withdrawUser,
+                @V("creditUser") String creditUser,
+                @V("amountInUSD") double amountInUSD) {
             return new TransactionDetails(withdrawUser, creditUser, amountInUSD);
         }
     }
@@ -691,11 +727,10 @@ public class SupervisorAgentIT {
         typed_banker_test(false);
     }
 
-    public record ExchangeRequest(String originalCurrency, Double amount, String targetCurrency) { }
+    public record ExchangeRequest(String originalCurrency, Double amount, String targetCurrency) {}
 
     public interface TypedExchangeAgent {
-        @UserMessage(
-                """
+        @UserMessage("""
             You are an operator exchanging money in different currencies.
             Use the tool to calculate the given {{exchangeRequest}}
             returning only the final amount provided by the tool as it is and nothing else.
@@ -871,13 +906,12 @@ public class SupervisorAgentIT {
             assertThat(toolExec.result()).isNotNull();
         }
 
-        Set<String> toolNames = allToolExecutions.stream()
-                .map(te -> te.request().name())
-                .collect(Collectors.toSet());
+        Set<String> toolNames =
+                allToolExecutions.stream().map(te -> te.request().name()).collect(Collectors.toSet());
         assertThat(toolNames).contains("withdraw", "credit");
 
         System.out.println(execution);
-//        generateReport(monitor, Path.of("src", "test", "resources", "agents-exection-with-tools.html"));
+        //        generateReport(monitor, Path.of("src", "test", "resources", "agents-exection-with-tools.html"));
     }
 
     private List<ToolExecution> collectToolExecutions(AgentInvocation invocation) {
@@ -931,7 +965,8 @@ public class SupervisorAgentIT {
         String lionJoke1 = supervisorAgent.respond("supervisor", "Tell me a joke about lions");
         assertThat(lionJoke1).isNotNull().containsIgnoringCase("lion");
 
-        // Simulate recreating the same functional Supervisor System, same memory and all, new unique names will be generated
+        // Simulate recreating the same functional Supervisor System, same memory and all, new unique names will be
+        // generated
         JokesterAssistant jokesterAssistant2 = AgenticServices.agentBuilder(JokesterAssistant.class)
                 .chatModel(baseModel())
                 .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(10))
@@ -952,7 +987,8 @@ public class SupervisorAgentIT {
         String lionJoke2 = supervisorAgent2.respond("supervisor", "tell me a joke about cheetahs");
         assertThat(lionJoke2).isNotNull().containsIgnoringCase("cheetah");
 
-        List<ChatMessage> supervisorMessages = supervisorAgent.getChatMemory("supervisor").messages();
+        List<ChatMessage> supervisorMessages =
+                supervisorAgent.getChatMemory("supervisor").messages();
 
         Set<String> agentNames = supervisorMessages.stream()
                 .filter(AiMessage.class::isInstance)
@@ -960,14 +996,13 @@ public class SupervisorAgentIT {
                 .map(AiMessage::text)
                 .map(text -> {
                     int start = text.indexOf("\"agentName\":") + "agentName:".length();
-                    int agentNameStart = text.indexOf('"', start + 1)+1;
+                    int agentNameStart = text.indexOf('"', start + 1) + 1;
                     return text.substring(agentNameStart, text.indexOf('"', agentNameStart + 1));
-                }).collect(Collectors.toSet());
+                })
+                .collect(Collectors.toSet());
 
         // only 2 agents, the jokester and done
-        assertThat(agentNames)
-                .hasSize(2)
-                .containsExactly("JokesterAgent$1", "done");
+        assertThat(agentNames).hasSize(2).containsExactly("JokesterAgent$1", "done");
     }
 
     @Test
@@ -985,7 +1020,8 @@ public class SupervisorAgentIT {
                 .subAgents(colorExpert, colorMixerExpert)
                 .build();
 
-        String result = colorSupervisor.invoke("Which color do you get by mixing the color of blood and the color of the sky?");
+        String result =
+                colorSupervisor.invoke("Which color do you get by mixing the color of blood and the color of the sky?");
         assertThat(result).containsIgnoringCase("purple");
     }
 
@@ -1005,7 +1041,8 @@ public class SupervisorAgentIT {
                 .subAgents(loanApplicationExtractor, loanApplicationEvaluator)
                 .build();
 
-        String result = loanAgent.invoke("John Doe submitted a loan application of 80000. He is 30 years old. Evaluate his application.");
+        String result = loanAgent.invoke(
+                "John Doe submitted a loan application of 80000. He is 30 years old. Evaluate his application.");
         assertThat(result).containsIgnoringCase("rejected");
     }
 
@@ -1020,9 +1057,7 @@ public class SupervisorAgentIT {
                     }
                     """;
 
-            return ChatResponse.builder()
-                    .aiMessage(AiMessage.from(json))
-                    .build();
+            return ChatResponse.builder().aiMessage(AiMessage.from(json)).build();
         }
     }
 
@@ -1058,9 +1093,7 @@ public class SupervisorAgentIT {
                     }
                     """;
 
-            return ChatResponse.builder()
-                    .aiMessage(AiMessage.from(json))
-                    .build();
+            return ChatResponse.builder().aiMessage(AiMessage.from(json)).build();
         }
     }
 
@@ -1083,5 +1116,4 @@ public class SupervisorAgentIT {
 
         assertThat(result).isEqualTo("The capital of France is Paris");
     }
-
 }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
@@ -101,7 +101,7 @@ public class SupervisorAgentIT {
             """)
         @Agent("An agent that categorizes the user request")
         String categorizeRequest(
-                @P(name = "request", description = "The complete end-user request to categorize") String request);
+                @V("request") @P("The complete end-user request to categorize") String request);
     }
 
     @Test
@@ -183,7 +183,8 @@ public class SupervisorAgentIT {
             Withdraw {{amountInUSD}} USD from {{withdrawUser}}'s account and return the new balance.
             """)
         @Agent("A banker that withdraw USD from an account")
-        String withdraw(@V("withdrawUser") String withdrawUser, @V("amountInUSD") Double amountInUSD);
+        String withdraw(@V("withdrawUser") @P("The user to withdraw from") String withdrawUser,
+                        @V("amountInUSD") @P("The amount to withdraw") Double amountInUSD);
     }
 
     public interface CreditAgent {
@@ -194,7 +195,8 @@ public class SupervisorAgentIT {
             Credit {{amountInUSD}} USD to {{creditUser}}'s account and return the new balance.
             """)
         @Agent("A banker that credit USD to an account")
-        String credit(@V("creditUser") String creditUser, @V("amountInUSD") Double amountInUSD);
+        String credit(@V("creditUser") @P("The user to credit") String creditUser,
+                      @V("amountInUSD") @P("The amount to credit") Double amountInUSD);
     }
 
     static class BankTool {

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
@@ -103,7 +103,8 @@ public class SupervisorAgentIT {
             The user request is: '{{request}}'.
             """)
         @Agent("An agent that categorizes the user request")
-        String categorizeRequest(@V("request") String request);
+        String categorizeRequest(
+                @P(name = "request", description = "The complete end-user request to categorize") String request);
     }
 
     @Test

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgentUtilTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgentUtilTest.java
@@ -3,9 +3,9 @@ package dev.langchain4j.agentic.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
-import dev.langchain4j.agent.tool.P;
 import java.lang.reflect.Method;
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgentUtilTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgentUtilTest.java
@@ -5,10 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.agent.tool.P;
+import java.lang.reflect.Method;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class AgentUtilTest {
+
+    static class DescribedArguments {
+        void invoke(@P(name = "query", description = "Text to search for") String query) {}
+    }
 
     record Address(String street, String city) {}
 
@@ -104,5 +110,15 @@ class AgentUtilTest {
         assertThatThrownBy(() ->
                         AgentUtil.agentInvocationArguments(scope, List.of(new AgentArgument(Person.class, "person"))))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_preserve_parameter_description_for_agent_planner() throws Exception {
+        Method method = DescribedArguments.class.getDeclaredMethod("invoke", String.class);
+
+        AgentArgument argument = AgentUtil.argumentFromParameter(method.getParameters()[0]);
+
+        assertThat(argument.name()).isEqualTo("query");
+        assertThat(argument.description()).isEqualTo("Text to search for");
     }
 }


### PR DESCRIPTION
Closes #6227

## Summary
- preserve optional parameter descriptions in AgentArgument while keeping existing constructors
- propagate @P(description/value) into agent arguments
- preserve MCP tool input schema descriptions for MCP agent arguments
- append ` - description` in supervisor cards only when a description is present
- add focused regression coverage for @P description propagation

## Verification
- `git diff --check` passes
- Maven compile/test is currently blocked by the configured artifact repositories: the gitflow incremental builder extension cannot be resolved (HTTP blocker/internal repository TLS or availability).

The implementation keeps the existing output unchanged for arguments without descriptions and retains a default method on the MCP internal interface for compatibility.