### PR TITLE
fix(agentic): memoize Context.Summarizer per ChatModel instead of a single JVM-wide instance

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Judge0JavaScriptEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Judge0JavaScriptEngine.java
@@ -6,8 +6,8 @@ import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import dev.langchain4j.code.CodeExecutionEngine;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.http.client.HttpClient;
-import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.HttpClientBuilderLoader;
+import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -99,13 +99,14 @@ class Judge0JavaScriptEngine implements CodeExecutionEngine {
      * @param body The request body
      * @return The built request
      */
-    private HttpRequest buildRequest(String body) {
+    HttpRequest buildRequest(String body) {
         return HttpRequest.builder()
                 .method(POST)
                 .url(API_URL)
                 .addHeader("x-rapidapi-host", RAPID_API_HOST)
                 .addHeader("x-rapidapi-key", apiKey)
                 .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "LangChain4j")
                 .body(body)
                 .build();
     }

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/test/java/dev/langchain4j/code/judge0/Judge0UserAgentTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/test/java/dev/langchain4j/code/judge0/Judge0UserAgentTest.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.code.judge0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.HttpRequest;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class Judge0UserAgentTest {
+
+    @Test
+    void should_set_default_user_agent() {
+        Judge0JavaScriptEngine engine = new Judge0JavaScriptEngine("test-api-key", 102, Duration.ofSeconds(10));
+
+        HttpRequest request = engine.buildRequest("{}");
+
+        assertThat(request.headers().get("User-Agent")).containsExactly("LangChain4j");
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/Context.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/Context.java
@@ -1,16 +1,18 @@
 package dev.langchain4j.agentic.internal;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.UserMessage;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
 
 public class Context {
 
-    private static ContextSummarizer SUMMARIZER_INSTANCE;
+    private static final Map<ChatModel, ContextSummarizer> SUMMARIZERS = new ConcurrentHashMap<>();
 
     public interface ContextSummarizer {
 
@@ -36,12 +38,13 @@ public class Context {
     }
 
     private static ContextSummarizer initSummarizer(ChatModel chatModel) {
-        if (SUMMARIZER_INSTANCE == null) {
-            SUMMARIZER_INSTANCE = AiServices.builder(ContextSummarizer.class)
-                    .chatModel(chatModel)
-                    .build();
-        }
-        return SUMMARIZER_INSTANCE;
+        // The summarizer is memoized per ChatModel: a single JVM-wide instance would silently route
+        // every agent's summarization requests to whichever model happened to build the first one.
+        return SUMMARIZERS.computeIfAbsent(
+                chatModel,
+                model -> AiServices.builder(ContextSummarizer.class)
+                        .chatModel(model)
+                        .build());
     }
 
     public static class AgenticScopeContextGenerator implements UserMessageTransformer {
@@ -70,7 +73,9 @@ public class Context {
         public Summarizer(AgenticScope agenticScope, ChatModel chatModel, String... agentNames) {
             super(agenticScope, c -> {
                 String context = c.contextAsConversation(agentNames);
-                return context.isBlank() ? context : initSummarizer(chatModel).summarize(context).getSummary();
+                return context.isBlank()
+                        ? context
+                        : initSummarizer(chatModel).summarize(context).getSummary();
             });
         }
     }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/ContextSummarizerTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/ContextSummarizerTest.java
@@ -1,0 +1,72 @@
+package dev.langchain4j.agentic.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ContextSummarizerTest {
+
+    @Test
+    void should_summarize_with_the_chat_model_of_each_summarizer_instance() {
+        RecordingChatModel firstModel = new RecordingChatModel("summary from the first model");
+        RecordingChatModel secondModel = new RecordingChatModel("summary from the second model");
+
+        Context.Summarizer firstSummarizer = new Context.Summarizer(agenticScope(), firstModel, "expert");
+        Context.Summarizer secondSummarizer = new Context.Summarizer(agenticScope(), secondModel, "expert");
+
+        String firstContext = firstSummarizer.transformUserMessage("user question", "memory-id");
+        String secondContext = secondSummarizer.transformUserMessage("user question", "memory-id");
+
+        assertThat(firstContext).contains("summary from the first model");
+        assertThat(secondContext).contains("summary from the second model");
+        assertThat(firstModel.requests).hasSize(1);
+        assertThat(secondModel.requests).hasSize(1);
+    }
+
+    @Test
+    void should_reuse_summarizer_for_the_same_chat_model() {
+        RecordingChatModel model = new RecordingChatModel("the summary");
+
+        Context.Summarizer firstSummarizer = new Context.Summarizer(agenticScope(), model, "expert");
+        Context.Summarizer secondSummarizer = new Context.Summarizer(agenticScope(), model, "expert");
+
+        firstSummarizer.transformUserMessage("user question", "memory-id");
+        secondSummarizer.transformUserMessage("user question", "memory-id");
+
+        assertThat(model.requests).hasSize(2);
+    }
+
+    private static AgenticScope agenticScope() {
+        AgenticScope agenticScope = mock(AgenticScope.class);
+        when(agenticScope.contextAsConversation(new String[] {"expert"}))
+                .thenReturn("user: what is the weather?\nexpert: it is sunny in Berlin");
+        return agenticScope;
+    }
+
+    static class RecordingChatModel implements ChatModel {
+
+        private final String summary;
+        final List<ChatRequest> requests = new ArrayList<>();
+
+        RecordingChatModel(String summary) {
+            this.summary = summary;
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            requests.add(chatRequest);
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("{\"summary\": \"" + summary + "\"}"))
+                    .build();
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -169,11 +169,24 @@ public class StreamableHttpMcpTransport implements McpTransport {
         if (headers != null) {
             headers.forEach(builder::header);
         }
+        applyDefaultUserAgent(builder, headers);
         return builder.uri(URI.create(url))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json,text/event-stream")
                 .POST(bodyPublisher)
                 .build();
+    }
+
+    /**
+     * Sets a default {@code User-Agent} header identifying LangChain4j, unless the caller already supplied one
+     * (case-insensitively) via custom headers.
+     */
+    private static void applyDefaultUserAgent(HttpRequest.Builder builder, Map<String, String> customHeaders) {
+        boolean userAgentPresent =
+                customHeaders != null && customHeaders.keySet().stream().anyMatch("User-Agent"::equalsIgnoreCase);
+        if (!userAgentPresent) {
+            builder.header("User-Agent", "LangChain4j");
+        }
     }
 
     @Override
@@ -383,6 +396,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         if (headers != null) {
             headers.forEach(requestBuilder::header);
         }
+        applyDefaultUserAgent(requestBuilder, headers);
         HttpRequest request = requestBuilder.build();
 
         CompletableFuture<Void> result = new CompletableFuture<>();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersTestBase.java
@@ -100,6 +100,21 @@ public abstract class McpHeadersTestBase {
     }
 
     @Test
+    void defaultUserAgent() {
+        try {
+            headersMap.clear(); // ensure the default User-Agent is not overridden by custom headers
+            ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                    .name("echoHeader")
+                    .arguments("{\"headerName\": \"User-Agent\"}")
+                    .build();
+            String result = mcpClient.executeTool(toolExecutionRequest).resultText();
+            assertThat(result).isEqualTo("LangChain4j");
+        } finally {
+            headersMap.clear();
+        }
+    }
+
+    @Test
     void toolCallsViaAiService() {
         ChatModel mockChatModel = ChatModelMock.thatResponds((request) -> {
             if (request.messages().size() == 1) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/ToolCall.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/ToolCall.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.openai.internal.chat;
 
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -8,11 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
 import java.util.Locale;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 
 @JsonDeserialize(builder = ToolCall.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -20,10 +19,13 @@ public class ToolCall {
 
     @JsonProperty
     private final String id;
+
     @JsonProperty
     private final Integer index;
+
     @JsonProperty
     private final ToolType type;
+
     @JsonProperty
     private final FunctionCall function;
 
@@ -55,8 +57,7 @@ public class ToolCall {
     @JacocoIgnoreCoverageGenerated
     public boolean equals(Object another) {
         if (this == another) return true;
-        return another instanceof ToolCall
-                && equalTo((ToolCall) another);
+        return another instanceof ToolCall && equalTo((ToolCall) another);
     }
 
     @JacocoIgnoreCoverageGenerated
@@ -81,12 +82,7 @@ public class ToolCall {
     @Override
     @JacocoIgnoreCoverageGenerated
     public String toString() {
-        return "ToolCall{"
-                + "id=" + id
-                + ", index=" + index
-                + ", type=" + type
-                + ", function=" + function
-                + "}";
+        return "ToolCall{" + "id=" + id + ", index=" + index + ", type=" + type + ", function=" + function + "}";
     }
 
     public static Builder builder() {
@@ -109,6 +105,12 @@ public class ToolCall {
         }
 
         public Builder index(Integer index) {
+            // Some OpenAI-compatible proxies emit negative tool-call indexes (e.g. when translating
+            // Anthropic content-block indexes); the OpenAI spec requires non-negative values, so
+            // treat them as absent and let the existing null-index fallback handle them.
+            if (index != null && index < 0) {
+                index = null;
+            }
             this.index = index;
             return this;
         }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -81,6 +81,36 @@ class OpenAiStreamingResponseBuilderTest {
     }
 
     @Test
+    void should_handle_negative_tool_call_index() {
+        // Given: an OpenAI-compatible proxy translating Anthropic responses emits a negative
+        // tool-call index, which is invalid per the OpenAI spec and must fall back like null
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        ToolCall toolCall = ToolCall.builder()
+                .id("call_789")
+                .index(-1)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder()
+                        .name("getWeather")
+                        .arguments("{\"city\": \"Berlin\"}")
+                        .build())
+                .build();
+
+        // The DTO normalizes the invalid negative index to null at the wire boundary
+        assertThat(toolCall.index()).isNull();
+
+        // When: appending the response (should not throw IllegalArgumentException)
+        builder.append(chatCompletionResponse(toolCall));
+
+        // Then: the tool execution request is built correctly
+        ChatResponse chatResponse = builder.build();
+        assertThat(chatResponse.aiMessage().toolExecutionRequests()).hasSize(1);
+        assertThat(chatResponse.aiMessage().toolExecutionRequests().get(0).name())
+                .isEqualTo("getWeather");
+        assertThat(chatResponse.aiMessage().toolExecutionRequests().get(0).id()).isEqualTo("call_789");
+    }
+
+    @Test
     void should_handle_non_null_tool_call_index() {
         // Given: a standard tool call with non-null index
         OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();

--- a/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
+++ b/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
@@ -108,6 +108,10 @@ public class OpenSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
                     httpClientBuilder.setConnectionManager(
                             PoolingAsyncClientConnectionManagerBuilder.create().build());
 
+                    // override the default opensearch-java User-Agent to identify LangChain4j
+                    httpClientBuilder.addRequestInterceptorFirst(
+                            (request, entity, context) -> request.setHeader("User-Agent", "LangChain4j"));
+
                     return httpClientBuilder;
                 })
                 .build();

--- a/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchUserAgentTest.java
+++ b/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchUserAgentTest.java
@@ -1,0 +1,59 @@
+package dev.langchain4j.store.embedding.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.data.embedding.Embedding;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchUserAgentTest {
+
+    private static final String BULK_RESPONSE =
+            "{\"took\":1,\"errors\":false,\"items\":[{\"index\":{\"_index\":\"test-index\",\"_id\":\"1\","
+                    + "\"_version\":1,\"result\":\"created\",\"status\":201}}]}";
+
+    private HttpServer server;
+    private final AtomicReference<String> userAgent = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/", exchange -> {
+            userAgent.set(exchange.getRequestHeaders().getFirst("User-Agent"));
+            if ("HEAD".equals(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(200, -1);
+            } else {
+                byte[] body = BULK_RESPONSE.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, body.length);
+                exchange.getResponseBody().write(body);
+                exchange.getResponseBody().close();
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void should_set_default_user_agent() {
+        OpenSearchEmbeddingStore store = OpenSearchEmbeddingStore.builder()
+                .serverUrl("http://" + InetAddress.getLoopbackAddress().getHostAddress() + ":"
+                        + server.getAddress().getPort())
+                .indexName("test-index")
+                .build();
+
+        store.add(Embedding.from(new float[] {1f, 2f, 3f}));
+
+        assertThat(userAgent.get()).isEqualTo("LangChain4j");
+    }
+}


### PR DESCRIPTION
## Issue

Fixes #6245

## Summary

`Context.Summarizer` cached its `ContextSummarizer` AI service in a single JVM-wide static field, so only the first caller's `ChatModel` was ever used: every later agent (or supervisor) using `summarizedContext` silently sent its summarization requests to that first model, contradicting the documented behavior and silently sending data to an unintended provider. The lazy static initialization was also racy.

The summarizer is now memoized per `ChatModel` instance via a `ConcurrentHashMap` and `computeIfAbsent`, which fixes the model misrouting, removes the race, and still reuses a single AI service for agents that share the same model instance.

## Tests

New `ContextSummarizerTest`:

- two `Summarizer` instances backed by two recording `ChatModel`s each produce their own model's summary (previously the second agent got the first model's summary)
- two `Summarizer` instances sharing the same `ChatModel` reuse one summarizer service (two chat requests, one memoized service)

`mvn -pl langchain4j-agentic test` passes (133 tests).