### PR TITLE
fix: Do not build a base `TokenUsage` in the reactive AI Service

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingEventPublisher.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingEventPublisher.java
@@ -22,6 +22,7 @@ import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatModelHelper;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
@@ -29,13 +30,12 @@ import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.RawStreamingEvent;
-import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.observability.api.event.AiServiceCompletedEvent;
 import dev.langchain4j.observability.api.event.AiServiceErrorEvent;
-import dev.langchain4j.observability.api.event.CompensationReason;
 import dev.langchain4j.observability.api.event.AiServiceRequestIssuedEvent;
 import dev.langchain4j.observability.api.event.AiServiceResponseReceivedEvent;
+import dev.langchain4j.observability.api.event.CompensationReason;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.AiServiceStreamingEvent.AfterToolExecutionEvent;
 import dev.langchain4j.service.AiServiceStreamingEvent.BeforeToolExecutionEvent;
@@ -194,49 +194,54 @@ public class AiServiceStreamingEventPublisher implements Flow.Publisher<AiServic
         TubeConfiguration config = new TubeConfiguration()
                 .withBackpressureStrategy(BackpressureStrategy.BUFFER)
                 .withBufferSize(bufferSize);
-        return ZeroPublisher.create(config, tube -> events.subscribe(new Flow.Subscriber<>() {
+        return ZeroPublisher.create(
+                config,
+                tube -> events.subscribe(new Flow.Subscriber<>() {
 
-            @Override
-            public void onSubscribe(Flow.Subscription subscription) {
-                if (tube.cancelled()) {
-                    subscription.cancel();
-                    return;
-                }
-                tube.whenTerminates(subscription::cancel);
-                subscription.request(Long.MAX_VALUE);
-            }
+                    @Override
+                    public void onSubscribe(Flow.Subscription subscription) {
+                        if (tube.cancelled()) {
+                            subscription.cancel();
+                            return;
+                        }
+                        tube.whenTerminates(subscription::cancel);
+                        subscription.request(Long.MAX_VALUE);
+                    }
 
-            @Override
-            public void onNext(AiServiceStreamingEvent event) {
-                if (tube.cancelled()) {
-                    return;
-                }
-                if (hasOutputGuardrails) {
-                    if (event instanceof FinalResponseEvent finalResponseEvent) {
-                        String text = finalResponseEvent.chatResponse().aiMessage().text();
-                        if (text != null) {
-                            tube.send(text);
+                    @Override
+                    public void onNext(AiServiceStreamingEvent event) {
+                        if (tube.cancelled()) {
+                            return;
+                        }
+                        if (hasOutputGuardrails) {
+                            if (event instanceof FinalResponseEvent finalResponseEvent) {
+                                String text = finalResponseEvent
+                                        .chatResponse()
+                                        .aiMessage()
+                                        .text();
+                                if (text != null) {
+                                    tube.send(text);
+                                }
+                            }
+                        } else if (event instanceof PartialResponseEvent partialResponseEvent) {
+                            tube.send(partialResponseEvent.partialResponse().text());
                         }
                     }
-                } else if (event instanceof PartialResponseEvent partialResponseEvent) {
-                    tube.send(partialResponseEvent.partialResponse().text());
-                }
-            }
 
-            @Override
-            public void onError(Throwable error) {
-                if (!tube.cancelled()) {
-                    tube.fail(error);
-                }
-            }
+                    @Override
+                    public void onError(Throwable error) {
+                        if (!tube.cancelled()) {
+                            tube.fail(error);
+                        }
+                    }
 
-            @Override
-            public void onComplete() {
-                if (!tube.cancelled()) {
-                    tube.complete();
-                }
-            }
-        }));
+                    @Override
+                    public void onComplete() {
+                        if (!tube.cancelled()) {
+                            tube.complete();
+                        }
+                    }
+                }));
     }
 
     /**
@@ -257,7 +262,7 @@ public class AiServiceStreamingEventPublisher implements Flow.Publisher<AiServic
         private final boolean hasOutputGuardrails = context.guardrailService().hasOutputGuardrails(methodKey);
         private ChatExecutor chatExecutor;
         private final Executor toolExecutor = context.toolService.effectiveToolExecutor();
-        private TokenUsage tokenUsage = new TokenUsage();
+        private TokenUsage tokenUsage;
         private int roundTripsLeft = context.toolService.maxToolCallingRoundTrips();
 
         private Loop(Tube<AiServiceStreamingEvent> tube) {
@@ -288,13 +293,14 @@ public class AiServiceStreamingEventPublisher implements Flow.Publisher<AiServic
                 Map<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>> startedTools =
                         (Map<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>>) claimed[1];
                 if (round != null) {
-                    round.toolsFuture().whenComplete((combined, error) -> doCancellationCompensation(
-                            round.toolRequests(), combined != null ? combined.results() : null));
+                    round.toolsFuture()
+                            .whenComplete((combined, error) -> doCancellationCompensation(
+                                    round.toolRequests(), combined != null ? combined.results() : null));
                 } else if (startedTools != null && !startedTools.isEmpty()) {
                     List<ToolExecutionRequest> requests = new ArrayList<>(startedTools.keySet());
                     ToolService.combineToolResultsCollectingErrors(startedTools)
-                            .whenComplete((combined, error) -> doCancellationCompensation(
-                                    requests, combined != null ? combined.results() : null));
+                            .whenComplete((combined, error) ->
+                                    doCancellationCompensation(requests, combined != null ? combined.results() : null));
                 } else {
                     doCancellationCompensation(null, null);
                 }
@@ -310,7 +316,10 @@ public class AiServiceStreamingEventPublisher implements Flow.Publisher<AiServic
                 ChatRequestParameters parameters =
                         chatRequestParameters(invocationContext.methodArguments(), effectiveTools);
                 ChatRequest chatRequest = context.chatRequestTransformer.apply(
-                        ChatRequest.builder().messages(messages).parameters(parameters).build(),
+                        ChatRequest.builder()
+                                .messages(messages)
+                                .parameters(parameters)
+                                .build(),
                         invocationContext.chatMemoryId());
 
                 chatExecutor = ChatExecutor.builder(context.streamingChatModel)
@@ -589,12 +598,7 @@ public class AiServiceStreamingEventPublisher implements Flow.Publisher<AiServic
                 String preCollectedFailedToolName) {
 
             ToolService.ToolResultsOutcome outcome = context.toolService.processToolResults(
-                    context,
-                    toolRequests,
-                    toolResults,
-                    new ArrayList<>(),
-                    invocationContext,
-                    currentToolContext);
+                    context, toolRequests, toolResults, new ArrayList<>(), invocationContext, currentToolContext);
 
             CompletableFuture<Void> compensated = context.toolService.compensateIfNeededAsync(
                     toolRequests,
@@ -672,7 +676,8 @@ public class AiServiceStreamingEventPublisher implements Flow.Publisher<AiServic
             ChatResponse finalChatResponse = ChatResponse.builder()
                     .aiMessage(aiMessage)
                     .metadata(chatResponse.metadata().toBuilder()
-                            .tokenUsage(tokenUsage.add(chatResponse.metadata().tokenUsage()))
+                            .tokenUsage(TokenUsage.sum(
+                                    tokenUsage, chatResponse.metadata().tokenUsage()))
                             .build())
                     .build();
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingTokenUsageTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingTokenUsageTest.java
@@ -7,11 +7,18 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.chat.response.CompleteResponse;
+import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import mutiny.zero.BackpressureStrategy;
+import mutiny.zero.TubeConfiguration;
+import mutiny.zero.ZeroPublisher;
 import org.junit.jupiter.api.Test;
 
 class AiServiceStreamingTokenUsageTest {
@@ -19,6 +26,11 @@ class AiServiceStreamingTokenUsageTest {
     interface Assistant {
 
         TokenStream chat(String userMessage);
+    }
+
+    interface ReactiveAssistant {
+
+        Flow.Publisher<AiServiceStreamingEvent> chat(String userMessage);
     }
 
     @Test
@@ -46,6 +58,57 @@ class AiServiceStreamingTokenUsageTest {
         assertThat(response.tokenUsage()).isSameAs(tokenUsage);
     }
 
+    @Test
+    void should_not_fail_on_the_reactive_path_when_the_model_reports_no_token_usage() throws Exception {
+
+        ReactiveAssistant assistant = AiServices.create(ReactiveAssistant.class, modelReturning(null));
+
+        ChatResponse response = complete(assistant.chat("Hello"));
+
+        assertThat(response.metadata()).isInstanceOf(TestChatResponseMetadata.class);
+        assertThatCode(response::tokenUsage).doesNotThrowAnyException();
+        assertThat(response.tokenUsage()).isNull();
+    }
+
+    @Test
+    void should_keep_the_token_usage_reported_by_the_model_on_the_reactive_path() throws Exception {
+
+        TestTokenUsage tokenUsage = new TestTokenUsage(1, 2);
+
+        ReactiveAssistant assistant = AiServices.create(ReactiveAssistant.class, modelReturning(tokenUsage));
+
+        ChatResponse response = complete(assistant.chat("Hello"));
+
+        assertThat(response.tokenUsage()).isSameAs(tokenUsage);
+    }
+
+    private static ChatResponse complete(Flow.Publisher<AiServiceStreamingEvent> publisher) throws Exception {
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        publisher.subscribe(new Flow.Subscriber<>() {
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(AiServiceStreamingEvent event) {
+                if (event instanceof AiServiceStreamingEvent.FinalResponseEvent finalResponse) {
+                    future.complete(finalResponse.chatResponse());
+                }
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+
+            @Override
+            public void onComplete() {}
+        });
+        return future.get(10, SECONDS);
+    }
+
     private static ChatResponse complete(TokenStream tokenStream) throws Exception {
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
         tokenStream
@@ -62,16 +125,33 @@ class AiServiceStreamingTokenUsageTest {
             @Override
             public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
                 handler.onPartialResponse("Hi");
-                handler.onCompleteResponse(ChatResponse.builder()
-                        .aiMessage(AiMessage.from("Hi"))
-                        .metadata(TestChatResponseMetadata.builder()
-                                .id("id")
-                                .modelName("model")
-                                .tokenUsage(tokenUsage)
-                                .build())
-                        .build());
+                handler.onCompleteResponse(chatResponse(tokenUsage));
+            }
+
+            @Override
+            public Flow.Publisher<ChatModelStreamingEvent> doChat(ChatRequest chatRequest) {
+                TubeConfiguration config = new TubeConfiguration()
+                        .withBackpressureStrategy(BackpressureStrategy.BUFFER)
+                        .withBufferSize(256);
+
+                return ZeroPublisher.create(config, tube -> {
+                    tube.send(new PartialResponse("Hi"));
+                    tube.send(new CompleteResponse(chatResponse(tokenUsage)));
+                    tube.complete();
+                });
             }
         };
+    }
+
+    private static ChatResponse chatResponse(TokenUsage tokenUsage) {
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from("Hi"))
+                .metadata(TestChatResponseMetadata.builder()
+                        .id("id")
+                        .modelName("model")
+                        .tokenUsage(tokenUsage)
+                        .build())
+                .build();
     }
 
     /**


### PR DESCRIPTION
## Issue

No separate issue. #6203 removed this seed from `AiServiceStreamingResponseHandler`; the reactive publisher
added in #5527 was in flight at the time and still carries it.

## Change

`AiServiceStreamingEventPublisher.Loop` seeded its accumulator with a base `TokenUsage` and merged with
`add(...)` when rebuilding the final metadata. `add(null)` returns `this`, so when the model reports no usage
the base instance survives into the rebuilt metadata, and a provider that narrows the accessor throws
`ClassCastException`:

```java
private TokenUsage tokenUsage;
...
.tokenUsage(TokenUsage.sum(tokenUsage, chatResponse.metadata().tokenUsage()))
```

This is the shape `AiServiceStreamingResponseHandler` already uses: no base seed, and `TokenUsage.sum` at both
the accumulating and the final site. The publisher already used `sum` when accumulating across tool-calling
rounds and only differed at the rebuild, so the two are now consistent.

Both lines are needed. `sum` returns the second argument when the first is null and the first when the second
is null, so keeping the seed and only switching to `sum` still returns the base instance, and seeding null while
keeping `add` throws `NullPointerException`.

Behaviour change: when a model reports no token usage at all, the final metadata now carries `null` rather than
a zero-valued `TokenUsage`, which is what the handler above already returns.

`add` now has no callers left in `src/main`. The one other `new TokenUsage()` there, in
`GoogleGenAiStreamingChatModel`, is a local that is assigned rather than merged and whose metadata does not
narrow the accessor, so it cannot fail this way and is left alone.

Most of the diff is the spotless ratchet, which reformats the whole file once it is edited; the change itself
is the two lines above.

### Tests

- `AiServiceStreamingTokenUsageTest` gains two cases on the reactive path:
  `should_not_fail_on_the_reactive_path_when_the_model_reports_no_token_usage` drives a `Flow.Publisher`
  returning method against a metadata type that narrows `tokenUsage()`, and
  `should_keep_the_token_usage_reported_by_the_model_on_the_reactive_path` asserts a reported usage still
  arrives intact.

Both fail on unmodified `main`, the first with `ClassCastException: class TokenUsage cannot be cast to class
TestTokenUsage` and the second on the value. The two existing cases in that class pass either way, which is the
point: they cover the non-reactive path #6203 already fixed.

```
mvn -o -pl langchain4j test -Dtest=AiServiceStreamingTokenUsageTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j test        Tests run: 1707, Failures: 0, Errors: 0, Skipped: 19
mvn -o -pl langchain4j-core test   Tests run: 1371, Failures: 0, Errors: 0, Skipped: 5
mvn -o -pl langchain4j spotless:check   BUILD SUCCESS
```

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

The first box is unchecked because of the `null` aggregate described above. The module I changed is `langchain4j`
itself, so the fourth and fifth boxes cover the same suite: its unit tests and those of `langchain4j-core` are
green and listed above, but the 38 integration test classes there need provider API keys and were not run.
