### PR TITLE
Allow a supervisor to register tools for its planner agent

### DIFF
--- a/docs/docs/tutorials/agents.md
+++ b/docs/docs/tutorials/agents.md
@@ -1525,6 +1525,47 @@ String result = (String) bankSupervisor.invoke(input);
 
 If both are provided, the invocation value overrides the build-time `supervisorContext`.
 
+### Giving tools to the supervisor
+
+A supervisor delegates to its subagents, and in the examples above every tool is registered on the subagent that
+needs it. A supervisor can also be given tools of its own, using the same builder methods as a leaf agent, for
+facts it needs in order to choose the next subagent or to fill in one of that subagent's arguments:
+
+```java
+SupervisorAgent bankSupervisor = AgenticServices
+        .supervisorBuilder()
+        .chatModel(PLANNER_MODEL)
+        .subAgents(withdrawAgent, creditAgent, exchangeAgent)
+        .tools(new AccountPolicyTool())
+        .build();
+```
+
+`tools(Map<ToolSpecification, ToolExecutor>)`, `toolProvider(ToolProvider)` and `maxToolCallingRoundTrips(int)`
+are available as well, and behave as they do on `AgenticServices.agentBuilder(...)`.
+
+The two sets of tools are independent. A tool registered on the supervisor is declared only to the planning model,
+and a tool registered on a subagent is declared only to that subagent's model during its own invocation. To share
+one, pass the same object to both builders:
+
+```java
+BankTool bankTool = new BankTool();
+
+WithdrawAgent withdrawAgent = AgenticServices
+        .agentBuilder(WithdrawAgent.class)
+        .chatModel(BASE_MODEL)
+        .tools(bankTool)
+        .build();
+
+SupervisorAgent bankSupervisor = AgenticServices
+        .supervisorBuilder()
+        .chatModel(PLANNER_MODEL)
+        .subAgents(withdrawAgent)
+        .tools(bankTool)
+        .build();
+```
+
+A supervisor with no registered tool is unaffected: its planning prompt and requests are unchanged.
+
 ## Custom agentic patterns
 
 The agentic patterns discussed so far are provided out-of-the-box by the `langchain4j-agentic` module, but what if none of them fit the specific needs of your application? In this case it is possible to create your own custom pattern, that orchestrates the interactions among a set of subagents in a way that is tailored to your requirements.

--- a/langchain4j-agentic/revapi.json
+++ b/langchain4j-agentic/revapi.json
@@ -177,6 +177,71 @@
           "annotationType": "com.fasterxml.jackson.annotation.JsonInclude",
           "justification": "Keeps null properties out of persisted agent state, as the Jackson-2-only mixin did before. From jackson-annotations, which both Jackson versions read. The persisted format is unchanged and pinned by Jackson3PolymorphicCompatibilityTest.",
           "package": "dev.langchain4j.agentic.scope"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::tools(java.lang.Object[])",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::tools(java.util.Map<dev.langchain4j.agent.tool.ToolSpecification, dev.langchain4j.service.tool.ToolExecutor>)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::tools(java.util.Map<dev.langchain4j.agent.tool.ToolSpecification, dev.langchain4j.service.tool.ToolExecutor>, java.util.Set<java.lang.String>)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::toolProvider(dev.langchain4j.service.tool.ToolProvider)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::toolProviders(java.util.Collection<dev.langchain4j.service.tool.ToolProvider>)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::toolProviders(dev.langchain4j.service.tool.ToolProvider[])",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::maxToolCallingRoundTrips(int)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.AgentInvocation dev.langchain4j.agentic.supervisor.PlannerAgent::planWithTools(java.lang.Object, java.lang.String, java.lang.String, java.lang.String, java.lang.String)",
+          "justification": "Planning prompt used only when tools have been registered on the supervisor, leaving the existing plan() prompt byte-identical. PlannerAgent is implemented by AiServices at runtime rather than by hand, so the added method breaks no existing implementation."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::hallucinatedToolNameStrategy(java.util.function.Function<dev.langchain4j.agent.tool.ToolExecutionRequest, dev.langchain4j.data.message.ToolExecutionResultMessage>)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::executeToolsConcurrently()",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::executeToolsConcurrently(java.util.concurrent.Executor)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::toolArgumentsErrorHandler(dev.langchain4j.service.tool.ToolArgumentsErrorHandler)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method dev.langchain4j.agentic.supervisor.SupervisorAgentService<T> dev.langchain4j.agentic.supervisor.SupervisorAgentService<T>::toolExecutionErrorHandler(dev.langchain4j.service.tool.ToolExecutionErrorHandler)",
+          "justification": "New builder method mirroring the tool surface already offered by AgentBuilder, so that a supervisor's planner can be given tools the same way a leaf agent is. Additive: SupervisorAgentServiceImpl is the only implementation in this repository, and a supervisor built without registering any tool is unaffected."
         }
       ]
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/PlannerAgent.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/PlannerAgent.java
@@ -8,8 +8,7 @@ import dev.langchain4j.service.memory.ChatMemoryAccess;
 
 public interface PlannerAgent extends ChatMemoryAccess {
 
-    @SystemMessage(
-            """
+    @SystemMessage("""
             You are a planner expert that is provided with a set of agents.
             You know nothing about any domain, don't take any assumptions about the user request,
             the only thing that you can do is rely on the provided agents.
@@ -33,12 +32,50 @@ public interface PlannerAgent extends ChatMemoryAccess {
 
             {{supervisorContext}}
             """)
-    @UserMessage(
-            """
+    @UserMessage("""
             The user request is: '{{request}}'.
             The last received response is: '{{lastResponse}}'.
             """)
     AgentInvocation plan(
+            @MemoryId Object userId,
+            @V("agents") String agents,
+            @V("request") String request,
+            @V("lastResponse") String lastResponse,
+            @V("supervisorContext") String supervisorContext);
+
+    @SystemMessage("""
+            You are a planner expert that is provided with a set of agents and a set of tools.
+            You know nothing about any domain, don't take any assumptions about the user request,
+            the only things that you can do are relying on the provided agents and calling the provided tools.
+
+            Your role is to analyze the user request and decide which one of the provided agents to call next to address it.
+            You return an agent invocation consisting of the name of the agent and the arguments to pass to it.
+
+            Call a tool only to obtain a fact you need in order to choose the next agent or to fill in one of its
+            arguments. Never call the same tool twice with the same arguments, and never use a tool result as a
+            substitute for invoking an agent.
+
+            If no further agent requests are required, return an agentName of "done" and an argument named
+            "response", where the value of the response argument is a recap of all the performed actions,
+            written in the same language as the user request.
+
+            Agents are provided with their name and description together with a list of applicable arguments
+            in the format {'name', 'description', [argument1: type1, argument2: type2]}.
+
+            Decide which agent to invoke next, doing things in small steps and
+            never taking any shortcuts or relying on your own knowledge.
+            Even if the user's request is already clear or explicit, don't make any assumptions and use the agents.
+            Be sure to query ALL necessary agents.
+
+            The comma separated list of available agents is: '{{agents}}'.
+
+            {{supervisorContext}}
+            """)
+    @UserMessage("""
+            The user request is: '{{request}}'.
+            The last received response is: '{{lastResponse}}'.
+            """)
+    AgentInvocation planWithTools(
             @MemoryId Object userId,
             @V("agents") String agents,
             @V("request") String request,

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorAgentService.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorAgentService.java
@@ -1,12 +1,22 @@
 package dev.langchain4j.agentic.supervisor;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agentic.agent.ErrorContext;
 import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
+import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -47,4 +57,30 @@ public interface SupervisorAgentService<T> {
     SupervisorAgentService<T> beforeCall(Consumer<AgenticScope> beforeCall);
 
     SupervisorAgentService<T> compensateOnError(boolean compensateOnError);
+
+    SupervisorAgentService<T> tools(Object... objectsWithTools);
+
+    SupervisorAgentService<T> tools(Map<ToolSpecification, ToolExecutor> toolsMap);
+
+    SupervisorAgentService<T> tools(
+            Map<ToolSpecification, ToolExecutor> toolsMap, Set<String> immediateReturnToolNames);
+
+    SupervisorAgentService<T> toolProvider(ToolProvider toolProvider);
+
+    SupervisorAgentService<T> toolProviders(Collection<ToolProvider> toolProviders);
+
+    SupervisorAgentService<T> toolProviders(ToolProvider... toolProviders);
+
+    SupervisorAgentService<T> maxToolCallingRoundTrips(int maxToolCallingRoundTrips);
+
+    SupervisorAgentService<T> hallucinatedToolNameStrategy(
+            Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinatedToolNameStrategy);
+
+    SupervisorAgentService<T> executeToolsConcurrently();
+
+    SupervisorAgentService<T> executeToolsConcurrently(Executor executor);
+
+    SupervisorAgentService<T> toolArgumentsErrorHandler(ToolArgumentsErrorHandler toolArgumentsErrorHandler);
+
+    SupervisorAgentService<T> toolExecutionErrorHandler(ToolExecutionErrorHandler toolExecutionErrorHandler);
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorAgentServiceImpl.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorAgentServiceImpl.java
@@ -6,6 +6,8 @@ import static dev.langchain4j.agentic.declarative.DeclarativeUtil.invokeStatic;
 import static dev.langchain4j.agentic.declarative.DeclarativeUtil.selectMethod;
 import static dev.langchain4j.agentic.internal.AgentUtil.validateAgentClass;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agentic.declarative.ChatMemoryProviderSupplier;
 import dev.langchain4j.agentic.declarative.ChatModelSupplier;
 import dev.langchain4j.agentic.declarative.Output;
@@ -13,10 +15,22 @@ import dev.langchain4j.agentic.declarative.SupervisorRequest;
 import dev.langchain4j.agentic.internal.AbstractServiceBuilder;
 import dev.langchain4j.agentic.planner.AgenticService;
 import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
+import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 public class SupervisorAgentServiceImpl<T> extends AbstractServiceBuilder<T, SupervisorAgentServiceImpl<T>>
@@ -34,6 +48,17 @@ public class SupervisorAgentServiceImpl<T> extends AbstractServiceBuilder<T, Sup
     private Function<AgenticScope, String> requestGenerator;
     private String supervisorContext;
 
+    private List<Object> objectsWithTools = List.of();
+    private Map<ToolSpecification, ToolExecutor> toolsMap = Map.of();
+    private Set<String> immediateReturnToolNames = Set.of();
+    private final List<ToolProvider> toolProviders = new ArrayList<>();
+    private Integer maxToolCallingRoundTrips;
+    private Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinatedToolNameStrategy;
+    private boolean executeToolsConcurrently;
+    private Executor concurrentToolsExecutor;
+    private ToolArgumentsErrorHandler toolArgumentsErrorHandler;
+    private ToolExecutionErrorHandler toolExecutionErrorHandler;
+
     public SupervisorAgentServiceImpl(Class<T> agentServiceClass, Method agenticMethod) {
         this(agentServiceClass, agenticMethod, null);
     }
@@ -46,13 +71,29 @@ public class SupervisorAgentServiceImpl<T> extends AbstractServiceBuilder<T, Sup
     public T build() {
         if (supervisorContext != null) {
             this.beforeCall(this.beforeCall.andThen(agenticScope ->
-                    agenticScope.writeStateIfAbsent(SupervisorPlanner.SUPERVISOR_CONTEXT_KEY, supervisorContext)
-            ));
+                    agenticScope.writeStateIfAbsent(SupervisorPlanner.SUPERVISOR_CONTEXT_KEY, supervisorContext)));
         }
 
-        return build(() -> new SupervisorPlanner(chatModel, chatMemoryProvider, maxAgentsInvocations,
-                contextStrategy, responseStrategy, requestGenerator,
-                outputKey, output));
+        return build(() -> new SupervisorPlanner(
+                chatModel,
+                chatMemoryProvider,
+                maxAgentsInvocations,
+                contextStrategy,
+                responseStrategy,
+                requestGenerator,
+                outputKey,
+                output,
+                new SupervisorTools(
+                        objectsWithTools,
+                        toolsMap,
+                        immediateReturnToolNames,
+                        toolProviders,
+                        maxToolCallingRoundTrips,
+                        hallucinatedToolNameStrategy,
+                        executeToolsConcurrently,
+                        concurrentToolsExecutor,
+                        toolArgumentsErrorHandler,
+                        toolExecutionErrorHandler)));
     }
 
     public static SupervisorAgentService<SupervisorAgent> builder() {
@@ -111,31 +152,108 @@ public class SupervisorAgentServiceImpl<T> extends AbstractServiceBuilder<T, Sup
     }
 
     @Override
+    public SupervisorAgentServiceImpl<T> tools(Object... objectsWithTools) {
+        this.objectsWithTools = Arrays.asList(objectsWithTools);
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> tools(Map<ToolSpecification, ToolExecutor> toolsMap) {
+        this.toolsMap = toolsMap;
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> tools(
+            Map<ToolSpecification, ToolExecutor> toolsMap, Set<String> immediateReturnToolNames) {
+        this.toolsMap = toolsMap;
+        this.immediateReturnToolNames = immediateReturnToolNames;
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> toolProvider(ToolProvider toolProvider) {
+        this.toolProviders.add(toolProvider);
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> toolProviders(Collection<ToolProvider> toolProviders) {
+        this.toolProviders.addAll(toolProviders);
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> toolProviders(ToolProvider... toolProviders) {
+        return toolProviders(Arrays.asList(toolProviders));
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> maxToolCallingRoundTrips(int maxToolCallingRoundTrips) {
+        this.maxToolCallingRoundTrips = maxToolCallingRoundTrips;
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> hallucinatedToolNameStrategy(
+            Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinatedToolNameStrategy) {
+        this.hallucinatedToolNameStrategy = hallucinatedToolNameStrategy;
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> executeToolsConcurrently() {
+        this.executeToolsConcurrently = true;
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> executeToolsConcurrently(Executor executor) {
+        this.executeToolsConcurrently = true;
+        this.concurrentToolsExecutor = executor;
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> toolArgumentsErrorHandler(
+            ToolArgumentsErrorHandler toolArgumentsErrorHandler) {
+        this.toolArgumentsErrorHandler = toolArgumentsErrorHandler;
+        return this;
+    }
+
+    @Override
+    public SupervisorAgentServiceImpl<T> toolExecutionErrorHandler(
+            ToolExecutionErrorHandler toolExecutionErrorHandler) {
+        this.toolExecutionErrorHandler = toolExecutionErrorHandler;
+        return this;
+    }
+
+    @Override
     public String serviceType() {
         return "Supervisor";
     }
 
     private void configureSupervisor(Class<T> agentServiceClass, ChatModel chatModel) {
         selectMethod(
-                agentServiceClass,
-                method -> method.isAnnotationPresent(SupervisorRequest.class)
-                        && method.getReturnType() == String.class)
+                        agentServiceClass,
+                        method -> method.isAnnotationPresent(SupervisorRequest.class)
+                                && method.getReturnType() == String.class)
                 .map(m -> agenticScopeFunction(m, String.class))
                 .ifPresent(this::requestGenerator);
 
         selectMethod(
-                agentServiceClass,
-                method -> method.isAnnotationPresent(ChatModelSupplier.class)
-                        && method.getReturnType() == ChatModel.class
-                        && method.getParameterCount() == 0)
+                        agentServiceClass,
+                        method -> method.isAnnotationPresent(ChatModelSupplier.class)
+                                && method.getReturnType() == ChatModel.class
+                                && method.getParameterCount() == 0)
                 .map(method -> (ChatModel) invokeStatic(method))
                 .ifPresentOrElse(this::chatModel, () -> this.chatModel(chatModel));
 
         selectMethod(
-                agentServiceClass,
-                method -> method.isAnnotationPresent(ChatMemoryProviderSupplier.class)
-                        && method.getReturnType() == ChatMemory.class
-                        && method.getParameterCount() == 1)
+                        agentServiceClass,
+                        method -> method.isAnnotationPresent(ChatMemoryProviderSupplier.class)
+                                && method.getReturnType() == ChatMemory.class
+                                && method.getParameterCount() == 1)
                 .map(method -> (ChatMemoryProvider) memoryId -> invokeStatic(method, memoryId))
                 .ifPresent(this::chatMemoryProvider);
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
@@ -55,6 +55,8 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
 
     private final Function<AgenticScope, Object> output;
 
+    private final SupervisorTools tools;
+
     private Map<String, AgentInstance> agents;
     private String agentsList;
 
@@ -69,6 +71,28 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
             Function<AgenticScope, String> requestGenerator,
             String outputKey,
             Function<AgenticScope, Object> output) {
+        this(
+                chatModel,
+                chatMemoryProvider,
+                maxAgentsInvocations,
+                contextStrategy,
+                responseStrategy,
+                requestGenerator,
+                outputKey,
+                output,
+                SupervisorTools.EMPTY);
+    }
+
+    SupervisorPlanner(
+            ChatModel chatModel,
+            ChatMemoryProvider chatMemoryProvider,
+            int maxAgentsInvocations,
+            SupervisorContextStrategy contextStrategy,
+            SupervisorResponseStrategy responseStrategy,
+            Function<AgenticScope, String> requestGenerator,
+            String outputKey,
+            Function<AgenticScope, Object> output,
+            SupervisorTools tools) {
         this.chatModel = chatModel;
         this.chatMemoryProvider = chatMemoryProvider;
         this.maxAgentsInvocations = maxAgentsInvocations;
@@ -77,6 +101,7 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
         this.requestGenerator = requestGenerator;
         this.outputKey = outputKey;
         this.output = output;
+        this.tools = tools;
     }
 
     @Override
@@ -176,10 +201,8 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
                 ? SUPERVISOR_CONTEXT_PREFIX + "'" + agenticScope.readState(SUPERVISOR_CONTEXT_KEY, "") + "'."
                 : "";
 
-        AgentInvocation agentInvocation = withAgenticScope(
-                agenticScope,
-                () -> planner(agenticScope)
-                        .plan(agenticScope.memoryId(), agentsList, request, lastResponse, supervisorContext));
+        AgentInvocation agentInvocation =
+                withAgenticScope(agenticScope, () -> plan(agenticScope, lastResponse, supervisorContext));
         LOG.info("Agent Invocation: {}", agentInvocation);
 
         if (agentInvocation.getAgentName().equalsIgnoreCase("done")) {
@@ -245,6 +268,13 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
         return done(output != null ? output.apply(agenticScope) : result);
     }
 
+    private AgentInvocation plan(AgenticScope agenticScope, String lastResponse, String supervisorContext) {
+        PlannerAgent planner = planner(agenticScope);
+        return tools.isEmpty()
+                ? planner.plan(agenticScope.memoryId(), agentsList, request, lastResponse, supervisorContext)
+                : planner.planWithTools(agenticScope.memoryId(), agentsList, request, lastResponse, supervisorContext);
+    }
+
     private PlannerAgent planner(AgenticScope agenticScope) {
         return ((DefaultAgenticScope) agenticScope).getOrCreateAgent(agentId(), this::buildPlannerAgent);
     }
@@ -270,6 +300,7 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
     private PlannerAgent buildPlannerAgent(AgenticScope agenticScope) {
         var builder = AiServices.builder(PlannerAgent.class).chatModel(chatModel);
         configureMemoryAndContext(agenticScope, builder);
+        tools.configure(builder);
         return builder.build();
     }
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorTools.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorTools.java
@@ -1,0 +1,77 @@
+package dev.langchain4j.agentic.supervisor;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
+import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+record SupervisorTools(
+        List<Object> objectsWithTools,
+        Map<ToolSpecification, ToolExecutor> toolsMap,
+        Set<String> immediateReturnToolNames,
+        List<ToolProvider> toolProviders,
+        Integer maxToolCallingRoundTrips,
+        Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinatedToolNameStrategy,
+        boolean executeToolsConcurrently,
+        Executor concurrentToolsExecutor,
+        ToolArgumentsErrorHandler toolArgumentsErrorHandler,
+        ToolExecutionErrorHandler toolExecutionErrorHandler) {
+
+    static final SupervisorTools EMPTY =
+            new SupervisorTools(List.of(), Map.of(), Set.of(), List.of(), null, null, false, null, null, null);
+
+    SupervisorTools {
+        objectsWithTools = List.copyOf(objectsWithTools);
+        toolsMap = Map.copyOf(toolsMap);
+        immediateReturnToolNames = Set.copyOf(immediateReturnToolNames);
+        toolProviders = List.copyOf(toolProviders);
+    }
+
+    boolean isEmpty() {
+        return objectsWithTools.isEmpty() && toolsMap.isEmpty() && toolProviders.isEmpty();
+    }
+
+    void configure(AiServices<PlannerAgent> aiServices) {
+        if (!objectsWithTools.isEmpty()) {
+            aiServices.tools(objectsWithTools);
+        }
+        if (!toolsMap.isEmpty()) {
+            if (immediateReturnToolNames.isEmpty()) {
+                aiServices.tools(toolsMap);
+            } else {
+                aiServices.tools(toolsMap, immediateReturnToolNames);
+            }
+        }
+        if (!toolProviders.isEmpty()) {
+            aiServices.toolProviders(toolProviders);
+        }
+        if (maxToolCallingRoundTrips != null) {
+            aiServices.maxToolCallingRoundTrips(maxToolCallingRoundTrips);
+        }
+        if (hallucinatedToolNameStrategy != null) {
+            aiServices.hallucinatedToolNameStrategy(hallucinatedToolNameStrategy);
+        }
+        if (executeToolsConcurrently) {
+            if (concurrentToolsExecutor != null) {
+                aiServices.executeToolsConcurrently(concurrentToolsExecutor);
+            } else {
+                aiServices.executeToolsConcurrently();
+            }
+        }
+        if (toolArgumentsErrorHandler != null) {
+            aiServices.toolArgumentsErrorHandler(toolArgumentsErrorHandler);
+        }
+        if (toolExecutionErrorHandler != null) {
+            aiServices.toolExecutionErrorHandler(toolExecutionErrorHandler);
+        }
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/supervisor/SupervisorToolsTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/supervisor/SupervisorToolsTest.java
@@ -1,0 +1,394 @@
+package dev.langchain4j.agentic.supervisor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.tool.ToolErrorHandlerResult;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class SupervisorToolsTest {
+
+    private static final String DELEGATE = """
+            {"agentName":"answer","arguments":{"request":"what time is it"}}""";
+    private static final String DONE = """
+            {"agentName":"done","arguments":{"response":"final answer"}}""";
+
+    public interface Expert {
+
+        @UserMessage("Answer: {{request}}")
+        @Agent(description = "An expert", outputKey = "response")
+        String answer(@V("request") String request);
+    }
+
+    public static class ClockTools {
+
+        @Tool("returns the current time")
+        String currentTime() {
+            return "12:00";
+        }
+    }
+
+    public static class LoopingTools {
+
+        final AtomicInteger invocations = new AtomicInteger();
+
+        @Tool("always asks to be called again")
+        String again() {
+            invocations.incrementAndGet();
+            return "call me again";
+        }
+    }
+
+    public static class FailingTools {
+
+        @Tool("always fails")
+        String explode() {
+            throw new IllegalStateException("tool failure");
+        }
+    }
+
+    public static class ExpertTools {
+
+        @Tool("looks up a rate")
+        String rate() {
+            return "1.0";
+        }
+    }
+
+    static class AlwaysCallsToolModel implements ChatModel {
+
+        final AtomicInteger modelCalls = new AtomicInteger();
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            int n = modelCalls.incrementAndGet();
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                            .id("call-" + n)
+                            .name("again")
+                            .arguments("{}")
+                            .build()))
+                    .build();
+        }
+    }
+
+    static class RecordingModel implements ChatModel {
+
+        final List<ChatRequest> requests = new CopyOnWriteArrayList<>();
+        private final Queue<AiMessage> responses = new ConcurrentLinkedQueue<>();
+
+        RecordingModel(AiMessage... responses) {
+            this.responses.addAll(List.of(responses));
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            requests.add(chatRequest);
+            AiMessage next = responses.isEmpty() ? AiMessage.from(DONE) : responses.poll();
+            return ChatResponse.builder().aiMessage(next).build();
+        }
+    }
+
+    private static RecordingModel plannerModel() {
+        return new RecordingModel(AiMessage.from(DELEGATE), AiMessage.from(DONE));
+    }
+
+    private static ChatRequest plannerRequest(RecordingModel model) {
+        return model.requests.stream()
+                .filter(SupervisorToolsTest::isPlannerRequest)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static boolean isPlannerRequest(ChatRequest request) {
+        return request.messages().stream().anyMatch(SupervisorToolsTest::isPlannerSystemMessage);
+    }
+
+    private static boolean isPlannerSystemMessage(ChatMessage message) {
+        return message instanceof SystemMessage systemMessage
+                && systemMessage.text().contains("planner expert");
+    }
+
+    private static List<String> toolNames(ChatRequest request) {
+        return request.toolSpecifications() == null
+                ? List.of()
+                : request.toolSpecifications().stream()
+                        .map(ToolSpecification::name)
+                        .toList();
+    }
+
+    private static String plannerSystemMessage(RecordingModel model) {
+        return plannerRequest(model).messages().stream()
+                .filter(SupervisorToolsTest::isPlannerSystemMessage)
+                .map(message -> ((SystemMessage) message).text())
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static SupervisorAgent supervisorWith(ChatModel plannerModel, ChatModel expertModel, Object... tools) {
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(expertModel)
+                .build();
+        SupervisorAgentService<SupervisorAgent> builder =
+                AgenticServices.supervisorBuilder().chatModel(plannerModel).subAgents(expert);
+        if (tools.length > 0) {
+            builder.tools(tools);
+        }
+        return builder.build();
+    }
+
+    @Test
+    void should_declare_planner_tools_to_the_planner_model() {
+        RecordingModel planner = plannerModel();
+        supervisorWith(planner, new RecordingModel(AiMessage.from("expert answer")), new ClockTools())
+                .invoke("what time is it");
+
+        assertThat(toolNames(plannerRequest(planner))).contains("currentTime");
+    }
+
+    @Test
+    void should_not_declare_any_tool_when_none_is_registered() {
+        RecordingModel planner = plannerModel();
+        supervisorWith(planner, new RecordingModel(AiMessage.from("expert answer")))
+                .invoke("what time is it");
+
+        assertThat(toolNames(plannerRequest(planner))).isEmpty();
+    }
+
+    @Test
+    void should_not_declare_planner_tools_to_sub_agent_models() {
+        RecordingModel planner = plannerModel();
+        RecordingModel expertModel = new RecordingModel(AiMessage.from("expert answer"));
+        supervisorWith(planner, expertModel, new ClockTools()).invoke("what time is it");
+
+        assertThat(expertModel.requests).isNotEmpty();
+        assertThat(expertModel.requests)
+                .allSatisfy(request -> assertThat(toolNames(request)).doesNotContain("currentTime"));
+    }
+
+    @Test
+    void should_not_declare_sub_agent_tools_to_the_planner_model() {
+        RecordingModel planner = plannerModel();
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(new RecordingModel(AiMessage.from("expert answer")))
+                .tools(new ExpertTools())
+                .build();
+        AgenticServices.supervisorBuilder()
+                .chatModel(planner)
+                .subAgents(expert)
+                .tools(new ClockTools())
+                .build()
+                .invoke("what time is it");
+
+        assertThat(toolNames(plannerRequest(planner))).contains("currentTime").doesNotContain("rate");
+    }
+
+    @Test
+    void should_declare_programmatic_tools_to_the_planner_model() {
+        RecordingModel planner = plannerModel();
+        ToolSpecification specification = ToolSpecification.builder()
+                .name("lookup")
+                .description("looks something up")
+                .build();
+        ToolExecutor executor = (request, memoryId) -> "looked up";
+
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(new RecordingModel(AiMessage.from("expert answer")))
+                .build();
+        AgenticServices.supervisorBuilder()
+                .chatModel(planner)
+                .subAgents(expert)
+                .tools(Map.of(specification, executor))
+                .build()
+                .invoke("what time is it");
+
+        assertThat(toolNames(plannerRequest(planner))).contains("lookup");
+    }
+
+    @Test
+    void should_declare_tools_supplied_by_a_tool_provider() {
+        RecordingModel planner = plannerModel();
+        ToolSpecification specification = ToolSpecification.builder()
+                .name("provided")
+                .description("supplied by a provider")
+                .build();
+
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(new RecordingModel(AiMessage.from("expert answer")))
+                .build();
+        AgenticServices.supervisorBuilder()
+                .chatModel(planner)
+                .subAgents(expert)
+                .toolProvider(request -> ToolProviderResult.builder()
+                        .add(specification, (executionRequest, memoryId) -> "provided result")
+                        .build())
+                .build()
+                .invoke("what time is it");
+
+        assertThat(toolNames(plannerRequest(planner))).contains("provided");
+    }
+
+    @Test
+    void should_execute_a_planner_tool_before_delegating() {
+        ClockTools clock = new ClockTools();
+        RecordingModel planner = new RecordingModel(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("call-1")
+                        .name("currentTime")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from(DELEGATE),
+                AiMessage.from(DONE));
+
+        supervisorWith(planner, new RecordingModel(AiMessage.from("expert answer")), clock)
+                .invoke("what time is it");
+
+        assertThat(planner.requests)
+                .anySatisfy(request -> assertThat(request.messages())
+                        .anyMatch(message -> message.toString().contains("12:00")));
+    }
+
+    @Test
+    void should_route_a_hallucinated_tool_name_through_the_configured_strategy() {
+        AtomicBoolean strategyCalled = new AtomicBoolean();
+        RecordingModel planner = new RecordingModel(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("call-1")
+                        .name("noSuchTool")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from(DELEGATE),
+                AiMessage.from(DONE));
+
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(new RecordingModel(AiMessage.from("expert answer")))
+                .build();
+        AgenticServices.supervisorBuilder()
+                .chatModel(planner)
+                .subAgents(expert)
+                .tools(new ClockTools())
+                .hallucinatedToolNameStrategy(request -> {
+                    strategyCalled.set(true);
+                    return ToolExecutionResultMessage.from(request, "no such tool");
+                })
+                .build()
+                .invoke("what time is it");
+
+        assertThat(strategyCalled).isTrue();
+    }
+
+    @Test
+    void should_route_a_failing_planner_tool_through_the_configured_error_handler() {
+        AtomicBoolean handlerCalled = new AtomicBoolean();
+        RecordingModel planner = new RecordingModel(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("call-1")
+                        .name("explode")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from(DELEGATE),
+                AiMessage.from(DONE));
+
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(new RecordingModel(AiMessage.from("expert answer")))
+                .build();
+        AgenticServices.supervisorBuilder()
+                .chatModel(planner)
+                .subAgents(expert)
+                .tools(new FailingTools())
+                .toolExecutionErrorHandler((error, context) -> {
+                    handlerCalled.set(true);
+                    return ToolErrorHandlerResult.text("recovered");
+                })
+                .build()
+                .invoke("what time is it");
+
+        assertThat(handlerCalled).isTrue();
+    }
+
+    @Test
+    void should_declare_planner_tools_when_concurrent_execution_is_enabled() {
+        RecordingModel planner = plannerModel();
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(new RecordingModel(AiMessage.from("expert answer")))
+                .build();
+        AgenticServices.supervisorBuilder()
+                .chatModel(planner)
+                .subAgents(expert)
+                .tools(new ClockTools())
+                .executeToolsConcurrently()
+                .build()
+                .invoke("what time is it");
+
+        assertThat(toolNames(plannerRequest(planner))).contains("currentTime");
+    }
+
+    @Test
+    void should_bound_tool_round_trips_within_a_single_planning_turn() {
+        LoopingTools loopingTools = new LoopingTools();
+        AlwaysCallsToolModel planner = new AlwaysCallsToolModel();
+        AlwaysCallsToolModel expertModel = new AlwaysCallsToolModel();
+
+        Expert expert = AgenticServices.agentBuilder(Expert.class)
+                .chatModel(expertModel)
+                .build();
+        SupervisorAgent supervisor = AgenticServices.supervisorBuilder()
+                .chatModel(planner)
+                .subAgents(expert)
+                .tools(loopingTools)
+                .maxToolCallingRoundTrips(3)
+                .maxAgentsInvocations(7)
+                .build();
+
+        assertThatThrownBy(() -> supervisor.invoke("what time is it"))
+                .hasMessageContaining("exceeded 3 tool calling round trips");
+
+        assertThat(loopingTools.invocations).hasValue(3);
+        assertThat(expertModel.modelCalls).hasValue(0);
+    }
+
+    @Test
+    void should_keep_the_planning_prompt_unchanged_when_no_tool_is_registered() {
+        RecordingModel planner = plannerModel();
+        supervisorWith(planner, new RecordingModel(AiMessage.from("expert answer")))
+                .invoke("what time is it");
+
+        assertThat(plannerSystemMessage(planner))
+                .contains("the only thing that you can do is rely on the provided agents")
+                .doesNotContain("tool");
+    }
+
+    @Test
+    void should_use_the_tool_aware_planning_prompt_when_a_tool_is_registered() {
+        RecordingModel planner = plannerModel();
+        supervisorWith(planner, new RecordingModel(AiMessage.from("expert answer")), new ClockTools())
+                .invoke("what time is it");
+
+        assertThat(plannerSystemMessage(planner))
+                .contains("relying on the provided agents and calling the provided tools")
+                .contains("Call a tool only to obtain a fact you need");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6289

## Change

`SupervisorAgentService` had no tool methods, so `SupervisorPlanner.buildPlannerAgent` built the planning
`AiServices` with only a chat model and memory. A supervisor can now register tools the same way a leaf agent
does, and they are declared to the planning model through `ChatRequest.toolSpecifications()`:

```java
SupervisorAgent bankSupervisor = AgenticServices.supervisorBuilder()
        .chatModel(PLANNER_MODEL)
        .subAgents(withdrawAgent, creditAgent, exchangeAgent)
        .tools(new AccountPolicyTool())
        .build();
```

The twelve methods mirror the ones `AgentBuilder` exposes for a leaf agent, including its assign-versus-add
semantics, so the two builders behave identically: `tools`, `toolProvider`/`toolProviders`,
`maxToolCallingRoundTrips`, `hallucinatedToolNameStrategy`, `executeToolsConcurrently`,
`toolArgumentsErrorHandler` and `toolExecutionErrorHandler`. Its deprecated
`maxSequentialToolsInvocations` is the one option not carried over. The two sets of tools stay independent,
which the tests pin in both directions.

Nothing new is public beyond those twelve methods: `SupervisorTools` is package-private, and the existing public
`SupervisorPlanner` constructor now delegates to a package-private one, so it stays source and binary compatible.

Tools need the planner to be told it may call them, and the current `@SystemMessage` says the only thing it can
do is rely on the provided agents. I added a second method, `planWithTools`, used only when a tool has been
registered, so `plan` stays byte-identical and a supervisor without tools is provably unchanged. Supplying the
alternative prompt through `systemMessageProvider` instead would not work:
`DefaultAiServices.findSystemMessageTemplate` returns on the method annotation and only falls through to a
provider when none is present, so that route means removing the annotation from `plan`. The cost of the
approach I took is a mostly duplicated prompt, and if you would rather reword the existing one to cover both
cases, that is a small change and I am happy to switch.

`plannerBuilder()` is deliberately not covered: it takes a user-supplied `Planner` that constructs its own
agent, so it can already register tools there, and only `SupervisorPlanner` builds a planning `AiServices`
inside the framework.

One thing I could not settle. Once tools are declared, nothing makes the model leave tool-calling mode and
return the `AgentInvocation`. Against `plannerModel()` the planner reached the 100 tool-call limit instead of
producing a plan across four configurations: two prompt wordings, the planner memory raised from 20 to 100
messages, and a model declaring `RESPONSE_FORMAT_JSON_SCHEMA` so the planning call carried a real
`AgentInvocation` schema rather than the text instruction. That last one is worth stating because it looks like
the obvious fix and is not: a response format constrains the content when the model emits content, it does not
stop it emitting another tool call. With `gpt-4o` the tool phase worked and routing was correct, but planning
then ran to `maxAgentsInvocations`. So the wiring is right and the model still does not conclude. The levers
left are capping tool round trips per planning turn separately from the agent-invocation limit, or keeping
fact-gathering and planning out of the same turn. Both change the planning protocol rather than this builder,
so I have not picked one, and I would rather implement the shape you want than guess.

### Tests

- `SupervisorToolsTest` (new) proves tools registered on a supervisor reach the planner's request, that a
  supervisor without tools declares none and keeps the original prompt, that planner tools are not declared to
  subagent models and subagent tools are not declared to the planner, that the `Map` and `ToolProvider`
  overloads arrive, and that a registered executor actually runs, and that a hallucinated tool name and a failing tool reach the
  configured handlers.

Reverting `tools.configure(builder)` in `SupervisorPlanner` fails 5 of the 12; reverting the `planWithTools`
selection fails 1. No test passes either way.

```
mvn -o -pl langchain4j-agentic verify -DskipITs
  Tests run: 143, Failures: 0, Errors: 0, Skipped: 0
  revapi: API checks completed without failures.

mvn -o -pl langchain4j-core test    Tests run: 1371, Failures: 0, Errors: 0, Skipped: 5
mvn -o -pl langchain4j test         Tests run: 1705, Failures: 0, Errors: 0, Skipped: 19
```

I did not add an integration test, and did not run the module's existing key-gated ITs. An IT for this feature
would assert that a planner uses a tool and then delegates, which is exactly the behaviour described above that
I could not make reliable, and a failing key-gated IT would land in the nightly rather than on this PR.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
