### PR TITLE
fix(mcp): make x-mcp-header duplicate detection locale-independent

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -366,7 +367,7 @@ class ToolSpecificationHelper {
             errors.add("x-mcp-header value '" + headerName + "' is not a valid HTTP token (property '" + propertyPath
                     + "')");
         }
-        if (!seenHeaderNamesLower.add(headerName.toLowerCase())) {
+        if (!seenHeaderNamesLower.add(headerName.toLowerCase(Locale.ROOT))) {
             errors.add("duplicate x-mcp-header value '" + headerName + "' (case-insensitive, property '" + propertyPath
                     + "')");
         }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperLocaleTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperLocaleTest.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.mcp.client.transport.McpJson;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * and single-threaded to avoid races with the otherwise parallel test suite.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class ToolSpecificationHelperLocaleTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ"})
+    void toolWithDuplicateCaseInsensitiveMcpHeaderIsExcludedInAnyLocale(String languageTag) {
+        String text = """
+                [{
+                    "name": "bad_tool",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "first": {
+                          "type": "string",
+                          "x-mcp-header": "ID"
+                        },
+                        "second": {
+                          "type": "string",
+                          "x-mcp-header": "id"
+                        }
+                      }
+                    }
+                }]
+                """;
+
+        withDefaultLocale(languageTag, () -> {
+            List<Map<String, Object>> json = McpJson.deserialize(McpJson.parse(text), List.class);
+            assertThat(ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json))
+                    .isEmpty();
+        });
+    }
+
+    private static void withDefaultLocale(String languageTag, Runnable action) {
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
+            action.run();
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}


### PR DESCRIPTION

## Issue
Closes #6262

## Change

`ToolSpecificationHelper` rejects a tool whose schema declares two `x-mcp-header` values differing only in case, and the error it raises calls that check case-insensitive. It lowercased each name with the JVM default locale, so under a Turkish or Azerbaijani locale `"ID"` becomes `"ıd"` while `"id"` stays `"id"`, the names stop colliding, and the tool is accepted with two parameters mapping to the same HTTP header.

The lowercasing now uses `Locale.ROOT`:

```java
if (!seenHeaderNamesLower.add(headerName.toLowerCase(Locale.ROOT))) {
```

This is the same fix and the same reasoning as #6235, which made MCP log level parsing locale-independent, and as #6147, #5961 and #5861 elsewhere in the project.

I swept every `toLowerCase`/`toUpperCase` call in `langchain4j-mcp`: this was the only one still using the default locale. `McpLogLevel` and `McpPromptContent` already pass `Locale.ROOT`, so the module is now consistent.

The existing `toolWithDuplicateCaseInsensitiveMcpHeaderIsExcluded` test uses `"Region"` and `"region"`, which the Turkish casing rules do not affect, which is why it never caught this.

### Tests

- `ToolSpecificationHelperLocaleTest` (new) proves the duplicate is detected and the tool excluded under `tr-TR` and `az-AZ`.

Both cases fail on unmodified `main`, where the tool is returned carrying `mcp-param-headers={first=ID, second=id}`. The class sets and restores the JVM default locale, so it is annotated `@Isolated` and `SAME_THREAD` to keep it out of the parallel suite, matching the test added by #6235.

```
mvn -o -pl langchain4j-mcp test
Tests run: 217, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1282, Failures: 0, Errors: 0, Skipped: 5

mvn -o -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-mcp spotless:check
BUILD SUCCESS
```

The module's integration tests were not run: they need a live MCP server.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
