### PR TITLE
fix(mcp): report a tool-execution timeout as an error result

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -455,8 +455,8 @@ public class DefaultMcpClient implements McpClient {
                         error.getData() == null ? null : McpJson.serialize(error.getData()));
             }
             log.debug("MCP server discover result: {}", response);
-            McpServerDiscoverResponse.Result discovered =
-                    McpJson.deserialize(response, McpServerDiscoverResponse.class).getResult();
+            McpServerDiscoverResponse.Result discovered = McpJson.deserialize(response, McpServerDiscoverResponse.class)
+                    .getResult();
             initializeResult = toInitializeResultFromDiscover(response, discovered);
             modernProtocol = true;
             McpDiscoverResult discoverResult = toDiscoverResult(discovered);
@@ -828,13 +828,12 @@ public class DefaultMcpClient implements McpClient {
         // built on demand, not once at construction: a custom converter must not be invoked
         // for a tool call that never happened
         return toolResultConverter.convert(
-                List.of(Map.of("type", "text", "text", toolExecutionTimeoutErrorMessage)), false);
+                List.of(Map.of("type", "text", "text", toolExecutionTimeoutErrorMessage)), true);
     }
 
     private ToolExecutionResult extractResultAndNotifyListeners(McpCallContext context, String finalResult) {
         try {
-            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(
-                    finalResult, false, toolResultConverter);
+            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(finalResult, false, toolResultConverter);
             notifyListeners(finalResult, (l, response) -> l.afterExecuteTool(context, toolResult, response));
             return toolResult;
         } catch (ToolExecutionException e) {
@@ -1531,7 +1530,6 @@ public class DefaultMcpClient implements McpClient {
                 McpJson.deserialize(response, McpErrorResponse.class).getError();
         return error == null ? "" : error.getMessage();
     }
-
 
     @Override
     public void close() {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -441,6 +441,97 @@ public class DefaultMcpClientTest {
     }
 
     @Test
+    public void should_report_a_tool_execution_timeout_as_an_error() {
+        final McpTransport transport = getMinimalMcpTransportMock();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenAnswer(invocation -> new CompletableFuture<>());
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .toolExecutionTimeout(java.time.Duration.ofMillis(1))
+                .build();
+
+        ToolExecutionResult result = client.executeTool(
+                ToolExecutionRequest.builder().name("test").arguments("{}").build());
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultText()).isEqualTo("There was a timeout executing the tool");
+    }
+
+    @Test
+    public void should_report_a_tool_execution_timeout_as_an_error_on_the_reactive_path() throws Exception {
+        final McpTransport transport = getMinimalMcpTransportMock();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenAnswer(invocation -> new CompletableFuture<>());
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .toolExecutionTimeout(java.time.Duration.ofMillis(1))
+                .build();
+
+        ToolExecutionResult result = client.executeToolAsync(
+                        ToolExecutionRequest.builder()
+                                .name("test")
+                                .arguments("{}")
+                                .build(),
+                        null)
+                .get();
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultText()).isEqualTo("There was a timeout executing the tool");
+    }
+
+    @Test
+    public void should_pass_the_error_flag_to_a_custom_tool_result_converter_on_timeout() {
+        final McpTransport transport = getMinimalMcpTransportMock();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenAnswer(invocation -> new CompletableFuture<>());
+
+        McpToolResultConverter converter = (content, isError) -> ToolExecutionResult.builder()
+                .resultText(String.valueOf(content.get(0).get("text")))
+                .isError(isError)
+                .build();
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .toolExecutionTimeout(java.time.Duration.ofMillis(1))
+                .toolResultConverter(converter)
+                .build();
+
+        ToolExecutionResult result = client.executeTool(
+                ToolExecutionRequest.builder().name("test").arguments("{}").build());
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultText()).isEqualTo("There was a timeout executing the tool");
+    }
+
+    @Test
+    public void should_not_report_a_successful_tool_execution_as_an_error() {
+        final McpTransport transport = getMinimalMcpTransportMock();
+        ObjectNode toolResult = JsonNodeFactory.instance.objectNode();
+        toolResult
+                .putObject("result")
+                .putArray("content")
+                .addObject()
+                .put("type", "text")
+                .put("text", "ok");
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(toolResult));
+
+        DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+
+        ToolExecutionResult result = client.executeTool(
+                ToolExecutionRequest.builder().name("test").arguments("{}").build());
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.resultText()).isEqualTo("ok");
+    }
+
+    @Test
     public void should_use_custom_tool_result_extractor_for_listener_application_level_error_path() throws Exception {
         final McpTransport transport = getMinimalMcpTransportMock();
         ObjectNode toolResult = JsonNodeFactory.instance.objectNode();


### PR DESCRIPTION
## Issue

Closes #6309

## Change

`handleToolTimeout`, the timeout path since #6117, passed `false` for the converter's `isError` argument, so a
call that never completed came back as a success:

```java
return toolResultConverter.convert(
        List.of(Map.of("type", "text", "text", toolExecutionTimeoutErrorMessage)), true);
```

`ToolExecutionResult#isError()` is specified as "`true` if the tool execution failed", and the same method
already treats the timeout as one everywhere else: `onExecuteToolError`, the cancelled operation, the
cancellation notification. Only the returned flag disagreed. The message text is unchanged, and both entry
points reach this method, so `executeTool` and `executeToolAsync` stay in step.

One caller acts on the flag: `DefaultMcpClientBuilder.java:223` in `langchain4j-agentic-mcp` throws when
`isError()` is set, so an agentic tool that times out now fails there instead of handing the timeout text to the
output parser. That reads as the intent of that code, but I am happy to leave that path as it was.

`ToolExecutionHelper` already propagates `isError` and the two resources-as-tools executors throw, so this was
the only place in the module returning a failure as a success. The three formatting hunks are the spotless
ratchet reformatting a file that does not currently pass `spotless:check`.

### Tests

- `DefaultMcpClientTest` gains four cases: a timeout through `executeTool` and one through `executeToolAsync`
  both assert `isError()` is `true` and that `resultText()` is still the timeout message; a third asserts a custom
  `McpToolResultConverter` receives the flag; and `should_not_report_a_successful_tool_execution_as_an_error`
  asserts a normal result is still `false`.

The first three fail on unmodified `main` with `Expecting value to be true but was false`. The success case passes
either way and is there to bound the change. There is one production file, and reverting it fails exactly those
three and leaves the other 60 in the class green.

```
mvn -o -pl langchain4j-mcp test -Dtest=DefaultMcpClientTest
Tests run: 63, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-mcp test           Tests run: 235, Failures: 0, Errors: 0, Skipped: 0
mvn -o -pl langchain4j-agentic-mcp test   Tests run: 26, Failures: 0, Errors: 0, Skipped: 0

mvn -pl langchain4j-mcp verify -DskipTests
revapi:0.15.1:check (default) @ langchain4j-mcp
Comparing [dev.langchain4j:langchain4j-mcp:jar:1.20.0-beta30] against [dev.langchain4j:langchain4j-mcp:jar:1.21.0-beta31-SNAPSHOT].
API checks completed without failures.

mvn -o -pl langchain4j-core test   Tests run: 1371, Failures: 0, Errors: 0, Skipped: 5
mvn -o -pl langchain4j test        Tests run: 1705, Failures: 0, Errors: 0, Skipped: 19
```

The MCP integration tests were not run: they launch their server through `jbang`, which is not installed here.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

The first box is unchecked because `isError()` flips from `false` to `true` for a timed-out tool call, which is
the point of the change, and because of the `langchain4j-agentic-mcp` consequence described above. The fourth is
unchecked because the module's integration tests need `jbang`; the unit tests are green and are listed above.
