### PR TITLE
Run output guardrails and drain buffered tokens without onCompleteResponse

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -376,48 +376,49 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         } else {
             ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
 
-            if (completeResponseHandler != null) {
-                // Invoke output guardrails
-                if (hasOutputGuardrails) {
-                    if (commonGuardrailParams != null) {
-                        var newCommonParams = commonGuardrailParams.toBuilder()
-                                .chatMemory(getMemory())
-                                .build();
+            // Output guardrails must run, and the buffered partial responses must be
+            // replayed, whether or not the caller registered a complete-response handler:
+            // onCompleteResponse is optional (validateConfiguration only rejects registering
+            // it more than once), while onPartialResponse buffers unconditionally once
+            // guardrails are active.
+            if (hasOutputGuardrails) {
+                if (commonGuardrailParams != null) {
+                    var newCommonParams = commonGuardrailParams.toBuilder()
+                            .chatMemory(getMemory())
+                            .build();
 
-                        var outputGuardrailParams = OutputGuardrailRequest.builder()
-                                .responseFromLLM(finalChatResponse)
-                                .chatExecutor(ToolAwareRepromptExecutor.wrap(
-                                        chatExecutor,
-                                        context,
-                                        invocationContext.chatMemoryId(),
-                                        chatRequest.parameters(),
-                                        invocationContext,
-                                        toolServiceContext,
-                                        this::executeSynchronously))
-                                .requestParams(newCommonParams)
-                                .build();
+                    var outputGuardrailParams = OutputGuardrailRequest.builder()
+                            .responseFromLLM(finalChatResponse)
+                            .chatExecutor(ToolAwareRepromptExecutor.wrap(
+                                    chatExecutor,
+                                    context,
+                                    invocationContext.chatMemoryId(),
+                                    chatRequest.parameters(),
+                                    invocationContext,
+                                    toolServiceContext,
+                                    this::executeSynchronously))
+                            .requestParams(newCommonParams)
+                            .build();
 
-                        finalChatResponse =
-                                context.guardrailService().executeGuardrails(methodKey, outputGuardrailParams);
-                    }
-
-                    // If we have output guardrails, we should process all of the partial responses first before
-                    // completing
-                    if (partialResponseHandler != null) {
-                        responseBuffer.forEach(partialResponseHandler::accept);
-                    } else if (partialResponseWithContextHandler != null) {
-                        PartialResponseContext partialResponseContext =
-                                new PartialResponseContext(new CancellationUnsupportedStreamingHandle());
-                        responseBuffer.forEach(s -> partialResponseWithContextHandler.accept(
-                                new PartialResponse(s), partialResponseContext));
-                    }
-                    responseBuffer.clear();
+                    finalChatResponse = context.guardrailService().executeGuardrails(methodKey, outputGuardrailParams);
                 }
 
-                fireInvocationComplete(finalChatResponse);
+                // If we have output guardrails, we should process all of the partial responses first before
+                // completing
+                if (partialResponseHandler != null) {
+                    responseBuffer.forEach(partialResponseHandler::accept);
+                } else if (partialResponseWithContextHandler != null) {
+                    PartialResponseContext partialResponseContext =
+                            new PartialResponseContext(new CancellationUnsupportedStreamingHandle());
+                    responseBuffer.forEach(s ->
+                            partialResponseWithContextHandler.accept(new PartialResponse(s), partialResponseContext));
+                }
+                responseBuffer.clear();
+            }
+
+            fireInvocationComplete(finalChatResponse);
+            if (completeResponseHandler != null) {
                 completeResponseHandler.accept(finalChatResponse);
-            } else {
-                fireInvocationComplete(finalChatResponse);
             }
         }
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/guardrail/StreamingOutputGuardrailBufferDrainTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/guardrail/StreamingOutputGuardrailBufferDrainTest.java
@@ -13,6 +13,7 @@ import dev.langchain4j.service.TokenStream;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,21 @@ class StreamingOutputGuardrailBufferDrainTest {
         }
     }
 
+    interface StreamingAssistantWithRecordingGuardrail {
+        @dev.langchain4j.service.guardrail.OutputGuardrails(RecordingOutputGuardrail.class)
+        TokenStream chat(String message);
+    }
+
+    public static class RecordingOutputGuardrail implements OutputGuardrail {
+        static final CountDownLatch INVOKED = new CountDownLatch(1);
+
+        @Override
+        public OutputGuardrailResult validate(OutputGuardrailRequest request) {
+            INVOKED.countDown();
+            return success();
+        }
+    }
+
     @Test
     void should_drain_buffered_tokens_to_BiConsumer_handler_when_output_guardrails_active() throws Exception {
         StreamingChatModel model = StreamingChatModelMock.thatAlwaysStreams("Hello", " ", "world", "!");
@@ -57,6 +73,36 @@ class StreamingOutputGuardrailBufferDrainTest {
 
         future.get(5, TimeUnit.SECONDS);
 
+        assertThat(String.join("", received)).isEqualTo("Hello world!");
+    }
+
+    @Test
+    void should_run_guardrails_and_drain_buffer_when_no_complete_response_handler_registered() throws Exception {
+        StreamingChatModel model = StreamingChatModelMock.thatAlwaysStreams("Hello", " ", "world", "!");
+
+        StreamingAssistantWithRecordingGuardrail assistant = AiServices.builder(
+                        StreamingAssistantWithRecordingGuardrail.class)
+                .streamingChatModel(model)
+                .build();
+
+        List<String> received = new CopyOnWriteArrayList<>();
+
+        // onCompleteResponse is optional: validateConfiguration only rejects registering it
+        // more than once. Omitting it must not skip the output guardrail or swallow the
+        // buffered tokens.
+        assistant
+                .chat("hi")
+                .onPartialResponse(received::add)
+                .onError(Throwable::printStackTrace)
+                .start();
+
+        assertThat(RecordingOutputGuardrail.INVOKED.await(5, TimeUnit.SECONDS))
+                .as("output guardrail must run even without a complete-response handler")
+                .isTrue();
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (received.isEmpty() && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
         assertThat(String.join("", received)).isEqualTo("Hello world!");
     }
 


### PR DESCRIPTION
Both the output-guardrail execution and the `responseBuffer` drain sit inside `if (completeResponseHandler != null)` in `AiServiceStreamingResponseHandler`. But `onCompleteResponse` is optional — `AiServiceTokenStream.validateConfiguration()` only rejects registering it *more* than once — while `onPartialResponse` buffers unconditionally as soon as guardrails are active.

So an AI service with `@OutputGuardrails` returning a `TokenStream`, consumed without `onCompleteResponse`, drops every token **and** never runs the guardrail:

```java
assistant.chat("hi")
    .onPartialResponse(out::print)
    .onError(Throwable::printStackTrace)
    .start();
// no output, and the output guardrail never executes
```

Silently skipping an output guardrail is the part that matters — it's a validation/redaction hook, so callers can reasonably assume it ran.

This is the remaining sibling of #5249, where the same drain was gated on the wrong handler and was fixed for the `BiConsumer` variant in #5252. Distinct from #4316 and #5728, which are about buffering making output non-streaming by design, not about the drain being skipped.

The fix hoists the guardrail and drain out of the gate; the complete-response callback is still only invoked when registered. Test added to the existing `StreamingOutputGuardrailBufferDrainTest`, verified failing before the change and passing after. `mvn -pl langchain4j test` over the guardrail and AI-service suites: 687 pass. `spotless:apply` run.

One related defect I did **not** touch, to keep this reviewable: the immediate-tool-return path (`ToolService.shouldReturnImmediately`) also returns without running guardrails or draining the buffer, and that one leaks even when `onCompleteResponse` *is* registered. Happy to fold it in here or send a follow-up — let me know which you prefer.
