### PR TITLE
Fix NullPointerException when completing a pending response with a null value

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScope.java
@@ -184,7 +184,8 @@ public interface AgenticScope extends LangChain4jManaged {
      * a human's response after a process restart or when using a polling/event-driven model.
      *
      * @param responseId the unique identifier of the pending response
-     * @param value the value to complete the response with
+     * @param value the value to complete the response with, or {@code null} to complete it with no value,
+     *              which removes the key from the state as {@link #writeState(String, Object)} does
      * @return {@code true} if a matching pending response was found and completed
      */
     default boolean completePendingResponse(String responseId, Object value) {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
@@ -1,10 +1,12 @@
 package dev.langchain4j.agentic.scope;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
 import static dev.langchain4j.agentic.internal.AgentUtil.keyDefaultValue;
 import static dev.langchain4j.agentic.internal.AgentUtil.keyName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.agentic.agent.ChatMessagesAccess;
@@ -38,9 +40,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -453,7 +452,7 @@ public class DefaultAgenticScope implements AgenticScope {
                     && deferred.responseId().equals(responseId)) {
                 boolean completed = ((DeferredResponse<Object>) deferred).complete(value);
                 if (completed) {
-                    withReadLock(() -> state.put(entry.getKey(), value));
+                    writeState(entry.getKey(), value);
                 }
                 return completed;
             }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/CompletePendingResponseTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/CompletePendingResponseTest.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.agentic.scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agentic.internal.PendingResponse;
+import org.junit.jupiter.api.Test;
+
+class CompletePendingResponseTest {
+
+    @Test
+    void should_complete_with_a_value() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        PendingResponse<String> pending = new PendingResponse<>("response-1");
+        scope.writeState("humanInput", pending);
+
+        boolean completed = scope.completePendingResponse("response-1", "yes");
+
+        assertThat(completed).isTrue();
+        assertThat(pending.blockingGet()).isEqualTo("yes");
+        assertThat(scope.readState("humanInput")).isEqualTo("yes");
+    }
+
+    @Test
+    void should_complete_with_null_value() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        PendingResponse<String> pending = new PendingResponse<>("response-1");
+        scope.writeState("humanInput", pending);
+
+        boolean completed = scope.completePendingResponse("response-1", null);
+
+        assertThat(completed).isTrue();
+        assertThat(pending.isDone()).isTrue();
+        assertThat(pending.blockingGet()).isNull();
+    }
+
+    @Test
+    void should_remove_the_key_when_completed_with_null_as_writeState_does() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        scope.writeState("humanInput", new PendingResponse<String>("response-1"));
+
+        scope.completePendingResponse("response-1", null);
+
+        assertThat(scope.hasState("humanInput")).isFalse();
+        assertThat(scope.readState("humanInput")).isNull();
+    }
+
+    @Test
+    void should_clear_the_pending_id_when_completed_with_null() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        scope.writeState("humanInput", new PendingResponse<String>("response-1"));
+        assertThat(scope.pendingResponseIds()).containsExactly("response-1");
+
+        scope.completePendingResponse("response-1", null);
+
+        assertThat(scope.pendingResponseIds()).isEmpty();
+    }
+
+    @Test
+    void should_complete_the_single_pending_response_with_null() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        PendingResponse<String> pending = new PendingResponse<>("response-1");
+        scope.writeState("humanInput", pending);
+
+        boolean completed = scope.completePendingResponse(null);
+
+        assertThat(completed).isTrue();
+        assertThat(pending.blockingGet()).isNull();
+        assertThat(scope.hasState("humanInput")).isFalse();
+    }
+
+    @Test
+    void should_not_touch_the_state_when_the_response_is_already_completed() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        PendingResponse<String> pending = new PendingResponse<>("response-1");
+        pending.complete("first");
+        scope.writeState("humanInput", pending);
+
+        boolean completed = scope.completePendingResponse("response-1", null);
+
+        assertThat(completed).isFalse();
+        assertThat(scope.state()).containsEntry("humanInput", pending);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6298

## Change

`DefaultAgenticScope.completePendingResponse` stored the completed value with an unconditional
`state.put(...)` into a `ConcurrentHashMap`, so a null value threw after the `DeferredResponse` had already
been completed. The caller got a `NullPointerException`, anything blocked on the response was already released,
and the completed response stayed in the state under its key.

`writeState` in the same class already handles this: null removes the key, and `AgenticScope.writeState`
documents that. The fix routes the completion through it rather than repeating the mapping, so the two paths
cannot diverge again:

```java
if (completed) {
    writeState(entry.getKey(), value);
}
```

`writeState` also completes an outgoing `DeferredResponse` found under the key, which is a no-op here because
the response was just completed and the branch is guarded by `isDone()`. Locking is unchanged: the previous
code took the read lock around the `put` and `writeState` takes the same one around its body.

The path is reachable from the documented resume API, not only from the scope directly:
`ResultWithAgenticScope.completePendingResponse` forwards to it at `ResultWithAgenticScope.java:83`.

The `AgenticScope.completePendingResponse` Javadoc now states the null behaviour, matching how
`writeState(String, Object)` documents it. If you would rather keep the two independent and inline the null
check instead, that is a two-line change and I am happy to switch.

### Tests

- `CompletePendingResponseTest` (new) proves completing with null completes the response, removes the key and
  clears the pending id, through both the two-argument method and the single-argument convenience overload;
  that completing with a value still stores it; and that an already-completed response returns `false` and
  leaves the state untouched.

Four of the six fail on unmodified `main` with the `NullPointerException`. The other two pass either way and
are there because the fix changes the storing path for every value, not only null.

```
mvn -o -pl langchain4j-agentic verify -DskipITs
  Tests run: 137, Failures: 0, Errors: 0, Skipped: 0
  revapi: API checks completed without failures.

mvn -o -pl langchain4j-core test    Tests run: 1371, Failures: 0, Errors: 0, Skipped: 5
mvn -o -pl langchain4j test         Tests run: 1705, Failures: 0, Errors: 0, Skipped: 19
```

The module's integration tests are key-gated and were not run.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
