### PR TITLE
fix: guarantee AgenticScope cleanup on Planner initialization failure

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -215,11 +215,10 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
             beforeAgentInvocation(agentListener, currentScope, this, namedArgs);
         }
 
-        Planner planner = plannerSupplier.get();
-        planner.init(new InitPlanningContext(currentScope, this, subagents));
-
         Object result;
         try {
+            Planner planner = plannerSupplier.get();
+            planner.init(new InitPlanningContext(currentScope, this, subagents));
             result = new PlannerLoop(planner, currentScope, registry).loop();
         } catch (Exception e) {
             currentScope.compensateAll();

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/PlannerInitFailureTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/PlannerInitFailureTest.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
+import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.planner.Action;
+import dev.langchain4j.agentic.planner.InitPlanningContext;
+import dev.langchain4j.agentic.planner.Planner;
+import dev.langchain4j.agentic.planner.PlanningContext;
+import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import org.junit.jupiter.api.Test;
+
+class PlannerInitFailureTest {
+
+    public static class FailingInitPlanner implements Planner {
+
+        @Override
+        public void init(InitPlanningContext initPlanningContext) {
+            throw new IllegalStateException("planner initialization failed");
+        }
+
+        @Override
+        public Action nextAction(PlanningContext planningContext) {
+            return done();
+        }
+    }
+
+    public interface FailingPlannerWorkflow {
+
+        @Agent
+        String run();
+    }
+
+    private static FailingPlannerWorkflow workflowWith(AgentMonitor monitor) {
+        return AgenticServices.plannerBuilder(FailingPlannerWorkflow.class)
+                .subAgents(AgenticServices.agentAction(agenticScope -> agenticScope.writeState("unused", "value")))
+                .planner(FailingInitPlanner::new)
+                .listener(monitor)
+                .build();
+    }
+
+    @Test
+    void ephemeral_agentic_scope_is_evicted_when_planner_init_fails() {
+        AgentMonitor monitor = new AgentMonitor();
+        FailingPlannerWorkflow workflow = workflowWith(monitor);
+
+        assertThatThrownBy(workflow::run).isInstanceOf(IllegalStateException.class);
+
+        AgenticScopeRegistry registry = ((AgenticScopeOwner) workflow).registry();
+        assertThat(registry.getAllAgenticScopeKeysInMemory()).isEmpty();
+    }
+
+    @Test
+    void monitor_has_no_ongoing_execution_when_planner_init_fails() {
+        AgentMonitor monitor = new AgentMonitor();
+        FailingPlannerWorkflow workflow = workflowWith(monitor);
+
+        assertThatThrownBy(workflow::run).isInstanceOf(IllegalStateException.class);
+
+        assertThat(monitor.ongoingExecutions()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6285

## Change

`executeAgentMethod` started the root call and notified the listeners, then obtained the planner and called `Planner.init(...)`, and only then entered the `try` whose `catch` evicts the scope, records the error and compensates. An exception from `init` escaped before any of that ran, so the ephemeral `AgenticScope` was never evicted, `AgentMonitor` kept the invocation in `ongoingExecutions()` forever as `duration=in progress`, no failed execution was recorded, and `compensateAll()` never ran. `Planner` is a public extension point supplied through `AgenticServices.plannerBuilder(...).planner(...)`, so `init` can fail on user code.

Both statements now sit inside the existing `try`:

```java
Object result;
try {
    Planner planner = plannerSupplier.get();
    planner.init(new InitPlanningContext(currentScope, this, subagents));
    result = new PlannerLoop(planner, currentScope, registry).loop();
} catch (Exception e) {
    currentScope.compensateAll();
    ...
```

No new code and no new cleanup path: the two statements simply move under the handler that already existed two lines below, and `planner` was never read after the `try`. The exception is rethrown unchanged, so a caller still sees exactly what `init` threw. `plannerSupplier.get()` moves with it because it has the same exposure.

The leak matters because an ephemeral scope is meant to be short-lived: `DefaultAgenticScope.java:237-239` evicts it immediately on `rootCallEnded` precisely because it is single-use.

### Tests

- `PlannerInitFailureTest` (new): `ephemeral_agentic_scope_is_evicted_when_planner_init_fails` asserts the registry is empty after the failure, using the same `((AgenticScopeOwner) workflow).registry()` check the suspension and recoverability suites use; `monitor_has_no_ongoing_execution_when_planner_init_fails` asserts `AgentMonitor.ongoingExecutions()` is empty. Both also assert the `IllegalStateException` still reaches the caller, so the fix cannot pass by swallowing it.

Both fail on unmodified `main`, with `Expecting empty but was: [AgenticScopeKey[...]]` and `Expecting empty but was: {...duration=in progress...}`. There is one production file, and reverting it fails both.

```
mvn -pl langchain4j-agentic clean verify
Tests run: 125, Failures: 0, Errors: 0, Skipped: 0
Tests run: 149, Failures: 0, Errors: 0, Skipped: 121
revapi:0.15.1:check (default) @ langchain4j-agentic
BUILD SUCCESS

mvn -pl langchain4j-core test     Tests run: 1354, Failures: 0, Errors: 0, Skipped: 3
mvn -pl langchain4j test          Tests run: 1703, Failures: 0, Errors: 0, Skipped: 19
```

The 121 skipped integration tests are the ones gated on a model API key; the rest of the module's ITs ran.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
