### PR TITLE
Fix @P name being ignored when agent arguments are written into the AgenticScope

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentInvoker.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentInvoker.java
@@ -1,5 +1,12 @@
 package dev.langchain4j.agentic.internal;
 
+import static dev.langchain4j.agentic.internal.AgentUtil.AGENTIC_SCOPE_ARG_NAME;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgentInvocation;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.agentError;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agentic.UntypedAgent;
 import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.agentic.agent.ChatMessagesAccess;
 import dev.langchain4j.agentic.agent.MissingArgumentException;
@@ -8,7 +15,6 @@ import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.AgenticSystemSuspendedException;
-import dev.langchain4j.agentic.UntypedAgent;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.service.ParameterNameResolver;
@@ -18,23 +24,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static dev.langchain4j.agentic.internal.AgentUtil.AGENTIC_SCOPE_ARG_NAME;
-import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgentInvocation;
-import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.agentError;
-import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
-
 public interface AgentInvoker extends AgentInstance, InternalAgent {
 
     Method method();
 
     AgentInvocationArguments toInvocationArguments(AgenticScope agenticScope) throws MissingArgumentException;
 
-    default Object invoke(DefaultAgenticScope agenticScope, Object agent, AgentInvocationArguments args) throws AgentInvocationException {
+    default Object invoke(DefaultAgenticScope agenticScope, Object agent, AgentInvocationArguments args)
+            throws AgentInvocationException {
         AgentListener listener = listener();
         beforeAgentInvocation(listener, agenticScope, this, args.namedArgs());
         Object result = internalInvoke(agenticScope, listener, agent, args);
         if (agent instanceof ChatMessagesAccess chatMessagesAccess) {
-            afterAgentInvocation(listener, agenticScope, this, args.namedArgs(), result,
+            afterAgentInvocation(
+                    listener,
+                    agenticScope,
+                    this,
+                    args.namedArgs(),
+                    result,
                     chatMessagesAccess.lastChatRequest(agenticScope.memoryId()),
                     chatMessagesAccess.lastChatResponse(agenticScope.memoryId()));
         } else {
@@ -43,7 +50,8 @@ public interface AgentInvoker extends AgentInstance, InternalAgent {
         return result;
     }
 
-    private Object internalInvoke(DefaultAgenticScope agenticScope, AgentListener listener, Object agent, AgentInvocationArguments args) {
+    private Object internalInvoke(
+            DefaultAgenticScope agenticScope, AgentListener listener, Object agent, AgentInvocationArguments args) {
         LangChain4jManaged.setCurrent(Map.of(AgenticScope.class, agenticScope));
         try {
             return method().invoke(agent, args.positionalArgs());
@@ -52,7 +60,8 @@ public interface AgentInvoker extends AgentInstance, InternalAgent {
             if (cause instanceof AgenticSystemSuspendedException suspended) {
                 throw suspended;
             }
-            AgentInvocationException invocationException = new AgentInvocationException("Failed to invoke agent method: " + method(), e);
+            AgentInvocationException invocationException =
+                    new AgentInvocationException("Failed to invoke agent method: " + method(), e);
             agentError(listener, agenticScope, this, args.namedArgs(), invocationException);
             throw invocationException;
         } finally {
@@ -64,8 +73,14 @@ public interface AgentInvoker extends AgentInstance, InternalAgent {
         List<AgentArgument> arguments = spec.arguments() != null
                 ? spec.arguments()
                 : List.of(new AgentArgument(AgenticScope.class, AGENTIC_SCOPE_ARG_NAME));
-        InternalAgent agentInstance = new NonAiAgentInstance(agenticMethod.getDeclaringClass(),
-                name, spec.description(), agenticMethod.getGenericReturnType(), spec.outputKey(), spec.async(), arguments,
+        InternalAgent agentInstance = new NonAiAgentInstance(
+                agenticMethod.getDeclaringClass(),
+                name,
+                spec.description(),
+                agenticMethod.getGenericReturnType(),
+                spec.outputKey(),
+                spec.async(),
+                arguments,
                 spec.listener());
         return new SpecAgentInvoker(agenticMethod, agentInstance);
     }
@@ -80,10 +95,15 @@ public interface AgentInvoker extends AgentInstance, InternalAgent {
 
     static String parameterName(Parameter parameter) {
         return optionalParameterName(parameter)
-                .orElseThrow(() -> new IllegalArgumentException("Parameter name not specified and no @V or @K annotation present: " + parameter));
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Parameter name not specified and no @V or @K annotation present: " + parameter));
     }
 
     static Optional<String> optionalParameterName(Parameter parameter) {
+        P p = parameter.getAnnotation(P.class);
+        if (p != null && !p.name().isBlank()) {
+            return Optional.of(p.name());
+        }
         return Optional.ofNullable(ParameterNameResolver.name(parameter));
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -36,7 +36,6 @@ import dev.langchain4j.agentic.workflow.impl.ParallelMapperServiceImpl;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.service.MemoryId;
-import dev.langchain4j.service.ParameterNameResolver;
 import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import java.lang.reflect.InvocationHandler;
@@ -260,7 +259,10 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         }
         Map<String, Object> namedArgs = new HashMap<>();
         for (int i = 0; i < args.length; i++) {
-            namedArgs.put(ParameterNameResolver.name(method.getParameters()[i]), args[i]);
+            namedArgs.put(
+                    AgentInvoker.optionalParameterName(method.getParameters()[i])
+                            .orElse(null),
+                    args[i]);
         }
         return namedArgs;
     }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/RootArgumentNameTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/RootArgumentNameTest.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.observability.AgentRequest;
+import dev.langchain4j.service.V;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RootArgumentNameTest {
+
+    public static class Categorizer {
+
+        @Agent(outputKey = "category")
+        public String categorize(@V("request") String request) {
+            return "category of " + request;
+        }
+    }
+
+    public interface NamedArgumentWorkflow {
+
+        @Agent(outputKey = "category")
+        String process(@P(name = "request") String userRequest);
+    }
+
+    public interface DescribedArgumentWorkflow {
+
+        @Agent(outputKey = "category")
+        String process(@V("request") @P("The request to categorize") String userRequest);
+    }
+
+    static class InputKeyRecordingListener implements AgentListener {
+
+        private final List<Map<String, Object>> inputs = new ArrayList<>();
+
+        @Override
+        public void beforeAgentInvocation(AgentRequest agentRequest) {
+            inputs.add(agentRequest.inputs());
+        }
+
+        Map<String, Object> firstInputs() {
+            return inputs.get(0);
+        }
+    }
+
+    @Test
+    void root_argument_is_readable_under_the_name_declared_by_p() {
+        NamedArgumentWorkflow workflow = AgenticServices.sequenceBuilder(NamedArgumentWorkflow.class)
+                .subAgents(new Categorizer())
+                .outputKey("category")
+                .build();
+
+        assertThat(workflow.process("refund")).isEqualTo("category of refund");
+    }
+
+    @Test
+    void root_argument_keeps_the_v_name_when_p_only_carries_a_description() {
+        DescribedArgumentWorkflow workflow = AgenticServices.sequenceBuilder(DescribedArgumentWorkflow.class)
+                .subAgents(new Categorizer())
+                .outputKey("category")
+                .build();
+
+        assertThat(workflow.process("refund")).isEqualTo("category of refund");
+    }
+
+    @Test
+    void workflow_listener_receives_the_root_argument_named_by_p() {
+        InputKeyRecordingListener listener = new InputKeyRecordingListener();
+        NamedArgumentWorkflow workflow = AgenticServices.sequenceBuilder(NamedArgumentWorkflow.class)
+                .subAgents(new Categorizer())
+                .listener(listener)
+                .outputKey("category")
+                .build();
+
+        workflow.process("refund");
+
+        assertThat(listener.firstInputs()).containsExactly(Map.entry("request", "refund"));
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6282

## Change

`@P(name = "...")` on an `@Agent` method parameter was honoured when the agent's arguments were built but ignored when the invoked method's arguments were written into the `AgenticScope`.

`AgentUtil.parameterName` reads `@P` first (`AgentUtil.java:209-212`), so a planner and every sub-agent look a value up under the declared name. `writeAgenticScope` resolved the same parameter through `AgentInvoker.optionalParameterName`, which did not read `@P`, so the value was stored under the reflective parameter name or, without the `-parameters` javac option, not stored at all. A sub-agent requiring the declared name then failed with `MissingArgumentException`. `argToMap` had the same gap, so the invocation reported to an `AgentListener` carried a `null` key instead of the declared name.

`optionalParameterName` now resolves `@P` before delegating, which is the single point both paths already share:

```java
static Optional<String> optionalParameterName(Parameter parameter) {
    P p = parameter.getAnnotation(P.class);
    if (p != null && !p.name().isBlank()) {
        return Optional.of(p.name());
    }
    return Optional.ofNullable(ParameterNameResolver.name(parameter));
}
```

The precedence matches `AgentUtil.parameterName`, and `@V`, `@K` and `@MemoryId` keep resolving exactly as before: only a `@P` carrying a non-blank `name` changes anything. The `@P` check in `AgentUtil.parameterName` stays where it is, because there it has to run ahead of the `@MemoryId` and `@AgenticScope` names.

This is the case `@P` documents itself for: without `-parameters`, reflection yields `arg0`, and `name` is what restores a meaningful one.

The alternative is to teach `AgenticParameterNameResolver` about `@P`. I did not, because it is registered as the `ParameterNameResolver` service and so also drives `{{...}}` variable resolution for every AI service on a classpath that includes this module; if you would rather have it there, that is a small change and I am happy to switch.

Deliberately out of scope: on a standalone AI-service agent, `@P(name = ...)` still does not reach the prompt template, because `DefaultAiServices.prepareUserMessage` resolves `{{...}}` through the same service. That is core template resolution rather than agent argument binding, and it wants its own change.

`AgentInvoker.java` is not spotless-clean on `main`, so `spotless:apply` reformatted it: the change itself is 5 added lines, the other 28 added and 13 removed lines are the formatter.

### Tests

- `RootArgumentNameTest` (new): `root_argument_is_readable_under_the_name_declared_by_p` proves a sub-agent declaring `@V("request")` receives the value passed for `@P(name = "request")`; `workflow_listener_receives_the_root_argument_named_by_p` proves the `AgentListener` sees `request` rather than `null`.
- `root_argument_keeps_the_v_name_when_p_only_carries_a_description` is the guard for the other direction: a `@P` with only a description must not change the resolved name. It passes on unmodified `main` and is there to keep the fix from widening.

Two of the three fail on unmodified `main`. Each production file was reverted on its own to confirm it: without the `AgentInvoker` change both fail with `MissingArgumentException: Missing argument: request`; without the `PlannerBasedInvocationHandler` change only the listener test fails.

```
mvn -pl langchain4j-agentic clean verify
Tests run: 126, Failures: 0, Errors: 0, Skipped: 0
Tests run: 149, Failures: 0, Errors: 0, Skipped: 121
revapi:0.15.1:check (default) @ langchain4j-agentic
BUILD SUCCESS

mvn -pl langchain4j-core test     Tests run: 1354, Failures: 0, Errors: 0, Skipped: 3
mvn -pl langchain4j test          Tests run: 1703, Failures: 0, Errors: 0, Skipped: 19
```

The 121 skipped integration tests are the ones gated on a model API key; the rest of the module's ITs ran.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
