### PR TITLE
feat(document-parser-docling): DocumentRequest templates, async parsing, and custom request executor

### DIFF
--- a/docs/docs/integrations/document-parsers/docling.md
+++ b/docs/docs/integrations/document-parsers/docling.md
@@ -27,7 +27,7 @@ This module depends on `docling-serve-api` (the interface) and includes `docling
 <dependency>
     <groupId>ai.docling</groupId>
     <artifactId>docling-serve-client</artifactId>
-    <version>0.5.1</version>
+    <version>0.6.4</version>
 </dependency>
 ```
 
@@ -51,9 +51,27 @@ Document document = parser.parse(inputStream);
 String text = document.text();
 ```
 
-### Conversion Options
+To load documents from files, directories, URLs, or the classpath — and have
+standard metadata such as `file_name`, `absolute_directory_path`, and `url`
+populated automatically — use the loaders from the `langchain4j` module together
+with the parser:
 
-To customize Docling processing, pass [`ConvertDocumentOptions`](https://docling-project.github.io/docling-java/dev/docling-serve/serve-api/#requests-convertdocumentrequest) to the builder:
+```java
+Document fromFile = FileSystemDocumentLoader.loadDocument(Path.of("/tmp/report.pdf"), parser);
+Document fromUrl = UrlDocumentLoader.load("https://example.com/report.pdf", parser);
+```
+
+### Choosing the Docling Operation
+
+The operation performed by Docling — conversion, hierarchical chunking, or hybrid
+chunking — is controlled by the [`DocumentRequest`](https://docling-project.github.io/docling-java/dev/docling-serve/serve-api/#requests-convertdocumentrequest)
+template supplied to the builder. The template carries everything except the
+document source: the parser injects the source of the document being parsed into a
+fresh copy of the template for each call and routes it to the matching Docling
+endpoint. If no template is supplied, a plain `ConvertDocumentRequest` is used.
+
+To customize conversion, supply a `ConvertDocumentRequest` carrying your
+`ConvertDocumentOptions`:
 
 ```java
 ConvertDocumentOptions options = ConvertDocumentOptions.builder()
@@ -62,13 +80,75 @@ ConvertDocumentOptions options = ConvertDocumentOptions.builder()
 
 DoclingDocumentParser parser = DoclingDocumentParser.builder()
         .doclingClient(api)
-        .options(options)
+        .documentRequest(ConvertDocumentRequest.builder()
+                .options(options)
+                .build())
         .build();
 ```
 
+> The deprecated `Builder.options(ConvertDocumentOptions)` shortcut is still
+> available and simply delegates to `documentRequest(...)`, but prefer passing a
+> `ConvertDocumentRequest` so you can also choose the Docling operation.
+
+To chunk the document instead of converting it, supply a
+`HierarchicalChunkDocumentRequest` or a `HybridChunkDocumentRequest`:
+
+```java
+DoclingDocumentParser parser = DoclingDocumentParser.builder()
+        .doclingClient(api)
+        .documentRequest(HybridChunkDocumentRequest.builder().build())
+        .build();
+```
+
+Any document source carried by the template is ignored — the parser injects the
+source of the document being parsed. The template must describe an in-body
+operation: a `BatchConvertDocumentRequest`, or a request carrying a non-in-body
+target (for example a `ZipTarget` or `PresignedUrlTarget`), causes `build()` to
+fail.
+
 ### Custom Text Extraction
 
-By default, the parser extracts markdown content from the Docling response. You can customize how text is extracted by providing a `Function<InBodyConvertDocumentResponse, String>` via the `documentTextExtractor` builder method. The function receives the full `InBodyConvertDocumentResponse`, giving access to the converted document in various formats (markdown, HTML, text, doctags, JSON), conversion errors, processing time, and status information.
+By default, the parser extracts markdown content from a conversion response and
+joins chunk text (separated by newlines) from a chunk response. You can customize
+how text is extracted with two builder methods, each receiving the concrete
+response type — no casts required:
+
+- `documentTextExtractor(Function<InBodyConvertDocumentResponse, String>)` — used
+  for conversion requests. Gives access to the converted document in various
+  formats (markdown, HTML, text, doctags, JSON), conversion errors, processing
+  time, and status information.
+- `chunkTextExtractor(Function<ChunkDocumentResponse, String>)` — used for chunk
+  requests. Gives access to the chunks and their metadata.
+
+If you need control over the whole resulting `Document` — for example to attach
+extra `Metadata` such as provenance derived from the structured response — use the
+`Document`-returning variants instead:
+
+- `documentExtractor(Function<InBodyConvertDocumentResponse, Document>)`
+- `chunkExtractor(Function<ChunkDocumentResponse, Document>)`
+
+For each response kind you set **either** the text extractor **or** the
+`Document` extractor — the two variants of a pair are mutually exclusive, and
+configuring both (`documentTextExtractor` + `documentExtractor`, or
+`chunkTextExtractor` + `chunkExtractor`) makes `build()` throw an
+`IllegalArgumentException`.
+
+```java
+DoclingDocumentParser parser = DoclingDocumentParser.builder()
+        .doclingClient(api)
+        .documentRequest(ConvertDocumentRequest.builder()
+                .options(ConvertDocumentOptions.builder().toFormat(OutputFormat.JSON).build())
+                .build())
+        .documentExtractor(response -> {
+            DoclingDocument doc = response.getDocument().getJsonContent();
+            String fullText = buildFullText(doc);
+            return Document.from(fullText, buildProvenanceMetadata(doc, fullText));
+        })
+        .build();
+```
+
+The parser always adds the `document_size_bytes` metadata entry on top of whatever
+your extractor returns.
 
 For example, to extract HTML content instead of markdown:
 
@@ -88,9 +168,101 @@ DoclingDocumentParser parser = DoclingDocumentParser.builder()
         .build();
 ```
 
+And to customize how chunks are joined:
+
+```java
+DoclingDocumentParser parser = DoclingDocumentParser.builder()
+        .doclingClient(api)
+        .documentRequest(HybridChunkDocumentRequest.builder().build())
+        .chunkTextExtractor(response -> response.getChunks().stream()
+                .map(Chunk::getText)
+                .collect(Collectors.joining("\n\n")))
+        .build();
+```
+
+### Asynchronous / Reactive Parsing
+
+`DoclingDocumentParser.parse(InputStream)` satisfies the synchronous
+`DocumentParser` contract by blocking on the underlying asynchronous call. For
+reactive or non-blocking pipelines, use `parseAsync(InputStream)`, which returns a
+`CompletionStage<Document>`:
+
+```java
+CompletionStage<Document> stage = parser.parseAsync(inputStream);
+```
+
+`parseAsync` offloads reading the input stream and preparing the request onto a
+background thread (via `CompletableFuture.supplyAsync`, i.e. the common
+`ForkJoinPool`), so it returns without blocking the calling thread. The parsed
+`Document` — or any failure (a `null`/empty stream, a request-build error, or an
+error from the Docling call) — is delivered through the returned stage: it
+completes exceptionally rather than throwing, so reactive callers don't need a
+surrounding `try/catch`.
+
+This drops straight into a reactive type, for example Mutiny:
+
+```java
+Uni.createFrom().completionStage(() -> parser.parseAsync(inputStream));
+```
+
+> **Threading note.** `parseAsync` controls only where the stream is read; the
+> Docling network call itself runs on threads owned by the Docling client. The
+> reference `docling-serve-client` performs its HTTP and task polling on the common
+> `ForkJoinPool` and exposes no executor to change that. If you need to control
+> where the blocking network work runs (for example a dedicated pool or virtual
+> threads), supply a custom
+> [`DoclingRequestExecutor`](#customizing-how-docling-is-called) that invokes the
+> client on your own executor.
+
+### Customizing How Docling Is Called
+
+By default the parser calls Docling's asynchronous convert/chunk endpoints
+matching the request type. Those endpoints already submit a task, poll for
+completion, and fetch the result — all on the common `ForkJoinPool`, so there is
+no need for a custom executor just to get that task/queue behaviour. Supply a
+`DoclingRequestExecutor` when you want to:
+
+- add **retry or backoff** around the Docling call;
+- run the blocking call on **your own executor** (a dedicated pool or virtual
+  threads) instead of the common `ForkJoinPool`; or
+- perform **fully custom orchestration** (for example driving the task/queue
+  endpoints yourself with a custom poll cadence).
+
+To retry the conversion once on failure:
+
+```java
+DoclingDocumentParser parser = DoclingDocumentParser.builder()
+        .doclingClient(api)
+        .requestExecutor((client, request) -> {
+            ConvertDocumentRequest convertRequest = (ConvertDocumentRequest) request;
+            return client.convertSourceAsync(convertRequest)
+                    .exceptionallyCompose(error -> client.convertSourceAsync(convertRequest));
+        })
+        .build();
+```
+
+To run the blocking work on your own executor (here, virtual threads) — this uses
+the *synchronous* `convertSource` so the network call runs on the supplied pool
+rather than the common `ForkJoinPool`:
+
+```java
+Executor executor = Executors.newVirtualThreadPerTaskExecutor();
+
+DoclingDocumentParser parser = DoclingDocumentParser.builder()
+        .doclingClient(api)
+        .requestExecutor((client, request) -> CompletableFuture.supplyAsync(
+                () -> client.convertSource((ConvertDocumentRequest) request), executor))
+        .build();
+```
+
+When a custom executor is supplied, the parser no longer restricts the request
+type or target (the executor owns those semantics), so operations such as
+`BatchConvertDocumentRequest` or non-in-body targets become available.
+
 ## APIs
 
 - `DoclingDocumentParser`
+- `DoclingRequestExecutor`
 
 
 ## Examples

--- a/document-parsers/langchain4j-document-parser-docling/pom.xml
+++ b/document-parsers/langchain4j-document-parser-docling/pom.xml
@@ -13,7 +13,7 @@
     <name>LangChain4j :: Document Parser :: Docling</name>
 
     <properties>
-        <docling.version>0.6.0</docling.version>
+        <docling.version>0.6.4</docling.version>
     </properties>
 
     <dependencyManagement>
@@ -36,10 +36,21 @@
             <version>1.20.0-SNAPSHOT</version>
         </dependency>
 
+        <!--
+            Docling transitively declares jspecify 1.0.1, while langchain4j-core brings jspecify 1.0.0.
+            Exclude Docling's copy so the build converges on core's version. jspecify contains only
+            compile-time annotations (CLASS retention, no runtime code), so the patch difference is harmless.
+        -->
         <dependency>
             <groupId>ai.docling</groupId>
             <artifactId>docling-serve-api</artifactId>
             <version>${docling.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jspecify</groupId>
+                    <artifactId>jspecify</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Docling reference client - optional; frameworks like Spring/Quarkus provide their own impl -->
@@ -49,6 +60,12 @@
             <version>${docling.version}</version>
             <scope>runtime</scope>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jspecify</groupId>
+                    <artifactId>jspecify</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Testing -->
@@ -58,6 +75,12 @@
             <artifactId>docling-testcontainers</artifactId>
             <version>${docling.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jspecify</groupId>
+                    <artifactId>jspecify</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/document-parsers/langchain4j-document-parser-docling/revapi.json
+++ b/document-parsers/langchain4j-document-parser-docling/revapi.json
@@ -23,6 +23,21 @@
           "code": "java.class.externalClassExposedInAPI",
           "new": "missing-class dev.langchain4j.data.document.Document",
           "justification": "Core langchain4j type intentionally part of the document parser API"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class ai.docling.serve.api.request.DocumentRequest",
+          "justification": "Docling Serve API type intentionally exposed so callers can choose the Docling operation (convert, hierarchical chunk, hybrid chunk) via a request template"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class ai.docling.serve.api.chunk.response.ChunkDocumentResponse",
+          "justification": "Docling Serve API type intentionally exposed to allow custom text extraction from chunk responses"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class ai.docling.serve.api.response.ProcessedDocumentResponse",
+          "justification": "Docling Serve API type intentionally exposed by DoclingRequestExecutor so callers can customize how Docling is invoked"
         }
       ]
     }

--- a/document-parsers/langchain4j-document-parser-docling/src/main/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParser.java
+++ b/document-parsers/langchain4j-document-parser-docling/src/main/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParser.java
@@ -166,15 +166,13 @@ public class DoclingDocumentParser implements DocumentParser {
     }
 
     private static RuntimeException toParseException(Throwable cause) {
-        final RuntimeException result;
         if (cause instanceof BlankDocumentException blank) {
-            result = blank;
+            return blank;
         } else if (cause instanceof IllegalArgumentException illegalArgument) {
-            result = illegalArgument;
-        } else {
-            result = new RuntimeException("Docling failed to parse document: " + cause.getMessage(), cause);
+            return illegalArgument;
         }
-        return result;
+
+        return new RuntimeException("Docling failed to parse document: " + cause.getMessage(), cause);
     }
 
     /**

--- a/document-parsers/langchain4j-document-parser-docling/src/main/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParser.java
+++ b/document-parsers/langchain4j-document-parser-docling/src/main/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParser.java
@@ -3,12 +3,19 @@ package dev.langchain4j.data.document.parser.docling;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
 import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.chunk.request.HierarchicalChunkDocumentRequest;
+import ai.docling.serve.api.chunk.request.HybridChunkDocumentRequest;
+import ai.docling.serve.api.chunk.response.Chunk;
+import ai.docling.serve.api.chunk.response.ChunkDocumentResponse;
+import ai.docling.serve.api.convert.request.BatchConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.options.ConvertDocumentOptions;
 import ai.docling.serve.api.convert.request.source.FileSource;
-import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
+import ai.docling.serve.api.convert.request.target.InBodyTarget;
+import ai.docling.serve.api.convert.request.target.Target;
 import ai.docling.serve.api.convert.response.InBodyConvertDocumentResponse;
-import ai.docling.serve.api.convert.response.ResponseType;
+import ai.docling.serve.api.request.DocumentRequest;
+import ai.docling.serve.api.response.ProcessedDocumentResponse;
 import dev.langchain4j.data.document.BlankDocumentException;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentParser;
@@ -17,34 +24,129 @@ import dev.langchain4j.internal.ValidationUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A {@link DocumentParser} backed by a Docling Serve instance.
+ * <p>
+ * The operation performed by Docling (convert, hierarchical chunking, hybrid chunking, ...) is controlled by the
+ * {@link DocumentRequest} template supplied to the {@link Builder}. The template carries everything except the document
+ * source: the parser injects the source of the {@link InputStream} being parsed into a fresh copy of the template for
+ * each call, then routes the request to the matching Docling endpoint. How the resulting response is turned into a
+ * {@link Document} is controlled by the {@linkplain Builder#documentExtractor(Function) document extractor} (for
+ * conversion requests) and the {@linkplain Builder#chunkExtractor(Function) chunk extractor} (for chunk requests);
+ * {@linkplain Builder#documentTextExtractor(Function) text-only} variants are also available.
+ * <p>
+ * How Docling is actually called is controlled by the {@linkplain Builder#requestExecutor(DoclingRequestExecutor)
+ * request executor}. By default the parser calls the asynchronous convert/chunk endpoints and exposes both a blocking
+ * {@link #parse(InputStream)} and a non-blocking {@link #parseAsync(InputStream)}.
+ */
 public class DoclingDocumentParser implements DocumentParser {
-    private static final Logger log = LoggerFactory.getLogger(DoclingDocumentParser.class);
 
-    private static final Function<InBodyConvertDocumentResponse, String> DEFAULT_DOCUMENT_TEXT_EXTRACTOR =
-            response -> response.getDocument().getMarkdownContent();
+    private record PreparedRequest(DocumentRequest request, int sizeBytes) {}
+
+    private static final Logger log = LoggerFactory.getLogger(DoclingDocumentParser.class);
+    private static final String DEFAULT_FILENAME = "document";
+    private static final String DOCUMENT_SIZE_BYTES = "document_size_bytes";
+    private static final DocumentRequest DEFAULT_DOCUMENT_REQUEST =
+            ConvertDocumentRequest.builder().build();
+
+    private static final Function<InBodyConvertDocumentResponse, Document> DEFAULT_DOCUMENT_EXTRACTOR =
+            response -> textToDocument(response.getDocument().getMarkdownContent());
+
+    private static final Function<ChunkDocumentResponse, Document> DEFAULT_CHUNK_EXTRACTOR = response ->
+            textToDocument(response.getChunks().stream().map(Chunk::getText).collect(Collectors.joining("\n")));
+
+    private static final DoclingRequestExecutor DEFAULT_REQUEST_EXECUTOR = (client, request) -> {
+        if (request instanceof ConvertDocumentRequest convertRequest) {
+            return client.convertSourceAsync(convertRequest);
+        } else if (request instanceof HierarchicalChunkDocumentRequest hierarchicalRequest) {
+            return client.chunkSourceWithHierarchicalChunkerAsync(hierarchicalRequest);
+        } else if (request instanceof HybridChunkDocumentRequest hybridRequest) {
+            return client.chunkSourceWithHybridChunkerAsync(hybridRequest);
+        }
+
+        throw new IllegalArgumentException(
+                "Unsupported request type: " + request.getClass().getName());
+    };
 
     private final DoclingServeApi doclingClient;
-    private final ConvertDocumentOptions options;
-    private final Function<InBodyConvertDocumentResponse, String> documentTextExtractor;
+    private final DocumentRequest documentRequest;
+    private final Function<InBodyConvertDocumentResponse, Document> documentExtractor;
+    private final Function<ChunkDocumentResponse, Document> chunkExtractor;
+    private final DoclingRequestExecutor requestExecutor;
 
+    /**
+     * @deprecated use {@link #builder()} with {@link Builder#doclingClient(DoclingServeApi)} instead
+     */
     @Deprecated(forRemoval = true)
     public DoclingDocumentParser(DoclingServeApi doclingClient) {
-        this(doclingClient, null);
+        this(builder().doclingClient(doclingClient));
     }
 
+    /**
+     * @deprecated use {@link #builder()} with {@link Builder#doclingClient(DoclingServeApi)} and a
+     *             {@link Builder#documentRequest(DocumentRequest)} carrying a {@link ConvertDocumentRequest} with the
+     *             desired {@link ConvertDocumentOptions} instead
+     */
     @Deprecated(forRemoval = true)
     public DoclingDocumentParser(DoclingServeApi doclingClient, ConvertDocumentOptions options) {
-        this(builder().doclingClient(doclingClient).options(options));
+        this(builder().doclingClient(doclingClient).documentRequest(convertRequest(options)));
     }
 
     private DoclingDocumentParser(Builder builder) {
         this.doclingClient = ValidationUtils.ensureNotNull(builder.doclingClient, "doclingClient");
-        this.options = builder.options;
-        this.documentTextExtractor = getOrDefault(builder.documentTextExtractor, DEFAULT_DOCUMENT_TEXT_EXTRACTOR);
+        var request = getOrDefault(builder.documentRequest, DEFAULT_DOCUMENT_REQUEST);
+        this.requestExecutor = getOrDefault(builder.requestExecutor, DEFAULT_REQUEST_EXECUTOR);
+
+        // The default executor targets the in-body convert/chunk endpoints, so the request shape is validated
+        // eagerly only when no custom executor takes over the invocation.
+        if (builder.requestExecutor == null) {
+            validateDefaultExecutorRequest(request);
+        }
+
+        this.documentRequest = request;
+        this.documentExtractor = resolveDocumentExtractor(builder);
+        this.chunkExtractor = resolveChunkExtractor(builder);
+    }
+
+    private static Function<InBodyConvertDocumentResponse, Document> resolveDocumentExtractor(Builder builder) {
+        ensureMutuallyExclusive(
+                builder.documentExtractor, builder.documentTextExtractor, "documentExtractor", "documentTextExtractor");
+
+        return Optional.ofNullable(builder.documentExtractor)
+                .orElseGet(() -> Optional.ofNullable(builder.documentTextExtractor)
+                        .map(DoclingDocumentParser::wrapTextExtractor)
+                        .orElse(DEFAULT_DOCUMENT_EXTRACTOR));
+    }
+
+    private static Function<ChunkDocumentResponse, Document> resolveChunkExtractor(Builder builder) {
+        ensureMutuallyExclusive(
+                builder.chunkExtractor, builder.chunkTextExtractor, "chunkExtractor", "chunkTextExtractor");
+
+        return Optional.ofNullable(builder.chunkExtractor)
+                .orElseGet(() -> Optional.ofNullable(builder.chunkTextExtractor)
+                        .map(DoclingDocumentParser::wrapTextExtractor)
+                        .orElse(DEFAULT_CHUNK_EXTRACTOR));
+    }
+
+    private static <R> Function<R, Document> wrapTextExtractor(Function<R, String> textExtractor) {
+        return response -> textToDocument(textExtractor.apply(response));
+    }
+
+    private static void ensureMutuallyExclusive(
+            Object documentVariant, Object textVariant, String documentName, String textName) {
+        if ((documentVariant != null) && (textVariant != null)) {
+            throw new IllegalArgumentException("Set at most one of %s(...) and %s(...) — they are mutually exclusive."
+                    .formatted(documentName, textName));
+        }
     }
 
     public static Builder builder() {
@@ -53,40 +155,76 @@ public class DoclingDocumentParser implements DocumentParser {
 
     @Override
     public Document parse(InputStream inputStream) {
-        ValidationUtils.ensureNotNull(inputStream, "inputStream");
-
         try {
-            byte[] documentBytes = inputStream.readAllBytes();
+            return parseAsync(inputStream).toCompletableFuture().join();
+        } catch (CompletionException e) {
+            throw toParseException((e.getCause() != null) ? e.getCause() : e);
+        } catch (RuntimeException e) {
+            // parseAsync threw synchronously (or join() threw, e.g. CancellationException) — wrap consistently
+            throw toParseException(e);
+        }
+    }
 
-            var metadata = new Metadata();
-            metadata.put("document_size_bytes", String.valueOf(documentBytes.length));
+    private static RuntimeException toParseException(Throwable cause) {
+        final RuntimeException result;
+        if (cause instanceof BlankDocumentException blank) {
+            result = blank;
+        } else if (cause instanceof IllegalArgumentException illegalArgument) {
+            result = illegalArgument;
+        } else {
+            result = new RuntimeException("Docling failed to parse document: " + cause.getMessage(), cause);
+        }
+        return result;
+    }
 
-            if (documentBytes.length == 0) {
-                throw new BlankDocumentException();
-            }
+    /**
+     * Parses the given {@link InputStream} without blocking, returning a stage that completes with the resulting
+     * {@link Document}. This is the asynchronous counterpart of {@link #parse(InputStream)} and is intended for reactive
+     * or non-blocking pipelines.
+     *
+     * @param inputStream
+     *            the document content to parse; the caller owns its lifecycle and this method does not close it
+     *
+     * @return a stage completing with the parsed {@link Document}
+     */
+    public CompletionStage<Document> parseAsync(InputStream inputStream) {
+        // Offload the blocking read and request preparation so the caller thread is never blocked and any
+        // failure (null input, empty document, request build) is delivered through the returned stage.
+        return CompletableFuture.supplyAsync(() -> prepareRequest(inputStream))
+                .thenCompose(prepared -> this.requestExecutor
+                        .execute(this.doclingClient, prepared.request())
+                        .thenApply(response -> buildDocument(response, prepared.sizeBytes())));
+    }
 
-            var base64Content = Base64.getEncoder().encodeToString(documentBytes);
+    private PreparedRequest prepareRequest(InputStream inputStream) {
+        ValidationUtils.ensureNotNull(inputStream, "inputStream");
+        var documentBytes = readBytes(inputStream);
 
-            var requestBuilder = ConvertDocumentRequest.builder()
-                    .source(FileSource.builder()
-                            .base64String(base64Content)
-                            .filename("document")
-                            .build());
+        if (documentBytes.length == 0) {
+            throw new BlankDocumentException();
+        }
 
-            if (this.options != null) {
-                requestBuilder.options(this.options);
-            }
+        var request = this.documentRequest.toBuilder()
+                .clearSources()
+                .source(fileSource(documentBytes, DEFAULT_FILENAME))
+                .build();
 
-            ConvertDocumentResponse response = doclingClient.convertSource(requestBuilder.build());
+        return new PreparedRequest(request, documentBytes.length);
+    }
 
-            if (response.getResponseType() != ResponseType.IN_BODY) {
-                throw new IllegalStateException(
-                        "Only %s response types expected. Docling returned unexpected response type: %s"
-                                .formatted(ResponseType.IN_BODY, response.getResponseType()));
-            }
+    private Document buildDocument(ProcessedDocumentResponse response, int documentSizeBytes) {
+        var document = extract(response);
 
-            var inBodyResponse = (InBodyConvertDocumentResponse) response;
+        if (document == null) {
+            throw new BlankDocumentException();
+        }
 
+        document.metadata().put(DOCUMENT_SIZE_BYTES, String.valueOf(documentSizeBytes));
+        return document;
+    }
+
+    private Document extract(ProcessedDocumentResponse response) {
+        if (response instanceof InBodyConvertDocumentResponse inBodyResponse) {
             if (!inBodyResponse.getErrors().isEmpty()) {
                 var first = inBodyResponse.getErrors().get(0);
                 log.warn(
@@ -95,55 +233,230 @@ public class DoclingDocumentParser implements DocumentParser {
                         first.getComponentType(),
                         first.getErrorMessage());
             }
+            return this.documentExtractor.apply(inBodyResponse);
+        } else if (response instanceof ChunkDocumentResponse chunkResponse) {
+            return this.chunkExtractor.apply(chunkResponse);
+        }
 
-            var parsedText = documentTextExtractor.apply(inBodyResponse);
-            if ((parsedText == null) || parsedText.isBlank()) {
-                throw new BlankDocumentException();
-            }
+        throw new IllegalStateException(
+                "Unsupported response type: " + response.getClass().getName());
+    }
 
-            return Document.from(parsedText, metadata);
+    private static void validateDefaultExecutorRequest(DocumentRequest request) {
+        if (!((request instanceof ConvertDocumentRequest)
+                || (request instanceof HierarchicalChunkDocumentRequest)
+                || (request instanceof HybridChunkDocumentRequest))) {
+            throw new IllegalArgumentException("Unsupported request type: "
+                    + request.getClass().getName()
+                    + ". DoclingDocumentParser only supports ConvertDocumentRequest, "
+                    + "HierarchicalChunkDocumentRequest, and HybridChunkDocumentRequest. "
+                    + "Supply a custom DoclingRequestExecutor to use other Docling operations.");
+        }
+
+        Target target = request.getTarget();
+        if ((target != null) && !(target instanceof InBodyTarget)) {
+            throw new IllegalArgumentException(
+                    "Only an in-body (IN_BODY) target is supported by the default DoclingRequestExecutor, but the "
+                            + "request template carries a " + target.getClass().getName()
+                            + ". Supply a custom DoclingRequestExecutor to handle other targets.");
+        }
+    }
+
+    private static Document textToDocument(String text) {
+        if ((text == null) || text.isBlank()) {
+            throw new BlankDocumentException();
+        }
+
+        return Document.from(text);
+    }
+
+    private static byte[] readBytes(InputStream inputStream) {
+        try {
+            // Intentionally does not close the stream - the caller owns its lifecycle.
+            return inputStream.readAllBytes();
         } catch (IOException e) {
             throw new RuntimeException("Failed to read input stream: " + e.getMessage(), e);
-        } catch (BlankDocumentException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException("Docling failed to parse document: " + e.getMessage(), e);
         }
+    }
+
+    private static FileSource fileSource(byte[] documentBytes, String filename) {
+        return FileSource.builder()
+                .base64String(Base64.getEncoder().encodeToString(documentBytes))
+                .filename(filename)
+                .build();
+    }
+
+    private static ConvertDocumentRequest convertRequest(ConvertDocumentOptions options) {
+        var requestBuilder = ConvertDocumentRequest.builder();
+
+        if (options != null) {
+            requestBuilder.options(options);
+        }
+
+        return requestBuilder.build();
     }
 
     public static final class Builder {
         private DoclingServeApi doclingClient;
-        private ConvertDocumentOptions options;
+        private DocumentRequest documentRequest;
+        private Function<InBodyConvertDocumentResponse, Document> documentExtractor;
         private Function<InBodyConvertDocumentResponse, String> documentTextExtractor;
+        private Function<ChunkDocumentResponse, Document> chunkExtractor;
+        private Function<ChunkDocumentResponse, String> chunkTextExtractor;
+        private DoclingRequestExecutor requestExecutor;
 
         private Builder() {}
 
+        /**
+         * Sets the Docling client that will be used to perform operations.
+         *
+         * @param doclingClient
+         *            the {@link DoclingServeApi} instance to communicate with Docling backend services
+         *
+         * @return this builder instance
+         */
         public Builder doclingClient(DoclingServeApi doclingClient) {
             this.doclingClient = doclingClient;
             return this;
         }
 
-        public Builder options(ConvertDocumentOptions options) {
-            this.options = options;
+        /**
+         * Sets the {@link DocumentRequest} template describing the Docling operation to perform (for example
+         * {@link ConvertDocumentRequest}, {@link HierarchicalChunkDocumentRequest}, or
+         * {@link HybridChunkDocumentRequest}) along with its options.
+         * <p>
+         * Any document source carried by the template is ignored — the parser injects the source of the document being
+         * parsed into a fresh copy of the template for each call. With the default request executor the template must
+         * describe an in-body operation: a {@link BatchConvertDocumentRequest} or a request carrying a
+         * non-{@link InBodyTarget} target causes {@link #build()} to fail. Supplying a custom
+         * {@link #requestExecutor(DoclingRequestExecutor)} lifts those restrictions.
+         * <p>
+         * If not set, defaults to a plain {@link ConvertDocumentRequest} with default options.
+         *
+         * @param documentRequest
+         *            the request template
+         *
+         * @return this builder
+         */
+        public Builder documentRequest(DocumentRequest documentRequest) {
+            this.documentRequest = documentRequest;
             return this;
         }
 
         /**
-         * Sets a custom function to extract text content from the Docling conversion response.
+         * Sets a custom function to build a {@link Document} from a Docling {@link InBodyConvertDocumentResponse}
+         * (produced by a {@link ConvertDocumentRequest}). Unlike {@link #documentTextExtractor(Function)}, this gives
+         * full control over the returned {@link Document}, including its {@link Metadata} — useful for carrying, for
+         * example, provenance information derived from the structured response. The parser adds the
+         * {@value #DOCUMENT_SIZE_BYTES} metadata entry on top of whatever the function returns.
          * <p>
-         * The function receives the full {@link InBodyConvertDocumentResponse}, giving access to
-         * the converted document (in various formats: markdown, HTML, text, doctags, JSON),
-         * conversion errors, processing time, and status information.
-         * <p>
-         * If not set, defaults to extracting markdown content:
-         * {@code response -> response.getDocument().getMarkdownContent()}.
+         * Mutually exclusive with {@link #documentTextExtractor(Function)}: configuring both causes {@link #build()} to
+         * throw an {@link IllegalArgumentException}. If neither is set, the markdown content of the converted document is
+         * used.
          *
-         * @param documentTextExtractor the function to extract document text from the response
+         * @param documentExtractor
+         *            the function to build a {@link Document} from a conversion response
+         *
+         * @return this builder
+         */
+        public Builder documentExtractor(Function<InBodyConvertDocumentResponse, Document> documentExtractor) {
+            this.documentExtractor = documentExtractor;
+            return this;
+        }
+
+        /**
+         * Sets a custom function to extract text content from a Docling {@link InBodyConvertDocumentResponse} (produced
+         * by a {@link ConvertDocumentRequest}). The function receives the full response, giving access to the converted
+         * document, conversion errors, processing time, and status information. The returned text is wrapped in a
+         * {@link Document}; for control over the {@link Document} itself use {@link #documentExtractor(Function)}.
+         * <p>
+         * Mutually exclusive with {@link #documentExtractor(Function)}: configuring both causes {@link #build()} to
+         * throw an {@link IllegalArgumentException}. If not set, defaults to extracting the markdown content of the
+         * converted document.
+         *
+         * @param documentTextExtractor
+         *            the function to extract document text from a conversion response
+         *
          * @return this builder
          */
         public Builder documentTextExtractor(Function<InBodyConvertDocumentResponse, String> documentTextExtractor) {
             this.documentTextExtractor = documentTextExtractor;
             return this;
+        }
+
+        /**
+         * Sets a custom function to build a {@link Document} from a Docling {@link ChunkDocumentResponse} (produced by a
+         * {@link HierarchicalChunkDocumentRequest} or {@link HybridChunkDocumentRequest}). Unlike
+         * {@link #chunkTextExtractor(Function)}, this gives full control over the returned {@link Document}, including
+         * its {@link Metadata}. The parser adds the {@value #DOCUMENT_SIZE_BYTES} metadata entry on top of whatever the
+         * function returns.
+         * <p>
+         * Mutually exclusive with {@link #chunkTextExtractor(Function)}: configuring both causes {@link #build()} to
+         * throw an {@link IllegalArgumentException}. If neither is set, the text of all chunks joined by newlines is
+         * used.
+         *
+         * @param chunkExtractor
+         *            the function to build a {@link Document} from a chunk response
+         *
+         * @return this builder
+         */
+        public Builder chunkExtractor(Function<ChunkDocumentResponse, Document> chunkExtractor) {
+            this.chunkExtractor = chunkExtractor;
+            return this;
+        }
+
+        /**
+         * Sets a custom function to extract text content from a Docling {@link ChunkDocumentResponse} (produced by a
+         * {@link HierarchicalChunkDocumentRequest} or {@link HybridChunkDocumentRequest}). The function receives the
+         * full response, giving access to the chunks and their metadata. The returned text is wrapped in a
+         * {@link Document}; for control over the {@link Document} itself use {@link #chunkExtractor(Function)}.
+         * <p>
+         * Mutually exclusive with {@link #chunkExtractor(Function)}: configuring both causes {@link #build()} to throw
+         * an {@link IllegalArgumentException}. If not set, defaults to joining the text of all chunks separated by
+         * newlines.
+         *
+         * @param chunkTextExtractor
+         *            the function to extract document text from a chunk response
+         *
+         * @return this builder
+         */
+        public Builder chunkTextExtractor(Function<ChunkDocumentResponse, String> chunkTextExtractor) {
+            this.chunkTextExtractor = chunkTextExtractor;
+            return this;
+        }
+
+        /**
+         * Sets the strategy used to invoke Docling for a prepared request. The default executor calls the asynchronous
+         * convert/chunk endpoints matching the request type (which already submit, poll, and fetch the result on the
+         * common {@link java.util.concurrent.ForkJoinPool}). Supplying a custom executor lets callers control exactly
+         * how Docling is called (for example to add retry behaviour, or to run the blocking call on their own executor
+         * instead of the common {@link java.util.concurrent.ForkJoinPool}) and lifts the request-type and target
+         * restrictions enforced for the default executor.
+         *
+         * @param requestExecutor
+         *            the executor that invokes Docling
+         *
+         * @return this builder
+         */
+        public Builder requestExecutor(DoclingRequestExecutor requestExecutor) {
+            this.requestExecutor = requestExecutor;
+            return this;
+        }
+
+        /**
+         * Sets the conversion options.
+         *
+         * @param options
+         *            the {@link ConvertDocumentOptions} to use
+         *
+         * @return this builder
+         *
+         * @deprecated use {@link Builder#documentRequest(DocumentRequest)} with a
+         *             {@link ConvertDocumentRequest} carrying the desired options instead
+         */
+        @Deprecated
+        public Builder options(ConvertDocumentOptions options) {
+            return documentRequest(convertRequest(options));
         }
 
         public DoclingDocumentParser build() {

--- a/document-parsers/langchain4j-document-parser-docling/src/main/java/dev/langchain4j/data/document/parser/docling/DoclingRequestExecutor.java
+++ b/document-parsers/langchain4j-document-parser-docling/src/main/java/dev/langchain4j/data/document/parser/docling/DoclingRequestExecutor.java
@@ -1,0 +1,35 @@
+package dev.langchain4j.data.document.parser.docling;
+
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.request.DocumentRequest;
+import ai.docling.serve.api.response.ProcessedDocumentResponse;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Strategy that decides how {@link DoclingDocumentParser} invokes Docling to obtain a
+ * {@link ProcessedDocumentResponse} for a prepared {@link DocumentRequest} (the document source has already been
+ * injected into the request by the parser).
+ * <p>
+ * The {@linkplain DoclingDocumentParser.Builder#requestExecutor(DoclingRequestExecutor) default executor} calls the
+ * asynchronous convert/chunk endpoints matching the request type; those endpoints already submit a task, poll for
+ * completion, and fetch the result on the common {@link java.util.concurrent.ForkJoinPool}. Supplying a custom executor
+ * lets callers control exactly how Docling is called — for example to add retry or backoff, to run the blocking call on
+ * their own executor (such as the synchronous convert/chunk methods on a dedicated pool or virtual threads) instead of
+ * the common {@link java.util.concurrent.ForkJoinPool}, or for fully custom orchestration. When a custom executor is
+ * supplied, the parser no longer restricts the request type or target, since the executor owns those semantics.
+ */
+@FunctionalInterface
+public interface DoclingRequestExecutor {
+
+    /**
+     * Invokes Docling for the given request.
+     *
+     * @param client
+     *            the Docling client configured on the parser
+     * @param request
+     *            the request template with the document source already injected
+     *
+     * @return a stage that completes with the Docling response
+     */
+    CompletionStage<? extends ProcessedDocumentResponse> execute(DoclingServeApi client, DocumentRequest request);
+}

--- a/document-parsers/langchain4j-document-parser-docling/src/test/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParserIT.java
+++ b/document-parsers/langchain4j-document-parser-docling/src/test/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParserIT.java
@@ -3,10 +3,12 @@ package dev.langchain4j.data.document.parser.docling;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.chunk.request.HierarchicalChunkDocumentRequest;
 import ai.docling.testcontainers.serve.DoclingServeContainer;
 import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
 import dev.langchain4j.data.document.Document;
 import java.io.InputStream;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -66,6 +68,34 @@ class DoclingDocumentParserIT {
 
             assertThat(document).isNotNull();
             assertThat(document.text()).isNotEmpty().isUpperCase();
+        }
+    }
+
+    @Test
+    void shouldParsePdfDocumentAsync() throws Exception {
+        DoclingDocumentParser parser = new DoclingDocumentParser(client);
+
+        try (InputStream inputStream = getClass().getResourceAsStream("/test-file.pdf")) {
+            assertThat(parser.parseAsync(inputStream).toCompletableFuture())
+                    .succeedsWithin(Duration.ofMinutes(2))
+                    .extracting(Document::text)
+                    .asString()
+                    .isNotEmpty();
+        }
+    }
+
+    @Test
+    void shouldParsePdfDocumentWithHierarchicalChunker() throws Exception {
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(client)
+                .documentRequest(HierarchicalChunkDocumentRequest.builder().build())
+                .build();
+
+        try (InputStream inputStream = getClass().getResourceAsStream("/test-file.pdf")) {
+            Document document = parser.parse(inputStream);
+
+            assertThat(document).isNotNull();
+            assertThat(document.text()).isNotEmpty();
         }
     }
 }

--- a/document-parsers/langchain4j-document-parser-docling/src/test/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParserTest.java
+++ b/document-parsers/langchain4j-document-parser-docling/src/test/java/dev/langchain4j/data/document/parser/docling/DoclingDocumentParserTest.java
@@ -3,19 +3,33 @@ package dev.langchain4j.data.document.parser.docling;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.chunk.request.HierarchicalChunkDocumentRequest;
+import ai.docling.serve.api.chunk.request.HybridChunkDocumentRequest;
+import ai.docling.serve.api.chunk.response.Chunk;
+import ai.docling.serve.api.chunk.response.ChunkDocumentResponse;
+import ai.docling.serve.api.convert.request.BatchConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.options.ConvertDocumentOptions;
+import ai.docling.serve.api.convert.request.source.FileSource;
+import ai.docling.serve.api.convert.request.target.PresignedUrlTarget;
 import ai.docling.serve.api.convert.response.DocumentResponse;
 import ai.docling.serve.api.convert.response.InBodyConvertDocumentResponse;
 import dev.langchain4j.data.document.BlankDocumentException;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.Metadata;
 import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -147,14 +161,14 @@ class DoclingDocumentParserTest {
 
     @Test
     void shouldAllowAccessToFullResponse() {
-        when(mockApi.convertSource(any(ConvertDocumentRequest.class)))
-                .thenReturn(InBodyConvertDocumentResponse.builder()
+        when(mockApi.convertSourceAsync(any(ConvertDocumentRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(InBodyConvertDocumentResponse.builder()
                         .document(DocumentResponse.builder()
                                 .markdownContent("content")
                                 .build())
                         .status("SUCCESS")
                         .processingTime(1.5)
-                        .build());
+                        .build()));
 
         var parser = DoclingDocumentParser.builder()
                 .doclingClient(mockApi)
@@ -170,7 +184,22 @@ class DoclingDocumentParserTest {
     }
 
     @Test
-    void shouldBuildWithOptions() {
+    void shouldBuildWithConvertRequestOptions() {
+        mockResponseWithMarkdown("# Content");
+
+        var options = ConvertDocumentOptions.builder().build();
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .documentRequest(
+                        ConvertDocumentRequest.builder().options(options).build())
+                .build();
+        var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
+
+        assertThat(document.text()).isEqualTo("# Content");
+    }
+
+    @Test
+    void shouldBuildWithDeprecatedOptionsDelegate() {
         mockResponseWithMarkdown("# Content");
 
         var options = ConvertDocumentOptions.builder().build();
@@ -184,29 +213,272 @@ class DoclingDocumentParserTest {
     }
 
     @Test
-    void shouldExtractTextContent() {
-        mockResponseWith(null, null, "Plain text content", null);
+    void shouldRouteHierarchicalChunkRequestToChunkEndpoint() {
+        when(mockApi.chunkSourceWithHierarchicalChunkerAsync(any(HierarchicalChunkDocumentRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(ChunkDocumentResponse.builder()
+                        .chunk(Chunk.builder().text("first").build())
+                        .chunk(Chunk.builder().text("second").build())
+                        .build()));
 
         var parser = DoclingDocumentParser.builder()
                 .doclingClient(mockApi)
-                .documentTextExtractor(response -> response.getDocument().getTextContent())
+                .documentRequest(HierarchicalChunkDocumentRequest.builder().build())
                 .build();
         var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
 
-        assertThat(document.text()).isEqualTo("Plain text content");
+        assertThat(document.text()).isEqualTo("first\nsecond");
+        verify(mockApi, never()).convertSourceAsync(any());
+        verify(mockApi, never()).chunkSourceWithHybridChunkerAsync(any());
     }
 
     @Test
-    void shouldExtractDoctagsContent() {
-        mockResponseWith(null, null, null, "<doctag>content</doctag>");
+    void shouldRouteHybridChunkRequestToChunkEndpoint() {
+        when(mockApi.chunkSourceWithHybridChunkerAsync(any(HybridChunkDocumentRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(ChunkDocumentResponse.builder()
+                        .chunk(Chunk.builder().text("only").build())
+                        .build()));
 
         var parser = DoclingDocumentParser.builder()
                 .doclingClient(mockApi)
-                .documentTextExtractor(response -> response.getDocument().getDoctagsContent())
+                .documentRequest(HybridChunkDocumentRequest.builder().build())
                 .build();
         var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
 
-        assertThat(document.text()).isEqualTo("<doctag>content</doctag>");
+        assertThat(document.text()).isEqualTo("only");
+        verify(mockApi, never()).convertSourceAsync(any());
+    }
+
+    @Test
+    void shouldUseCustomChunkTextExtractor() {
+        when(mockApi.chunkSourceWithHybridChunkerAsync(any(HybridChunkDocumentRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(ChunkDocumentResponse.builder()
+                        .chunk(Chunk.builder().text("alpha").build())
+                        .chunk(Chunk.builder().text("beta").build())
+                        .build()));
+
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .documentRequest(HybridChunkDocumentRequest.builder().build())
+                .chunkTextExtractor(response -> response.getChunks().stream()
+                        .map(Chunk::getText)
+                        .reduce((a, b) -> a + " | " + b)
+                        .orElse(""))
+                .build();
+        var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
+
+        assertThat(document.text()).isEqualTo("alpha | beta");
+    }
+
+    @Test
+    void shouldThrowWhenBatchConvertRequestIsUsed() {
+        var batchRequest = BatchConvertDocumentRequest.builder()
+                .target(PresignedUrlTarget.builder().build())
+                .build();
+
+        assertThatThrownBy(() -> DoclingDocumentParser.builder()
+                        .doclingClient(mockApi)
+                        .documentRequest(batchRequest)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Batch");
+    }
+
+    @Test
+    void shouldThrowWhenConvertRequestCarriesNonInBodyTarget() {
+        var request = ConvertDocumentRequest.builder()
+                .target(PresignedUrlTarget.builder().build())
+                .build();
+
+        assertThatThrownBy(() -> DoclingDocumentParser.builder()
+                        .doclingClient(mockApi)
+                        .documentRequest(request)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("in-body");
+    }
+
+    @Test
+    void shouldIgnoreSourceCarriedByTemplate() {
+        mockResponseWithMarkdown("# Content");
+        var template = ConvertDocumentRequest.builder()
+                .source(FileSource.builder()
+                        .base64String("aWdub3JlZA==")
+                        .filename("ignored.pdf")
+                        .build())
+                .build();
+
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .documentRequest(template)
+                .build();
+        parser.parse(new ByteArrayInputStream("data".getBytes()));
+
+        var request = captureConvertRequest();
+        assertThat(request.getSources())
+                .singleElement()
+                .isInstanceOfSatisfying(
+                        FileSource.class,
+                        source -> assertThat(source.getFilename()).isEqualTo("document"));
+    }
+
+    @Test
+    void shouldParseAsync() {
+        mockResponseWithMarkdown("# Async");
+
+        var parser = DoclingDocumentParser.builder().doclingClient(mockApi).build();
+        var stage = parser.parseAsync(new ByteArrayInputStream("data".getBytes()));
+
+        assertThat(stage.toCompletableFuture())
+                .succeedsWithin(Duration.ofSeconds(5))
+                .extracting(Document::text)
+                .isEqualTo("# Async");
+    }
+
+    @Test
+    void shouldReturnFailedStageForNullInput() {
+        var parser = DoclingDocumentParser.builder().doclingClient(mockApi).build();
+
+        // parseAsync must not throw synchronously — the failure is delivered through the returned stage.
+        assertThat(parser.parseAsync(null).toCompletableFuture())
+                .failsWithin(Duration.ofSeconds(5))
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldReturnFailedStageForEmptyInput() {
+        var parser = DoclingDocumentParser.builder().doclingClient(mockApi).build();
+
+        assertThat(parser.parseAsync(new ByteArrayInputStream(new byte[0])).toCompletableFuture())
+                .failsWithin(Duration.ofSeconds(5))
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(BlankDocumentException.class);
+    }
+
+    @Test
+    void shouldReturnFailedStageWhenExecutorFails() {
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .requestExecutor((client, request) -> CompletableFuture.failedFuture(new RuntimeException("boom")))
+                .build();
+
+        assertThat(parser.parseAsync(new ByteArrayInputStream("data".getBytes()))
+                        .toCompletableFuture())
+                .failsWithin(Duration.ofSeconds(5))
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RuntimeException.class)
+                .withMessageContaining("boom");
+
+        assertThatThrownBy(() -> parser.parse(new ByteArrayInputStream("data".getBytes())))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Docling failed to parse document")
+                .cause()
+                .hasMessage("boom");
+    }
+
+    @Test
+    void shouldUseCustomDocumentExtractor() {
+        mockResponseWithMarkdown("# Markdown");
+
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .documentExtractor(response ->
+                        Document.from(response.getDocument().getMarkdownContent(), Metadata.from("provenance", "0-9")))
+                .build();
+        var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
+
+        assertThat(document.text()).isEqualTo("# Markdown");
+        assertThat(document.metadata().getString("provenance")).isEqualTo("0-9");
+        assertThat(document.metadata().getString("document_size_bytes")).isNotNull();
+    }
+
+    @Test
+    void shouldUseCustomChunkExtractor() {
+        when(mockApi.chunkSourceWithHybridChunkerAsync(any(HybridChunkDocumentRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(ChunkDocumentResponse.builder()
+                        .chunk(Chunk.builder().text("a").build())
+                        .chunk(Chunk.builder().text("b").build())
+                        .build()));
+
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .documentRequest(HybridChunkDocumentRequest.builder().build())
+                .chunkExtractor(response ->
+                        Document.from("count=" + response.getChunks().size(), Metadata.from("kind", "chunks")))
+                .build();
+        var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
+
+        assertThat(document.text()).isEqualTo("count=2");
+        assertThat(document.metadata().getString("kind")).isEqualTo("chunks");
+    }
+
+    @Test
+    void shouldFailWhenBothDocumentExtractorVariantsAreConfigured() {
+        assertThatThrownBy(() -> DoclingDocumentParser.builder()
+                        .doclingClient(mockApi)
+                        .documentTextExtractor(
+                                response -> response.getDocument().getMarkdownContent())
+                        .documentExtractor(response -> Document.from("ignored"))
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("documentExtractor")
+                .hasMessageContaining("documentTextExtractor");
+    }
+
+    @Test
+    void shouldFailWhenBothChunkExtractorVariantsAreConfigured() {
+        assertThatThrownBy(() -> DoclingDocumentParser.builder()
+                        .doclingClient(mockApi)
+                        .documentRequest(HybridChunkDocumentRequest.builder().build())
+                        .chunkTextExtractor(response -> "text")
+                        .chunkExtractor(response -> Document.from("ignored"))
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chunkExtractor")
+                .hasMessageContaining("chunkTextExtractor");
+    }
+
+    @Test
+    void shouldUseCustomRequestExecutor() {
+        var response = InBodyConvertDocumentResponse.builder()
+                .document(DocumentResponse.builder()
+                        .markdownContent("# From executor")
+                        .build())
+                .build();
+
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .requestExecutor((client, request) -> CompletableFuture.completedFuture(response))
+                .build();
+        var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
+
+        assertThat(document.text()).isEqualTo("# From executor");
+        verify(mockApi, never()).convertSourceAsync(any());
+    }
+
+    @Test
+    void shouldAllowUnsupportedRequestTypeWithCustomExecutor() {
+        var response = InBodyConvertDocumentResponse.builder()
+                .document(DocumentResponse.builder().markdownContent("# Batch").build())
+                .build();
+        var batchRequest = BatchConvertDocumentRequest.builder()
+                .target(PresignedUrlTarget.builder().build())
+                .build();
+
+        var parser = DoclingDocumentParser.builder()
+                .doclingClient(mockApi)
+                .documentRequest(batchRequest)
+                .requestExecutor((client, request) -> CompletableFuture.completedFuture(response))
+                .build();
+        var document = parser.parse(new ByteArrayInputStream("data".getBytes()));
+
+        assertThat(document.text()).isEqualTo("# Batch");
+    }
+
+    private ConvertDocumentRequest captureConvertRequest() {
+        var captor = ArgumentCaptor.forClass(ConvertDocumentRequest.class);
+        verify(mockApi).convertSourceAsync(captor.capture());
+        return captor.getValue();
     }
 
     private void mockResponseWithMarkdown(String markdown) {
@@ -214,14 +486,14 @@ class DoclingDocumentParserTest {
     }
 
     private void mockResponseWith(String markdown, String html, String text, String doctags) {
-        when(mockApi.convertSource(any(ConvertDocumentRequest.class)))
-                .thenReturn(InBodyConvertDocumentResponse.builder()
+        when(mockApi.convertSourceAsync(any(ConvertDocumentRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(InBodyConvertDocumentResponse.builder()
                         .document(DocumentResponse.builder()
                                 .markdownContent(markdown)
                                 .htmlContent(html)
                                 .textContent(text)
                                 .doctagsContent(doctags)
                                 .build())
-                        .build());
+                        .build()));
     }
 }


### PR DESCRIPTION
## Issue

No separate tracked issue — this PR is the Docling parser enhancement discussed in review.

## Change

Enhances `DoclingDocumentParser` to control **which Docling operation runs**, **how the response becomes a `Document`**, and **how Docling is invoked**, and adds **non-blocking parsing**.

- **Operation selection via a `DocumentRequest` template.** `documentRequest(DocumentRequest)` carries everything except the document source; the parser injects the source per parse (`toBuilder().clearSources().source(src).build()`) and routes to the matching endpoint — convert, hierarchical chunk, or hybrid chunk. With the default executor the template must describe an in-body operation; a `BatchConvertDocumentRequest` or a non-in-body target is rejected at `build()`.
- **Response-to-`Document` extraction.** Per response kind you set *either* a text extractor *or* a full-`Document` extractor; the two variants of a pair are mutually exclusive (setting both throws at `build()`):
  - convert: `documentTextExtractor(Function<InBodyConvertDocumentResponse, String>)` / `documentExtractor(Function<InBodyConvertDocumentResponse, Document>)` (default: markdown)
  - chunk: `chunkTextExtractor(Function<ChunkDocumentResponse, String>)` / `chunkExtractor(Function<ChunkDocumentResponse, Document>)` (default: chunk text joined by newlines)

  The `Document`-returning variants enable provenance/metadata use cases; `document_size_bytes` metadata is always added.
- **Non-blocking parsing.** `parseAsync(InputStream)` returns `CompletionStage<Document>`, offloading the blocking read/request-prep and delivering failures through the stage; `parse(InputStream)` delegates to it.
- **Pluggable invocation via `DoclingRequestExecutor`.** By default the parser calls Docling's asynchronous convert/chunk endpoints (which submit, poll, and fetch on the common `ForkJoinPool`). A custom executor adds retry, runs the blocking call on your own executor, or drives fully custom orchestration, and lifts the request-type/target restrictions.
- **Endpoint/behaviour change.** The default invocation now targets the async convert/chunk endpoints (`convertSourceAsync`, `chunkSourceWith*Async`) instead of the synchronous in-body endpoint.
- **Dependency bump** to docling `0.6.4` (promotes `DocumentRequest.toBuilder()` onto the abstract base, enabling downcast-free source injection).
- Deprecated `Builder.options(ConvertDocumentOptions)` and the two `DoclingDocumentParser(...)` constructors remain (with `@deprecated` javadoc pointing to the builder).

`revapi.json` ignores the intentional exposure of Docling Serve API types (`DoclingServeApi`, `DocumentRequest`, `InBodyConvertDocumentResponse`, `ChunkDocumentResponse`, `ProcessedDocumentResponse`, `ConvertDocumentOptions`) and the core `Document` type on the parser / `DoclingRequestExecutor` API.

## Tests

- `DoclingDocumentParserTest` — 32 unit tests: operation routing, batch/non-in-body rejection, custom & default extractors (text and `Document`), extractor mutual-exclusivity failures, source-injection, `parseAsync` success and failed-stage (null/empty/executor-error) delivery, and custom `DoclingRequestExecutor`.
- `DoclingDocumentParserIT` — 6 Testcontainers integration tests.
- `./mvnw -pl document-parsers/langchain4j-document-parser-docling verify` — unit + IT + revapi green.
- Docs updated: `docs/docs/integrations/document-parsers/docling.md`.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
