### PR TITLE
fix(mcp): restore interrupt flag in readResource and getPrompt

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -823,7 +823,7 @@ public class DefaultMcpClient implements McpClient {
             notifyListeners(l -> l.onResourceGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (McpException e) {
             notifyListeners(l -> l.onResourceGetError(context, e));
@@ -886,7 +886,7 @@ public class DefaultMcpClient implements McpClient {
             notifyListeners(l -> l.onPromptGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (McpException e) {
             notifyListeners(l -> l.onPromptGetError(context, e));


### PR DESCRIPTION
Both InterruptedException handlers called Thread.interrupted(), which
clears the interrupt status, instead of `Thread.currentThread().interrupt()`,
which preserves it. Clearing the flag swallows the interrupt so callers
doing cooperative cancellation never learn the thread was interrupted.
This aligns them with `executeTool`, `subscribeToResource` and
`unsubscribeFromResource`, which already restore the flag correctly.