### PR TITLE
feat: set default User-Agent to LangChain4j in judge0, OpenSearch and MCP HTTP transport

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Judge0JavaScriptEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Judge0JavaScriptEngine.java
@@ -6,8 +6,8 @@ import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import dev.langchain4j.code.CodeExecutionEngine;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.http.client.HttpClient;
-import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.HttpClientBuilderLoader;
+import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -99,13 +99,14 @@ class Judge0JavaScriptEngine implements CodeExecutionEngine {
      * @param body The request body
      * @return The built request
      */
-    private HttpRequest buildRequest(String body) {
+    HttpRequest buildRequest(String body) {
         return HttpRequest.builder()
                 .method(POST)
                 .url(API_URL)
                 .addHeader("x-rapidapi-host", RAPID_API_HOST)
                 .addHeader("x-rapidapi-key", apiKey)
                 .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "LangChain4j")
                 .body(body)
                 .build();
     }

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/test/java/dev/langchain4j/code/judge0/Judge0UserAgentTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/test/java/dev/langchain4j/code/judge0/Judge0UserAgentTest.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.code.judge0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.HttpRequest;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class Judge0UserAgentTest {
+
+    @Test
+    void should_set_default_user_agent() {
+        Judge0JavaScriptEngine engine = new Judge0JavaScriptEngine("test-api-key", 102, Duration.ofSeconds(10));
+
+        HttpRequest request = engine.buildRequest("{}");
+
+        assertThat(request.headers().get("User-Agent")).containsExactly("LangChain4j");
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -169,11 +169,24 @@ public class StreamableHttpMcpTransport implements McpTransport {
         if (headers != null) {
             headers.forEach(builder::header);
         }
+        applyDefaultUserAgent(builder, headers);
         return builder.uri(URI.create(url))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json,text/event-stream")
                 .POST(bodyPublisher)
                 .build();
+    }
+
+    /**
+     * Sets a default {@code User-Agent} header identifying LangChain4j, unless the caller already supplied one
+     * (case-insensitively) via custom headers.
+     */
+    private static void applyDefaultUserAgent(HttpRequest.Builder builder, Map<String, String> customHeaders) {
+        boolean userAgentPresent =
+                customHeaders != null && customHeaders.keySet().stream().anyMatch("User-Agent"::equalsIgnoreCase);
+        if (!userAgentPresent) {
+            builder.header("User-Agent", "LangChain4j");
+        }
     }
 
     @Override
@@ -383,6 +396,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         if (headers != null) {
             headers.forEach(requestBuilder::header);
         }
+        applyDefaultUserAgent(requestBuilder, headers);
         HttpRequest request = requestBuilder.build();
 
         CompletableFuture<Void> result = new CompletableFuture<>();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersTestBase.java
@@ -100,6 +100,21 @@ public abstract class McpHeadersTestBase {
     }
 
     @Test
+    void defaultUserAgent() {
+        try {
+            headersMap.clear(); // ensure the default User-Agent is not overridden by custom headers
+            ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                    .name("echoHeader")
+                    .arguments("{\"headerName\": \"User-Agent\"}")
+                    .build();
+            String result = mcpClient.executeTool(toolExecutionRequest).resultText();
+            assertThat(result).isEqualTo("LangChain4j");
+        } finally {
+            headersMap.clear();
+        }
+    }
+
+    @Test
     void toolCallsViaAiService() {
         ChatModel mockChatModel = ChatModelMock.thatResponds((request) -> {
             if (request.messages().size() == 1) {

--- a/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
+++ b/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
@@ -108,6 +108,10 @@ public class OpenSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
                     httpClientBuilder.setConnectionManager(
                             PoolingAsyncClientConnectionManagerBuilder.create().build());
 
+                    // override the default opensearch-java User-Agent to identify LangChain4j
+                    httpClientBuilder.addRequestInterceptorFirst(
+                            (request, entity, context) -> request.setHeader("User-Agent", "LangChain4j"));
+
                     return httpClientBuilder;
                 })
                 .build();

--- a/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchUserAgentTest.java
+++ b/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchUserAgentTest.java
@@ -1,0 +1,59 @@
+package dev.langchain4j.store.embedding.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.data.embedding.Embedding;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchUserAgentTest {
+
+    private static final String BULK_RESPONSE =
+            "{\"took\":1,\"errors\":false,\"items\":[{\"index\":{\"_index\":\"test-index\",\"_id\":\"1\","
+                    + "\"_version\":1,\"result\":\"created\",\"status\":201}}]}";
+
+    private HttpServer server;
+    private final AtomicReference<String> userAgent = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/", exchange -> {
+            userAgent.set(exchange.getRequestHeaders().getFirst("User-Agent"));
+            if ("HEAD".equals(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(200, -1);
+            } else {
+                byte[] body = BULK_RESPONSE.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, body.length);
+                exchange.getResponseBody().write(body);
+                exchange.getResponseBody().close();
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void should_set_default_user_agent() {
+        OpenSearchEmbeddingStore store = OpenSearchEmbeddingStore.builder()
+                .serverUrl("http://" + InetAddress.getLoopbackAddress().getHostAddress() + ":"
+                        + server.getAddress().getPort())
+                .indexName("test-index")
+                .build();
+
+        store.add(Embedding.from(new float[] {1f, 2f, 3f}));
+
+        assertThat(userAgent.get()).isEqualTo("LangChain4j");
+    }
+}


### PR DESCRIPTION
## Issue

Refs #967 (next batch, following #6105)

## Summary

Adds a default `User-Agent: LangChain4j` header to the remaining HTTP-based modules that are not covered by #6105 or already handled on `main`:

- **langchain4j-code-execution-engine-judge0** (`Judge0JavaScriptEngine`): adds the header to the Judge0 API request. `buildRequest` was made package-private so it can be asserted in a unit test.
- **langchain4j-opensearch** (`OpenSearchEmbeddingStore`): the Apache HttpClient 5 transport used by `opensearch-java` sends `User-Agent: opensearch-java/<version> (Java/<version>)` on every request, which overrides anything set via `HttpAsyncClientBuilder.setUserAgent`. The header is therefore overridden per request via a request interceptor added in the existing `setHttpClientConfigCallback`. The AWS path (`AwsSdk2Transport`) is intentionally untouched since the AWS SDK controls its User-Agent.
- **langchain4j-mcp** (`StreamableHttpMcpTransport`): both the JSON-RPC POST path and the subsidiary SSE GET path now send `User-Agent: LangChain4j` unless the caller supplies their own via `customHeadersSupplier` (case-insensitive check).

## Tests

- `Judge0UserAgentTest`: asserts the header on the built request.
- `OpenSearchUserAgentTest`: spins up a local `com.sun.net.httpserver.HttpServer`, points the store at it, and asserts the received `User-Agent` is `LangChain4j`.
- `McpHeadersTestBase#defaultUserAgent`: uses the existing `echoHeader` MCP test server tool to verify the server receives `User-Agent: LangChain4j` (runs in the IT stage where jbang is available).

`mvn test` passes for the three modules locally.

## Remaining modules not covered

- `langchain4j-watsonx`: HTTP calls happen inside the IBM `watsonx-ai` SDK.
- SDK/gRPC-based modules (Pinecone, Qdrant, Milvus, Weaviate, MongoDB, Cassandra, AWS Bedrock, Azure, Couchbase, etc.) control their own User-Agent headers.