### PR TITLE
fix(mcp): map json schema types to exact Java scalars (#6226)

### DIFF
--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
@@ -1,11 +1,15 @@
 package dev.langchain4j.agentic.mcp;
 
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
+import static dev.langchain4j.internal.Utils.getAnnotatedMethod;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.declarative.McpClientAgent;
 import dev.langchain4j.agentic.internal.AgentInvoker;
+import dev.langchain4j.agentic.internal.AgentUtil;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.internal.McpClientBuilder;
 import dev.langchain4j.agentic.observability.AgentListener;
@@ -26,6 +30,7 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +51,7 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
 
     private String[] inputKeys;
     private Map<String, String> inputDescriptions = Map.of();
+    private List<AgentArgument> arguments = List.of();
     private String outputKey;
     private boolean async;
 
@@ -114,10 +120,29 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
             }
         }
 
+        if (agentServiceClass == UntypedAgent.class) {
+            this.arguments = McpSchemaToType.arguments(params, inputKeys);
+        } else {
+            this.arguments = McpSchemaToType.mergeDescriptions(typedArguments(), inputDescriptions);
+        }
+
         Object agent = Proxy.newProxyInstance(
                 agentServiceClass.getClassLoader(), new Class<?>[] {agentServiceClass, McpClientInstance.class}, this);
 
         return (T) agent;
+    }
+
+    private List<AgentArgument> typedArguments() {
+        for (Method method : agentServiceClass.getMethods()) {
+            Optional<Method> agentMethod = getAnnotatedMethod(method, Agent.class);
+            if (agentMethod.isEmpty()) {
+                agentMethod = getAnnotatedMethod(method, McpClientAgent.class);
+            }
+            if (agentMethod.isPresent()) {
+                return AgentUtil.argumentsFromMethod(agentMethod.get());
+            }
+        }
+        return List.of();
     }
 
     private ToolSpecification findTool() {
@@ -269,7 +294,7 @@ public class DefaultMcpClientBuilder<T> implements McpClientBuilder<T>, Internal
 
     @Override
     public List<AgentArgument> arguments() {
-        return List.of();
+        return arguments;
     }
 
     @Override

--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientAgentInvoker.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientAgentInvoker.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.agentic.mcp;
 
+import static dev.langchain4j.agentic.internal.AgentUtil.argumentsFromMethod;
 import static dev.langchain4j.agentic.internal.AgentUtil.untypedAgentInvocationArguments;
 
 import dev.langchain4j.agentic.UntypedAgent;
@@ -31,6 +32,7 @@ public class McpClientAgentInvoker implements AgentInvoker {
     private final String toolName;
     private final String toolDescription;
     private final Method method;
+    private final List<AgentArgument> arguments;
 
     private InternalAgent parent;
 
@@ -42,6 +44,9 @@ public class McpClientAgentInvoker implements AgentInvoker {
         this.agentId = name();
         this.inputKeys = inputKeys(mcpClientInstance);
         this.inputDescriptions = mcpClientInstance.inputDescriptions();
+        this.arguments = isUntyped()
+                ? mcpClientInstance.arguments()
+                : McpSchemaToType.mergeDescriptions(argumentsFromMethod(method), inputDescriptions);
     }
 
     private String[] inputKeys(McpClientInstance mcpClientInstance) {
@@ -99,9 +104,7 @@ public class McpClientAgentInvoker implements AgentInvoker {
 
     @Override
     public List<AgentArgument> arguments() {
-        return Stream.of(inputKeys)
-                .map(input -> new AgentArgument(Object.class, input, null, false, inputDescriptions.get(input)))
-                .toList();
+        return arguments;
     }
 
     @Override
@@ -111,7 +114,15 @@ public class McpClientAgentInvoker implements AgentInvoker {
 
     @Override
     public AgentInvocationArguments toInvocationArguments(AgenticScope agenticScope) {
-        return isUntyped() ? untypedAgentInvocationArguments(agenticScope) : agentInvocationArguments(agenticScope);
+        if (isUntyped()) {
+            for (AgentArgument argument : arguments) {
+                if (!argument.isOptional() && agenticScope.readState(argument.name()) == null) {
+                    throw new MissingArgumentException(argument.name());
+                }
+            }
+            return untypedAgentInvocationArguments(agenticScope);
+        }
+        return agentInvocationArguments(agenticScope);
     }
 
     private AgentInvocationArguments agentInvocationArguments(AgenticScope agenticScope) {

--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpSchemaToType.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpSchemaToType.java
@@ -1,0 +1,216 @@
+package dev.langchain4j.agentic.mcp;
+
+import dev.langchain4j.agentic.planner.AgentArgument;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNullSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+final class McpSchemaToType {
+
+    private McpSchemaToType() {}
+
+    static List<AgentArgument> arguments(JsonObjectSchema parameters, String[] inputKeys) {
+        if (inputKeys == null || inputKeys.length == 0) {
+            return List.of();
+        }
+
+        Map<String, JsonSchemaElement> properties =
+                parameters == null || parameters.properties() == null ? Map.of() : parameters.properties();
+        List<String> required = parameters == null || parameters.required() == null ? List.of() : parameters.required();
+        Map<String, JsonSchemaElement> definitions =
+                parameters == null || parameters.definitions() == null ? Map.of() : parameters.definitions();
+
+        return Arrays.stream(inputKeys)
+                .map(name -> {
+                    JsonSchemaElement schema = properties.get(name);
+                    MappedType mappedType = typeOf(schema, definitions, Set.of());
+                    boolean optional = schema != null && !required.contains(name) || mappedType.nullable();
+                    String description = schema == null ? null : schema.description();
+                    if (description != null && description.isBlank()) {
+                        description = null;
+                    }
+                    return new AgentArgument(mappedType.type(), name, null, optional, description);
+                })
+                .toList();
+    }
+
+    static List<AgentArgument> mergeDescriptions(List<AgentArgument> arguments, Map<String, String> inputDescriptions) {
+        if (inputDescriptions.isEmpty()) {
+            return arguments;
+        }
+
+        return arguments.stream()
+                .map(argument -> {
+                    String description = argument.description();
+                    if (description != null && !description.isBlank()) {
+                        return argument;
+                    }
+
+                    String schemaDescription = inputDescriptions.get(argument.name());
+                    if (schemaDescription == null || schemaDescription.isBlank()) {
+                        return argument;
+                    }
+
+                    return argument.withDescription(schemaDescription);
+                })
+                .toList();
+    }
+
+    private static MappedType typeOf(
+            JsonSchemaElement schema, Map<String, JsonSchemaElement> definitions, Set<String> resolvingReferences) {
+        if (schema == null) {
+            return new MappedType(Object.class, false);
+        }
+        if (schema instanceof JsonStringSchema || schema instanceof JsonEnumSchema) {
+            return new MappedType(String.class, false);
+        }
+        if (schema instanceof JsonIntegerSchema) {
+            return new MappedType(Integer.class, false);
+        }
+        if (schema instanceof JsonNumberSchema) {
+            return new MappedType(Double.class, false);
+        }
+        if (schema instanceof JsonBooleanSchema) {
+            return new MappedType(Boolean.class, false);
+        }
+        if (schema instanceof JsonArraySchema arraySchema) {
+            return new MappedType(
+                    parameterizedType(
+                            List.class,
+                            typeOf(arraySchema.items(), definitions, resolvingReferences)
+                                    .type()),
+                    false);
+        }
+        if (schema instanceof JsonObjectSchema) {
+            return new MappedType(parameterizedType(Map.class, String.class, Object.class), false);
+        }
+        if (schema instanceof JsonAnyOfSchema anyOfSchema) {
+            return typeOfAnyOf(anyOfSchema, definitions, resolvingReferences);
+        }
+        if (schema instanceof JsonReferenceSchema referenceSchema) {
+            JsonSchemaElement referencedSchema = resolve(referenceSchema, definitions);
+            if (referencedSchema == null) {
+                return new MappedType(Object.class, false);
+            }
+
+            Set<String> nextReferences = new HashSet<>(resolvingReferences);
+            if (!nextReferences.add(referenceSchema.reference())) {
+                return new MappedType(Object.class, false);
+            }
+            return typeOf(referencedSchema, definitions, nextReferences);
+        }
+        if (schema instanceof JsonNullSchema || schema instanceof JsonRawSchema) {
+            return new MappedType(Object.class, schema instanceof JsonNullSchema);
+        }
+        return new MappedType(Object.class, false);
+    }
+
+    private static MappedType typeOfAnyOf(
+            JsonAnyOfSchema schema, Map<String, JsonSchemaElement> definitions, Set<String> resolvingReferences) {
+        List<MappedType> mappedTypes = schema.anyOf().stream()
+                .filter(option -> !(option instanceof JsonNullSchema))
+                .map(option -> typeOf(option, definitions, resolvingReferences))
+                .toList();
+
+        boolean nullable = schema.anyOf().stream().anyMatch(option -> option instanceof JsonNullSchema)
+                || mappedTypes.stream().anyMatch(MappedType::nullable);
+
+        if (mappedTypes.isEmpty()) {
+            return new MappedType(Object.class, true);
+        }
+
+        Type firstType = mappedTypes.get(0).type();
+        boolean sameType = mappedTypes.stream().allMatch(mappedType -> Objects.equals(firstType, mappedType.type()));
+        // A heterogeneous union has no honest Java common type, so Object is intentional here.
+        return new MappedType(sameType ? firstType : Object.class, nullable);
+    }
+
+    private static JsonSchemaElement resolve(
+            JsonReferenceSchema referenceSchema, Map<String, JsonSchemaElement> definitions) {
+        if (definitions.isEmpty() || referenceSchema.reference() == null) {
+            return null;
+        }
+
+        JsonSchemaElement resolved = definitions.get(referenceSchema.reference());
+        if (resolved != null) {
+            return resolved;
+        }
+
+        String reference = referenceSchema.reference();
+        if (reference.startsWith("#/$defs/")) {
+            return definitions.get(reference.substring("#/$defs/".length()));
+        }
+        if (reference.startsWith("#/definitions/")) {
+            return definitions.get(reference.substring("#/definitions/".length()));
+        }
+        return null;
+    }
+
+    private record MappedType(Type type, boolean nullable) {}
+
+    private static ParameterizedType parameterizedType(Class<?> rawType, Type... typeArguments) {
+        return new ParameterizedTypeImpl(rawType, typeArguments);
+    }
+
+    private record ParameterizedTypeImpl(Class<?> rawType, Type[] actualTypeArguments) implements ParameterizedType {
+
+        private ParameterizedTypeImpl {
+            actualTypeArguments = actualTypeArguments.clone();
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return actualTypeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof ParameterizedType that)) {
+                return false;
+            }
+            return Objects.equals(rawType, that.getRawType())
+                    && Objects.equals(getOwnerType(), that.getOwnerType())
+                    && Arrays.equals(actualTypeArguments, that.getActualTypeArguments());
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(actualTypeArguments) ^ Objects.hashCode(rawType);
+        }
+
+        @Override
+        public String toString() {
+            return rawType.getTypeName() + "<"
+                    + Arrays.stream(actualTypeArguments).map(Type::getTypeName).collect(Collectors.joining(", "))
+                    + ">";
+        }
+    }
+}

--- a/langchain4j-agentic-mcp/src/test/java/dev/langchain4j/agentic/mcp/McpAgentTest.java
+++ b/langchain4j-agentic-mcp/src/test/java/dev/langchain4j/agentic/mcp/McpAgentTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agentic.Agent;
@@ -15,14 +16,26 @@ import dev.langchain4j.agentic.UntypedAgent;
 import dev.langchain4j.agentic.agent.MissingArgumentException;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.observability.AgentRequest;
+import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.scope.AgentInvocation;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNullSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.service.V;
 import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -87,6 +100,307 @@ class McpAgentTest {
     }
 
     @Test
+    void untyped_mcp_agent_preserves_argument_types_from_schema() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("search_records")
+                .description("Search records")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty("recordType", new JsonStringSchema())
+                        .addProperty(
+                                "fields",
+                                JsonArraySchema.builder()
+                                        .description("Fields to include in the search")
+                                        .items(new JsonStringSchema())
+                                        .build())
+                        .addProperty("limit", new JsonIntegerSchema())
+                        .addProperty(
+                                "filters",
+                                JsonObjectSchema.builder()
+                                        .addStringProperty("status")
+                                        .build())
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+
+        List<AgentArgument> arguments = ((McpClientInstance) agent).arguments();
+        assertThat(arguments)
+                .extracting(AgentArgument::name)
+                .containsExactly("recordType", "fields", "limit", "filters");
+        assertThat(arguments.get(0).type()).isEqualTo(String.class);
+        assertThat(arguments.get(2).type()).isEqualTo(Integer.class);
+        assertThat(arguments.get(1).description()).isEqualTo("Fields to include in the search");
+        assertThat(((McpClientInstance) agent).inputDescriptions())
+                .containsEntry("fields", "Fields to include in the search");
+
+        ParameterizedType fieldsType = (ParameterizedType) arguments.get(1).type();
+        assertThat(fieldsType.getRawType()).isEqualTo(List.class);
+        assertThat(fieldsType.getActualTypeArguments()).containsExactly(String.class);
+
+        ParameterizedType filtersType = (ParameterizedType) arguments.get(3).type();
+        assertThat(filtersType.getRawType()).isEqualTo(Map.class);
+        assertThat(filtersType.getActualTypeArguments()).containsExactly(String.class, Object.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_maps_scalar_schema_types() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("typed_search")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty("text", new JsonStringSchema())
+                        .addProperty("limit", new JsonIntegerSchema())
+                        .addProperty("score", new JsonNumberSchema())
+                        .addProperty("exact", new JsonBooleanSchema())
+                        .addProperty(
+                                "order",
+                                JsonEnumSchema.builder()
+                                        .enumValues("asc", "desc")
+                                        .build())
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+
+        assertThat(((McpClientInstance) agent).arguments())
+                .extracting(AgentArgument::rawType)
+                .containsExactly(String.class, Integer.class, Double.class, Boolean.class, String.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_preserves_types_for_explicit_input_keys() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("search_records")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty(
+                                "fields",
+                                JsonArraySchema.builder()
+                                        .items(new JsonStringSchema())
+                                        .build())
+                        .addProperty("query", new JsonStringSchema())
+                        .addProperty("unused", new JsonBooleanSchema())
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent =
+                McpAgent.builder(mcpClient).inputKeys("fields", "query").build();
+        McpClientInstance mcpAgent = (McpClientInstance) agent;
+        List<AgentArgument> arguments = mcpAgent.arguments();
+
+        assertThat(arguments).extracting(AgentArgument::name).containsExactly("fields", "query");
+        ParameterizedType fieldsType = (ParameterizedType) arguments.get(0).type();
+        assertThat(fieldsType.getRawType()).isEqualTo(List.class);
+        assertThat(fieldsType.getActualTypeArguments()).containsExactly(String.class);
+        assertThat(arguments.get(1).type()).isEqualTo(String.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_falls_back_to_object_for_unknown_schema_properties() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("search_records")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty("known", new JsonStringSchema())
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent =
+                McpAgent.builder(mcpClient).inputKeys("known", "missing").build();
+        List<AgentArgument> arguments = ((McpClientInstance) agent).arguments();
+
+        assertThat(arguments.get(0).type()).isEqualTo(String.class);
+        assertThat(arguments.get(1).type()).isEqualTo(Object.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_falls_back_to_object_for_unresolved_references() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("reference_tool")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty(
+                                "value",
+                                JsonReferenceSchema.builder()
+                                        .reference("MissingDefinition")
+                                        .build())
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+
+        assertThat(((McpClientInstance) agent).arguments().get(0).type()).isEqualTo(Object.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_resolves_dollar_defs_references() {
+        JsonObjectSchema address =
+                JsonObjectSchema.builder().addStringProperty("city").build();
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("dollar_defs_tool")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty(
+                                "address",
+                                JsonReferenceSchema.builder()
+                                        .reference("#/$defs/Address")
+                                        .build())
+                        .definitions(Map.of("Address", address))
+                        .build())
+                .build();
+
+        McpClient mcpClient = mock(McpClient.class);
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+
+        ParameterizedType addressType = (ParameterizedType)
+                ((McpClientInstance) agent).arguments().get(0).type();
+        assertThat(addressType.getRawType()).isEqualTo(Map.class);
+        assertThat(addressType.getActualTypeArguments()).containsExactly(String.class, Object.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_maps_raw_schema_to_object() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("raw_tool")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty("value", JsonRawSchema.from("{\"type\":\"string\"}"))
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+
+        assertThat(((McpClientInstance) agent).arguments().get(0).type()).isEqualTo(Object.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_preserves_nested_array_types() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("nested_search")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty(
+                                "values",
+                                JsonArraySchema.builder()
+                                        .items(JsonArraySchema.builder()
+                                                .items(new JsonIntegerSchema())
+                                                .build())
+                                        .build())
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+        ParameterizedType outerType = (ParameterizedType)
+                ((McpClientInstance) agent).arguments().get(0).type();
+        ParameterizedType innerType = (ParameterizedType) outerType.getActualTypeArguments()[0];
+
+        assertThat(outerType.getRawType()).isEqualTo(List.class);
+        assertThat(innerType.getRawType()).isEqualTo(List.class);
+        assertThat(innerType.getActualTypeArguments()).containsExactly(Integer.class);
+    }
+
+    @Test
+    void untyped_mcp_agent_resolves_references_and_unions() {
+        JsonObjectSchema address =
+                JsonObjectSchema.builder().addStringProperty("city").build();
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .addProperty(
+                        "name",
+                        JsonAnyOfSchema.builder()
+                                .anyOf(new JsonStringSchema(), new JsonNullSchema())
+                                .build())
+                .addProperty(
+                        "sameType",
+                        JsonAnyOfSchema.builder()
+                                .anyOf(
+                                        new JsonStringSchema(),
+                                        JsonEnumSchema.builder()
+                                                .enumValues("a", "b")
+                                                .build())
+                                .build())
+                .addProperty(
+                        "differentTypes",
+                        JsonAnyOfSchema.builder()
+                                .anyOf(new JsonStringSchema(), new JsonIntegerSchema())
+                                .build())
+                .addProperty(
+                        "address",
+                        JsonReferenceSchema.builder()
+                                .reference("#/definitions/Address")
+                                .build())
+                .addProperty(
+                        "addresses",
+                        JsonArraySchema.builder()
+                                .items(JsonReferenceSchema.builder()
+                                        .reference("Address")
+                                        .build())
+                                .build())
+                .required("sameType", "differentTypes", "address", "addresses")
+                .definitions(Map.of("Address", address))
+                .build();
+
+        McpClient mcpClient = mock(McpClient.class);
+        when(mcpClient.listTools())
+                .thenReturn(List.of(ToolSpecification.builder()
+                        .name("schema_tool")
+                        .parameters(parameters)
+                        .build()));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+        List<AgentArgument> arguments = ((McpClientInstance) agent).arguments();
+
+        assertThat(arguments)
+                .extracting(AgentArgument::name)
+                .containsExactly("name", "sameType", "differentTypes", "address", "addresses");
+        assertThat(arguments.get(0).type()).isEqualTo(String.class);
+        assertThat(arguments.get(0).isOptional()).isTrue();
+        assertThat(arguments.get(1).type()).isEqualTo(String.class);
+        assertThat(arguments.get(1).isOptional()).isFalse();
+        assertThat(arguments.get(2).type()).isEqualTo(Object.class);
+        assertThat(arguments.get(3).type()).isNotEqualTo(Object.class);
+        assertThat(arguments.get(3).isOptional()).isFalse();
+
+        ParameterizedType addressType = (ParameterizedType) arguments.get(3).type();
+        assertThat(addressType.getRawType()).isEqualTo(Map.class);
+        assertThat(addressType.getActualTypeArguments()).containsExactly(String.class, Object.class);
+
+        ParameterizedType addressesType = (ParameterizedType) arguments.get(4).type();
+        assertThat(addressesType.getRawType()).isEqualTo(List.class);
+        assertThat(addressesType.getActualTypeArguments()).containsExactly(addressType);
+    }
+
+    @Test
+    void untyped_mcp_agent_validates_required_schema_arguments() {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("required_tool")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("required")
+                        .addStringProperty("optional")
+                        .required("required")
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        UntypedAgent agent = McpAgent.builder(mcpClient).build();
+        UntypedAgent pipeline =
+                AgenticServices.sequenceBuilder().subAgents(agent).build();
+
+        assertThatThrownBy(() -> pipeline.invoke(Map.of("optional", "value")))
+                .isInstanceOf(MissingArgumentException.class)
+                .hasMessageContaining("required");
+    }
+
+    @Test
     void untyped_mcp_agent_with_explicit_input_keys() {
         McpClient mcpClient = mockMcpClient("greet", "Generate a greeting", "name", "language");
         mockToolResult(mcpClient, "Hello, Mario!");
@@ -105,6 +419,79 @@ class McpAgentTest {
 
         @Agent(description = "Translate text")
         String translate(@V("text") String text, @V("language") String language);
+    }
+
+    public interface TypedCollectionAgent {
+
+        @Agent(description = "Search records")
+        String search(@V("fields") List<String> fields, @V("recordIds") String[] recordIds);
+    }
+
+    public interface TypedDescribedCollectionAgent {
+
+        @Agent(description = "Search records")
+        String search(
+                @V("fields") @P(name = "fields") List<String> fields,
+                @V("recordIds") @P(name = "recordIds", description = "IDs selected by the caller") String[] recordIds);
+    }
+
+    @Test
+    void typed_mcp_agent_preserves_generic_argument_types() throws Exception {
+        McpClient mcpClient = mockMcpClient("search_records", "Search records", "fields", "recordIds");
+        TypedCollectionAgent agent =
+                McpAgent.builder(mcpClient, TypedCollectionAgent.class).build();
+
+        Method method = TypedCollectionAgent.class.getMethod("search", List.class, String[].class);
+        List<AgentArgument> clientArguments = ((McpClientInstance) agent).arguments();
+        assertThat(clientArguments).extracting(AgentArgument::name).containsExactly("fields", "recordIds");
+        assertThat(clientArguments.get(0).type()).isEqualTo(method.getGenericParameterTypes()[0]);
+        assertThat(clientArguments.get(1).type()).isEqualTo(method.getGenericParameterTypes()[1]);
+
+        List<AgentArgument> arguments = new McpClientAgentInvoker((McpClientInstance) agent, method).arguments();
+
+        assertThat(arguments.get(0).type()).isEqualTo(method.getGenericParameterTypes()[0]);
+        assertThat(arguments.get(1).type()).isEqualTo(method.getGenericParameterTypes()[1]);
+    }
+
+    @Test
+    void typed_mcp_agent_combines_method_types_and_schema_descriptions() throws Exception {
+        McpClient mcpClient = mock(McpClient.class);
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("search_records")
+                .description("Search records")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty(
+                                "fields",
+                                JsonArraySchema.builder()
+                                        .description("Fields to include in the search")
+                                        .items(new JsonStringSchema())
+                                        .build())
+                        .addProperty(
+                                "recordIds",
+                                JsonArraySchema.builder()
+                                        .description("MCP record identifiers")
+                                        .items(new JsonStringSchema())
+                                        .build())
+                        .build())
+                .build();
+        when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
+
+        TypedDescribedCollectionAgent agent =
+                McpAgent.builder(mcpClient, TypedDescribedCollectionAgent.class).build();
+        Method method = TypedDescribedCollectionAgent.class.getMethod("search", List.class, String[].class);
+
+        List<AgentArgument> clientArguments = ((McpClientInstance) agent).arguments();
+        assertThat(clientArguments)
+                .extracting(AgentArgument::type)
+                .containsExactly(method.getGenericParameterTypes()[0], method.getGenericParameterTypes()[1]);
+        assertThat(clientArguments)
+                .extracting(AgentArgument::description)
+                .containsExactly("Fields to include in the search", "IDs selected by the caller");
+
+        List<AgentArgument> invokerArguments = new McpClientAgentInvoker((McpClientInstance) agent, method).arguments();
+        assertThat(invokerArguments)
+                .extracting(AgentArgument::description)
+                .containsExactly("Fields to include in the search", "IDs selected by the caller");
     }
 
     @Test
@@ -346,6 +733,7 @@ class McpAgentTest {
 
         UntypedAgent agent = McpAgent.builder(mcpClient).outputKey("time").build();
 
+        assertThat(((McpClientInstance) agent).arguments()).isEmpty();
         Object result = agent.invoke(Map.of());
         assertThat(result).isEqualTo("2024-01-01T00:00:00Z");
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentArgument.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentArgument.java
@@ -17,6 +17,10 @@ public record AgentArgument(Type type, String name, Object defaultValue, boolean
         this(type, name, defaultValue, false);
     }
 
+    public AgentArgument withDescription(String description) {
+        return new AgentArgument(type, name, defaultValue, isOptional, description);
+    }
+
     public Class<?> rawType() {
         return AgentUtil.rawType(type);
     }


### PR DESCRIPTION
## Issue## Issue
Closes #6226

## Change
- Derive MCP agent argument types from tool JSON Schema, including scalar, array, object, reference, nullable, and union schemas.
- Preserve typed MCP agent argument types through `McpClientInstance.arguments()`.
- Render generic collections, arrays, maps, and object fields correctly in SupervisorPlanner agent cards.
- Add regression tests for schema mappings, `#/$defs/` references, typed generic arguments, and final planner prompt rendering.

## Tests
- `./mvnw -pl langchain4j-agentic,langchain4j-agentic-mcp -am test`
- `./mvnw -Pspotless validate`

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo
- [ ] I have added/updated Spring Boot starter(s)