### PR TITLE
fix(mcp): encode blob resource contents with standard Base64 (#6279)

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpBlobResourceContents.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpBlobResourceContents.java
@@ -4,7 +4,6 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Base64;
 import java.util.Objects;
 
@@ -22,15 +21,16 @@ public final class McpBlobResourceContents implements McpResourceContents {
     }
 
     public static McpBlobResourceContents create(String uri, byte[] blob) {
-        return new McpBlobResourceContents(uri, Base64.getMimeEncoder().encodeToString(blob), null);
+        // Use the standard Base64 encoder: the MCP schema defines 'blob' as plain Base64, while the
+        // MIME encoder inserts CRLF line breaks every 76 characters, which strict decoders reject.
+        return new McpBlobResourceContents(uri, Base64.getEncoder().encodeToString(blob), null);
     }
 
     @JsonCreator
     public McpBlobResourceContents(
             @JsonProperty("uri") String uri,
             @JsonProperty("blob") String blob,
-            @JsonProperty("mimeType") String mimeType
-    ) {
+            @JsonProperty("mimeType") String mimeType) {
         ensureNotNull(uri, "uri");
         ensureNotNull(blob, "blob");
         this.uri = uri;
@@ -60,9 +60,9 @@ public final class McpBlobResourceContents implements McpResourceContents {
         if (obj == this) return true;
         if (obj == null || obj.getClass() != this.getClass()) return false;
         var that = (McpBlobResourceContents) obj;
-        return Objects.equals(this.uri, that.uri) &&
-                Objects.equals(this.blob, that.blob) &&
-                Objects.equals(this.mimeType, that.mimeType);
+        return Objects.equals(this.uri, that.uri)
+                && Objects.equals(this.blob, that.blob)
+                && Objects.equals(this.mimeType, that.mimeType);
     }
 
     @Override
@@ -72,9 +72,6 @@ public final class McpBlobResourceContents implements McpResourceContents {
 
     @Override
     public String toString() {
-        return "McpBlobResourceContents[" +
-                "uri=" + uri + ", " +
-                "blob=" + blob + ", " +
-                "mimeType=" + mimeType + ']';
+        return "McpBlobResourceContents[" + "uri=" + uri + ", " + "blob=" + blob + ", " + "mimeType=" + mimeType + ']';
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpBlobResourceContentsTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpBlobResourceContentsTest.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+class McpBlobResourceContentsTest {
+
+    @Test
+    void byte_array_factory_produces_standard_base64_without_line_breaks() {
+        byte[] payload = new byte[58];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) i;
+        }
+
+        McpBlobResourceContents contents = McpBlobResourceContents.create("file:///tmp/blob.bin", payload);
+
+        assertThat(contents.blob()).doesNotContain("\\r").doesNotContain("\\n");
+        assertThat(Base64.getDecoder().decode(contents.blob())).isEqualTo(payload);
+    }
+}


### PR DESCRIPTION
## 改动
- McpBlobResourceContents.create(String, byte[]) 改用标准 Base64 编码器（Base64.getEncoder()），与同模块 McpHeaderEncoding 一致；
- 新增回归测试：58 字节负载编码结果无 CR/LF，且可用严格解码器还原。

## 原因
原实现使用 MIME Base64 编码器，每 76 个字符插入 CRLF 换行；MCP 规范定义 blob 为纯 Base64，严格解码器会直接拒绝，换行也会被传进 JSON 字符串（issue #6279）。

## 验证
- 新增 McpBlobResourceContentsTest 通过；
- spotless 检查通过。

Fixes #6279
