### PR TITLE
fix(mcp): preserve JSON-RPC error data in McpException

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpErrorHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpErrorHelper.java
@@ -14,7 +14,10 @@ class McpErrorHelper {
         McpErrorResponse.Error error =
                 McpJson.deserialize(mcpMessage, McpErrorResponse.class).getError();
         if (error != null) {
-            throw new McpException(error.getCode(), error.getMessage());
+            throw McpException.withErrorData(
+                    error.getCode(),
+                    error.getMessage(),
+                    error.getData() == null ? null : McpJson.serialize(error.getData()));
         }
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -217,6 +217,28 @@ public class DefaultMcpClientTest {
     }
 
     @Test
+    public void should_preserve_error_data_when_tool_list_is_refused() throws Exception {
+        final McpTransport transport = getMinimalMcpTransportMock();
+        final DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+        final ObjectNode errorResponse = JsonNodeFactory.instance.objectNode();
+        errorResponse.put("jsonrpc", "2.0").put("id", 1);
+        final ObjectNode error = errorResponse.putObject("error");
+        error.put("code", -32001).put("message", "Rate limited");
+        error.putObject("data").put("retryAfter", 5);
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse));
+
+        final Throwable thrown = catchThrowable(client::listTools);
+
+        assertThat(thrown).isInstanceOf(McpException.class);
+        final McpException exception = (McpException) thrown;
+        assertThat(exception.errorCode()).isEqualTo(-32001);
+        assertThat(exception.errorDataAsJson()).isEqualTo("{\"retryAfter\":5}");
+        assertThat(exception.errorDataAsMap()).containsEntry("retryAfter", 5);
+    }
+
+    @Test
     public void should_cache_tool_list() throws Exception {
         // given
         final McpTransport transport = getMinimalMcpTransportMock();


### PR DESCRIPTION

## Issue
Closes #6277

## Change

`McpErrorHelper.checkForErrors` deserialised the whole JSON-RPC error and then built the exception from the code and message only, so the `data` member was dropped. `McpException` publishes that member through `errorDataAsJson()`, `errorDataAsMap()` and `errorDataAsObject()`, and all three always returned null for every operation that goes through this check: tool, resource, resource-template and prompt listing, resource reads, prompt rendering and subscription errors.

It now builds the exception the same way the discovery path already does:

```java
throw McpException.withErrorData(
        error.getCode(),
        error.getMessage(),
        error.getData() == null ? null : McpJson.serialize(error.getData()));
```

That is the existing call in `DefaultMcpClient`, unchanged. `withErrorData` arrived with #6117 and discovery was moved onto it; this helper was not. The exception type, code, message and control flow are untouched, and an error without a `data` member still produces null, so nothing that works today behaves differently.

I checked the other places that hold a parsed error. `errorMessageOf` extracts only the message on purpose, since it builds a string rather than an exception, and `ToolExecutionHelper` raises `ToolArgumentsException` and `ToolExecutionException`, which have no data member at all; giving them one would change their public API and is not part of this. So this helper was the only place constructing an `McpException` without the field.

### Tests

- `DefaultMcpClientTest.should_preserve_error_data_when_tool_list_is_refused` (new) proves a refused `listTools()` surfaces the server's `data` through both `errorDataAsJson()` and `errorDataAsMap()`, alongside the existing code and message.

It fails on unmodified `main`, where both accessors return null. It sits beside `should_throw_mcp_exception_when_tool_list_is_refused`, which already covers the code and message on the same path and still passes unchanged.

```
mvn -o -pl langchain4j-mcp test
Tests run: 224, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1363, Failures: 0, Errors: 0, Skipped: 5

mvn -o -pl langchain4j test
Tests run: 1703, Failures: 0, Errors: 0, Skipped: 19

mvn -o -pl langchain4j-mcp spotless:check
BUILD SUCCESS
```

The module's integration tests were not run: they need a live MCP server.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
