### PR TITLE
fix(mcp): support image and resource content types in tool results

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverter.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverter.java
@@ -26,12 +26,25 @@ public class DefaultMcpToolResultConverter implements McpToolResultConverter {
 
     private String extractText(Map<String, Object> contentItem) {
         Object type = contentItem.get("type");
-        if (!"text".equals(type)) {
-            // Preserve the historical error message format from ToolExecutionHelper,
-            // where the JSON string value is rendered with quotes.
+        if ("text".equals(type)) {
+            Object text = contentItem.get("text");
+            return text == null ? "" : String.valueOf(text);
+        } else if ("image".equals(type)) {
+            Object data = contentItem.get("data");
+            Object mimeType = contentItem.get("mimeType");
+            if (data != null && mimeType != null) {
+                return "data:" + mimeType + ";base64," + data;
+            }
+            return "[image: missing data or mimeType]";
+        } else if ("resource".equals(type)) {
+            Object resource = contentItem.get("resource");
+            if (resource instanceof Map) {
+                Object text = ((Map<?, ?>) resource).get("text");
+                return text == null ? "" : String.valueOf(text);
+            }
+            return "";
+        } else {
             throw new RuntimeException("Unsupported content type: \"" + type + "\"");
         }
-        Object text = contentItem.get("text");
-        return text == null ? "" : String.valueOf(text);
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverterTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverterTest.java
@@ -37,9 +37,32 @@ class DefaultMcpToolResultConverterTest {
 
     @Test
     void rejects_unsupported_content_type() {
-        assertThatThrownBy(() -> extractor.convert(List.of(Map.of("type", "image", "data", "xxx")), false))
+        assertThatThrownBy(() -> extractor.convert(List.of(Map.of("type", "audio", "data", "xxx")), false))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Unsupported content type");
+    }
+
+    @Test
+    void extracts_image_as_data_uri() {
+        ToolExecutionResult result = extractor.convert(
+                List.of(Map.of("type", "image", "data", "iVBORw0KGgo=", "mimeType", "image/png")), false);
+
+        assertThat(result.resultText()).isEqualTo("data:image/png;base64,iVBORw0KGgo=");
+    }
+
+    @Test
+    void handles_image_with_missing_fields() {
+        ToolExecutionResult result = extractor.convert(List.of(Map.of("type", "image", "data", "xxx")), false);
+
+        assertThat(result.resultText()).isEqualTo("[image: missing data or mimeType]");
+    }
+
+    @Test
+    void extracts_resource_text_content() {
+        ToolExecutionResult result = extractor.convert(
+                List.of(Map.of("type", "resource", "resource", Map.of("text", "resource text"))), false);
+
+        assertThat(result.resultText()).isEqualTo("resource text");
     }
 
     @Test


### PR DESCRIPTION
Closes #3364

## Summary

`DefaultMcpToolResultConverter.extractText()` threw `RuntimeException` for any content type other than `"text"`. MCP servers can return `"image"` (base64-encoded) and `"resource"` (embedded text) content items.

## Changes

| Content type | Before | After |
|---|---|---|
| `text` | Extracted | Unchanged |
| `image` | RuntimeException | Returns data-URI (`data:image/png;base64,...`) |
| `resource` | RuntimeException | Extracts `resource.text` field |
| Other | RuntimeException | Unchanged (still throws) |

## Details

- `image` items carry `data` (base64) and `mimeType` fields per the MCP spec. The converter returns a data-URI string that downstream consumers can use.
- `resource` items carry an embedded `resource` map with a `text` field (for text resources). The converter extracts that text.
- Missing fields on image items produce a descriptive fallback string instead of crashing.

## Tests

- Updated `rejects_unsupported_content_type` to use `"audio"` (still unsupported)
- Added `extracts_image_as_data_uri`
- Added `handles_image_with_missing_fields`
- Added `extracts_resource_text_content`