### PR TITLE
Make SupervisorAgentIT's Invoice constructible from the planner's arguments

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
@@ -303,14 +303,14 @@ public class AgentUtil {
                 throw new MissingArgumentException(arg.name());
             }
         }
-        Object parsedArgument = adaptValueToType(argValue, arg.rawType());
+        Object parsedArgument = adaptValueToType(argValue, arg.rawType(), arg.name());
         if (argValue != parsedArgument) {
             agenticScope.writeState(arg.name(), parsedArgument);
         }
         return parsedArgument;
     }
 
-    private static Object adaptValueToType(Object value, Class<?> type) {
+    private static Object adaptValueToType(Object value, Class<?> type, String argumentName) {
         if (type.isInstance(value)) {
             return value;
         }
@@ -322,14 +322,7 @@ public class AgentUtil {
                 case "double", "java.lang.Double" -> Double.parseDouble(s);
                 case "float", "java.lang.Float" -> Float.parseFloat(s);
                 case "boolean", "java.lang.Boolean" -> Boolean.parseBoolean(s);
-                default -> {
-                    try {
-                        yield Json.fromJson(s, type);
-                    } catch (Exception e) {
-                        throw new IllegalArgumentException(
-                                "Cannot deserialize value '" + s + "' to type " + type.getName(), e);
-                    }
-                }
+                default -> readArgument(s, type, argumentName);
             };
         }
         if (value instanceof Number n) {
@@ -345,7 +338,7 @@ public class AgentUtil {
             };
         }
         if (value instanceof Map && !Map.class.isAssignableFrom(type)) {
-            return Json.fromJson(Json.toJson(value), type);
+            return readArgument(Json.toJson(value), type, argumentName);
         }
         if (value instanceof Image image && type == ImageContent.class) {
             return ImageContent.from(image);
@@ -354,6 +347,25 @@ public class AgentUtil {
             return imageContent.image();
         }
         return value;
+    }
+
+    /**
+     * A planner describes an argument as JSON, so a type used as an agent argument has to be one a
+     * JSON library can build: a record, a type with a no-arg constructor, or one whose constructor
+     * carries {@code @JsonCreator}. Saying that is more use than the JSON library's own message,
+     * which names neither the argument nor what to do about it. The value itself is left out: it
+     * came from a model and can carry anything the prompt did.
+     */
+    private static <T> T readArgument(String json, Class<T> type, String argumentName) {
+        try {
+            return Json.fromJson(json, type);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Cannot read agent argument '" + argumentName + "' as " + type.getName()
+                            + ". A type used as an agent argument must be a record, have a no-arg"
+                            + " constructor, or have a constructor annotated with @JsonCreator.",
+                    e);
+        }
     }
 
     public static Method validateAgentClass(Class<?> agentServiceClass) {

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AgentArgumentConversionTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AgentArgumentConversionTest.java
@@ -1,0 +1,75 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agentic.internal.AgentUtil;
+import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.service.V;
+import java.lang.reflect.Method;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A planner describes an agent argument as JSON, so the declared parameter type has to be one a JSON
+ * library can build. When it is not, the failure should name the argument and say what to do, rather
+ * than pass on the JSON library's own wording.
+ */
+class AgentArgumentConversionTest {
+
+    static class NotConstructible {
+        private final String author;
+
+        NotConstructible(String author) {
+            this.author = author;
+        }
+
+        public String getAuthor() {
+            return author;
+        }
+    }
+
+    record Constructible(String author, double amountInUSD) {}
+
+    interface RegistrationAgent {
+        @Agent("registers something")
+        String register(@V("doc") NotConstructible doc);
+    }
+
+    interface RecordAgent {
+        @Agent("registers something")
+        String register(@V("doc") Constructible doc);
+    }
+
+    @Test
+    void a_type_the_planner_cannot_build_names_the_argument_and_the_remedy() {
+        assertThatThrownBy(() -> arguments(RegistrationAgent.class, Map.of("author", "Mario")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("doc")
+                .hasMessageContaining(NotConstructible.class.getName())
+                .hasMessageContaining("@JsonCreator")
+                .hasMessageContaining("record");
+    }
+
+    @Test
+    void the_message_does_not_repeat_what_the_model_sent() {
+        assertThatThrownBy(() -> arguments(RegistrationAgent.class, Map.of("author", "some-sensitive-value")))
+                .hasMessageNotContaining("some-sensitive-value");
+    }
+
+    @Test
+    void a_record_argument_is_built_from_the_planners_map() {
+        Object argument = arguments(RecordAgent.class, Map.of("author", "Mario", "amountInUSD", 100.0));
+
+        assertThat(argument).isInstanceOf(Constructible.class);
+        assertThat(((Constructible) argument).author()).isEqualTo("Mario");
+    }
+
+    private static Object arguments(Class<?> agentClass, Map<String, Object> plannerValue) {
+        DefaultAgenticScope scope = new AgenticScopeRegistry("test-agent").create("test-memory");
+        scope.writeState("doc", plannerValue);
+        Method method = agentClass.getDeclaredMethods()[0];
+        return AgentUtil.agentInvocationArguments(scope, method).positionalArgs()[0];
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/InvoiceFixtureTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/InvoiceFixtureTest.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.internal.Json;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The planner hands an agent argument over as a Map, which AgentUtil.adaptValueToType reads into the
+ * declared parameter type. Covers that SupervisorAgentIT's Invoice can survive that, without needing
+ * a model.
+ */
+class InvoiceFixtureTest {
+
+    @Test
+    void invoice_is_readable_from_the_map_a_planner_produces() {
+        Map<String, Object> fromPlanner = Map.of("author", "Mario", "amountInUSD", 100.0);
+
+        SupervisorAgentIT.Invoice invoice =
+                Json.fromJson(Json.toJson(fromPlanner), SupervisorAgentIT.Invoice.class);
+
+        assertThat(invoice.getAuthor()).isEqualTo("Mario");
+        assertThat(invoice.getAmountInUSD()).isEqualTo(100.0);
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1138,7 +1140,13 @@ public class SupervisorAgentIT {
 
         private final double amountInUSD;
 
-        Invoice(String author, double amountInUSD) {
+        // The planner returns the argument as a JSON object, which AgentUtil.adaptValueToType reads
+        // back into this type. A class with final fields and no no-arg constructor gives Jackson
+        // nothing to construct from, so the creator has to be named explicitly. The other argument
+        // fixtures here are records, which carry that for free; this one cannot be, because the
+        // point of the test is a field inherited from a superclass.
+        @JsonCreator
+        Invoice(@JsonProperty("author") String author, @JsonProperty("amountInUSD") double amountInUSD) {
             super(author);
             this.amountInUSD = amountInUSD;
         }


### PR DESCRIPTION
The planner returns an agent argument as a JSON object, and adaptValueToType reads it back into the declared parameter type. Invoice has final fields and a single unannotated constructor, which gives Jackson nothing to construct from, so the supervisor failed with "no Creators, like default constructor, exist" on every run. Naming the creator fixes it for Jackson 2 and Jackson 3 alike, since these are jackson-annotations. The other argument fixtures here are records and get that for free; this one cannot be a record because the test is about a field inherited from a superclass.

The test that covers this needs a planner and a key, so it is skipped everywhere except the nightly, and it had never actually run. InvoiceFixtureTest performs the same conversion directly, so the next time the fixture drifts a normal build says so.