### PR TITLE
fix(mcp): preserve the HTTP status code when a Streamable HTTP request is rejected

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.JsonException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
@@ -292,13 +293,14 @@ public class StreamableHttpMcpTransport implements McpTransport {
                                         });
                             } else {
                                 // Reinitialization did not help; fail instead of leaving the caller hanging
-                                future.completeExceptionally(new RuntimeException(
+                                future.completeExceptionally(new HttpException(
+                                        responseInfo.statusCode(),
                                         "Session expired again after reinitialization: server returned status code "
                                                 + responseInfo.statusCode()));
                             }
                         } else {
-                            future.completeExceptionally(
-                                    new RuntimeException("Unexpected status code: " + responseInfo.statusCode()));
+                            future.completeExceptionally(new HttpException(
+                                    responseInfo.statusCode(), "Unexpected status code: " + responseInfo.statusCode()));
                         }
                         return HttpResponse.BodySubscribers.discarding();
                     } else {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportStatusCodeTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportStatusCodeTest.java
@@ -1,0 +1,125 @@
+package dev.langchain4j.mcp.client.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.mcp.protocol.McpInitializeRequest;
+import dev.langchain4j.mcp.protocol.McpListToolsRequest;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class StreamableHttpMcpTransportStatusCodeTest {
+
+    private static final String INITIALIZE_RESULT =
+            "{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"test-server\",\"version\":\"1.0\"}}}";
+
+    private static final String TOOLS_LIST_RESULT = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}";
+
+    private HttpServer server;
+    private StreamableHttpMcpTransport transport;
+
+    private void startServer(int toolsListStatus) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/mcp", exchange -> {
+            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            String method = McpJson.parse(body).path("method").asText();
+            if ("initialize".equals(method)) {
+                exchange.getResponseHeaders().set("Mcp-Session-Id", "session-1");
+                respond(exchange, 200, INITIALIZE_RESULT);
+            } else if ("notifications/initialized".equals(method)) {
+                respond(exchange, 200, "{}");
+            } else if (toolsListStatus == 200) {
+                respond(exchange, 200, TOOLS_LIST_RESULT);
+            } else {
+                respond(exchange, toolsListStatus, "{}");
+            }
+        });
+        server.start();
+        transport = StreamableHttpMcpTransport.builder()
+                .url("http://localhost:" + server.getAddress().getPort() + "/mcp")
+                .setHttpVersion1_1()
+                .build();
+        transport.start(new McpOperationHandler(
+                new ConcurrentHashMap<>(),
+                () -> Collections.emptyList(),
+                transport,
+                null,
+                () -> {},
+                null,
+                () -> {},
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+    }
+
+    private static void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (transport != null) {
+            transport.close();
+        }
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void rejected_credential_carries_the_status_code() throws Exception {
+        startServer(401);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        assertThat(failureOf(response).statusCode()).isEqualTo(401);
+    }
+
+    @Test
+    void server_error_carries_its_own_status_code() throws Exception {
+        startServer(500);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        assertThat(failureOf(response).statusCode()).isEqualTo(500);
+    }
+
+    @Test
+    void successful_request_is_unaffected() throws Exception {
+        startServer(200);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        assertThat(response.get(5, TimeUnit.SECONDS)).contains("\"tools\":[]");
+    }
+
+    private static HttpException failureOf(CompletableFuture<String> response) {
+        Throwable thrown = catchThrowable(() -> response.get(5, TimeUnit.SECONDS));
+        assertThat(thrown).isInstanceOf(ExecutionException.class).hasCauseInstanceOf(HttpException.class);
+        return (HttpException) thrown.getCause();
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6290

## Change

Both non-2xx paths in `StreamableHttpMcpTransport` now fail with the core `HttpException`, which carries
`statusCode()`, instead of a `RuntimeException` whose message was the only place the status survived:

```java
future.completeExceptionally(new HttpException(
        responseInfo.statusCode(), "Unexpected status code: " + responseInfo.statusCode()));
```

The issue names the first site. The second, the 404 that survives reinitialization, had the same gap in the same
method and gets the same treatment, so the two do not diverge.

Compatibility: `HttpException extends LangChain4jException extends RuntimeException`, so existing `catch` blocks
are unaffected, and both message strings are byte-identical, so callers currently matching on the literal keep
working. No signature changes and revapi is clean. Code asserting the exact class `RuntimeException`, or catching
`LangChain4jException` specifically, would see the difference; nothing in this repository does either.

On #2910: happy to drop this if you would rather the status only surfaced through the HTTP client SPI migration.

### Tests

- `StreamableHttpMcpTransportStatusCodeTest` (new) serves a fixed status from a local `HttpServer` and asserts the
  cause is an `HttpException` whose `statusCode()` is 401, and separately 500, so the two are distinguishable
  without reading the message. A third case asserts a 2xx `tools/list` still returns its result, so the change is
  shown not to affect the success path. It follows `StreamableHttpMcpTransportSessionExpiryTest`, the existing
  offline server test for this transport.

The two failure cases fail on unmodified `main` with `Expecting a throwable with cause being an instance of
HttpException but was an instance of RuntimeException`; the success case passes either way and is there to bound
the change. There is one production file and reverting it fails both failure cases.

```
mvn -o -pl langchain4j-mcp test
Tests run: 229, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-mcp verify -DskipTests
revapi:0.15.1:check (default) @ langchain4j-mcp
BUILD SUCCESS

mvn -pl langchain4j-core test   Tests run: 1354, Failures: 0, Errors: 0, Skipped: 3
mvn -pl langchain4j test        Tests run: 1705, Failures: 0, Errors: 0, Skipped: 19
```

The stdio integration tests were not run: they launch their server through `jbang`, which is not installed here.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
