### PR TITLE
fix(mcp): propagate WebSocket send failures

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
-import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -241,8 +241,10 @@ public class WebSocketMcpTransport implements McpTransport {
                 trafficLog.info("> " + messageJson);
             }
             synchronized (wsToUse) {
-                wsToUse.sendText(messageJson, true).thenAccept(ws -> {
-                    if (id == null) {
+                wsToUse.sendText(messageJson, true).whenComplete((ws, error) -> {
+                    if (error != null) {
+                        future.completeExceptionally(error);
+                    } else if (id == null) {
                         // for operations without an ID, consider them done immediately after the message was sent
                         future.complete(null);
                     }
@@ -395,5 +397,4 @@ public class WebSocketMcpTransport implements McpTransport {
     public void executeOperationWithoutResponse(McpCallContext context) {
         sendMessage(context);
     }
-
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/WebSocketMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/WebSocketMcpTransportTest.java
@@ -1,9 +1,19 @@
 package dev.langchain4j.mcp.client.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.mcp.client.transport.websocket.WebSocketMcpTransport;
+import dev.langchain4j.mcp.protocol.McpPingRequest;
 import java.lang.reflect.Field;
+import java.net.http.WebSocket;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import org.junit.jupiter.api.Test;
 
@@ -39,9 +49,53 @@ class WebSocketMcpTransportTest {
         assertThat(extractSslContext(transport)).isSameAs(reloadedContext);
     }
 
+    @Test
+    void shouldPropagateSendFailure() throws Exception {
+        RuntimeException sendFailure = new RuntimeException("send failed");
+        WebSocketMcpTransport transport = transportSending(CompletableFuture.failedFuture(sendFailure));
+
+        CompletableFuture<String> result = transport.sendRequest(new McpPingRequest(42L));
+
+        assertThat(result).isCompletedExceptionally();
+        assertThatThrownBy(result::get).isInstanceOf(ExecutionException.class).hasCause(sendFailure);
+    }
+
+    @Test
+    void shouldLeaveRequestPendingWhenSendSucceeds() throws Exception {
+        WebSocketMcpTransport transport = transportSending(CompletableFuture.completedFuture(mock(WebSocket.class)));
+
+        CompletableFuture<String> result = transport.sendRequest(new McpPingRequest(42L));
+
+        assertThat(result).isNotDone();
+    }
+
+    private static WebSocketMcpTransport transportSending(CompletableFuture<WebSocket> sendResult) throws Exception {
+        WebSocket webSocket = mock(WebSocket.class);
+        when(webSocket.sendText(anyString(), eq(true))).thenReturn(sendResult);
+        WebSocketMcpTransport transport =
+                WebSocketMcpTransport.builder().url("ws://localhost/mcp").build();
+        setField(transport, "operationHandler", mock(McpOperationHandler.class));
+        webSocketRef(transport).set(CompletableFuture.completedFuture(webSocket));
+        return transport;
+    }
+
     private static SSLContext extractSslContext(WebSocketMcpTransport transport) throws Exception {
         Field field = WebSocketMcpTransport.class.getDeclaredField("sslContext");
         field.setAccessible(true);
         return (SSLContext) field.get(transport);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static AtomicReference<CompletableFuture<WebSocket>> webSocketRef(WebSocketMcpTransport transport)
+            throws Exception {
+        Field field = WebSocketMcpTransport.class.getDeclaredField("webSocketRef");
+        field.setAccessible(true);
+        return (AtomicReference<CompletableFuture<WebSocket>>) field.get(transport);
+    }
+
+    private static void setField(WebSocketMcpTransport transport, String name, Object value) throws Exception {
+        Field field = WebSocketMcpTransport.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(transport, value);
     }
 }


### PR DESCRIPTION

## Issue
Closes #6258

## Change

`WebSocketMcpTransport.execute` attached `thenAccept` to the future returned by `WebSocket.sendText`, so the callback ran only on success and a failed send was discarded. The pending operation was never completed, and the caller blocked for its full timeout before failing with a timeout instead of the real cause.

`whenComplete` replaces it, so the failure completes the same future the caller holds:

```java
wsToUse.sendText(messageJson, true).whenComplete((ws, error) -> {
    if (error != null) {
        future.completeExceptionally(error);
    } else if (id == null) {
        future.complete(null);
    }
});
```

The success path is unchanged: an operation without an id still completes as soon as the message is sent, and a request still waits for the server's response.

Both sibling transports already behave this way. `StdioMcpTransport.execute` completes the future exceptionally when the write throws, and `StreamableHttpMcpTransport` attaches `exceptionally` to every stage of its send chain. This restores the same behaviour on the only transport whose send is asynchronous.

The pending entry registered through `expectResponse` is deliberately left in place when a send fails, matching what `StdioMcpTransport` does on the same path; changing that would affect all three transports and belongs in its own PR.

The diff also carries two formatting fixes in the same file, an import order and a trailing blank line, which `spotless:check` requires once the file is touched.

### Tests

- `WebSocketMcpTransportTest.shouldPropagateSendFailure` (new) proves a failed `sendText` completes the caller's future with that failure as its cause.
- `WebSocketMcpTransportTest.shouldLeaveRequestPendingWhenSendSucceeds` (new) proves a successful send still leaves a request pending until the server responds.

Both drive the real `execute` path through `sendRequest` with a stubbed `WebSocket`, so no server and no network are involved. One of the two fails on unmodified `main`; the second passes either way and is there to guard the success path that the fix reorders.

```
mvn -o -pl langchain4j-mcp test
Tests run: 217, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1282, Failures: 0, Errors: 0, Skipped: 5

mvn -o -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-mcp spotless:check
BUILD SUCCESS
```

The module's integration tests were not run: they need a live MCP server.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)