### PR TITLE
fix(mcp): send cancellation notifications for timed-out paginated lists

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -1421,10 +1421,14 @@ public class DefaultMcpClient implements McpClient {
             McpCallContext context = new McpCallContext(invocationContext, operation);
             applyMeta(operation, context);
             JsonNode result;
+            CompletableFuture<JsonNode> resultFuture = null;
             try {
-                CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
+                resultFuture = executeViaTransport(context);
                 result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
-            } catch (ExecutionException | InterruptedException | TimeoutException e) {
+            } catch (TimeoutException e) {
+                cancelTimedOutOperation(e, operation.getId(), resultFuture);
+                throw new RuntimeException(e);
+            } catch (ExecutionException | InterruptedException e) {
                 throw new RuntimeException(e);
             } finally {
                 pendingOperations.remove(operation.getId());

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -1620,6 +1620,54 @@ public class DefaultMcpClientTest {
     }
 
     @Test
+    public void list_timeout_over_stdio_sends_cancellation_notification_modern() throws Exception {
+        McpTransport transport = getModernStdioTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .toolExecutionTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        assertThatThrownBy(client::listTools).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
+    public void list_timeout_over_http_does_not_send_cancellation_notification_modern() throws Exception {
+        McpTransport transport = getModernHttpTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .toolExecutionTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        assertThatThrownBy(client::listTools).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, never()).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
     public void timeout_over_http_sends_cancellation_notification_legacy() throws Exception {
         McpTransport transport = getLegacyHttpTransportMock();
 


### PR DESCRIPTION
## Issue
Closes #6266

## Change

`fetchPaginatedList` caught `TimeoutException` together with `ExecutionException` and `InterruptedException` and only removed the operation from `pendingOperations`. The local response future stayed alive after the caller had already timed out, and the server was never told the request was abandoned. This covered `listTools()`, `listResources()`, `listResourceTemplates()` and `listPrompts()`, on every page.

The timeout now goes through the same cleanup the other request paths use:

```java
} catch (TimeoutException e) {
    cancelTimedOutOperation(e, operation.getId(), resultFuture);
    throw new RuntimeException(e);
} catch (ExecutionException | InterruptedException e) {
    throw new RuntimeException(e);
}
```

`cancelTimedOutOperation` cancels the future, drops the pending entry and sends `notifications/cancelled` only when the transport requires it. The exception surface is unchanged: callers still get a `RuntimeException` wrapping the timeout, and `ExecutionException` and `InterruptedException` behave exactly as before.

This completes the behaviour established by #6175, which fixed the read, prompt and subscribe paths after #6159 raised it. That issue named the paginated list path as possibly affected and it was not part of the implementation.

I checked the remaining timeout handlers: this was the last user-facing request path without the cleanup. The two health-check paths still catch the timeout plainly, which looks deliberate, since a failed health check triggers a reconnection that tears the transport down, so cancelling one request and notifying a server the client is about to drop would achieve nothing. I left them alone.

### Tests

- `DefaultMcpClientTest.list_timeout_over_stdio_sends_cancellation_notification_modern` (new) proves a timed-out `listTools()` cancels the future and sends one cancellation notification.
- `DefaultMcpClientTest.list_timeout_over_http_does_not_send_cancellation_notification_modern` (new) proves the same call cancels the future but sends no notification where the transport does not require one.

Both mirror the pair added by #6175 for `tools/call`. Both fail on unmodified `main` on `assertThat(neverCompletes.isCancelled()).isTrue()`.

```
mvn -o -pl langchain4j-mcp test
Tests run: 219, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1282, Failures: 0, Errors: 0, Skipped: 5

mvn -o -pl langchain4j test
Tests run: 1392, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-mcp spotless:check
BUILD SUCCESS
```

The module's integration tests were not run: they need a live MCP server.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
