### PR TITLE
docs: document The Grid as an OpenAI-compatible provider

### DIFF
--- a/docs/docs/integrations/language-models/openai-compatible.md
+++ b/docs/docs/integrations/language-models/openai-compatible.md
@@ -134,6 +134,46 @@ ChatModel model = OpenAiChatModel.builder()
 ```
 You can find available model names on the [Groq models page](https://console.groq.com/docs/models).
 
+## The Grid
+
+**Deployment:** SaaS (Key Required)
+
+**Description:** [The Grid](https://thegrid.ai) is a spot market for inference. Model names are market instruments — a task type (`text`, `code`, `agent`) paired with a quality tier (`standard`, `prime`, `max`), plus lab-scoped markets such as `claude-opus-latest`. Each request is filled by whichever supplier is competitive at the time, so the model reported in the response is the one that served the request, not the instrument you asked for.
+
+**Setup:**
+To use The Grid, you'll need an API key from [The Grid](https://thegrid.ai/docs/start-here/quickstart).
+
+The Grid answers inference requests with a [`307` redirect](https://thegrid.ai/docs/api-reference/request-routing-and-redirects) to its routing layer on the same host. Java's `HttpClient` does not follow redirects by default, so configure `followRedirects` — otherwise the call fails with an HTML redirect body rather than a chat response:
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-http-client-jdk</artifactId>
+    <version>1.20.0</version>
+</dependency>
+```
+
+```java
+import java.net.http.HttpClient;
+import dev.langchain4j.http.client.jdk.JdkHttpClient;
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
+
+...
+
+JdkHttpClientBuilder httpClientBuilder = JdkHttpClient.builder()
+        .httpClientBuilder(HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL));
+
+ChatModel model = OpenAiChatModel.builder()
+        .baseUrl("https://api.thegrid.ai/v1")
+        .apiKey(System.getenv("THEGRID_API_KEY"))
+        .modelName("text-standard") // Or any other instrument, e.g. code-prime, agent-max
+        .httpClientBuilder(httpClientBuilder)
+        .build();
+```
+
+The same `httpClientBuilder` applies to `OpenAiStreamingChatModel`. Chat, streaming, tool calling and structured outputs are supported. You can find available instruments on [The Grid instruments page](https://thegrid.ai/docs/instrument-specifications/current-instruments).
+
 ## Docker Model Runner
 
 **Deployment:** Local


### PR DESCRIPTION
Adds a `## The Grid` section to the OpenAI-compatible providers page.

**Disclosure:** I work on The Grid, and this description was written with AI assistance. Everything claimed below was verified by running it, not inferred from source.

[The Grid](https://thegrid.ai) is a spot market for inference: model names are market instruments — a task type (`text`, `code`, `agent`) paired with a quality tier (`standard`, `prime`, `max`) — and each request is filled by whichever supplier is competitive at the time.

### Why this section is worth having

The Grid answers inference requests with a [documented `307` redirect](https://thegrid.ai/docs/api-reference/request-routing-and-redirects) to its routing layer on the same host. **Java's `HttpClient` does not follow redirects by default**, so the obvious configuration fails in a way that is hard to diagnose — you get an HTML redirect body where a chat response should be:

```
<html><body>You are being <a href="https://api.thegrid.ai/r/v1/chat/completions?token=...">redirected</a>.</body></html>
```

That is the whole reason for this page entry rather than leaving users to work it out from a base URL. The fix is one builder, in the same shape as the existing LM Studio section's HTTP/1.1 workaround:

```java
JdkHttpClientBuilder httpClientBuilder = JdkHttpClient.builder()
        .httpClientBuilder(HttpClient.newBuilder()
                .followRedirects(HttpClient.Redirect.NORMAL));
```

### Verified

Run against the live API with `langchain4j-open-ai` and `langchain4j-http-client-jdk` **1.20.0**:

| Case | Result |
|---|---|
| `OpenAiChatModel` without `followRedirects` | fails with the HTML body above |
| `OpenAiChatModel` with `followRedirects(NORMAL)` | `OK` |
| `OpenAiStreamingChatModel` with the same builder | streams correctly; `OpenAiTokenUsage { inputTokenCount = 138, outputTokenCount = 33, totalTokenCount = 171 }` |

I also checked the streaming tool-call shape, since this page documents `accumulateToolCallId(false)` for gateways that resend the whole id in every chunk. **The Grid does not need it** — ids appear once on the first chunk of each tool call and are `null` thereafter, with arguments arriving as fragments, which is the standard OpenAI shape. So the section deliberately omits that flag rather than copying it defensively from a neighbouring provider.

### Scope

One file, 40 added lines, no deletions. Chat, streaming, tool calling and structured outputs only — `/v1/embeddings` returns `404` on The Grid, so the section says nothing about `OpenAiEmbeddingModel`.

I left `language-models/index.md` alone: the OpenAI row's cell there is an illustrative list ending in "etc.", and those table rows are column-aligned, so editing one risks churn for no information gain. Happy to add it if you'd prefer consistency with earlier entries.
