### PR TITLE
Fix: Prevent retired stdio processes from cancelling active operations

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -6,8 +6,8 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
-import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -60,21 +60,33 @@ public class StdioMcpTransport implements McpTransport {
         log.debug("Starting process: {}", command);
         ProcessBuilder processBuilder = new ProcessBuilder(command);
         processBuilder.environment().putAll(environment);
+        Process startedProcess;
         try {
-            process = processBuilder.start();
-            log.debug("PID of the started process: {}", process.pid());
-            process.onExit().thenRun(() -> {
-                if (messageHandler != null) {
-                    messageHandler.cancelAllPendingOperations("Process has exited");
+            startedProcess = processBuilder.start();
+            synchronized (this) {
+                process = startedProcess;
+            }
+            log.debug("PID of the started process: {}", startedProcess.pid());
+            startedProcess.onExit().thenRun(() -> {
+                McpOperationHandler handlerToCancel;
+                synchronized (this) {
+                    handlerToCancel = process == startedProcess ? messageHandler : null;
                 }
-                log.debug("Subprocess has exited with code: {}", process.exitValue());
+                if (handlerToCancel != null) {
+                    handlerToCancel.cancelAllPendingOperations("Process has exited");
+                }
+                log.debug("Subprocess has exited with code: {}", startedProcess.exitValue());
             });
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
         jsonRpcIoHandler = new JsonRpcIoHandler(
-                process.getInputStream(), process.getOutputStream(), messageHandler::onMessage, logEvents, logger);
-        stderrHandler = new ProcessStderrHandler(process);
+                startedProcess.getInputStream(),
+                startedProcess.getOutputStream(),
+                messageHandler::onMessage,
+                logEvents,
+                logger);
+        stderrHandler = new ProcessStderrHandler(startedProcess);
         executorService.submit(jsonRpcIoHandler);
         executorService.submit(stderrHandler);
     }
@@ -141,6 +153,16 @@ public class StdioMcpTransport implements McpTransport {
      * before starting a replacement process during reconnection.
      */
     private void stopCurrentProcess() {
+        Process processToStop;
+        McpOperationHandler handlerToCancel;
+        synchronized (this) {
+            processToStop = process;
+            process = null;
+            handlerToCancel = processToStop != null ? messageHandler : null;
+        }
+        if (handlerToCancel != null) {
+            handlerToCancel.cancelAllPendingOperations("Process has exited");
+        }
         if (stderrHandler != null) {
             try {
                 stderrHandler.close();
@@ -155,9 +177,8 @@ public class StdioMcpTransport implements McpTransport {
             }
             jsonRpcIoHandler = null;
         }
-        if (process != null) {
-            process.destroy();
-            process = null;
+        if (processToStop != null) {
+            processToStop.destroy();
         }
     }
 
@@ -307,5 +328,4 @@ public class StdioMcpTransport implements McpTransport {
     public void executeOperationWithoutResponse(McpCallContext context) {
         sendMessage(context);
     }
-
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransportTest.java
@@ -1,10 +1,16 @@
 package dev.langchain4j.mcp.client.transport.stdio;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -13,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 class StdioMcpTransportTest {
 
@@ -57,5 +64,72 @@ class StdioMcpTransportTest {
         } finally {
             executorService.shutdownNow();
         }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void retired_process_should_not_cancel_replacement_operations(@TempDir Path tempDir)
+            throws IOException, InterruptedException {
+        Path releaseExit = tempDir.resolve("release-exit");
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        StdioMcpTransport transport = transportWithBlockedExit(releaseExit, executorService);
+        McpOperationHandler messageHandler = mock(McpOperationHandler.class);
+
+        try {
+            transport.start(messageHandler);
+            Process firstProcess = transport.getProcess();
+            verify(messageHandler, timeout(5_000)).onMessage("{\"ready\":true}");
+
+            transport.start(messageHandler);
+            Process secondProcess = transport.getProcess();
+            verify(messageHandler, timeout(5_000).times(2)).onMessage("{\"ready\":true}");
+            clearInvocations(messageHandler);
+
+            Files.write(releaseExit, new byte[0]);
+            assertThat(firstProcess.waitFor(5, TimeUnit.SECONDS)).isTrue();
+
+            verify(messageHandler, after(1_000).never()).cancelAllPendingOperations("Process has exited");
+            assertThat(secondProcess.isAlive()).isTrue();
+        } finally {
+            Files.write(releaseExit, new byte[0]);
+            transport.close();
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void retiring_a_process_should_cancel_its_own_pending_operations(@TempDir Path tempDir)
+            throws IOException, InterruptedException {
+        Path releaseExit = tempDir.resolve("release-exit");
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        StdioMcpTransport transport = transportWithBlockedExit(releaseExit, executorService);
+        McpOperationHandler messageHandler = mock(McpOperationHandler.class);
+
+        try {
+            transport.start(messageHandler);
+            Process firstProcess = transport.getProcess();
+            verify(messageHandler, timeout(5_000)).onMessage("{\"ready\":true}");
+            clearInvocations(messageHandler);
+
+            transport.start(messageHandler);
+
+            verify(messageHandler).cancelAllPendingOperations("Process has exited");
+            assertThat(firstProcess.isAlive()).isTrue();
+        } finally {
+            Files.write(releaseExit, new byte[0]);
+            transport.close();
+            executorService.shutdownNow();
+        }
+    }
+
+    private static StdioMcpTransport transportWithBlockedExit(Path releaseExit, ExecutorService executorService) {
+        String script = "trap 'while [ ! -f \"$1\" ]; do sleep 0.01; done; exit 0' TERM; "
+                + "printf '{\"ready\":true}\\n'; while :; do sleep 1; done";
+        return new StdioMcpTransport.Builder()
+                .command(List.of("sh", "-c", script, "sh", releaseExit.toString()))
+                .environment(Map.of())
+                .executorService(executorService)
+                .build();
     }
 }


### PR DESCRIPTION

## Issue
Closes #6260

## Change

`StdioMcpTransport.start` registered an `onExit` callback that cancelled all pending operations unconditionally and read the mutable `process` field instead of the process it was registered for. After a reconnect the retired subprocess is reaped while the replacement is already serving requests, so its callback cancelled the replacement's in-flight operations and logged `exitValue()` from the wrong process.

The callback now captures the process it belongs to and acts only while that process is still the current one:

```java
McpOperationHandler handlerToCancel;
synchronized (this) {
    handlerToCancel = process == startedProcess ? messageHandler : null;
}
if (handlerToCancel != null) {
    handlerToCancel.cancelAllPendingOperations("Process has exited");
}
```

The I/O and stderr handlers are bound to the same captured process rather than the field.

That guard alone would leave a retired process's own operations outstanding forever, since its exit callback is what used to cancel them. `stopCurrentProcess` therefore cancels them as it retires the process, which also makes the timing deterministic rather than dependent on when the OS reaps the subprocess. The two halves are one concern and neither is correct without the other. Cancellation happens outside the lock in both places so the transport monitor is never held while the operation handler's own lock is taken.

This completes the reconnect teardown established by #5757, which introduced `stopCurrentProcess` but left the exit callback acting for a process the transport had already retired.

The diff also carries two formatting fixes in the same file, an import order and a trailing blank line, which `spotless:check` requires once the file is touched.

### Tests

- `StdioMcpTransportTest.retired_process_should_not_cancel_replacement_operations` (new) proves a retired subprocess cancels nothing once the replacement is live.
- `StdioMcpTransportTest.retiring_a_process_should_cancel_its_own_pending_operations` (new) proves retiring a subprocess cancels its own pending operations while it is still alive.

Both are deterministic rather than timing-dependent: the subprocess traps `TERM` and blocks its exit until the test releases it, so the retired process is reaped at a point the test controls. Both fail on unmodified `main`, the first with `Wanted at most 0 times but was 1` and the second with `Wanted but not invoked`.

```
mvn -o -pl langchain4j-mcp test
Tests run: 217, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1282, Failures: 0, Errors: 0, Skipped: 5

mvn -o -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-mcp spotless:check
BUILD SUCCESS
```

The module's integration tests were not run: they need a live MCP server.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
