### PR TITLE
fix: prevent infinite recursion in TokenUsage.add()

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/output/TokenUsage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/output/TokenUsage.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.model.output;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import java.util.Objects;
 
 /**
  * Represents the token usage of a response.
@@ -105,6 +105,9 @@ public class TokenUsage {
      *
      * <p>Fields which are null in both responses will be null in the result.
      *
+     * <p>Subclasses carrying their own fields should override this method to sum them as well;
+     * the base implementation only sums the fields declared here.
+     *
      * @param that The token usage to add to this one.
      * @return a new {@link TokenUsage} instance with the token usage of both responses added together.
      */
@@ -115,15 +118,27 @@ public class TokenUsage {
 
         if (that.getClass() != TokenUsage.class) {
             // when adding TokenUsage ("this") and one of TokenUsage's subclasses ("that"),
-            // we want to call "add" on the subclass to preserve extra information present in the subclass
-            return that.add(this);
+            // we want to call "add" on the subclass to preserve extra information present in the subclass.
+            // "this" is handed over as a plain TokenUsage: a subclass that inherits this method instead of
+            // overriding it would otherwise delegate straight back here, and the two instances would pass
+            // the call to each other until the stack overflows.
+            return that.add(asTokenUsage());
         }
 
         return new TokenUsage(
                 sum(this.inputTokenCount, that.inputTokenCount),
                 sum(this.outputTokenCount, that.outputTokenCount),
-                sum(this.totalTokenCount, that.totalTokenCount)
-        );
+                sum(this.totalTokenCount, that.totalTokenCount));
+    }
+
+    /**
+     * Returns this token usage as a plain {@link TokenUsage}, so that handing it to
+     * {@link #add(TokenUsage)} of a subclass cannot bounce the call back to a subclass implementation.
+     */
+    private TokenUsage asTokenUsage() {
+        return getClass() == TokenUsage.class
+                ? this
+                : new TokenUsage(inputTokenCount, outputTokenCount, totalTokenCount);
     }
 
     /**
@@ -158,10 +173,9 @@ public class TokenUsage {
 
     @Override
     public String toString() {
-        return "TokenUsage {" +
-                " inputTokenCount = " + inputTokenCount +
-                ", outputTokenCount = " + outputTokenCount +
-                ", totalTokenCount = " + totalTokenCount +
-                " }";
+        return "TokenUsage {" + " inputTokenCount = "
+                + inputTokenCount + ", outputTokenCount = "
+                + outputTokenCount + ", totalTokenCount = "
+                + totalTokenCount + " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/output/TokenUsage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/output/TokenUsage.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.model.output;
 
-import static dev.langchain4j.internal.Utils.getOrDefault;
-
 import java.util.Objects;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
 
 /**
  * Represents the token usage of a response.
@@ -105,8 +105,13 @@ public class TokenUsage {
      *
      * <p>Fields which are null in both responses will be null in the result.
      *
-     * <p>Subclasses carrying their own fields should override this method to sum them as well;
-     * the base implementation only sums the fields declared here.
+     * <p>When one of the two is an instance of a {@link TokenUsage} subclass, that subclass performs the
+     * addition, so that the extra fields it carries are preserved. The result then has the type of that
+     * subclass, no matter which of the two sides it was on.
+     *
+     * <p>A subclass carrying extra fields should therefore override this method and sum those fields as
+     * well. When neither side overrides it, there is nothing that knows how to sum the extra fields and
+     * the result is a plain {@link TokenUsage}.
      *
      * @param that The token usage to add to this one.
      * @return a new {@link TokenUsage} instance with the token usage of both responses added together.
@@ -118,22 +123,23 @@ public class TokenUsage {
 
         if (that.getClass() != TokenUsage.class) {
             // when adding TokenUsage ("this") and one of TokenUsage's subclasses ("that"),
-            // we want to call "add" on the subclass to preserve extra information present in the subclass.
-            // "this" is handed over as a plain TokenUsage: a subclass that inherits this method instead of
-            // overriding it would otherwise delegate straight back here, and the two instances would pass
-            // the call to each other until the stack overflows.
+            // we want to call "add" on the subclass to preserve extra information present in the subclass
             return that.add(asTokenUsage());
         }
 
         return new TokenUsage(
                 sum(this.inputTokenCount, that.inputTokenCount),
                 sum(this.outputTokenCount, that.outputTokenCount),
-                sum(this.totalTokenCount, that.totalTokenCount));
+                sum(this.totalTokenCount, that.totalTokenCount)
+        );
     }
 
     /**
-     * Returns this token usage as a plain {@link TokenUsage}, so that handing it to
-     * {@link #add(TokenUsage)} of a subclass cannot bounce the call back to a subclass implementation.
+     * Returns this token usage as a plain {@link TokenUsage}.
+     *
+     * <p>{@link #add(TokenUsage)} hands "this" to a subclass argument, and a subclass that inherits that
+     * method instead of overriding it would hand it straight back: passing an instance that is not a
+     * subclass stops the two from delegating to each other until the stack overflows.
      */
     private TokenUsage asTokenUsage() {
         return getClass() == TokenUsage.class
@@ -173,9 +179,10 @@ public class TokenUsage {
 
     @Override
     public String toString() {
-        return "TokenUsage {" + " inputTokenCount = "
-                + inputTokenCount + ", outputTokenCount = "
-                + outputTokenCount + ", totalTokenCount = "
-                + totalTokenCount + " }";
+        return "TokenUsage {" +
+                " inputTokenCount = " + inputTokenCount +
+                ", outputTokenCount = " + outputTokenCount +
+                ", totalTokenCount = " + totalTokenCount +
+                " }";
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/output/TokenUsageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/output/TokenUsageTest.java
@@ -77,4 +77,99 @@ class TokenUsageTest implements WithAssertions {
 
         assertThat(sum(null, new TokenUsage(4, 5, 6))).isEqualTo(new TokenUsage(4, 5, 6));
     }
+
+    @Test
+    void should_not_recurse_infinitely_when_a_subclass_does_not_override_add() {
+
+        // given two instances of a subclass that only narrows the type and inherits add()
+        TokenUsage first = new NarrowingTokenUsage(1, 2);
+        TokenUsage second = new NarrowingTokenUsage(4, 5);
+
+        // when
+        TokenUsage sum = first.add(second);
+
+        // then the inherited implementation sums them instead of handing the call back and forth
+        assertThat(sum.inputTokenCount()).isEqualTo(5);
+        assertThat(sum.outputTokenCount()).isEqualTo(7);
+        assertThat(sum.totalTokenCount()).isEqualTo(12);
+    }
+
+    @Test
+    void should_not_recurse_infinitely_when_a_subclass_delegates_add_to_super() {
+
+        TokenUsage first = new SuperDelegatingTokenUsage(1, 2);
+        TokenUsage second = new SuperDelegatingTokenUsage(4, 5);
+
+        assertThat(first.add(second)).isEqualTo(new TokenUsage(5, 7, 12));
+        assertThat(sum(first, second)).isEqualTo(new TokenUsage(5, 7, 12));
+    }
+
+    @Test
+    void should_delegate_to_the_subclass_to_preserve_its_extra_data() {
+
+        TokenUsage base = new TokenUsage(1, 2, 3);
+        TokenUsage extended = new ExtendedTokenUsage(4, 5, 6);
+
+        assertThat(base.add(extended)).isEqualTo(new ExtendedTokenUsage(5, 7, 9));
+        assertThat(sum(base, extended)).isEqualTo(new ExtendedTokenUsage(5, 7, 9));
+        assertThat(sum(extended, base)).isEqualTo(new ExtendedTokenUsage(5, 7, 9));
+    }
+
+    @Test
+    void should_still_delegate_when_only_the_other_subclass_overrides_add() {
+
+        // a subclass that inherits add() must still let a subclass that overrides it do the work,
+        // otherwise the provider-specific data carried by the latter would be silently dropped
+        TokenUsage narrowing = new NarrowingTokenUsage(1, 2);
+        TokenUsage extended = new ExtendedTokenUsage(4, 5, 6);
+
+        assertThat(narrowing.add(extended)).isEqualTo(new ExtendedTokenUsage(5, 7, 9));
+        assertThat(sum(narrowing, extended)).isEqualTo(new ExtendedTokenUsage(5, 7, 9));
+    }
+
+    /**
+     * Mimics the provider subclasses that only narrow the type and inherit {@link TokenUsage#add(TokenUsage)}.
+     */
+    static class NarrowingTokenUsage extends TokenUsage {
+
+        NarrowingTokenUsage(Integer inputTokenCount, Integer outputTokenCount) {
+            super(inputTokenCount, outputTokenCount);
+        }
+    }
+
+    /**
+     * Mimics a subclass that overrides {@link TokenUsage#add(TokenUsage)} but relies on the base implementation.
+     */
+    static class SuperDelegatingTokenUsage extends TokenUsage {
+
+        SuperDelegatingTokenUsage(Integer inputTokenCount, Integer outputTokenCount) {
+            super(inputTokenCount, outputTokenCount);
+        }
+
+        @Override
+        public TokenUsage add(TokenUsage that) {
+            return super.add(that);
+        }
+    }
+
+    /**
+     * Mimics the provider subclasses that override {@link TokenUsage#add(TokenUsage)} to keep their own data.
+     */
+    static class ExtendedTokenUsage extends TokenUsage {
+
+        ExtendedTokenUsage(Integer inputTokenCount, Integer outputTokenCount, Integer totalTokenCount) {
+            super(inputTokenCount, outputTokenCount, totalTokenCount);
+        }
+
+        @Override
+        public ExtendedTokenUsage add(TokenUsage that) {
+            if (that == null) {
+                return this;
+            }
+            return new ExtendedTokenUsage(
+                    sum(this.inputTokenCount(), that.inputTokenCount()),
+                    sum(this.outputTokenCount(), that.outputTokenCount()),
+                    sum(this.totalTokenCount(), that.totalTokenCount()));
+        }
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenUsageAggregationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenUsageAggregationTest.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class AiServiceTokenUsageAggregationTest {
+
+    interface Assistant {
+
+        Result<String> chat(String userMessage);
+    }
+
+    static class Tools {
+
+        @Tool
+        String currentTemperature() {
+            return "42";
+        }
+    }
+
+    /**
+     * Mimics a provider {@link TokenUsage} subclass that only narrows the type and therefore
+     * has no reason to override {@link TokenUsage#add(TokenUsage)}.
+     */
+    static class VendorTokenUsage extends TokenUsage {
+
+        VendorTokenUsage(Integer inputTokenCount, Integer outputTokenCount) {
+            super(inputTokenCount, outputTokenCount);
+        }
+    }
+
+    @Test
+    void should_aggregate_token_usage_across_tool_calling_round_trips() {
+
+        AtomicInteger modelCalls = new AtomicInteger();
+
+        ChatModel chatModel = new ChatModel() {
+
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                if (modelCalls.getAndIncrement() == 0) {
+                    return ChatResponse.builder()
+                            .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                                    .id("1")
+                                    .name("currentTemperature")
+                                    .arguments("{}")
+                                    .build()))
+                            .metadata(ChatResponseMetadata.builder()
+                                    .tokenUsage(new VendorTokenUsage(10, 5))
+                                    .build())
+                            .build();
+                }
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("It is 42 degrees"))
+                        .metadata(ChatResponseMetadata.builder()
+                                .tokenUsage(new VendorTokenUsage(20, 7))
+                                .build())
+                        .build();
+            }
+        };
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .tools(new Tools())
+                .build();
+
+        Result<String> result = assistant.chat("What is the temperature?");
+
+        assertThat(result.content()).isEqualTo("It is 42 degrees");
+        assertThat(modelCalls).hasValue(2);
+        assertThat(result.tokenUsage().inputTokenCount()).isEqualTo(30);
+        assertThat(result.tokenUsage().outputTokenCount()).isEqualTo(12);
+        assertThat(result.tokenUsage().totalTokenCount()).isEqualTo(42);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6321

## Change

`TokenUsage.add` delegated to its argument whenever that argument was a subclass,
so that the subclass could preserve its own fields:

```java
if (that.getClass() != TokenUsage.class) {
    return that.add(this);
}
```

The delegation was symmetric, so a subclass that inherits this method instead of
overriding it delegated straight back and two such instances passed the call to
each other until the stack overflowed. A subclass that overrides `add` and calls
`super.add` hit the same thing.

The delegation now hands `this` over as a plain `TokenUsage`, which cannot
delegate again:

```java
return that.add(asTokenUsage());
```

A subclass that does override `add` still receives the call and keeps its own
data, so the reason the delegation exists is unaffected.

The javadoc on `add` now also spells out the part of the contract this fix leans
on: the addition is carried out by the subclass side, the result therefore has
that subclass's type no matter which of the two operands it was, and when neither
side overrides `add` there is nothing that knows how to sum the extra fields, so
the result is a plain `TokenUsage`.

### Effect on existing behaviour

The behaviour was enumerated over 242 combinations of `add` and `sum` across a
base `TokenUsage`, two different subclasses that inherit `add`, a subclass that
overrides it, a subclass that delegates to `super.add`, and `null`, before and
after the change:

- 50 combinations ended in `StackOverflowError` before and now return the correct
  sum. None is left.
- Every other combination returns exactly what it returned before, with one
  exception: the delegate is now handed a plain `TokenUsage` copy instead of the
  original receiver, so a subclass whose `add` inspects the runtime type of its
  argument sees `TokenUsage` where it previously saw the receiver's class.

No subclass in this repository can reach that exception. All six of them override
`add` and none calls `super.add`, so `TokenUsage.add` never runs with one of them
as `this`. Reaching it takes a subclass that overrides `add`, calls `super.add`,
and is handed to a *different* subclass that type-inspects its argument.

### Reachability

`ToolService` seeds `aggregateTokenUsage` with the `TokenUsage` reported by the
model (`ToolService.java:631`) and adds the next one to it
(`ToolService.java:708`), so a single tool calling round trip adds two instances
of the provider subclass. All six subclasses in this repository override `add`
and reimplement the summation by hand, so no built-in provider is affected today;
the fix is to the base class as an extension point.

### Tests

- `TokenUsageTest.should_not_recurse_infinitely_when_a_subclass_does_not_override_add`
  and `..._when_a_subclass_delegates_add_to_super` fail with `StackOverflowError`
  without the change.
- `TokenUsageTest.should_delegate_to_the_subclass_to_preserve_its_extra_data` and
  `should_still_delegate_when_only_the_other_subclass_overrides_add` pass both
  before and after, pinning the behaviour that must not change.
- `AiServiceTokenUsageAggregationTest` covers the same thing end to end through an
  AI Service with a tool call.

The production change is limited to one line in `add`, the private `asTokenUsage()`
helper and the javadoc; nothing else in `TokenUsage.java` is reformatted.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
