### PR TITLE
fix(onnx-scoring): release native resources when initialization fails

### DIFF
--- a/docs/docs/integrations/scoring-reranking-models/in-process.md
+++ b/docs/docs/integrations/scoring-reranking-models/in-process.md
@@ -34,9 +34,6 @@ Double score = response.content();
 ```
 
 `OnnxScoringModel` implements `AutoCloseable`; close it when it is no longer needed to release its native resources.
-If model initialization fails, resources created before the failure are also closed, even though no model instance
-is returned to the caller. The original initialization failure is preserved, with any cleanup failures attached as
-suppressed exceptions.
 
 If you want to use the GPU, `onnxruntime_gpu` version can be found
 [here](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html).

--- a/docs/docs/integrations/scoring-reranking-models/in-process.md
+++ b/docs/docs/integrations/scoring-reranking-models/in-process.md
@@ -33,6 +33,11 @@ Response<Double> response = scoringModel.score("query", "passage");
 Double score = response.content();
 ```
 
+`OnnxScoringModel` implements `AutoCloseable`; close it when it is no longer needed to release its native resources.
+If model initialization fails, resources created before the failure are also closed, even though no model instance
+is returned to the caller. The original initialization failure is preserved, with any cleanup failures attached as
+suppressed exceptions.
+
 If you want to use the GPU, `onnxruntime_gpu` version can be found
 [here](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html).
 ```xml

--- a/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoder.java
+++ b/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoder.java
@@ -28,10 +28,12 @@ class OnnxScoringBertCrossEncoder implements AutoCloseable {
             String pathToTokenizer,
             int modelMaxLength,
             boolean normalize) {
+        OrtSession initializedSession = null;
+        HuggingFaceTokenizer initializedTokenizer = null;
         try (options) { // properly release parent session at the end of this block to prevent leaks
             this.environment = OrtEnvironment.getEnvironment();
-            this.session = this.environment.createSession(modelPath, options);
-            this.expectedInputs = session.getInputNames();
+            initializedSession = this.environment.createSession(modelPath, options);
+            this.expectedInputs = initializedSession.getInputNames();
             Map<String, String> tokenizerOptions = new HashMap<String, String>() {
                 {
                     put("padding", "true");
@@ -43,9 +45,26 @@ class OnnxScoringBertCrossEncoder implements AutoCloseable {
                 }
             };
             this.normalize = normalize;
-            this.tokenizer = HuggingFaceTokenizer.newInstance(Paths.get(pathToTokenizer), tokenizerOptions);
-        } catch (Exception e) {
+            initializedTokenizer = HuggingFaceTokenizer.newInstance(Paths.get(pathToTokenizer), tokenizerOptions);
+        } catch (Exception | Error e) {
+            closeOnFailure(initializedTokenizer, e);
+            closeOnFailure(initializedSession, e);
+            if (e instanceof Error error) {
+                throw error;
+            }
             throw new RuntimeException(e);
+        }
+        this.session = initializedSession;
+        this.tokenizer = initializedTokenizer;
+    }
+
+    private static void closeOnFailure(AutoCloseable resource, Throwable failure) {
+        if (resource != null) {
+            try {
+                resource.close();
+            } catch (Exception | Error closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
         }
     }
 

--- a/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoder.java
+++ b/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoder.java
@@ -47,9 +47,10 @@ class OnnxScoringBertCrossEncoder implements AutoCloseable {
             this.normalize = normalize;
             initializedTokenizer = HuggingFaceTokenizer.newInstance(Paths.get(pathToTokenizer), tokenizerOptions);
         } catch (Exception | Error e) {
-            closeOnFailure(initializedTokenizer, e);
             closeOnFailure(initializedSession, e);
+            closeOnFailure(initializedTokenizer, e);
             if (e instanceof Error error) {
+                // may originate from either native library (ONNX Runtime or DJL tokenizer), so it is not relabelled
                 throw error;
             }
             throw new RuntimeException(e);

--- a/langchain4j-onnx-scoring/src/test/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoderLifecycleTest.java
+++ b/langchain4j-onnx-scoring/src/test/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoderLifecycleTest.java
@@ -1,0 +1,148 @@
+package dev.langchain4j.model.scoring.onnx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class OnnxScoringBertCrossEncoderLifecycleTest {
+
+    private OrtEnvironment environment;
+    private OrtSession session;
+    private OrtSession.SessionOptions options;
+    private HuggingFaceTokenizer tokenizer;
+    private MockedStatic<OrtEnvironment> environments;
+    private MockedStatic<HuggingFaceTokenizer> tokenizers;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        environment = mock(OrtEnvironment.class);
+        session = mock(OrtSession.class);
+        options = mock(OrtSession.SessionOptions.class);
+        tokenizer = mock(HuggingFaceTokenizer.class);
+        environments = mockStatic(OrtEnvironment.class);
+        tokenizers = mockStatic(HuggingFaceTokenizer.class);
+
+        environments.when(OrtEnvironment::getEnvironment).thenReturn(environment);
+        when(environment.createSession("model.onnx", options)).thenReturn(session);
+        when(session.getInputNames()).thenReturn(Set.of("input_ids", "attention_mask"));
+        tokenizers
+                .when(() -> HuggingFaceTokenizer.newInstance(eq(Path.of("tokenizer.json")), anyMap()))
+                .thenReturn(tokenizer);
+    }
+
+    @AfterEach
+    void closeFactories() {
+        tokenizers.close();
+        environments.close();
+    }
+
+    @Test
+    void should_close_session_when_tokenizer_loading_fails() throws Exception {
+        IOException failure = new IOException("Invalid tokenizer JSON");
+        failTokenizerLoading(failure);
+
+        assertThatThrownBy(this::createEncoder)
+                .isInstanceOf(RuntimeException.class)
+                .hasCause(failure);
+
+        verify(session).close();
+        verify(options).close();
+        verifyNoInteractions(tokenizer);
+    }
+
+    @Test
+    void should_close_session_and_preserve_tokenizer_native_loading_error() throws Exception {
+        UnsatisfiedLinkError failure = new UnsatisfiedLinkError("Tokenizer native library could not be loaded");
+        failTokenizerLoading(failure);
+
+        assertThatThrownBy(this::createEncoder).isSameAs(failure);
+
+        verify(session).close();
+        verify(options).close();
+    }
+
+    @Test
+    void should_preserve_initialization_failure_when_cleanup_also_fails() throws Exception {
+        IOException failure = new IOException("Invalid tokenizer JSON");
+        OrtException closeFailure = new OrtException("Session cleanup failed");
+        failTokenizerLoading(failure);
+        doThrow(closeFailure).when(session).close();
+
+        assertThatThrownBy(this::createEncoder).hasCause(failure);
+
+        assertThat(failure.getSuppressed()).containsExactly(closeFailure);
+        verify(session).close();
+        verify(options).close();
+    }
+
+    @Test
+    void should_close_both_resources_when_closing_options_fails() throws Exception {
+        IllegalStateException failure = new IllegalStateException("Options cleanup failed");
+        IllegalStateException tokenizerCloseFailure = new IllegalStateException("Tokenizer cleanup failed");
+        doThrow(failure).when(options).close();
+        doThrow(tokenizerCloseFailure).when(tokenizer).close();
+
+        assertThatThrownBy(this::createEncoder).hasCause(failure);
+
+        verify(tokenizer).close();
+        verify(session).close();
+        assertThat(failure.getSuppressed()).containsExactly(tokenizerCloseFailure);
+    }
+
+    @Test
+    void should_close_options_when_session_creation_fails() throws Exception {
+        OrtException failure = new OrtException("Invalid ONNX model");
+        when(environment.createSession("model.onnx", options)).thenThrow(failure);
+
+        assertThatThrownBy(this::createEncoder).hasCause(failure);
+
+        verify(options).close();
+        verifyNoInteractions(session, tokenizer);
+    }
+
+    @Test
+    void should_keep_resources_open_until_successful_encoder_is_closed() throws Exception {
+        OnnxScoringBertCrossEncoder encoder = createEncoder();
+
+        verify(options).close();
+        verify(session, never()).close();
+        verify(tokenizer, never()).close();
+
+        encoder.close();
+        encoder.close();
+
+        verify(session).close();
+        verify(tokenizer).close();
+        verify(environment, never()).close();
+    }
+
+    private void failTokenizerLoading(Throwable failure) {
+        tokenizers
+                .when(() -> HuggingFaceTokenizer.newInstance(eq(Path.of("tokenizer.json")), anyMap()))
+                .thenThrow(failure);
+    }
+
+    private OnnxScoringBertCrossEncoder createEncoder() {
+        return new OnnxScoringBertCrossEncoder("model.onnx", options, "tokenizer.json", 512, false);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6317

## Change

`OnnxScoringBertCrossEncoder` creates the `OrtSession` before loading the Hugging Face tokenizer. When tokenizer loading failed, the constructor closed only its `SessionOptions`, leaving the native session allocated. Because construction fails, the caller never receives an object it could close, so wrapping model creation in try-with-resources cannot help. An application that retries lazy initialization repeats the leak on every attempt.

Resources acquired during construction are now tracked and closed when initialization fails, in the same order `close()` uses (session, then tokenizer). The original exception or error is preserved, with cleanup failures attached as suppressed exceptions. An `Error` is rethrown unchanged rather than relabelled by `OnnxScoringModel.wrapNativeLibraryLoadFailure()`, because it may originate from either native library — ONNX Runtime or the DJL tokenizer. Successfully constructed models keep their existing explicit-close lifecycle.

The change includes six lifecycle tests and a short note in the ONNX scoring documentation. It changes no public API, adds no dependencies, and does not alter scoring or tokenization.

## Verification

- Without the fix, four of the six new lifecycle tests fail on `main`, the tokenizer-failure case reporting `Wanted but not invoked: ortSession.close()`.
- With the fix, all 12 ONNX scoring unit tests pass, including the six new lifecycle tests.
- `mvn -pl langchain4j-onnx-scoring,langchain4j -am -Dit.test=OnnxScoringModelIT -Dfailsafe.failIfNoSpecifiedTests=false verify` passed (a local proxy was configured for dependency/model downloads):
  - `langchain4j-core`: 1,371 unit tests, 4 skipped, 0 failures/errors;
  - `langchain4j`: 1,705 unit tests, 19 skipped, 0 failures/errors;
  - ONNX scoring: 12 unit tests and 5 real-model integration tests, no skips/failures/errors;
  - required reactor dependencies and Revapi API compatibility checks passed.
- Integration tests in `langchain4j-core` and `langchain4j` were not run: failsafe was restricted to `OnnxScoringModelIT`. External-provider integration suites and unrelated modules were not selected. This is not a claim that every repository test was run.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [x] I have added/updated the documentation
- [ ] I have added an example in the examples repo (not applicable to this fix)
- [ ] I have added/updated Spring Boot starter(s) (not applicable to this fix)
