### PR TITLE
feat(open-ai): expose web search queries and citations in Responses metadata

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatResponseMetadata.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatResponseMetadata.java
@@ -1,20 +1,20 @@
 package dev.langchain4j.model.openai;
 
+import static dev.langchain4j.internal.Utils.copy;
+
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.util.List;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.Utils.copy;
 
 public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
 
     private final Long createdAt;
     private final Long completedAt;
     private final String serviceTier;
+    private final OpenAiResponsesWebSearchMetadata webSearchMetadata;
     private final SuccessfulHttpResponse rawHttpResponse;
     private final List<ServerSentEvent> rawServerSentEvents;
 
@@ -23,6 +23,7 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
         this.createdAt = builder.createdAt;
         this.completedAt = builder.completedAt;
         this.serviceTier = builder.serviceTier;
+        this.webSearchMetadata = builder.webSearchMetadata;
         this.rawHttpResponse = builder.rawHttpResponse;
         this.rawServerSentEvents = copy(builder.rawServerSentEvents);
     }
@@ -55,6 +56,10 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
         return serviceTier;
     }
 
+    public OpenAiResponsesWebSearchMetadata webSearchMetadata() {
+        return webSearchMetadata;
+    }
+
     public SuccessfulHttpResponse rawHttpResponse() {
         return rawHttpResponse;
     }
@@ -69,6 +74,7 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
                 .createdAt(createdAt)
                 .completedAt(completedAt)
                 .serviceTier(serviceTier)
+                .webSearchMetadata(webSearchMetadata)
                 .rawHttpResponse(rawHttpResponse)
                 .rawServerSentEvents(rawServerSentEvents);
     }
@@ -82,6 +88,7 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
         return Objects.equals(createdAt, that.createdAt)
                 && Objects.equals(completedAt, that.completedAt)
                 && Objects.equals(serviceTier, that.serviceTier)
+                && Objects.equals(webSearchMetadata, that.webSearchMetadata)
                 && Objects.equals(rawHttpResponse, that.rawHttpResponse)
                 && Objects.equals(rawServerSentEvents, that.rawServerSentEvents);
     }
@@ -93,6 +100,7 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
                 createdAt,
                 completedAt,
                 serviceTier,
+                webSearchMetadata,
                 rawHttpResponse,
                 rawServerSentEvents);
     }
@@ -106,7 +114,8 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
                 + finishReason() + ", createdAt="
                 + createdAt + ", completedAt="
                 + completedAt + ", serviceTier='"
-                + serviceTier + '\'' + ", rawHttpResponse="
+                + serviceTier + '\'' + ", webSearchMetadata="
+                + webSearchMetadata + ", rawHttpResponse="
                 + rawHttpResponse + ", rawServerSentEvents="
                 + rawServerSentEvents + '}';
     }
@@ -120,6 +129,7 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
         private Long createdAt;
         private Long completedAt;
         private String serviceTier;
+        private OpenAiResponsesWebSearchMetadata webSearchMetadata;
         private SuccessfulHttpResponse rawHttpResponse;
         private List<ServerSentEvent> rawServerSentEvents;
 
@@ -135,6 +145,11 @@ public class OpenAiResponsesChatResponseMetadata extends ChatResponseMetadata {
 
         public Builder serviceTier(String serviceTier) {
             this.serviceTier = serviceTier;
+            return this;
+        }
+
+        public Builder webSearchMetadata(OpenAiResponsesWebSearchMetadata webSearchMetadata) {
+            this.webSearchMetadata = webSearchMetadata;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -1,11 +1,11 @@
 package dev.langchain4j.model.openai;
 
 import static dev.langchain4j.http.client.sse.ServerSentEventParsingHandleUtils.toStreamingHandle;
+import static dev.langchain4j.internal.CompletableFutureUtils.propagateCancellation;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.*;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.CompletableFutureUtils.propagateCancellation;
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -36,7 +36,6 @@ import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.http.client.sse.ServerSentEventContext;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.internal.ExceptionMapper;
-import dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.internal.MappingTrackingStreamingChatResponseHandler;
 import dev.langchain4j.internal.ProviderJson;
@@ -48,16 +47,16 @@ import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.model.chat.response.ChatModelStreamingEvent;
 import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
+import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.reactive.streaming.HttpStreamingChatPublisher;
 import dev.langchain4j.reactive.streaming.TubeBackedStreamingChatResponseHandler;
-import dev.langchain4j.model.output.FinishReason;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -128,6 +127,13 @@ class OpenAiResponsesClient {
     private static final String FIELD_OUTPUT_TOKENS_DETAILS = "output_tokens_details";
     private static final String FIELD_REASONING_TOKENS = "reasoning_tokens";
     private static final String FIELD_MODEL = "model";
+    private static final String FIELD_ANNOTATIONS = "annotations";
+    private static final String FIELD_ACTION = "action";
+    private static final String FIELD_QUERY = "query";
+    private static final String FIELD_URL = "url";
+    private static final String FIELD_TITLE = "title";
+    private static final String FIELD_START_INDEX = "start_index";
+    private static final String FIELD_END_INDEX = "end_index";
     private static final String FIELD_INPUT = "input";
     private static final String FIELD_STREAM = "stream";
     private static final String FIELD_STORE = "store";
@@ -185,6 +191,8 @@ class OpenAiResponsesClient {
     private static final String TYPE_FUNCTION_CALL_OUTPUT = "function_call_output";
     private static final String TYPE_JSON_OBJECT = "json_object";
     private static final String TYPE_JSON_SCHEMA = "json_schema";
+    private static final String TYPE_WEB_SEARCH_CALL = "web_search_call";
+    private static final String TYPE_URL_CITATION = "url_citation";
 
     private final HttpClient httpClient;
     private final String baseUrl;
@@ -206,7 +214,8 @@ class OpenAiResponsesClient {
         this.apiKey = builder.apiKey;
         this.organizationId = builder.organizationId;
         this.streamingBufferSize = ensureGreaterThanZero(
-                getOrDefault(builder.streamingBufferSize, OpenAiClient.DEFAULT_STREAMING_BUFFER_SIZE), "streamingBufferSize");
+                getOrDefault(builder.streamingBufferSize, OpenAiClient.DEFAULT_STREAMING_BUFFER_SIZE),
+                "streamingBufferSize");
         this.customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, () -> Map::of);
     }
 
@@ -490,7 +499,6 @@ class OpenAiResponsesClient {
         return requestBuilder.body(requestBody).build();
     }
 
-
     // --- JSON accessors over the plain JDK values (Map/List/String/Number/Boolean) a parsed response is made of ---
 
     /** Mirrors {@code node.path(field)}: an absent field yields null rather than an exception. */
@@ -588,6 +596,55 @@ class OpenAiResponsesClient {
         return null;
     }
 
+    /**
+     * Collects the web-search data from the response output: queries from {@code web_search_call}
+     * items and {@code url_citation} annotations from {@code output_text} content parts.
+     *
+     * @return the metadata, or {@code null} when the response contains neither
+     */
+    private static OpenAiResponsesWebSearchMetadata extractWebSearchMetadata(Object output) {
+        List<String> searchQueries = new ArrayList<>();
+        List<OpenAiResponsesWebSearchMetadata.UrlCitation> citations = new ArrayList<>();
+        for (Object item : arr(output)) {
+            String type = str(at(item, FIELD_TYPE));
+            if (TYPE_WEB_SEARCH_CALL.equals(type)) {
+                Object action = at(item, FIELD_ACTION);
+                String query = str(at(action != null ? action : item, FIELD_QUERY), null);
+                if (query != null && !query.isBlank()) {
+                    searchQueries.add(query);
+                }
+            } else if (TYPE_MESSAGE.equals(type)) {
+                for (Object content : arr(at(item, FIELD_CONTENT))) {
+                    if (!TYPE_OUTPUT_TEXT.equals(str(at(content, FIELD_TYPE)))) {
+                        continue;
+                    }
+                    for (Object annotation : arr(at(content, FIELD_ANNOTATIONS))) {
+                        if (!TYPE_URL_CITATION.equals(str(at(annotation, FIELD_TYPE)))) {
+                            continue;
+                        }
+                        Integer startIndex = hasNonNull(annotation, FIELD_START_INDEX)
+                                ? intOf(at(annotation, FIELD_START_INDEX))
+                                : null;
+                        Integer endIndex =
+                                hasNonNull(annotation, FIELD_END_INDEX) ? intOf(at(annotation, FIELD_END_INDEX)) : null;
+                        citations.add(new OpenAiResponsesWebSearchMetadata.UrlCitation(
+                                str(at(annotation, FIELD_URL), null),
+                                str(at(annotation, FIELD_TITLE), null),
+                                startIndex,
+                                endIndex));
+                    }
+                }
+            }
+        }
+        if (searchQueries.isEmpty() && citations.isEmpty()) {
+            return null;
+        }
+        return OpenAiResponsesWebSearchMetadata.builder()
+                .searchQueries(searchQueries)
+                .citations(citations)
+                .build();
+    }
+
     private static List<ToolExecutionRequest> extractToolExecutionRequests(Object output) {
         List<ToolExecutionRequest> toolExecutionRequests = new ArrayList<>();
         for (Object item : arr(output)) {
@@ -630,8 +687,7 @@ class OpenAiResponsesClient {
         Object outputDetailsNode = at(usageNode, FIELD_OUTPUT_TOKENS_DETAILS);
         if (outputDetailsNode != null) {
             usageBuilder.outputTokensDetails(OpenAiTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(
-                            intOf(at(outputDetailsNode, FIELD_REASONING_TOKENS)))
+                    .reasoningTokens(intOf(at(outputDetailsNode, FIELD_REASONING_TOKENS)))
                     .build());
         }
 
@@ -698,6 +754,11 @@ class OpenAiResponsesClient {
 
         if (hasNonNull(responseNode, FIELD_SERVICE_TIER)) {
             metadataBuilder.serviceTier(str(at(responseNode, FIELD_SERVICE_TIER)));
+        }
+
+        OpenAiResponsesWebSearchMetadata webSearchMetadata = extractWebSearchMetadata(outputNode);
+        if (webSearchMetadata != null) {
+            metadataBuilder.webSearchMetadata(webSearchMetadata);
         }
 
         metadataBuilder.rawHttpResponse(rawHttpResponse);
@@ -1182,13 +1243,17 @@ class OpenAiResponsesClient {
                 metadataBuilder.createdAt(longOf(at(responseNode, FIELD_CREATED_AT)));
             }
             if (hasNonNull(responseNode, FIELD_COMPLETED_AT)) {
-                metadataBuilder.completedAt(
-                        longOf(at(responseNode, FIELD_COMPLETED_AT)));
+                metadataBuilder.completedAt(longOf(at(responseNode, FIELD_COMPLETED_AT)));
             }
             if (hasNonNull(responseNode, FIELD_SERVICE_TIER)) {
-                metadataBuilder.serviceTier(
-                        str(at(responseNode, FIELD_SERVICE_TIER)));
+                metadataBuilder.serviceTier(str(at(responseNode, FIELD_SERVICE_TIER)));
             }
+
+            OpenAiResponsesWebSearchMetadata webSearchMetadata = extractWebSearchMetadata(outputNode);
+            if (webSearchMetadata != null) {
+                metadataBuilder.webSearchMetadata(webSearchMetadata);
+            }
+
             if (rawHttpResponse != null) {
                 metadataBuilder.rawHttpResponse(rawHttpResponse);
             }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesWebSearchMetadata.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesWebSearchMetadata.java
@@ -1,0 +1,88 @@
+package dev.langchain4j.model.openai;
+
+import static dev.langchain4j.internal.Utils.copy;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Metadata about the {@code web_search} server tool of the OpenAI Responses API: the search
+ * queries that were executed and the citations ({@code url_citation} annotations) contained in
+ * the answer.
+ *
+ * <p>Exposed via {@link OpenAiResponsesChatResponseMetadata#webSearchMetadata()}, mirroring how
+ * the Gemini integration exposes grounding metadata.
+ */
+public class OpenAiResponsesWebSearchMetadata {
+
+    private final List<String> searchQueries;
+    private final List<UrlCitation> citations;
+
+    private OpenAiResponsesWebSearchMetadata(Builder builder) {
+        this.searchQueries = copy(builder.searchQueries);
+        this.citations = copy(builder.citations);
+    }
+
+    /**
+     * @return the queries that were executed for this response, in order. May be empty.
+     */
+    public List<String> searchQueries() {
+        return searchQueries;
+    }
+
+    /**
+     * @return the {@code url_citation} annotations contained in the answer, in order. May be empty.
+     */
+    public List<UrlCitation> citations() {
+        return citations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OpenAiResponsesWebSearchMetadata that = (OpenAiResponsesWebSearchMetadata) o;
+        return Objects.equals(searchQueries, that.searchQueries) && Objects.equals(citations, that.citations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(searchQueries, citations);
+    }
+
+    @Override
+    public String toString() {
+        return "OpenAiResponsesWebSearchMetadata{" + "searchQueries=" + searchQueries + ", citations=" + citations
+                + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<String> searchQueries;
+        private List<UrlCitation> citations;
+
+        public Builder searchQueries(List<String> searchQueries) {
+            this.searchQueries = searchQueries;
+            return this;
+        }
+
+        public Builder citations(List<UrlCitation> citations) {
+            this.citations = citations;
+            return this;
+        }
+
+        public OpenAiResponsesWebSearchMetadata build() {
+            return new OpenAiResponsesWebSearchMetadata(this);
+        }
+    }
+
+    /**
+     * A {@code url_citation} annotation attached to an {@code output_text} content part: the source
+     * the cited span (between {@code startIndex} and {@code endIndex} in the text) was taken from.
+     */
+    public record UrlCitation(String url, String title, Integer startIndex, Integer endIndex) {}
+}

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesChatModelWebSearchParsingTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesChatModelWebSearchParsingTest.java
@@ -1,0 +1,104 @@
+package dev.langchain4j.model.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers how the non-streaming Responses API response body is read: which field ends up where in
+ * the resulting {@link ChatResponse} metadata.
+ */
+class OpenAiResponsesChatModelWebSearchParsingTest {
+
+    private static final String RESPONSE_BODY_WITH_WEB_SEARCH = """
+            {
+              "id": "resp_1",
+              "model": "gpt-5.4-mini",
+              "status": "completed",
+              "output": [
+                {
+                  "type": "web_search_call",
+                  "id": "ws_1",
+                  "status": "completed",
+                  "action": {"type": "search", "query": "langchain4j OpenAI Responses"}
+                },
+                {
+                  "id": "msg_1",
+                  "type": "message",
+                  "role": "assistant",
+                  "content": [
+                    {
+                      "type": "output_text",
+                      "text": "The answer cites sources.",
+                      "annotations": [
+                        {
+                          "type": "url_citation",
+                          "start_index": 4,
+                          "end_index": 10,
+                          "url": "https://docs.langchain4j.dev",
+                          "title": "LangChain4j docs"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+    private static final String RESPONSE_BODY_WITHOUT_WEB_SEARCH = """
+            {
+              "id": "resp_1",
+              "model": "gpt-5.4-mini",
+              "status": "completed",
+              "output": [
+                {
+                  "id": "msg_1",
+                  "type": "message",
+                  "role": "assistant",
+                  "content": [{"type": "output_text", "text": "Hello, world"}]
+                }
+              ]
+            }
+            """;
+
+    private OpenAiResponsesChatModel modelWithResponseBody(String responseBody) {
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(responseBody)
+                .build());
+        return OpenAiResponsesChatModel.builder()
+                .apiKey("dummy")
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .modelName("gpt-5.4-mini")
+                .build();
+    }
+
+    @Test
+    void should_expose_web_search_queries_and_citations_in_metadata() {
+        ChatResponse response =
+                modelWithResponseBody(RESPONSE_BODY_WITH_WEB_SEARCH).chat(List.of(UserMessage.from("Hello")));
+
+        OpenAiResponsesChatResponseMetadata metadata = (OpenAiResponsesChatResponseMetadata) response.metadata();
+        assertThat(metadata.webSearchMetadata()).isNotNull();
+        assertThat(metadata.webSearchMetadata().searchQueries()).containsExactly("langchain4j OpenAI Responses");
+        assertThat(metadata.webSearchMetadata().citations())
+                .containsExactly(new OpenAiResponsesWebSearchMetadata.UrlCitation(
+                        "https://docs.langchain4j.dev", "LangChain4j docs", 4, 10));
+    }
+
+    @Test
+    void should_not_expose_web_search_metadata_when_output_has_no_search_data() {
+        ChatResponse response =
+                modelWithResponseBody(RESPONSE_BODY_WITHOUT_WEB_SEARCH).chat(List.of(UserMessage.from("Hello")));
+
+        OpenAiResponsesChatResponseMetadata metadata = (OpenAiResponsesChatResponseMetadata) response.metadata();
+        assertThat(metadata.webSearchMetadata()).isNull();
+    }
+}

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingEventParsingTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingEventParsingTest.java
@@ -105,19 +105,49 @@ class OpenAiResponsesStreamingEventParsingTest {
     }
 
     @Test
+    void should_expose_web_search_queries_and_citations_in_metadata() throws Exception {
+        ChatResponse response = chatWith(
+                event(
+                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.4-mini\",\"status\":\"completed\",\"output\":[{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"status\":\"completed\",\"action\":{\"type\":\"search\",\"query\":\"langchain4j OpenAI Responses\"}},{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"The answer cites sources.\",\"annotations\":[{\"type\":\"url_citation\",\"start_index\":4,\"end_index\":10,\"url\":\"https://docs.langchain4j.dev\",\"title\":\"LangChain4j docs\"}]}]}]}}"));
+
+        OpenAiResponsesChatResponseMetadata metadata = (OpenAiResponsesChatResponseMetadata) response.metadata();
+        assertThat(metadata.webSearchMetadata()).isNotNull();
+        assertThat(metadata.webSearchMetadata().searchQueries()).containsExactly("langchain4j OpenAI Responses");
+        assertThat(metadata.webSearchMetadata().citations())
+                .containsExactly(new OpenAiResponsesWebSearchMetadata.UrlCitation(
+                        "https://docs.langchain4j.dev", "LangChain4j docs", 4, 10));
+    }
+
+    @Test
+    void should_not_expose_web_search_metadata_when_output_has_no_search_data() throws Exception {
+        ChatResponse response = chatWith(
+                event(
+                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.4-mini\",\"status\":\"completed\",\"output\":[{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello, world\"}]}]}}"));
+
+        OpenAiResponsesChatResponseMetadata metadata = (OpenAiResponsesChatResponseMetadata) response.metadata();
+        assertThat(metadata.webSearchMetadata()).isNull();
+    }
+
+    @Test
     void should_stream_a_tool_call_assembled_from_its_events() throws Exception {
         ChatResponse response = chatWith(
                 event(
                         "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"getWeather\"}}"),
-                event("{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"{\\\"city\\\":\"}"),
-                event("{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"\\\"Munich\\\"}\"}"),
+                event(
+                        "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"{\\\"city\\\":\"}"),
+                event(
+                        "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"\\\"Munich\\\"}\"}"),
                 event(
                         "{\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_1\",\"arguments\":\"{\\\"city\\\":\\\"Munich\\\"}\"}"),
                 event(
                         "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.4-mini\",\"status\":\"completed\",\"output\":[]}}"));
 
         assertThat(partialToolCalls)
-                .extracting(PartialToolCall::index, PartialToolCall::id, PartialToolCall::name, PartialToolCall::partialArguments)
+                .extracting(
+                        PartialToolCall::index,
+                        PartialToolCall::id,
+                        PartialToolCall::name,
+                        PartialToolCall::partialArguments)
                 .containsExactly(
                         org.assertj.core.groups.Tuple.tuple(0, "call_1", "getWeather", "{\"city\":"),
                         org.assertj.core.groups.Tuple.tuple(0, "call_1", "getWeather", "\"Munich\"}"));
@@ -127,7 +157,9 @@ class OpenAiResponsesStreamingEventParsingTest {
                 .name("getWeather")
                 .arguments("{\"city\":\"Munich\"}")
                 .build();
-        assertThat(completeToolCalls).extracting(CompleteToolCall::toolExecutionRequest).containsExactly(expected);
+        assertThat(completeToolCalls)
+                .extracting(CompleteToolCall::toolExecutionRequest)
+                .containsExactly(expected);
         assertThat(response.aiMessage().toolExecutionRequests()).containsExactly(expected);
         assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
     }
@@ -151,9 +183,7 @@ class OpenAiResponsesStreamingEventParsingTest {
 
     @Test
     void should_read_the_metadata_of_the_completed_event() throws Exception {
-        ChatResponse response = chatWith(
-                event(
-                        """
+        ChatResponse response = chatWith(event("""
                         {"type":"response.completed","response":{
                           "id":"resp_1",
                           "model":"gpt-5.4-mini",
@@ -190,8 +220,9 @@ class OpenAiResponsesStreamingEventParsingTest {
 
     @Test
     void should_fail_with_the_error_message_of_the_failed_event() {
-        stream(event(
-                "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp_1\",\"error\":{\"code\":\"server_error\",\"message\":\"Something went wrong\"}}}"));
+        stream(
+                event(
+                        "{\"type\":\"response.failed\",\"response\":{\"id\":\"resp_1\",\"error\":{\"code\":\"server_error\",\"message\":\"Something went wrong\"}}}"));
 
         assertThatThrownBy(() -> futureResponse.get(5, TimeUnit.SECONDS))
                 .isInstanceOf(ExecutionException.class)
@@ -209,15 +240,14 @@ class OpenAiResponsesStreamingEventParsingTest {
 
     @Test
     void should_ignore_events_that_do_not_belong_to_a_known_tool_call() throws Exception {
-        ChatResponse response = chatWith(
-                Stream.of(
-                                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
-                                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"unknown\",\"delta\":\"{}\"}",
-                                "{\"type\":\"response.function_call_arguments.done\",\"item_id\":\"unknown\",\"arguments\":\"{}\"}",
-                                "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}",
-                                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.4-mini\",\"status\":\"completed\",\"output\":[]}}")
-                        .map(OpenAiResponsesStreamingEventParsingTest::event)
-                        .toArray(ServerSentEvent[]::new));
+        ChatResponse response = chatWith(Stream.of(
+                        "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}",
+                        "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"unknown\",\"delta\":\"{}\"}",
+                        "{\"type\":\"response.function_call_arguments.done\",\"item_id\":\"unknown\",\"arguments\":\"{}\"}",
+                        "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}",
+                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.4-mini\",\"status\":\"completed\",\"output\":[]}}")
+                .map(OpenAiResponsesStreamingEventParsingTest::event)
+                .toArray(ServerSentEvent[]::new));
 
         assertThat(partialToolCalls).isEmpty();
         assertThat(completeToolCalls).isEmpty();


### PR DESCRIPTION
## Issue
Closes #6237

## Change

When the `web_search` server tool runs, OpenAI Responses answers carry `web_search_call` output items and `url_citation` annotations on the `output_text` parts. Both were dropped during parsing, so the sources of an answer were only reachable by re-parsing raw SSE events.

This change parses them into a new `OpenAiResponsesWebSearchMetadata` (executed `searchQueries` + `citations` with url/title/start/end indexes) and exposes it via `OpenAiResponsesChatResponseMetadata.webSearchMetadata()`, mirroring how the Gemini integration exposes grounding metadata. It is wired for both `OpenAiResponsesChatModel` (response body) and `OpenAiResponsesStreamingChatModel` (response.completed event), and is `null` when the response contains no search data, so existing request/response JSON is unchanged.

Covered by new fixture-based tests for both the streaming SSE path and the blocking body path (plus negative cases), following the existing `OpenAiResponsesStreamingEventParsingTest` harness.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)