### PR TITLE
feat(mcp): merge allOf sub-schemas when converting tool input schemas

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -18,6 +18,7 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -105,14 +106,39 @@ class ToolSpecificationHelper {
             if (node.containsKey("description")) {
                 builder.description(string(node.get("description")));
             }
+            // MCP servers commonly compose object schemas with 'allOf' (e.g. one object schema per
+            // capability). JsonObjectSchema cannot represent 'allOf' itself, so object-typed
+            // sub-schemas are merged into this one: union of properties, union of required and
+            // collected definitions, with the node's own members taking precedence on conflicts.
+            // Entries that do not convert to an object (e.g. a $ref or a scalar constraint) are
+            // ignored, as they were before.
+            Map<String, JsonSchemaElement> mergedProperties = new LinkedHashMap<>();
+            Set<String> mergedRequired = new LinkedHashSet<>();
+            Map<String, JsonSchemaElement> mergedDefinitions = new LinkedHashMap<>();
+            if (node.containsKey("allOf")) {
+                for (Object allOfEntry : array(node.get("allOf"))) {
+                    JsonSchemaElement element = jsonNodeToJsonSchemaElement(object(allOfEntry));
+                    if (element instanceof JsonObjectSchema subSchema) {
+                        mergedProperties.putAll(subSchema.properties());
+                        mergedRequired.addAll(subSchema.required());
+                        mergedDefinitions.putAll(subSchema.definitions());
+                    }
+                }
+            }
             if (node.containsKey("properties")) {
                 for (Map.Entry<String, Object> property :
                         object(node.get("properties")).entrySet()) {
-                    builder.addProperty(property.getKey(), jsonNodeToJsonSchemaElement(object(property.getValue())));
+                    mergedProperties.put(property.getKey(), jsonNodeToJsonSchemaElement(object(property.getValue())));
                 }
             }
+            if (!mergedProperties.isEmpty()) {
+                builder.addProperties(mergedProperties);
+            }
             if (node.containsKey("required")) {
-                builder.required(toStringArray(node.get("required")));
+                mergedRequired.addAll(List.of(toStringArray(node.get("required"))));
+            }
+            if (!mergedRequired.isEmpty()) {
+                builder.required(List.copyOf(mergedRequired));
             }
             if (node.containsKey("additionalProperties")) {
                 Object additionalProperties = node.get("additionalProperties");
@@ -130,11 +156,12 @@ class ToolSpecificationHelper {
             // Handle $defs (draft 2019-09+) and definitions (draft-07)
             Object defsNode = node.containsKey("$defs") ? node.get("$defs") : node.get("definitions");
             if (defsNode != null) {
-                Map<String, JsonSchemaElement> definitions = new LinkedHashMap<>();
                 for (Map.Entry<String, Object> entry : object(defsNode).entrySet()) {
-                    definitions.put(entry.getKey(), jsonNodeToJsonSchemaElement(object(entry.getValue())));
+                    mergedDefinitions.put(entry.getKey(), jsonNodeToJsonSchemaElement(object(entry.getValue())));
                 }
-                builder.definitions(definitions);
+            }
+            if (!mergedDefinitions.isEmpty()) {
+                builder.definitions(mergedDefinitions);
             }
             return builder.build();
         } else if (typeNode instanceof String) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -1418,6 +1418,9 @@ class ToolSpecificationHelperTest {
 
         // properties from all sub-schemas are merged, required lists are united
         assertThat(parameters.properties()).containsOnlyKeys("identifier", "title", "requiredApproval");
+        assertThat(parameters.properties().get("identifier")).isInstanceOf(JsonStringSchema.class);
+        assertThat(parameters.properties().get("title")).isInstanceOf(JsonStringSchema.class);
+        assertThat(parameters.properties().get("requiredApproval")).isInstanceOf(JsonBooleanSchema.class);
         assertThat(parameters.required()).containsExactly("identifier");
     }
 
@@ -1447,6 +1450,7 @@ class ToolSpecificationHelperTest {
         JsonObjectSchema parameters = toolSpecification.parameters();
 
         assertThat(parameters.properties()).containsOnlyKeys("icon");
+        assertThat(parameters.properties().get("icon")).isInstanceOf(JsonStringSchema.class);
     }
 
     @Test

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -1379,4 +1379,143 @@ class ToolSpecificationHelperTest {
             throw new RuntimeException(e);
         }
     }
+
+    @Test
+    void allOfSubSchemasAreMergedIntoObjectSchema() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "allOf" : [ {
+                          "type" : "object",
+                          "properties" : {
+                            "identifier" : {
+                              "type" : "string"
+                            }
+                          },
+                          "required" : [ "identifier" ]
+                        }, {
+                          "type" : "object",
+                          "properties" : {
+                            "title" : {
+                              "type" : "string"
+                            },
+                            "requiredApproval" : {
+                              "type" : "boolean"
+                            }
+                          }
+                        } ]
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        // properties from all sub-schemas are merged, required lists are united
+        assertThat(parameters.properties()).containsOnlyKeys("identifier", "title", "requiredApproval");
+        assertThat(parameters.required()).containsExactly("identifier");
+    }
+
+    @Test
+    void allOfEntriesThatDoNotConvertToObjectsAreIgnored() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "properties" : {
+                          "icon" : {
+                            "type" : "string"
+                          }
+                        },
+                        "allOf" : [ {
+                          "type" : "string"
+                        } ]
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        assertThat(parameters.properties()).containsOnlyKeys("icon");
+    }
+
+    @Test
+    void allOfOwnPropertiesTakePrecedenceOverMergedSubSchemas() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "allOf" : [ {
+                          "type" : "object",
+                          "properties" : {
+                            "title" : {
+                              "type" : "string",
+                              "description" : "from allOf"
+                            }
+                          }
+                        } ],
+                        "properties" : {
+                          "title" : {
+                            "type" : "string",
+                            "description" : "from own schema"
+                          }
+                        }
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        JsonStringSchema title = (JsonStringSchema) parameters.properties().get("title");
+        assertThat(title.description()).isEqualTo("from own schema");
+    }
+
+    @Test
+    void arrayWithoutItemsIsAccepted() throws JsonProcessingException {
+        // Regression for #3585: 'items' is optional in JSON Schema, so an array property without
+        // it (e.g. {"type": "array"}) must convert instead of failing with "items cannot be null".
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "properties" : {
+                          "enum" : {
+                            "type" : "array"
+                          },
+                          "rules" : {
+                            "type" : "array"
+                          }
+                        }
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        JsonArraySchema enumProperty = (JsonArraySchema) parameters.properties().get("enum");
+        assertThat(enumProperty.items()).isNull();
+        JsonArraySchema rulesProperty =
+                (JsonArraySchema) parameters.properties().get("rules");
+        assertThat(rulesProperty.items()).isNull();
+    }
 }


### PR DESCRIPTION
## Issue
Closes #3585

## Change

MCP servers commonly compose input schemas with the `allOf` keyword (e.g. one object schema per capability). `JsonObjectSchema` cannot represent `allOf` itself, so until now such sub-schemas were silently ignored and their properties never reached the model.

This change merges object-typed `allOf` sub-schemas into the containing object schema during conversion in `ToolSpecificationHelper`:

- union of `properties`
- union of `required`
- collected ``/`definitions`
- the node's own members take precedence on conflicts

Entries that do not convert to an object (e.g. a `` or a scalar constraint) are ignored, as they were before this change.

Also pins the original #3585 regression case: an array property without the optional `items` keyword converts cleanly instead of failing with "items cannot be null" (that part was already fixed by #3452 — this test keeps it pinned).

Covered by four new unit tests in `ToolSpecificationHelperTest` (sub-schema merging, non-object entries ignored, own-schema precedence, missing `items`).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)