### PR TITLE
Fix three Jackson 3 defects the nightly integration run found

### DIFF
--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/QueryRequest.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/QueryRequest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.store.embedding.chroma;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.Internal;
 
 import static java.util.Arrays.asList;
@@ -31,6 +32,7 @@ class QueryRequest {
         return queryEmbeddings;
     }
 
+    @JsonProperty("n_results")
     public int getnResults() {
         return nResults;
     }

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreTest.java
@@ -174,6 +174,30 @@ class ChromaEmbeddingStoreTest {
         assertThat(matches).extracting(EmbeddingMatch::score).containsExactly(1.0 / 1.5);
     }
 
+    /**
+     * maxResults travels as "n_results". Its getter is getnResults(), which is a bean getter to
+     * Jackson 2 but not to Jackson 3, so the field silently vanished from every query under the
+     * Jackson 3 opt-in and Chroma applied its own default instead.
+     */
+    @Test
+    void a_search_sends_n_results() {
+        CapturingHttpClient httpClient = new CapturingHttpClient();
+
+        store(httpClient)
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(EMBEDDING_1)
+                        .maxResults(7)
+                        .build());
+
+        String queryBody = httpClient.writeRequests().stream()
+                .map(HttpRequest::body)
+                .filter(body -> body.contains("query_embeddings"))
+                .reduce((first, second) -> second)
+                .orElseThrow();
+
+        assertThat(queryBody).contains("\"n_results\"").contains("7");
+    }
+
     private static List<EmbeddingMatch<TextSegment>> search(CapturingHttpClient httpClient) {
         return store(httpClient)
                 .search(EmbeddingSearchRequest.builder()

--- a/langchain4j-core-jackson3/src/main/java/dev/langchain4j/jackson3/Jackson3ProviderJsonCodec.java
+++ b/langchain4j-core-jackson3/src/main/java/dev/langchain4j/jackson3/Jackson3ProviderJsonCodec.java
@@ -35,7 +35,12 @@ public class Jackson3ProviderJsonCodec implements Json.JsonCodec {
         if (spec.propertyNaming() == ProviderJsonSpec.PropertyNaming.SNAKE_CASE) {
             builder.propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         }
-        builder.changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(toJacksonInclude(spec.inclusion())));
+        // Content inclusion as well as value inclusion, because Jackson 2's serializationInclusion(...)
+        // sets both: without it a null map value is written where Jackson 2 omits it, and a provider
+        // that rejects an explicit null (Bedrock does) fails the request.
+        JsonInclude.Include include = toJacksonInclude(spec.inclusion());
+        builder.changeDefaultPropertyInclusion(
+                incl -> incl.withValueInclusion(include).withContentInclusion(include));
         this.objectMapper = builder.build();
     }
 

--- a/langchain4j-core-jackson3/src/test/java/dev/langchain4j/jackson3/Jackson3InclusionParityTest.java
+++ b/langchain4j-core-jackson3/src/test/java/dev/langchain4j/jackson3/Jackson3InclusionParityTest.java
@@ -1,0 +1,45 @@
+package dev.langchain4j.jackson3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.internal.ProviderJson;
+import dev.langchain4j.internal.ProviderJsonSpec;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Jackson 2's {@code serializationInclusion(NON_NULL)} sets value <em>and</em> content inclusion, so
+ * a null map value is left out. Providers rely on that: Bedrock rejects an explicit null where it
+ * accepts an absent field.
+ */
+class Jackson3InclusionParityTest {
+
+    private static final Json.JsonCodec CODEC = ProviderJson.codec(
+            ProviderJsonSpec.builder().inclusion(ProviderJsonSpec.Inclusion.NON_NULL).build());
+
+    @Test
+    void a_null_map_value_is_not_written() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("input_type", "search_document");
+        parameters.put("truncate", null);
+
+        assertThat(CODEC.toJson(parameters)).isEqualTo("{\"input_type\":\"search_document\"}");
+    }
+
+    @Test
+    void a_null_field_is_not_written() {
+        assertThat(CODEC.toJson(new Pojo("x", null))).isEqualTo("{\"set\":\"x\"}");
+    }
+
+    static class Pojo {
+        public String set;
+        public String unset;
+
+        Pojo(String set, String unset) {
+            this.set = set;
+            this.unset = unset;
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsTestBase.java
@@ -3,10 +3,10 @@ package dev.langchain4j.mcp.client.integration;
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.Json;
+import dev.langchain4j.internal.Types;
 import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.resourcesastools.DefaultMcpResourcesAsToolsPresenter;
@@ -16,11 +16,15 @@ import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public abstract class McpResourcesAsToolsTestBase {
+
+    private static final Type LIST_OF_MAPS = Types.listOf(Types.parameterized(Map.class, String.class, Object.class));
 
     static McpClient mcpClientAlice;
     static McpClient mcpClientBob;
@@ -54,14 +58,17 @@ public abstract class McpResourcesAsToolsTestBase {
         // call the list_resources tool and verify the output
         String listResourcesResult =
                 toolProviderResult.toolExecutorByName("list_resources").execute(null, null);
-        ArrayNode resources = Json.fromJson(listResourcesResult, ArrayNode.class);
-        assertThat(resources.size()).isEqualTo(1);
-        assertThat(resources.get(0).get("mcpServer").asText()).isEqualTo("alice");
-        assertThat(resources.get(0).get("uri").asText()).isEqualTo("file:///info");
-        assertThat(resources.get(0).get("uriTemplate").isNull()).isTrue();
-        assertThat(resources.get(0).get("name").asText()).isEqualTo("basicInfo");
-        assertThat(resources.get(0).get("description").asText()).isEqualTo("Basic information about Alice");
-        assertThat(resources.get(0).get("mimeType").asText()).isEqualTo("text/plain");
+        // Read as plain values rather than a Jackson node type: the codec behind Json is whichever
+        // JSON library the application opted into, and a node type belongs to one of them.
+        List<Map<String, Object>> resources = Json.fromJson(listResourcesResult, LIST_OF_MAPS);
+        assertThat(resources).hasSize(1);
+        assertThat(resources.get(0))
+                .containsEntry("mcpServer", "alice")
+                .containsEntry("uri", "file:///info")
+                .containsEntry("uriTemplate", null)
+                .containsEntry("name", "basicInfo")
+                .containsEntry("description", "Basic information about Alice")
+                .containsEntry("mimeType", "text/plain");
 
         // call the get_resource tool
         ToolExecutionRequest request = ToolExecutionRequest.builder()


### PR DESCRIPTION
The nightly that runs integration tests on Jackson 3 caught three things the unit tests could not, because each is about what goes on the wire rather than what the code does.

Chroma sent no n_results at all, so every query ignored maxResults and the server applied its own default. The getter is getnResults(), which Jackson 2 accepts as a bean getter and Jackson 3 does not, so the property was simply absent - no error, just a different result set. An explicit @JsonProperty is what both agree on. This is the only getter in the repository shaped that way.

The provider codec wrote null map values. Jackson 2's serializationInclusion(NON_NULL) sets content inclusion as well as value inclusion, and the Jackson 3 codec set only the latter, so a map entry with a null value was serialized where Jackson 2 leaves it out. Bedrock rejects an explicit null for a field it accepts as absent.

McpResourcesAsToolsTestBase asked the codec for a Jackson 2 ArrayNode. Which library is behind Json is the application's choice, so a test cannot name a type from one of them; it now reads plain values.

Both fixes get a test that fails without them, at a level that does not need a server: the Chroma one asserts the request body, which is what no test was looking at.