### PR TITLE
fix(pgvector): close the connection when getConnection() fails

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
@@ -684,16 +684,25 @@ public class PgVectorEmbeddingStore implements EmbeddingStore<TextSegment> {
      */
     protected Connection getConnection() throws SQLException {
         Connection connection = datasource.getConnection();
-        // Find a way to do the following code in connection initialization.
-        // Here we assume the datasource could handle a connection pool
-        // and we should add the vector type on each connection
-        if (!skipCreateVectorExtension) {
-            try (Statement statement = connection.createStatement()) {
-                statement.executeUpdate("CREATE EXTENSION IF NOT EXISTS vector");
+        try {
+            // Find a way to do the following code in connection initialization.
+            // Here we assume the datasource could handle a connection pool
+            // and we should add the vector type on each connection
+            if (!skipCreateVectorExtension) {
+                try (Statement statement = connection.createStatement()) {
+                    statement.executeUpdate("CREATE EXTENSION IF NOT EXISTS vector");
+                }
             }
+            PGvector.addVectorType(connection);
+            return connection;
+        } catch (Throwable t) {
+            try {
+                connection.close();
+            } catch (Throwable closeFailure) {
+                t.addSuppressed(closeFailure);
+            }
+            throw t;
         }
-        PGvector.addVectorType(connection);
-        return connection;
     }
 
     public static class DatasourceBuilder {

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreConnectionTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreConnectionTest.java
@@ -1,7 +1,10 @@
 package dev.langchain4j.store.embedding.pgvector;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,18 +30,36 @@ class PgVectorEmbeddingStoreConnectionTest {
     }
 
     @Test
-    void should_close_connection_when_creating_the_vector_extension_fails() throws SQLException {
+    void should_return_an_open_connection_when_initialization_succeeds() throws SQLException {
         DataSource dataSource = mock(DataSource.class);
         Connection connection = mock(Connection.class);
         Statement statement = mock(Statement.class);
         when(dataSource.getConnection()).thenReturn(connection);
         when(connection.createStatement()).thenReturn(statement);
-        when(statement.executeUpdate(CREATE_EXTENSION))
-                .thenThrow(new SQLException("permission denied to create extension \"vector\""));
+        // PGvector.addVectorType() unwraps the connection to register the vector type.
+        when(connection.unwrap(PGConnection.class)).thenReturn(mock(PGConnection.class));
 
         PgVectorEmbeddingStore store = storeWith(dataSource);
 
-        assertThatThrownBy(store::getConnection).isInstanceOf(SQLException.class);
+        assertThat(store.getConnection()).isSameAs(connection);
+
+        verify(statement).executeUpdate(CREATE_EXTENSION);
+        verify(connection, never()).close();
+    }
+
+    @Test
+    void should_close_connection_when_creating_the_vector_extension_fails() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        SQLException failure = new SQLException("permission denied to create extension \"vector\"");
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeUpdate(CREATE_EXTENSION)).thenThrow(failure);
+
+        PgVectorEmbeddingStore store = storeWith(dataSource);
+
+        assertThatThrownBy(store::getConnection).isSameAs(failure);
 
         verify(connection).close();
     }
@@ -47,12 +68,13 @@ class PgVectorEmbeddingStoreConnectionTest {
     void should_close_connection_when_creating_the_statement_fails() throws SQLException {
         DataSource dataSource = mock(DataSource.class);
         Connection connection = mock(Connection.class);
+        SQLException failure = new SQLException("connection is closed");
         when(dataSource.getConnection()).thenReturn(connection);
-        when(connection.createStatement()).thenThrow(new SQLException("connection is closed"));
+        when(connection.createStatement()).thenThrow(failure);
 
         PgVectorEmbeddingStore store = storeWith(dataSource);
 
-        assertThatThrownBy(store::getConnection).isInstanceOf(SQLException.class);
+        assertThatThrownBy(store::getConnection).isSameAs(failure);
 
         verify(connection).close();
     }
@@ -62,15 +84,33 @@ class PgVectorEmbeddingStoreConnectionTest {
         DataSource dataSource = mock(DataSource.class);
         Connection connection = mock(Connection.class);
         Statement statement = mock(Statement.class);
+        SQLException failure = new SQLException("cannot unwrap to PGConnection");
         when(dataSource.getConnection()).thenReturn(connection);
         when(connection.createStatement()).thenReturn(statement);
         // PGvector.addVectorType() unwraps the connection to register the vector type.
-        when(connection.unwrap(PGConnection.class)).thenThrow(new SQLException("cannot unwrap to PGConnection"));
+        when(connection.unwrap(PGConnection.class)).thenThrow(failure);
 
         PgVectorEmbeddingStore store = storeWith(dataSource);
 
-        assertThatThrownBy(store::getConnection).isInstanceOf(SQLException.class);
+        assertThatThrownBy(store::getConnection).isSameAs(failure);
 
         verify(connection).close();
+    }
+
+    @Test
+    void should_suppress_the_close_failure_on_the_original_exception() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        SQLException failure = new SQLException("permission denied to create extension \"vector\"");
+        SQLException closeFailure = new SQLException("connection has already been returned to the pool");
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeUpdate(CREATE_EXTENSION)).thenThrow(failure);
+        doThrow(closeFailure).when(connection).close();
+
+        PgVectorEmbeddingStore store = storeWith(dataSource);
+
+        assertThatThrownBy(store::getConnection).isSameAs(failure).hasSuppressedException(closeFailure);
     }
 }

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreConnectionTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreConnectionTest.java
@@ -1,0 +1,76 @@
+package dev.langchain4j.store.embedding.pgvector;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.postgresql.PGConnection;
+
+class PgVectorEmbeddingStoreConnectionTest {
+
+    private static final String CREATE_EXTENSION = "CREATE EXTENSION IF NOT EXISTS vector";
+
+    private static PgVectorEmbeddingStore storeWith(DataSource dataSource) {
+        return PgVectorEmbeddingStore.datasourceBuilder()
+                .datasource(dataSource)
+                .table("embeddings")
+                .dropTableFirst(false)
+                .createTable(false)
+                .useIndex(false)
+                .build();
+    }
+
+    @Test
+    void should_close_connection_when_creating_the_vector_extension_fails() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeUpdate(CREATE_EXTENSION))
+                .thenThrow(new SQLException("permission denied to create extension \"vector\""));
+
+        PgVectorEmbeddingStore store = storeWith(dataSource);
+
+        assertThatThrownBy(store::getConnection).isInstanceOf(SQLException.class);
+
+        verify(connection).close();
+    }
+
+    @Test
+    void should_close_connection_when_creating_the_statement_fails() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenThrow(new SQLException("connection is closed"));
+
+        PgVectorEmbeddingStore store = storeWith(dataSource);
+
+        assertThatThrownBy(store::getConnection).isInstanceOf(SQLException.class);
+
+        verify(connection).close();
+    }
+
+    @Test
+    void should_close_connection_when_registering_the_vector_type_fails() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        // PGvector.addVectorType() unwraps the connection to register the vector type.
+        when(connection.unwrap(PGConnection.class)).thenThrow(new SQLException("cannot unwrap to PGConnection"));
+
+        PgVectorEmbeddingStore store = storeWith(dataSource);
+
+        assertThatThrownBy(store::getConnection).isInstanceOf(SQLException.class);
+
+        verify(connection).close();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6323

## Change

`PgVectorEmbeddingStore.getConnection()` took a connection from the `DataSource` and then ran `CREATE EXTENSION IF NOT EXISTS vector` and `PGvector.addVectorType()` on it before returning it. If any of that threw, the connection was never closed, so it never went back to the pool. The method is called once per store operation, so a datasource whose user cannot create the extension loses one connection per call until the pool is exhausted, and the application ends up blocked on connection acquisition rather than seeing the permission error.

The connection is now closed if the method fails before handing it over, and a failure to close is attached as a suppressed exception — the same thing try-with-resources does, which this method cannot use because it returns the resource. `Throwable` is caught for that same reason: it is what try-with-resources compiles down to, so the connection also goes back to the pool if `PGvector` fails during class initialisation rather than throwing an `SQLException`. Behaviour on the success path is unchanged and the original exception is still what the caller sees.

Every other JDBC-backed store in the repository takes its connection inside try-with-resources; this factory was the only place that acquired one, did work that can throw, and returned it bare.

Added `PgVectorEmbeddingStoreConnectionTest` with five tests: the success path, where the connection is returned open and never closed; the three failure points — `createStatement()`, the `CREATE EXTENSION` statement, and the unwrap inside `addVectorType()`; and a failing `close()`, which has to surface as a suppressed exception on the original failure. Each failure test asserts that the exact exception instance is rethrown. The four failure tests fail on the previous code; the success test passes on both, since that path does not change.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)