### PR TITLE
fix(elasticsearch): skip text-only documents in script vector search

### DIFF
--- a/docs/docs/integrations/embedding-stores/elasticsearch.md
+++ b/docs/docs/integrations/embedding-stores/elasticsearch.md
@@ -69,6 +69,24 @@ ElasticsearchEmbeddingStore store = ElasticsearchEmbeddingStore.builder()
     .build();
 ```
 
+### Storing documents without an embedding
+
+Next to the usual `add(Embedding, TextSegment)` methods, the store can also index plain text, without computing an
+embedding for it:
+
+```java
+store.add("Printer troubleshooting guide");                    // generates an id
+store.add("my-id", "Printer troubleshooting guide");           // with your own id
+store.addAllText(List.of("First guide", "Second guide"));      // several at once
+```
+
+Because these documents have no vector, vector search never returns them, neither with
+[`ElasticsearchConfigurationKnn`](#elasticsearchconfigurationknn) nor with
+[`ElasticsearchConfigurationScript`](#elasticsearchconfigurationscript). They are still found by full text search, so a
+single index can hold both embedded and text-only documents, and you can search it both ways with
+[`ElasticsearchConfigurationFullText`](#elasticsearchconfigurationfulltext) or
+[`ElasticsearchConfigurationHybrid`](#elasticsearchconfigurationhybrid).
+
 ## ElasticsearchContentRetriever
 
 A ContentRetriever needs an embedding model:

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationScript.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationScript.java
@@ -22,11 +22,14 @@ import java.io.IOException;
  * <br>
  * Supports storing {@link Metadata} and filtering by it using {@link Filter}
  * (provided inside {@link EmbeddingSearchRequest}).
+ * <p>Documents without a vector value are excluded before scoring. This allows text-only documents to coexist
+ * with embedded documents in the same index while remaining available to {@link ElasticsearchConfigurationFullText}.
  *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-score-query.html#vector-functions-cosine">vector-functions-cosine</a>
  */
 public class ElasticsearchConfigurationScript implements ElasticsearchConfiguration {
-    private final Json.JsonCodec codec = ProviderJson.codec(ProviderJsonSpec.builder().build());
+    private final Json.JsonCodec codec =
+            ProviderJson.codec(ProviderJsonSpec.builder().build());
     private final boolean includeVectorResponse;
 
     public static class Builder {
@@ -84,11 +87,13 @@ public class ElasticsearchConfigurationScript implements ElasticsearchConfigurat
 
     private ScriptScoreQuery buildDefaultScriptScoreQuery(float[] vector, float minScore, Filter filter) {
         JsonData queryVector = toJsonData(vector);
+        Query hasVector = Query.of(q -> q.exists(e -> e.field(VECTOR_FIELD)));
         Query query;
         if (filter == null) {
-            query = Query.of(q -> q.matchAll(m -> m));
+            query = hasVector;
         } else {
-            query = ElasticsearchMetadataFilterMapper.map(filter);
+            query = Query.of(
+                    q -> q.bool(b -> b.filter(hasVector).filter(ElasticsearchMetadataFilterMapper.map(filter))));
         }
         return ScriptScoreQuery.of(q -> q.minScore(minScore)
                 .query(query)

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreScriptIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreScriptIT.java
@@ -1,5 +1,23 @@
 package dev.langchain4j.store.embedding.elasticsearch;
 
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.AugmentationRequest;
+import dev.langchain4j.rag.DefaultRetrievalAugmentor;
+import dev.langchain4j.rag.content.ContentMetadata;
+import dev.langchain4j.rag.content.retriever.elasticsearch.ElasticsearchContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
 class ElasticsearchEmbeddingStoreScriptIT extends AbstractElasticsearchEmbeddingStoreIT {
 
     @Override
@@ -11,5 +29,187 @@ class ElasticsearchEmbeddingStoreScriptIT extends AbstractElasticsearchEmbedding
         return ElasticsearchConfigurationScript.builder()
                 .includeVectorResponse(includeVector)
                 .build();
+    }
+
+    @Test
+    void should_search_vectors_when_index_also_contains_text_only_documents() throws Exception {
+        ElasticsearchEmbeddingStore store = (ElasticsearchEmbeddingStore) embeddingStore();
+        Embedding embedding = unitEmbedding(0);
+        store.addAll(
+                List.of("with-vector"),
+                List.of(embedding),
+                List.of(TextSegment.from("Printer network connection guide")));
+        elasticsearchClientHelper.refreshIndex(indexName);
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(embedding)
+                .maxResults(5)
+                .build();
+        assertThat(store.search(request).matches())
+                .extracting(EmbeddingMatch::embeddingId)
+                .containsExactly("with-vector");
+
+        store.add("text-only", "Printer troubleshooting guide");
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        assertThat(fullTextRetriever().retrieve(Query.from("printer")))
+                .extracting(content -> content.metadata().get(ContentMetadata.EMBEDDING_ID))
+                .containsExactlyInAnyOrder("with-vector", "text-only");
+
+        ElasticsearchEmbeddingStore knnStore = ElasticsearchEmbeddingStore.builder()
+                .client(elasticsearchClientHelper.client)
+                .indexName(indexName)
+                .configuration(ElasticsearchConfigurationKnn.builder().build())
+                .build();
+        assertThat(knnStore.search(request).matches())
+                .extracting(EmbeddingMatch::embeddingId)
+                .containsExactly("with-vector");
+
+        assertThat(store.search(request).matches())
+                .extracting(EmbeddingMatch::embeddingId)
+                .containsExactly("with-vector");
+    }
+
+    @Test
+    void should_return_no_vector_matches_when_index_contains_only_text() throws Exception {
+        ElasticsearchEmbeddingStore store = (ElasticsearchEmbeddingStore) embeddingStore();
+        store.add("text-only", "Printer troubleshooting guide");
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        assertThat(fullTextRetriever().retrieve(Query.from("printer"))).hasSize(1);
+        assertThat(store.search(EmbeddingSearchRequest.builder()
+                                .queryEmbedding(unitEmbedding(0))
+                                .build())
+                        .matches())
+                .isEmpty();
+    }
+
+    @Test
+    void should_preserve_metadata_filter_score_threshold_and_result_limit() throws Exception {
+        ElasticsearchEmbeddingStore store = (ElasticsearchEmbeddingStore) embeddingStore();
+        float[] relatedVector = new float[384];
+        relatedVector[0] = 0.8f;
+        relatedVector[1] = 0.6f;
+        store.addAll(
+                List.of("matching", "also-matching", "below-threshold", "archived"),
+                List.of(unitEmbedding(0), Embedding.from(relatedVector), unitEmbedding(1), unitEmbedding(0)),
+                List.of(
+                        TextSegment.from("Printer network guide", Metadata.from("status", "published")),
+                        TextSegment.from("Printer setup guide", Metadata.from("status", "published")),
+                        TextSegment.from("Printer installation guide", Metadata.from("status", "published")),
+                        TextSegment.from("Old printer guide", Metadata.from("status", "archived"))));
+        store.add("text-only", "Printer troubleshooting guide");
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        var matches = store.search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(unitEmbedding(0))
+                        .filter(metadataKey("status").isNotEqualTo("archived"))
+                        .minScore(0.8)
+                        .maxResults(1)
+                        .build())
+                .matches();
+
+        assertThat(matches).extracting(EmbeddingMatch::embeddingId).containsExactly("matching");
+        assertThat(matches.get(0).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void should_augment_using_full_text_and_script_search_from_the_same_index() throws Exception {
+        ElasticsearchEmbeddingStore store = (ElasticsearchEmbeddingStore) embeddingStore();
+        TextSegment segment = TextSegment.from("Printer network connection guide");
+        store.addAll(
+                List.of("with-vector"), List.of(embeddingModel().embed(segment).content()), List.of(segment));
+        ElasticsearchContentRetriever fullText = fullTextRetriever();
+        fullText.add("text-only", "Printer troubleshooting guide");
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        ElasticsearchContentRetriever vector = ElasticsearchContentRetriever.builder()
+                .client(elasticsearchClientHelper.client)
+                .indexName(indexName)
+                .configuration(withConfiguration())
+                .embeddingModel(embeddingModel())
+                .maxResults(5)
+                .build();
+        DefaultRetrievalAugmentor augmentor = DefaultRetrievalAugmentor.builder()
+                .queryRouter(query -> List.of(fullText, vector))
+                .executor(Runnable::run)
+                .build();
+        UserMessage message = UserMessage.from("printer");
+
+        var result = augmentor.augment(new AugmentationRequest(
+                message, new dev.langchain4j.rag.query.Metadata(message, "conversation", List.of())));
+
+        assertThat(result.contents())
+                .extracting(content -> content.metadata().get(ContentMetadata.EMBEDDING_ID))
+                .containsExactly("with-vector", "text-only");
+        assertThat(((UserMessage) result.chatMessage()).singleText())
+                .contains("Printer network connection guide", "Printer troubleshooting guide");
+    }
+
+    @Test
+    void should_not_lose_vector_matches_from_a_shard_containing_text_only_documents() throws Exception {
+        elasticsearchClientHelper
+                .client
+                .indices()
+                .create(c ->
+                        c.index(indexName).settings(s -> s.numberOfShards("2").numberOfReplicas("0")));
+        int textOnlyShard = shardFor("text-only");
+        String sameShardId = null;
+        String otherShardId = null;
+        for (int i = 0; i < 32 && (sameShardId == null || otherShardId == null); i++) {
+            String id = "vector-" + i;
+            if (shardFor(id) == textOnlyShard) {
+                sameShardId = id;
+            } else {
+                otherShardId = id;
+            }
+        }
+        assertThat(sameShardId).isNotNull();
+        assertThat(otherShardId).isNotNull();
+
+        ElasticsearchEmbeddingStore store = (ElasticsearchEmbeddingStore) embeddingStore();
+        store.addAll(
+                List.of(sameShardId, otherShardId),
+                List.of(unitEmbedding(0), unitEmbedding(0)),
+                List.of(TextSegment.from("Network printer guide"), TextSegment.from("USB printer guide")));
+        elasticsearchClientHelper.refreshIndex(indexName);
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(unitEmbedding(0))
+                .maxResults(5)
+                .build();
+        assertThat(store.search(request).matches())
+                .extracting(EmbeddingMatch::embeddingId)
+                .containsExactlyInAnyOrder(sameShardId, otherShardId);
+
+        store.add("text-only", "Printer troubleshooting guide");
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        assertThat(store.search(request).matches())
+                .extracting(EmbeddingMatch::embeddingId)
+                .containsExactlyInAnyOrder(sameShardId, otherShardId);
+    }
+
+    private int shardFor(String id) throws IOException {
+        return elasticsearchClientHelper
+                .client
+                .searchShards(s -> s.index(indexName).routing(id))
+                .shards()
+                .get(0)
+                .get(0)
+                .shard();
+    }
+
+    private ElasticsearchContentRetriever fullTextRetriever() {
+        return ElasticsearchContentRetriever.builder()
+                .client(elasticsearchClientHelper.client)
+                .indexName(indexName)
+                .configuration(ElasticsearchConfigurationFullText.builder().build())
+                .maxResults(5)
+                .build();
+    }
+
+    private static Embedding unitEmbedding(int axis) {
+        float[] vector = new float[384];
+        vector[axis] = 1.0f;
+        return Embedding.from(vector);
     }
 }

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreScriptIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreScriptIT.java
@@ -2,13 +2,11 @@ package dev.langchain4j.store.embedding.elasticsearch;
 
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.rag.AugmentationRequest;
-import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.content.retriever.elasticsearch.ElasticsearchContentRetriever;
 import dev.langchain4j.rag.query.Query;
@@ -86,7 +84,7 @@ class ElasticsearchEmbeddingStoreScriptIT extends AbstractElasticsearchEmbedding
     @Test
     void should_preserve_metadata_filter_score_threshold_and_result_limit() throws Exception {
         ElasticsearchEmbeddingStore store = (ElasticsearchEmbeddingStore) embeddingStore();
-        float[] relatedVector = new float[384];
+        float[] relatedVector = new float[embeddingModel().dimension()];
         relatedVector[0] = 0.8f;
         relatedVector[1] = 0.6f;
         store.addAll(
@@ -109,44 +107,13 @@ class ElasticsearchEmbeddingStoreScriptIT extends AbstractElasticsearchEmbedding
                 .matches();
 
         assertThat(matches).extracting(EmbeddingMatch::embeddingId).containsExactly("matching");
-        assertThat(matches.get(0).score()).isEqualTo(1.0);
-    }
-
-    @Test
-    void should_augment_using_full_text_and_script_search_from_the_same_index() throws Exception {
-        ElasticsearchEmbeddingStore store = (ElasticsearchEmbeddingStore) embeddingStore();
-        TextSegment segment = TextSegment.from("Printer network connection guide");
-        store.addAll(
-                List.of("with-vector"), List.of(embeddingModel().embed(segment).content()), List.of(segment));
-        ElasticsearchContentRetriever fullText = fullTextRetriever();
-        fullText.add("text-only", "Printer troubleshooting guide");
-        elasticsearchClientHelper.refreshIndex(indexName);
-
-        ElasticsearchContentRetriever vector = ElasticsearchContentRetriever.builder()
-                .client(elasticsearchClientHelper.client)
-                .indexName(indexName)
-                .configuration(withConfiguration())
-                .embeddingModel(embeddingModel())
-                .maxResults(5)
-                .build();
-        DefaultRetrievalAugmentor augmentor = DefaultRetrievalAugmentor.builder()
-                .queryRouter(query -> List.of(fullText, vector))
-                .executor(Runnable::run)
-                .build();
-        UserMessage message = UserMessage.from("printer");
-
-        var result = augmentor.augment(new AugmentationRequest(
-                message, new dev.langchain4j.rag.query.Metadata(message, "conversation", List.of())));
-
-        assertThat(result.contents())
-                .extracting(content -> content.metadata().get(ContentMetadata.EMBEDDING_ID))
-                .containsExactly("with-vector", "text-only");
-        assertThat(((UserMessage) result.chatMessage()).singleText())
-                .contains("Printer network connection guide", "Printer troubleshooting guide");
+        assertThat(matches.get(0).score()).isCloseTo(1.0, within(1e-6));
     }
 
     @Test
     void should_not_lose_vector_matches_from_a_shard_containing_text_only_documents() throws Exception {
+        // this test needs a two-shard index, so it creates one itself and must start from a clean slate
+        elasticsearchClientHelper.removeDataStore(indexName);
         elasticsearchClientHelper
                 .client
                 .indices()
@@ -207,8 +174,8 @@ class ElasticsearchEmbeddingStoreScriptIT extends AbstractElasticsearchEmbedding
                 .build();
     }
 
-    private static Embedding unitEmbedding(int axis) {
-        float[] vector = new float[384];
+    private Embedding unitEmbedding(int axis) {
+        float[] vector = new float[embeddingModel().dimension()];
         vector[axis] = 1.0f;
         return Embedding.from(vector);
     }


### PR DESCRIPTION
## Issue

Closes #6325

## Change

`ElasticsearchConfigurationScript` ran the cosine similarity script over every document selected by `match_all` (or by the metadata filter alone), including documents that have no `vector` field. Elasticsearch fails the script on such documents, so a single text-only document could break vector search for the whole index: on a single-shard index the search throws `search_phase_execution_exception`, and on a multi-shard index it can return HTTP 200 while silently dropping the valid matches that live on the failed shard.

Documents without a `vector` are the text-only documents added through `add(String)`, `add(String, String)` or `addAllText(List<String>)`, which the store supports on purpose.

The script query now requires the `vector` field to exist, combined with the metadata filter when one is given. The scoring formula, score threshold, result limit, stored document format and public API are unchanged, and text-only documents remain available to full text search.

Behaviour note: a script search against an index in which no document has a vector now returns no matches instead of failing.

## Tests

Four integration tests in `ElasticsearchEmbeddingStoreScriptIT`, each of which fails without the change:

- a mixed index, with full text and kNN control searches;
- an index containing only text;
- preservation of metadata filtering, minimum score and maximum results;
- silent loss of valid vector matches in a multi-shard index.

## Documentation

- A new "Storing documents without an embedding" section in `docs/docs/integrations/embedding-stores/elasticsearch.md`, describing the text-only `add` methods and how those documents behave in vector, full text and hybrid search.
- Class level Javadoc on `ElasticsearchConfigurationScript`.

## Verification

`mvn -pl langchain4j-elasticsearch verify` against Elasticsearch 9.3.1: 345 tests, 0 failures, 0 errors, 6 skipped, covering the 27 unit tests and all integration tests of the module, `ElasticsearchEmbeddingStoreScriptIT` included (112 tests). Reverting only the change in `ElasticsearchConfigurationScript` makes all four new tests fail. Revapi reports no API problems.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `ElasticsearchEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

The stored document format is unchanged: the new condition only requires the same `vector` field that previous versions already write.
