### PR TITLE
fix(mcp): preserve HTTP status for rejected responses

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.JsonException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
@@ -292,13 +293,14 @@ public class StreamableHttpMcpTransport implements McpTransport {
                                         });
                             } else {
                                 // Reinitialization did not help; fail instead of leaving the caller hanging
-                                future.completeExceptionally(new RuntimeException(
+                                future.completeExceptionally(new HttpException(
+                                        responseInfo.statusCode(),
                                         "Session expired again after reinitialization: server returned status code "
                                                 + responseInfo.statusCode()));
                             }
                         } else {
-                            future.completeExceptionally(
-                                    new RuntimeException("Unexpected status code: " + responseInfo.statusCode()));
+                            future.completeExceptionally(new HttpException(
+                                    responseInfo.statusCode(), "Unexpected status code: " + responseInfo.statusCode()));
                         }
                         return HttpResponse.BodySubscribers.discarding();
                     } else {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
 import dev.langchain4j.mcp.protocol.McpListToolsRequest;
@@ -38,9 +39,15 @@ class StreamableHttpMcpTransportSessionExpiryTest {
     private final AtomicInteger sessionCounter = new AtomicInteger();
     private final List<String> toolsListSessionIds = Collections.synchronizedList(new ArrayList<>());
     private volatile boolean retrySucceeds;
+    private volatile int rejectedStatusCode;
 
     private void startServer(boolean retrySucceeds) throws IOException {
+        startServer(retrySucceeds, 404);
+    }
+
+    private void startServer(boolean retrySucceeds, int rejectedStatusCode) throws IOException {
         this.retrySucceeds = retrySucceeds;
+        this.rejectedStatusCode = rejectedStatusCode;
         sessionCounter.set(0);
         toolsListSessionIds.clear();
         server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
@@ -61,8 +68,8 @@ class StreamableHttpMcpTransportSessionExpiryTest {
                     // simulate an expired session
                     respond(
                             exchange,
-                            404,
-                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"Session not found\"}}");
+                            rejectedStatusCode,
+                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"Request rejected\"}}");
                 }
             } else {
                 respond(exchange, 500, "{}");
@@ -134,5 +141,23 @@ class StreamableHttpMcpTransportSessionExpiryTest {
                 .isInstanceOf(ExecutionException.class)
                 .hasMessageContaining("after reinitialization");
         assertThat(toolsListSessionIds).containsExactly("session-1", "session-2");
+    }
+
+    @Test
+    void shouldExposeTheHttpStatusWhenARequestIsRejected() throws Exception {
+        startServer(false, 401);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        assertThatThrownBy(() -> response.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(HttpException.class)
+                .extracting(Throwable::getCause)
+                .extracting(HttpException.class::cast)
+                .extracting(HttpException::statusCode)
+                .isEqualTo(401);
+        assertThat(toolsListSessionIds).containsExactly("session-1");
     }
 }


### PR DESCRIPTION
## Issue
Closes #6290

## Change
`StreamableHttpMcpTransport` now completes non-2xx responses with the existing public `HttpException`, preserving the numeric HTTP status code for callers. This lets clients distinguish authentication/authorization failures from transient server failures without parsing exception messages.

The legacy 404 session-expiry reinitialization path is unchanged; only its final failure now carries the status code through `HttpException`.

## Verification
- `./mvnw -s /Users/yohanes/.m2/settings-public-central.xml -pl langchain4j-mcp -DskipITs -DfailIfNoTests=false test` (232 tests passed)
- `./mvnw -s /Users/yohanes/.m2/settings-public-central.xml -pl langchain4j-mcp spotless:check`

## Checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all unit tests in the changed module (232 passed; integration tests skipped)
- [ ] I have manually run all the unit and integration tests in the core and main modules
- [ ] I have added/updated the documentation (not required for this bug fix)
- [ ] I have added an example in the examples repo (not applicable)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)