### PR TITLE
fix(anthropic): send thinking blocks that carry only a signature

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -628,11 +628,18 @@ and [adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/ad
 It is controlled by the following parameters:
 - `thinkingType` and `thinkingBudgetTokens`: enable thinking,
   see more details [here](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking).
-- `thinkingDisplay`: controls how thinking content is returned. Valid values are `"summarized"` and `"omitted"`.
+- `thinkingDisplay`: controls whether the API returns readable thinking text next to the thinking signature.
+  Valid values are `"summarized"` (thinking blocks contain a readable summary of the reasoning)
+  and `"omitted"` (thinking blocks contain an empty thinking text, only the encrypted signature is returned).
+  When it is not set, the API picks a default that depends on the model: recent Claude models default to `"omitted"`,
+  older ones to `"summarized"`, see [Anthropic documentation](https://platform.claude.com/docs/en/build-with-claude/thinking).
+  Set it to `"summarized"` whenever the thinking text itself is needed, for example in order to show it to the end user.
+  The model thinks and is billed the same way in both cases; only the visibility of the thinking text changes.
 - `returnThinking`: controls whether to return thinking (if available) inside `AiMessage.thinking()`
   and whether to invoke `StreamingChatResponseHandler.onPartialThinking()` and `TokenStream.onPartialThinking()`
-  callbacks when using `BedrockStreamingChatModel`.
-  Disabled by default. If enabled, tinking signatures will also be stored and returned inside the `AiMessage.attributes()`.
+  callbacks when using `AnthropicStreamingChatModel`.
+  Disabled by default. If enabled, thinking signatures will also be stored and returned inside the `AiMessage.attributes()`.
+  Please note that `AiMessage.thinking()` stays empty when the API returns no thinking text, see `thinkingDisplay` above.
 - `sendThinking`: controls whether to send thinking and signatures stored in `AiMessage` to the LLM in follow-up requests.
 Enabled by default.
 
@@ -640,7 +647,7 @@ In order to configure `effort` parameter, set `customParameters` when building t
 ```java
 ChatModel model = AnthropicChatModel.builder()
         .apiKey(System.getenv("ANTHROPIC_API_KEY"))
-        .modelName("claude-sonnet-4-7")
+        .modelName("claude-sonnet-5")
         .customParameters(Map.of("output_config", Map.of("effort", "max")))
         ...
         .build();
@@ -654,6 +661,20 @@ ChatModel model = AnthropicChatModel.builder()
         .thinkingType("enabled")
         .thinkingBudgetTokens(1024)
         .maxTokens(1024 + 100)
+        .returnThinking(true)
+        .sendThinking(true)
+        .build();
+```
+
+Recent Claude models return no thinking text unless `thinkingDisplay` asks for it,
+so `AiMessage.thinking()` is empty when it is not set:
+```java
+ChatModel model = AnthropicChatModel.builder()
+        .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+        .modelName("claude-sonnet-5")
+        .thinkingType("adaptive")
+        .thinkingDisplay("summarized")
+        .maxTokens(16000)
         .returnThinking(true)
         .sendThinking(true)
         .build();

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicBatchChatModel.java
@@ -559,13 +559,20 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
         }
 
         /**
-         * Controls how thinking is returned by the API, e.g. {@code "summarized"} or {@code "omitted"}.
+         * Controls whether the API returns readable thinking text next to the thinking signature:
+         * {@code "summarized"} returns a readable summary of the reasoning,
+         * {@code "omitted"} returns an empty thinking text and only the encrypted signature.
+         * <p>
+         * When this is not set, the API picks a default that depends on the model:
+         * recent Claude models default to {@code "omitted"}, older ones to {@code "summarized"}.
+         * Set it to {@code "summarized"} whenever the thinking text itself is needed.
          * <p>
          * Applies only when thinking is enabled via
          * {@link AnthropicChatRequestParameters.Builder#thinkingType(String)}.
          *
          * @param thinkingDisplay the thinking display mode
          * @return {@code this}
+         * @see <a href="https://platform.claude.com/docs/en/build-with-claude/thinking">Anthropic documentation</a>
          * @see #returnThinking(Boolean)
          */
         public Builder thinkingDisplay(String thinkingDisplay) {
@@ -579,9 +586,13 @@ public final class AnthropicBatchChatModel implements BatchChatModel {
          * Disabled by default. Unlike {@link AnthropicChatModel}, this is resolved once per model rather than per
          * request, because results are mapped in {@link #retrieve(String)}, which has no access to the originating
          * request.
+         * <p>
+         * Please note that {@link AiMessage#thinking()} stays empty when the API returns no thinking text,
+         * which is the default for recent Claude models. See {@link #thinkingDisplay(String)}.
          *
          * @param returnThinking whether to return thinking
          * @return {@code this}
+         * @see #thinkingDisplay(String)
          */
         public Builder returnThinking(Boolean returnThinking) {
             this.returnThinking = returnThinking;

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -569,13 +569,23 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
-         * Controls how thinking content is returned in the response.
+         * Controls whether the API returns readable thinking text next to the thinking signature.
          * <p>
-         * Valid values: {@code "summarized"} and {@code "omitted"}. On Claude Opus 4.7
-         * the server default is {@code "omitted"}; on earlier Opus/Sonnet models the
-         * default is {@code "summarized"}. Set to {@code "summarized"} explicitly on
-         * Opus 4.7+ to restore visible thinking text for UIs that render it.
+         * Valid values:
+         * <ul>
+         *     <li>{@code "summarized"}: thinking blocks contain a readable summary of the reasoning.</li>
+         *     <li>{@code "omitted"}: thinking blocks contain an empty thinking text,
+         *     only the encrypted signature is returned.</li>
+         * </ul>
+         * When this is not set, the API picks a default that depends on the model:
+         * recent Claude models default to {@code "omitted"}, older ones to {@code "summarized"}.
+         * Set it to {@code "summarized"} whenever the thinking text itself is needed,
+         * for example in order to show it to the end user.
+         * <p>
+         * The model thinks and is billed the same way in both cases;
+         * only the visibility of the thinking text changes.
          *
+         * @see <a href="https://platform.claude.com/docs/en/build-with-claude/thinking">Anthropic documentation</a>
          * @see #thinkingType(String)
          * @see #returnThinking(Boolean)
          */
@@ -593,9 +603,13 @@ public class AnthropicChatModel implements ChatModel {
          * Disabled by default.
          * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
          * If enabled, thinking signatures will also be stored and returned inside the {@link AiMessage#attributes()}.
+         * <p>
+         * Please note that {@link AiMessage#thinking()} stays empty when the API returns no thinking text,
+         * which is the default for recent Claude models. See {@link #thinkingDisplay(String)}.
          *
          * @see #thinkingType(String)
          * @see #thinkingBudgetTokens(Integer)
+         * @see #thinkingDisplay(String)
          * @see #sendThinking(Boolean)
          */
         public AnthropicChatModelBuilder returnThinking(Boolean returnThinking) {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -423,13 +423,23 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Controls how thinking content is returned in the response stream.
+         * Controls whether the API streams readable thinking text next to the thinking signature.
          * <p>
-         * Valid values: {@code "summarized"} and {@code "omitted"}. On Claude Opus 4.7
-         * the server default is {@code "omitted"}; on earlier Opus/Sonnet models the
-         * default is {@code "summarized"}. Set to {@code "summarized"} explicitly on
-         * Opus 4.7+ to restore visible thinking text for UIs that stream it.
+         * Valid values:
+         * <ul>
+         *     <li>{@code "summarized"}: thinking blocks contain a readable summary of the reasoning.</li>
+         *     <li>{@code "omitted"}: thinking blocks contain an empty thinking text,
+         *     only the encrypted signature is returned.</li>
+         * </ul>
+         * When this is not set, the API picks a default that depends on the model:
+         * recent Claude models default to {@code "omitted"}, older ones to {@code "summarized"}.
+         * Set it to {@code "summarized"} whenever the thinking text itself is needed,
+         * for example in order to stream it to the end user.
+         * <p>
+         * The model thinks and is billed the same way in both cases;
+         * only the visibility of the thinking text changes.
          *
+         * @see <a href="https://platform.claude.com/docs/en/build-with-claude/thinking">Anthropic documentation</a>
          * @see #thinkingType(String)
          * @see #returnThinking(Boolean)
          */
@@ -448,9 +458,15 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
          * Disabled by default.
          * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
          * If enabled, thinking signatures will also be stored and returned inside the {@link AiMessage#attributes()}.
+         * <p>
+         * Please note that {@link AiMessage#thinking()} stays empty and
+         * {@link StreamingChatResponseHandler#onPartialThinking(PartialThinking)} is not invoked
+         * when the API returns no thinking text, which is the default for recent Claude models.
+         * See {@link #thinkingDisplay(String)}.
          *
          * @see #thinkingType(String)
          * @see #thinkingBudgetTokens(Integer)
+         * @see #thinkingDisplay(String)
          * @see #sendThinking(Boolean)
          */
         public AnthropicStreamingChatModelBuilder returnThinking(Boolean returnThinking) {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -224,9 +224,12 @@ public class AnthropicMapper {
     private static List<AnthropicMessageContent> toAnthropicMessageContents(AiMessage message, boolean sendThinking) {
         List<AnthropicMessageContent> contents = new ArrayList<>();
 
-        if (sendThinking && isNotNullOrBlank(message.thinking())) {
+        if (sendThinking) {
             String signature = message.attribute(THINKING_SIGNATURE_KEY, String.class);
-            contents.add(new AnthropicThinkingContent(message.thinking(), signature));
+            if (isNotNullOrBlank(message.thinking()) || isNotNullOrBlank(signature)) {
+                String thinking = message.thinking() != null ? message.thinking() : "";
+                contents.add(new AnthropicThinkingContent(thinking, signature));
+            }
         }
 
         if (sendThinking && message.attributes().containsKey(REDACTED_THINKING_KEY)) {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.anthropic.internal.mapper;
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
+import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
@@ -227,15 +228,15 @@ public class AnthropicMapper {
         if (sendThinking) {
             String signature = message.attribute(THINKING_SIGNATURE_KEY, String.class);
             if (isNotNullOrBlank(message.thinking()) || isNotNullOrBlank(signature)) {
-                String thinking = message.thinking() != null ? message.thinking() : "";
-                contents.add(new AnthropicThinkingContent(thinking, signature));
+                // "thinking" is required by the API, so an empty string is sent when the model returned no text
+                contents.add(new AnthropicThinkingContent(getOrDefault(message.thinking(), ""), signature));
             }
-        }
 
-        if (sendThinking && message.attributes().containsKey(REDACTED_THINKING_KEY)) {
-            List<String> redactedThinkings = message.attribute(REDACTED_THINKING_KEY, List.class);
-            for (String redactedThinking : redactedThinkings) {
-                contents.add(new AnthropicRedactedThinkingContent(redactedThinking));
+            if (message.attributes().containsKey(REDACTED_THINKING_KEY)) {
+                List<String> redactedThinkings = message.attribute(REDACTED_THINKING_KEY, List.class);
+                for (String redactedThinking : redactedThinkings) {
+                    contents.add(new AnthropicRedactedThinkingContent(redactedThinking));
+                }
             }
         }
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.ASSISTA
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.SYSTEM;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.USER;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.SERVER_TOOL_RESULTS_KEY;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.THINKING_SIGNATURE_KEY;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.retainKeys;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAiMessage;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicMessages;
@@ -41,6 +42,7 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessageContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicPdfContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicTextContent;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicThinkingContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicTool;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolResultContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolSchema;
@@ -1052,6 +1054,73 @@ class AnthropicMapperTest {
                           "source": {"type": "base64", "media_type": "application/pdf", "data": "%s"}
                         }
                         """.formatted(BASE64_PDF_DATA));
+    }
+
+    @Test
+    void should_send_thinking_block_that_has_only_a_signature() {
+        // Given an assistant turn whose thinking text is empty and whose content lives entirely in the
+        // (encrypted) signature — what adaptive-thinking models return.
+        AiMessage aiMessage = AiMessage.builder()
+                .thinking("")
+                .attributes(singletonMap(THINKING_SIGNATURE_KEY, "EoAECpABCBEYAipARsBWFsXRge7q"))
+                .toolExecutionRequests(singletonList(ToolExecutionRequest.builder()
+                        .id("tool-1")
+                        .name("getWeather")
+                        .arguments("{}")
+                        .build()))
+                .build();
+
+        // When
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage), true);
+
+        // Then the block must still be echoed back: Anthropic requires it for the next request of the turn.
+        assertThat(anthropicMessages).hasSize(1);
+        AnthropicMessageContent content = anthropicMessages.get(0).content.get(0);
+        assertThat(content).isInstanceOf(AnthropicThinkingContent.class);
+
+        AnthropicThinkingContent thinkingContent = (AnthropicThinkingContent) content;
+        // "" and not null: the field is required by the API and the class is @JsonInclude(NON_NULL).
+        assertThat(thinkingContent.thinking).isEmpty();
+        assertThat(thinkingContent.signature).isEqualTo("EoAECpABCBEYAipARsBWFsXRge7q");
+    }
+
+    @Test
+    void should_send_thinking_block_with_both_text_and_signature() {
+        AiMessage aiMessage = AiMessage.builder()
+                .text("Hello")
+                .thinking("Let me think about this")
+                .attributes(singletonMap(THINKING_SIGNATURE_KEY, "sig-abc"))
+                .build();
+
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage), true);
+
+        AnthropicMessageContent content = anthropicMessages.get(0).content.get(0);
+        assertThat(content).isInstanceOf(AnthropicThinkingContent.class);
+        AnthropicThinkingContent thinkingContent = (AnthropicThinkingContent) content;
+        assertThat(thinkingContent.thinking).isEqualTo("Let me think about this");
+        assertThat(thinkingContent.signature).isEqualTo("sig-abc");
+    }
+
+    @Test
+    void should_not_send_thinking_block_when_there_is_neither_text_nor_signature() {
+        AiMessage aiMessage = AiMessage.builder().text("Hello").thinking("").build();
+
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage), true);
+
+        assertThat(anthropicMessages.get(0).content).noneMatch(AnthropicThinkingContent.class::isInstance);
+    }
+
+    @Test
+    void should_not_send_thinking_block_when_sendThinking_is_false() {
+        AiMessage aiMessage = AiMessage.builder()
+                .text("Hello")
+                .thinking("")
+                .attributes(singletonMap(THINKING_SIGNATURE_KEY, "sig-abc"))
+                .build();
+
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage), false);
+
+        assertThat(anthropicMessages.get(0).content).noneMatch(AnthropicThinkingContent.class::isInstance);
     }
 
     @SafeVarargs

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class AnthropicMapperTest {
 
@@ -1058,11 +1059,50 @@ class AnthropicMapperTest {
 
     @Test
     void should_send_thinking_block_that_has_only_a_signature() {
-        // Given an assistant turn whose thinking text is empty and whose content lives entirely in the
-        // (encrypted) signature — what adaptive-thinking models return.
+        // given an assistant turn whose thinking text is empty and whose reasoning is carried entirely by the
+        // (encrypted) signature: this is what a model returns when "thinking.display" is "omitted",
+        // which is the default for claude-sonnet-5, claude-opus-5 and others
+        String signature = "EoAECpABCBEYAipARsBWFsXRge7q";
+
+        AnthropicContent thinking = AnthropicContent.builder()
+                .type("thinking")
+                .thinking("")
+                .signature(signature)
+                .build();
+
+        AnthropicContent toolUse = AnthropicContent.builder()
+                .type("tool_use")
+                .id("tool-1")
+                .name("getWeather")
+                .input(emptyMap())
+                .build();
+
+        AiMessage aiMessage = toAiMessage(asList(thinking, toolUse), true);
+        // "toAiMessage" turns the empty thinking text into null, so only the signature survives
+        assertThat(aiMessage.thinking()).isNull();
+        assertThat(aiMessage.attribute(THINKING_SIGNATURE_KEY, String.class)).isEqualTo(signature);
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage), true);
+
+        // then the block must still be echoed back: Anthropic requires the assistant turn to be sent back unchanged
+        assertThat(anthropicMessages).hasSize(1);
+        AnthropicMessageContent content = anthropicMessages.get(0).content.get(0);
+        assertThat(content).isInstanceOf(AnthropicThinkingContent.class);
+
+        AnthropicThinkingContent thinkingContent = (AnthropicThinkingContent) content;
+        // "" and not null: the field is required by the API and the class is @JsonInclude(NON_NULL)
+        assertThat(thinkingContent.thinking).isEmpty();
+        assertThat(thinkingContent.signature).isEqualTo(signature);
+    }
+
+    @Test
+    void should_send_thinking_block_that_has_only_a_signature_when_thinking_text_is_empty() {
+        // given an AiMessage that carries an empty instead of a null thinking text,
+        // for example one restored from a serialized chat memory
         AiMessage aiMessage = AiMessage.builder()
                 .thinking("")
-                .attributes(singletonMap(THINKING_SIGNATURE_KEY, "EoAECpABCBEYAipARsBWFsXRge7q"))
+                .attributes(singletonMap(THINKING_SIGNATURE_KEY, "sig-abc"))
                 .toolExecutionRequests(singletonList(ToolExecutionRequest.builder()
                         .id("tool-1")
                         .name("getWeather")
@@ -1070,18 +1110,16 @@ class AnthropicMapperTest {
                         .build()))
                 .build();
 
-        // When
+        // when
         List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage), true);
 
-        // Then the block must still be echoed back: Anthropic requires it for the next request of the turn.
-        assertThat(anthropicMessages).hasSize(1);
+        // then
         AnthropicMessageContent content = anthropicMessages.get(0).content.get(0);
         assertThat(content).isInstanceOf(AnthropicThinkingContent.class);
 
         AnthropicThinkingContent thinkingContent = (AnthropicThinkingContent) content;
-        // "" and not null: the field is required by the API and the class is @JsonInclude(NON_NULL).
         assertThat(thinkingContent.thinking).isEmpty();
-        assertThat(thinkingContent.signature).isEqualTo("EoAECpABCBEYAipARsBWFsXRge7q");
+        assertThat(thinkingContent.signature).isEqualTo("sig-abc");
     }
 
     @Test
@@ -1101,9 +1139,11 @@ class AnthropicMapperTest {
         assertThat(thinkingContent.signature).isEqualTo("sig-abc");
     }
 
-    @Test
-    void should_not_send_thinking_block_when_there_is_neither_text_nor_signature() {
-        AiMessage aiMessage = AiMessage.builder().text("Hello").thinking("").build();
+    @ParameterizedTest
+    @NullAndEmptySource
+    void should_not_send_thinking_block_when_there_is_neither_text_nor_signature(String thinking) {
+        AiMessage aiMessage =
+                AiMessage.builder().text("Hello").thinking(thinking).build();
 
         List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage), true);
 


### PR DESCRIPTION
## Issue
Closes #6244

## Change

`AnthropicMapper#toAnthropicMessageContents` gated sending a thinking block on `isNotNullOrBlank(message.thinking())` — the human-readable text. A thinking block can come back with an **empty** `thinking` text and all of its content carried in the encrypted `signature`, and such a block was therefore dropped even with `sendThinking(true)`.

Anthropic requires the thinking block, signature included, to be echoed back in the assistant turn when the conversation continues with tool results. Dropping it means the model loses its own reasoning from the previous turn on every round of a tool-calling loop, re-derives it, and can fail to converge at all.

The fix gates on the signature as well as the text:

```java
if (sendThinking) {
    String signature = message.attribute(THINKING_SIGNATURE_KEY, String.class);
    if (isNotNullOrBlank(message.thinking()) || isNotNullOrBlank(signature)) {
        String thinking = message.thinking() != null ? message.thinking() : "";
        contents.add(new AnthropicThinkingContent(thinking, signature));
    }
}
```

Two notes:

- Only the request side needed changing. `toAiMessage` already stores the signature under `THINKING_SIGNATURE_KEY` when the text is empty, so the data was captured correctly and then discarded on the way out.
- `thinking` is serialized as `""` rather than left null, because the field is required by the API and `AnthropicThinkingContent` is `@JsonInclude(NON_NULL)`.

**Behaviour delta:** the only case that changes is the one that was broken — an assistant message that has a thinking signature but no thinking text is now echoed back instead of silently dropped. No API change, and no change for messages with thinking text, without a signature, or with `sendThinking(false)`; each of those is pinned by a test below.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — n/a, this is a bug fix with no documented behaviour change
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) — n/a
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) — n/a

Tests added to `AnthropicMapperTest`:

| test | asserts |
| --- | --- |
| `should_send_thinking_block_that_has_only_a_signature` | the regression: empty text + signature is sent, with `thinking` as `""` |
| `should_send_thinking_block_with_both_text_and_signature` | the ordinary case is unaffected |
| `should_not_send_thinking_block_when_there_is_neither_text_nor_signature` | no over-correction |
| `should_not_send_thinking_block_when_sendThinking_is_false` | the flag still wins when a signature is present |

Test runs: `langchain4j-anthropic` 169 tests green, `langchain4j-core` 1282 green, `langchain4j` 1392 green. `mvn spotless:check` clean.

Verified end to end against a local build of this change: with it, the thinking blocks are echoed back on subsequent requests, and a tool-calling agent that previously exhausted `maxSequentialToolsInvocations` without answering converges and finishes normally.

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml` — n/a, no new module

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT` — n/a
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT` — n/a

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j — n/a
