### PR TITLE
feat: OpenAI Realtime voice gateway (end-to-end speech path)

### DIFF
--- a/docs/superpowers/plans/2026-09-04-openai-realtime-gateway.md
+++ b/docs/superpowers/plans/2026-09-04-openai-realtime-gateway.md
@@ -1,0 +1,613 @@
+# OpenAI Realtime Gateway 实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 在 `langchain4j-famdetxire` 新增模块 `langchain4j-open-ai-realtime`：出站 Realtime WebSocket 会话 + 入站类 OpenAI 事件网关 + 基于 `ToolSpecification`/`ToolExecutor` 的服务端 tools loop。
+
+**架构：** 单模块内分 `tools`（注册表/改写/loop）、`session`（出站 WS）、`gateway`（入站 WS 与一对一桥接）。应用构建时注册 tools pair；客户端 Bearer 用于出站；客户端可省略 `tools`（全量启用）。规格见 `docs/superpowers/specs/2026-09-04-openai-realtime-gateway-design.md`。
+
+**技术栈：** Java（与仓库 parent 一致）、Maven、Jackson 2、JUnit 5、OkHttp WebSocket（出站，parent 已管理）、Java-WebSocket（入站服务端）、`langchain4j-core`（ToolSpecification / ToolExecutor / ToolExecutionRequest）。不依赖 antaios / Spring。
+
+**规格：** `docs/superpowers/specs/2026-09-04-openai-realtime-gateway-design.md`
+
+---
+
+## 文件结构（将创建 / 修改）
+
+| 文件 | 职责 |
+|------|------|
+| `pom.xml`（仓库根） | 增加 `<module>langchain4j-open-ai-realtime</module>` |
+| `langchain4j-bom/pom.xml` | 增加 BOM 条目 |
+| `langchain4j-open-ai-realtime/pom.xml` | 新模块 POM |
+| `.../tools/RealtimeToolRegistry.java` | 持有 `Map<ToolSpecification, ToolExecutor>`，按 name 查找 |
+| `.../tools/SessionUpdateToolsRewriter.java` | 改写客户端 `session.update` JSON 中的 tools |
+| `.../tools/OpenAiRealtimeToolJson.java` | `ToolSpecification` → Realtime function tool JSON |
+| `.../tools/RealtimeToolLoop.java` | FC 并行执行并回灌 |
+| `.../tools/RealtimeOutboundWriter.java` | 出站写抽象（便于测 loop） |
+| `.../session/RealtimeTransport.java` | 出站传输接口 |
+| `.../session/FakeRealtimeTransport.java`（test） | 测试用传输 |
+| `.../session/OkHttpRealtimeTransport.java` | OkHttp 出站实现 |
+| `.../session/OpenAiRealtimeSession.java` | 会话：connect/send/listener/串行写出 |
+| `.../session/OpenAiRealtimeSessionListener.java` | 出站事件回调 |
+| `.../gateway/RealtimeGatewayConfig.java` | bind 地址、线程池等 |
+| `.../gateway/RealtimeGatewaySession.java` | 一对一桥接 + tools 改写 + 接 ToolLoop |
+| `.../gateway/RealtimeGatewayServer.java` | 入站 WS 服务 |
+| `.../OpenAiRealtimeGateway.java` | 对外 Builder 入口（注册 tools、start） |
+| `langchain4j-open-ai-realtime/README.md` | 用法与和纯 OpenAI 的差异 |
+| `src/test/java/...` | 单元 / 契约测试 |
+| `src/test/resources/realtime/fixtures/*.json` | GA 事件 fixture |
+
+包根：`dev.langchain4j.model.openai.realtime`
+
+出站默认 URL：`wss://api.openai.com/v1/realtime?model=` + session model（或 Builder 覆盖）。
+
+---
+
+### 任务 1：Maven 模块骨架
+
+**文件：**
+- 创建：`langchain4j-open-ai-realtime/pom.xml`
+- 修改：`pom.xml`（根 modules）
+- 修改：`langchain4j-bom/pom.xml`（在 `langchain4j-open-ai-official` 条目附近增加）
+
+- [ ] **步骤 1：创建模块 POM**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.20.0-beta30-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+    <artifactId>langchain4j-open-ai-realtime</artifactId>
+    <version>1.20.0-beta30-SNAPSHOT</version>
+    <name>LangChain4j :: Integration :: OpenAI Realtime</name>
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.20.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.20.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+（若 parent 未管理 `Java-WebSocket`，版本写死在本模块即可；OkHttp 走 BOM。）
+
+- [ ] **步骤 2：注册根 module 与 BOM**
+
+根 `pom.xml` 在 `langchain4j-open-ai-official` 后增加 module。  
+BOM 增加：
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-open-ai-realtime</artifactId>
+    <version>${langchain4j.beta.version}</version>
+</dependency>
+```
+
+- [ ] **步骤 3：验证模块可编译**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -am -DskipTests compile
+```
+
+预期：BUILD SUCCESS
+
+- [ ] **步骤 4：Commit**
+
+```bash
+git add pom.xml langchain4j-bom/pom.xml langchain4j-open-ai-realtime/pom.xml
+git commit -m "build: add langchain4j-open-ai-realtime module skeleton"
+```
+
+---
+
+### 任务 2：RealtimeToolRegistry + OpenAiRealtimeToolJson
+
+**文件：**
+- 创建：`langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolRegistry.java`
+- 创建：`langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJson.java`
+- 测试：`.../tools/RealtimeToolRegistryTest.java`
+- 测试：`.../tools/OpenAiRealtimeToolJsonTest.java`
+
+- [ ] **步骤 1：编写失败的 Registry 测试**
+
+```java
+@Test
+void lookupByName_returnsExecutor() {
+    ToolSpecification spec = ToolSpecification.builder()
+            .name("get_weather")
+            .description("weather")
+            .build();
+    ToolExecutor executor = (req, mem) -> "sunny";
+    RealtimeToolRegistry registry = RealtimeToolRegistry.from(Map.of(spec, executor));
+    assertThat(registry.findExecutor("get_weather")).isSameAs(executor);
+    assertThat(registry.findSpecification("get_weather")).isEqualTo(spec);
+    assertThat(registry.allSpecifications()).containsExactly(spec);
+}
+
+@Test
+void unknownName_returnsEmpty() {
+    RealtimeToolRegistry registry = RealtimeToolRegistry.from(Map.of());
+    assertThat(registry.findExecutor("nope")).isNull();
+}
+```
+
+- [ ] **步骤 2：运行测试确认失败**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -Dtest=RealtimeToolRegistryTest test
+```
+
+预期：编译失败或测试失败（类不存在）
+
+- [ ] **步骤 3：实现 RealtimeToolRegistry**
+
+```java
+public final class RealtimeToolRegistry {
+    private final Map<String, ToolSpecification> specsByName;
+    private final Map<String, ToolExecutor> executorsByName;
+
+    public static RealtimeToolRegistry from(Map<ToolSpecification, ToolExecutor> tools) {
+        // copy into LinkedHashMap by toolSpecification.name(); reject duplicate names
+    }
+
+    public ToolExecutor findExecutor(String name) { ... }
+    public ToolSpecification findSpecification(String name) { ... }
+    public List<ToolSpecification> allSpecifications() { ... }
+    public Set<String> names() { ... }
+}
+```
+
+- [ ] **步骤 4：编写 OpenAiRealtimeToolJson 测试**
+
+Realtime function 形态（与 Chat Completions 的 `type/function/function{}` 嵌套不同）：
+
+```json
+{ "type": "function", "name": "get_weather", "description": "...", "parameters": { "type": "object", ... } }
+```
+
+```java
+@Test
+void toFunctionTool_mapsNameDescriptionParameters() {
+    ToolSpecification spec = ToolSpecification.builder()
+            .name("get_weather")
+            .description("Get weather")
+            .parameters(JsonObjectSchema.builder()
+                    .addStringProperty("city")
+                    .required("city")
+                    .build())
+            .build();
+    ObjectNode node = OpenAiRealtimeToolJson.toFunctionTool(spec);
+    assertThat(node.get("type").asText()).isEqualTo("function");
+    assertThat(node.get("name").asText()).isEqualTo("get_weather");
+    assertThat(node.get("parameters").get("type").asText()).isEqualTo("object");
+}
+```
+
+实现时可参考 `langchain4j-open-ai` 的 `OpenAiUtils.toOpenAiParameters` 思路，或依赖 jackson 把 `JsonObjectSchema` 编成 map（与 `ExternalToolExecuteService.toOpenAiFunctionTool` / core JSON schema 工具对齐）。**不要**引入 antaios 依赖。
+
+- [ ] **步骤 5：实现并通过测试后 Commit**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -Dtest=RealtimeToolRegistryTest,OpenAiRealtimeToolJsonTest test
+git add langchain4j-open-ai-realtime
+git commit -m "feat(realtime): add tool registry and Realtime function JSON mapping"
+```
+
+---
+
+### 任务 3：SessionUpdateToolsRewriter
+
+**文件：**
+- 创建：`.../tools/SessionUpdateToolsRewriter.java`
+- 测试：`.../tools/SessionUpdateToolsRewriterTest.java`
+
+- [ ] **步骤 1：编写失败的测试**
+
+```java
+@Test
+void omitTools_usesFullRegistry() throws Exception {
+    // registry has get_weather + ping
+    String inbound = """
+        {"type":"session.update","session":{"type":"realtime","instructions":"hi"}}
+        """;
+    String outbound = rewriter.rewrite(inbound);
+    JsonNode tools = objectMapper.readTree(outbound).path("session").path("tools");
+    assertThat(tools).hasSize(2);
+}
+
+@Test
+void whitelist_filtersByName() throws Exception {
+    String inbound = """
+        {"type":"session.update","session":{"type":"realtime","tools":[{"type":"function","name":"ping"}]}}
+        """;
+    String outbound = rewriter.rewrite(inbound);
+    JsonNode tools = objectMapper.readTree(outbound).path("session").path("tools");
+    assertThat(tools).hasSize(1);
+    assertThat(tools.get(0).get("name").asText()).isEqualTo("ping");
+}
+
+@Test
+void unknownName_throws() {
+    String inbound = """
+        {"type":"session.update","session":{"tools":[{"type":"function","name":"unknown_tool"}]}}
+        """;
+    assertThatThrownBy(() -> rewriter.rewrite(inbound))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("unknown_tool");
+}
+```
+
+- [ ] **步骤 2：实现 rewriter**
+
+逻辑：
+
+1. 解析 JSON；若 `type` 不是 `session.update`，原样返回。
+2. 读 `session.tools`：缺失/null/空数组 → 使用 `registry.allSpecifications()`。
+3. 若存在：提取每个 tool 的 `name`（支持扁平 Realtime 或嵌套 `function.name`）；未知 name → `IllegalArgumentException`。
+4. 用 `OpenAiRealtimeToolJson` 重写 `session.tools` 数组；保留 session 其它字段。
+
+- [ ] **步骤 3：测试通过后 Commit**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -Dtest=SessionUpdateToolsRewriterTest test
+git add langchain4j-open-ai-realtime
+git commit -m "feat(realtime): rewrite session.update tools from registry"
+```
+
+---
+
+### 任务 4：RealtimeToolLoop
+
+**文件：**
+- 创建：`.../tools/RealtimeOutboundWriter.java`
+- 创建：`.../tools/RealtimeToolLoop.java`
+- 测试：`.../tools/RealtimeToolLoopTest.java`
+- 创建：`src/test/resources/realtime/fixtures/response-done-two-function-calls.json`
+
+- [ ] **步骤 1：准备 fixture**
+
+`response-done-two-function-calls.json` 需含 `type=response.done`，`response.output` 中两个 `type=function_call` 项（带 `name`、`arguments`、`call_id`）。字段名对齐 GA Realtime（参考 antaios `onResponseDone` 解析）。
+
+- [ ] **步骤 2：编写失败的 loop 测试**
+
+```java
+@Test
+void parallelFunctionCalls_emitOutputsThenSingleResponseCreate() {
+    List<String> sent = Collections.synchronizedList(new ArrayList<>());
+    RealtimeOutboundWriter writer = sent::add;
+    RealtimeToolRegistry registry = RealtimeToolRegistry.from(Map.of(
+            weatherSpec, (r, m) -> "sunny",
+            pingSpec, (r, m) -> "pong"));
+    RealtimeToolLoop loop = new RealtimeToolLoop(registry, writer, Runnable::run); // sync executor for test
+
+    loop.onServerEvent(loadFixture("response-done-two-function-calls.json"));
+
+    assertThat(sent.stream().filter(s -> s.contains("function_call_output"))).hasSize(2);
+    assertThat(sent.stream().filter(s -> s.contains("\"type\":\"response.create\""))).hasSize(1);
+    int lastOutputIdx = IntStream.range(0, sent.size())
+            .filter(i -> sent.get(i).contains("function_call_output"))
+            .max().orElseThrow();
+    int responseCreateIdx = IntStream.range(0, sent.size())
+            .filter(i -> sent.get(i).contains("\"type\":\"response.create\""))
+            .findFirst().orElseThrow();
+    assertThat(responseCreateIdx).isGreaterThan(lastOutputIdx);
+}
+
+@Test
+void executorException_stillEmitsOutputAndResponseCreate() {
+    ToolExecutor boom = (r, m) -> { throw new RuntimeException("fail"); };
+    // ... assert function_call_output contains error text, still one response.create
+}
+
+@Test
+void hallucinatedToolName_emitsErrorOutput() {
+    // registry empty for that name
+}
+```
+
+- [ ] **步骤 3：实现 RealtimeToolLoop**
+
+```java
+public final class RealtimeToolLoop {
+    public RealtimeToolLoop(RealtimeToolRegistry registry,
+                            RealtimeOutboundWriter writer,
+                            Executor toolExecutor) { ... }
+
+    /** @return true if event was a handled response.done with function calls */
+    public boolean onServerEvent(String json) { ... }
+}
+```
+
+行为：
+
+- 仅处理含 `function_call` 的 `response.done`（无 FC 则 return false，由网关透传）。
+- 构建 `ToolExecutionRequest`（id 可用 call_id）。
+- 并行 `CompletableFuture`（传入的 Executor）。
+- 每个结果：`conversation.item.create` + `item.type=function_call_output` + `call_id` + `output` 字符串。
+- 最后一次 `{"type":"response.create"}`。
+- 异常 / 未知 name：output 为错误说明字符串。
+
+- [ ] **步骤 4：测试通过后 Commit**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -Dtest=RealtimeToolLoopTest test
+git add langchain4j-open-ai-realtime
+git commit -m "feat(realtime): server-side function call tool loop"
+```
+
+---
+
+### 任务 5：出站传输抽象 + OpenAiRealtimeSession
+
+**文件：**
+- 创建：`.../session/RealtimeTransport.java`
+- 创建：`.../session/RealtimeTransportListener.java`
+- 创建：`.../session/OpenAiRealtimeSessionListener.java`
+- 创建：`.../session/OpenAiRealtimeSession.java`
+- 创建：`.../session/OkHttpRealtimeTransport.java`
+- 测试：`.../session/OpenAiRealtimeSessionTest.java`
+- 测试：`.../session/FakeRealtimeTransport.java`（可放 test 源码集）
+
+- [ ] **步骤 1：定义传输接口**
+
+```java
+public interface RealtimeTransport extends AutoCloseable {
+    void connect(String url, Map<String, String> headers, RealtimeTransportListener listener);
+    void sendText(String message);
+    void close();
+}
+
+public interface RealtimeTransportListener {
+    void onOpen();
+    void onTextMessage(String text);
+    void onClosed(int code, String reason);
+    void onFailure(Throwable t);
+}
+```
+
+- [ ] **步骤 2：Session 单元测试（Fake transport）**
+
+```java
+@Test
+void sendEvent_isSerializedOnSingleWriter() {
+    FakeRealtimeTransport transport = new FakeRealtimeTransport();
+    OpenAiRealtimeSession session = OpenAiRealtimeSession.builder()
+            .transport(transport)
+            .apiKey("sk-test")
+            .model("gpt-realtime-2.1")
+            .listener(events::add)
+            .build();
+    session.connect();
+    session.sendEvent("{\"type\":\"session.update\",\"session\":{\"type\":\"realtime\"}}");
+    assertThat(transport.sent).hasSize(1);
+}
+
+@Test
+void inboundServerMessage_notifiesListener() {
+    // transport.simulateText("{\"type\":\"session.created\"}")
+    // assert listener received same JSON
+}
+```
+
+- [ ] **步骤 3：实现 OpenAiRealtimeSession**
+
+- `connect()`：URL `wss://api.openai.com/v1/realtime?model={model}`（可 override）；header `Authorization: Bearer {apiKey}`；可选 `OpenAI-Safety-Identifier`。
+- 出站写：单线程/`BlockingQueue` 串行 `sendText`。
+- `sendEvent(String json)` 入队。
+- `close()` 关闭 transport。
+- Listener：原始 JSON 字符串回调（网关再解析）。
+
+- [ ] **步骤 4：实现 OkHttpRealtimeTransport**
+
+使用 `okhttp3.WebSocket` / `WebSocketListener`。单元测试可不连真网；可选 `@EnabledIfEnvironmentVariable(named="OPENAI_API_KEY")` 的 IT 放到任务 8。
+
+- [ ] **步骤 5：测试通过后 Commit**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -Dtest=OpenAiRealtimeSessionTest test
+git add langchain4j-open-ai-realtime
+git commit -m "feat(realtime): OpenAiRealtimeSession with pluggable transport"
+```
+
+---
+
+### 任务 6：RealtimeGatewaySession（桥接逻辑，无真实端口）
+
+**文件：**
+- 创建：`.../gateway/RealtimeGatewaySession.java`
+- 测试：`.../gateway/RealtimeGatewaySessionTest.java`
+
+桥接职责（规格核心）：
+
+1. 入站文本帧 → 若 `session.update` 则 rewriter；若客户端 `function_call_output` 则忽略（可回写 error JSON）；其它原样 `session.sendEvent`。
+2. 出站文本帧 → 先 `toolLoop.onServerEvent`；若已处理 FC 则**不再**把该 `response.done` 原样转给客户端也可选仍转发（推荐：**仍转发** `response.done`，另由 loop 写回灌事件，与「事件尽量一致」兼容）。若 loop 返回 false，原样转客户端。
+3. 持有 `RealtimeToolRegistry`、`SessionUpdateToolsRewriter`、`RealtimeToolLoop`、`OpenAiRealtimeSession`。
+4. 入站 close → `session.close()`；出站 failure → 入站发送 error 并 close。
+
+- [ ] **步骤 1：编写失败的桥接测试（Fake 入站 + Fake 出站）**
+
+用简单 `TestClientLink` / `TestServerLink`（队列模拟双向）或直接测 `RealtimeGatewaySession` 的 package 方法：
+
+```java
+@Test
+void sessionUpdate_rewritesToolsBeforeOutbound() { ... }
+
+@Test
+void clientFunctionCallOutput_isIgnored() { ... }
+
+@Test
+void responseDoneWithFunctionCall_runsLoopAndForwardsEvents() { ... }
+```
+
+- [ ] **步骤 2：实现并通过测试后 Commit**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -Dtest=RealtimeGatewaySessionTest test
+git add langchain4j-open-ai-realtime
+git commit -m "feat(realtime): gateway session bridge with tool rewrite and loop"
+```
+
+---
+
+### 任务 7：RealtimeGatewayServer + OpenAiRealtimeGateway Builder
+
+**文件：**
+- 创建：`.../gateway/RealtimeGatewayConfig.java`
+- 创建：`.../gateway/RealtimeGatewayServer.java`
+- 创建：`.../OpenAiRealtimeGateway.java`
+- 测试：`.../gateway/RealtimeGatewayServerTest.java`
+
+- [ ] **步骤 1：Builder API 设计（实现时锁定签名）**
+
+```java
+OpenAiRealtimeGateway gateway = OpenAiRealtimeGateway.builder()
+        .host("127.0.0.1")
+        .port(0) // ephemeral
+        .tools(Map.of(spec, executor)) // or .tools(objectWithTools)
+        .toolExecutor(Executors.newCachedThreadPool())
+        .build();
+gateway.start();
+URI wsUri = gateway.wsUri(); // ws://127.0.0.1:port/
+gateway.stop();
+```
+
+入站连接：从 HTTP headers 读 `Authorization: Bearer ...`；缺失则关闭。用该 key 创建 `OpenAiRealtimeSession`（生产 transport = OkHttp）。每个入站连接一个 `RealtimeGatewaySession`。
+
+- [ ] **步骤 2：本地环回测试（出站用 FakeRealtimeTransport 工厂）**
+
+为可测性，Builder 允许 `outboundTransportFactory(apiKey -> RealtimeTransport)`；测试注入 Fake，验证：
+
+1. 客户端连上并带 Bearer。
+2. 发无 tools 的 `session.update` → Fake 出站收到的 tools 为全量注册表。
+3. 模拟出站 `response.done`+FC → Fake 出站收到 `function_call_output` 与 `response.create`；客户端收到下行事件。
+
+使用 Java-WebSocket 客户端连本地 server。
+
+- [ ] **步骤 3：实现 Server（Java-WebSocket `WebSocketServer`）**
+
+注意：accept 线程与 tool 线程隔离；每个连接独立 session。
+
+- [ ] **步骤 4：测试通过后 Commit**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -Dtest=RealtimeGatewayServerTest test
+git add langchain4j-open-ai-realtime
+git commit -m "feat(realtime): inbound WebSocket gateway server and public builder"
+```
+
+---
+
+### 任务 8：README + 可选 IT
+
+**文件：**
+- 创建：`langchain4j-open-ai-realtime/README.md`
+- 创建：`.../OpenAiRealtimeSessionIT.java`（可选）
+
+- [ ] **步骤 1：README 必写差异**
+
+必须写明规格 5.4：
+
+1. tools schema 以应用注册表为准；客户端可省略 tools。  
+2. function call loop 在服务端。  
+3. 入站 Bearer 用于出站 OpenAI。  
+4. barge-in：客户端停播 + 客户端 `truncate`。  
+5. 最小代码示例：注册 `@Tool` / Map、start gateway、浏览器/ws 客户端连入。
+
+- [ ] **步骤 2：可选 IT**
+
+```java
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiRealtimeSessionIT {
+    @Test
+    void sessionUpdate_roundTrip() throws Exception {
+        // real OkHttp transport; send session.update; await session.updated within timeout
+    }
+}
+```
+
+- [ ] **步骤 3：全模块测试**
+
+```bash
+mvn -pl langchain4j-open-ai-realtime -am test
+```
+
+预期：非 IT 全部 PASS
+
+- [ ] **步骤 4：Commit**
+
+```bash
+git add langchain4j-open-ai-realtime
+git commit -m "docs(realtime): README and optional live Realtime IT"
+```
+
+---
+
+## 规格覆盖自检
+
+| 规格章节 | 任务 |
+|----------|------|
+| 出站 Realtime WS | 任务 5 |
+| 入站类 OpenAI WS | 任务 6–7 |
+| ToolSpecification+ToolExecutor 权威 | 任务 2–3、7 |
+| 客户端省略 tools = 全量 | 任务 3 |
+| name 白名单 / 未知失败 | 任务 3 |
+| 密钥模式 B | 任务 5、7 |
+| FC 并行 + 一次 response.create | 任务 4 |
+| 忽略客户端 function_call_output | 任务 6 |
+| 串行出站写 / 工具线程池 | 任务 4–5、7 |
+| 客户端 truncate（网关不自动） | README（任务 8）；无服务端 truncate 代码 |
+| 非目标（AiServices 等） | 不实现 |
+| 单元/契约/IT | 任务 2–8 |
+| 根 POM / BOM | 任务 1 |
+
+## 类型命名一致性
+
+- `RealtimeToolRegistry` / `SessionUpdateToolsRewriter` / `RealtimeToolLoop` / `RealtimeOutboundWriter`
+- `RealtimeTransport` / `OpenAiRealtimeSession` / `OpenAiRealtimeSessionListener`
+- `RealtimeGatewaySession` / `RealtimeGatewayServer` / `OpenAiRealtimeGateway`
+
+---
+
+## 执行交接
+
+计划已完成并保存到 `docs/superpowers/plans/2026-09-04-openai-realtime-gateway.md`。两种执行方式：
+
+**1. 子代理驱动（推荐）** - 每个任务调度一个新的子代理，任务间进行审查，快速迭代  
+
+**2. 内联执行** - 在当前会话中使用 executing-plans 执行任务，批量执行并设有检查点  
+
+选哪种方式？

--- a/docs/superpowers/specs/2026-09-04-openai-realtime-gateway-design.md
+++ b/docs/superpowers/specs/2026-09-04-openai-realtime-gateway-design.md
@@ -1,0 +1,192 @@
+# OpenAI Realtime Gateway（langchain4j-open-ai-realtime）设计规格
+
+**日期：** 2026-09-04  
+**仓库：** langchain4j-famdetxire（fork）  
+**状态：** 待实现（brainstorming 已批准）
+
+## 1. 目标
+
+在 fork 中新增模块 `langchain4j-open-ai-realtime`，提供：
+
+1. **出站** OpenAI Realtime WebSocket 客户端（GA 事件语义，对齐现网 antaios 已验证路径）。
+2. **入站** WebSocket 网关：对外 API 事件形状尽量与 [OpenAI Realtime / Voice agents](https://developers.openai.com/api/docs/guides/voice-agents) 一致。
+3. **工具**：以应用构建 Agent/Gateway 时注册的 `ToolSpecification` + `ToolExecutor` 配对为唯一权威；服务端执行 function call loop。
+
+典型部署（验收场景）：
+
+```
+浏览器 ──入站 WS（类 OpenAI 事件）──► Gateway（本模块）──出站 WS──► OpenAI Realtime
+```
+
+## 2. 非目标（v1）
+
+- 不实现 `ChatModel` / `StreamingChatModel` / `AiServices` 伪装接入。
+- 不实现 WebRTC、SIP、Agents SDK handoff/guardrails 产品面。
+- 不把 antaios `DynamicToolSpecificationBuilder` / `UnifiedToolExecutor` / HTTP Facade 搬进本模块。
+- 不替换 antaios `OpenaiVoiceLlmOutCallProcessor`（可后续另开变更迁移）。
+- 不做断线重连协议；不做慢工具填充语；不取消进行中的 tool 执行。
+
+## 3. 架构（方案 1：单模块网关一体）
+
+### 3.1 模块
+
+- **Artifact：** `langchain4j-open-ai-realtime`
+- **位置：** 与 `langchain4j-open-ai` 并列的顶层 Maven 模块
+- **依赖：** `langchain4j-core`；WebSocket 客户端与服务端库；JSON。不依赖 antaios。`openai-java` 可选（若复用类型再评估，非必须）
+
+### 3.2 内部分层
+
+| 包/层 | 职责 |
+|-------|------|
+| `gateway` | 入站 WS、一对一会话绑定、`session.update` 中 tools 改写、事件转发 |
+| `session` | 出站 `OpenAiRealtimeSession`（connect / sendEvent / server events） |
+| `tools` | `RealtimeToolLoop`：注册表、白名单过滤、FC 执行与回灌 |
+
+```
+客户端
+  │ Inbound WS + Authorization: Bearer <openai-key-or-ek>
+  ▼
+RealtimeGatewayServer
+  │ tools 改写 / 事件转发
+  ▼
+OpenAiRealtimeSession ──► OpenAI
+  │
+  └─ function_call → RealtimeToolLoop → function_call_output + response.create
+```
+
+### 3.3 与 antaios 的关系
+
+- antaios 现网：RTP ↔ Processor ↔ 出站 Realtime；工具经 HTTP `/agentic/tools/schema|execute`（进程边界 + 业务二次处理）。
+- 本模块：入站改为类 OpenAI 的 WS；工具直接使用 langchain 原生 `ToolSpecification`/`ToolExecutor`。
+- 后续：Processor 可改用本模块 `OpenAiRealtimeSession`；Facade 二次处理结果应注册为 pair 后再交给本模块。
+
+## 4. 配置与鉴权
+
+### 4.1 初始配置
+
+- **客户端主导**：连接后由客户端发送 `session.update`（model、instructions、audio、VAD、reasoning 等）。
+- **密钥模式 B**：入站 `Authorization: Bearer` 携带 OpenAI API key 或 ephemeral `ek_...`，网关**原样用于出站**。适合联调/内网；公网浏览器场景后续可再加应用层鉴权（非 v1 必做）。
+
+### 4.2 工具注册（应用构建时）
+
+应用在构建 Gateway/Agent 时注册：
+
+```text
+Map<ToolSpecification, ToolExecutor>
+```
+
+或与 `ToolService.tools(...)` 等价的 `@Tool` / `objectsWithTools` 扫描结果。
+
+**这是 tools 的唯一权威来源**（schema + 执行）。
+
+### 4.3 客户端 `session.update.tools`
+
+- **可省略**：省略时出站挂载**全部**已注册工具。
+- **若提供**：仅作 **name 白名单**，从注册表过滤；schema 仍来自注册表中的 `ToolSpecification`。
+- **未知 name**：该次 `session.update` **整次失败**，下行明确 `error`，出站不应用残缺 tools。
+
+## 5. 事件流
+
+### 5.1 连接
+
+- 一入站连接 ↔ 一出站 Realtime 连接；任一侧断开则关闭另一侧。
+- 出站连上后，将 OpenAI 的 `session.created` 等事件转给客户端。
+
+### 5.2 透传（为主）
+
+**上行（客户端 → 出站）：**  
+`input_audio_buffer.*`、`response.create` / `response.cancel`、`conversation.item.create`（非 function_call_output）、`conversation.item.truncate` 等。
+
+**下行（出站 → 客户端）：**  
+`response.output_audio.delta`（兼容旧名）、transcript/text、`session.updated`、`error` 等。
+
+网关不做 RTP/重采样；音频格式由客户端在 `session.audio` 中约定。
+
+### 5.3 工具循环（服务端）
+
+触发：出站 `response.done`（或等价）中含 `function_call`。
+
+1. 映射为 `ToolExecutionRequest`（name、arguments；`call_id` 用于回灌）。
+2. 按 name 查注册表 `ToolExecutor`；并行执行多个 FC。
+3. 逐个发送 `conversation.item.create`（`type=function_call_output`）。
+4. 全部完成后发送**一次** `response.create`。
+5. 后续音频/文本事件照常转客户端。
+
+规则：
+
+- 客户端**不应**发送 `function_call_output`；若发送则忽略（可选下行 `error`）。
+- 不实现「取消正在执行的 tool」。
+- 执行异常：捕获后以错误文案回灌该 `call_id`，不撕掉整会话；部分失败仍汇齐后一次 `response.create`。
+- 模型幻觉未知 tool name：回灌错误文案型 output，再继续。
+
+### 5.4 与纯 OpenAI 客户端的差异（必须文档化）
+
+1. tools schema 以应用注册表为准，不是客户端 JSON 权威。
+2. function call loop 在服务端完成。
+3. 入站 Bearer 用于出站 OpenAI（模式 B）。
+
+## 6. 打断与生命周期
+
+### 6.1 Barge-in
+
+- **停播**：客户端在收到 `input_audio_buffer.speech_started` 时清空本地播放。
+- **`conversation.item.truncate`**：v1 由**客户端**发送（客户端知道已播放时长）。网关不自动 truncate（与 antaios 电话侧服务端 truncate 不同，需文档说明）。
+
+### 6.2 Greeting
+
+- 不强制；由客户端自行 `response.create`。antaios 自动 greeting 留在应用层。
+
+### 6.3 并发
+
+- 工具执行使用独立线程池，避免阻塞音频转发。
+- 同一会话出站写入串行化（单写队列），防止帧交错。
+
+### 6.4 可观测（v1 最小）
+
+- 日志：connect、session.update（toolsCount）、每个 FC 的 name/call_id/耗时、出站 error。
+- 不强制 OpenTelemetry。
+
+## 7. 测试与验收
+
+### 7.1 Done 标准
+
+1. Bearer 出站可完成 `session.update` ↔ `session.updated`。
+2. 构建时注册 tools；客户端省略 tools 时出站为全量注册表。
+3. 白名单与未知 name 行为符合第 4.3 节。
+4. FC loop：并行执行、回灌、一次 `response.create`。
+5. 音频 append / output delta 可经网关往返（PCM fixture 即可）。
+6. 任一侧断开，对端关闭，无悬挂会话。
+7. 非目标未实现。
+
+### 7.2 测试分层
+
+| 层 | 内容 | 真 OpenAI |
+|----|------|-----------|
+| 单元 | tools 改写、FC 映射、并行回灌、忽略客户端 function_call_output | 否 |
+| 契约 | GA 事件 JSON fixture + 假 WS | 否 |
+| IT | 真 key 短会话（update / 工具 / 可选音频） | 是（可 EnabledIf） |
+| 手工 | 浏览器采音 + 一个 @Tool | 是 |
+
+## 8. 实现顺序建议（供 writing-plans）
+
+1. 模块骨架与出站 `OpenAiRealtimeSession`（参考 antaios `AntaiosOpenaiVoiceClient` 事件语义，无 RTP）。
+2. `RealtimeToolLoop` + 注册表 API。
+3. 入站 Gateway + tools 改写与透传。
+4. 单元/契约测试 + README 差异说明。
+5. 可选 IT / 浏览器手工验收。
+
+## 9. 决策记录
+
+| 决策 | 选择 |
+|------|------|
+| 仓库 | langchain4j-famdetxire |
+| 传输 | 服务端出站 WebSocket |
+| 模块形态 | 单模块网关一体（内部分层可日后拆分） |
+| langchain 兼容 | ToolSpecification + ToolExecutor；非 AiServices |
+| 对外 API | 入站 WS，事件对齐 OpenAI Realtime |
+| 初始配置 | 客户端传入 |
+| tools 权威 | 应用构建时注册的 pair |
+| 客户端 tools | 可省略=全量；提供则 name 白名单 |
+| 密钥 | 客户端 Bearer 出站（模式 B） |
+| truncate | 客户端负责（v1） |
+| antaios Facade | 不进本模块；属应用二次处理 |

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -196,6 +196,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-open-ai-realtime</artifactId>
+                <version>${langchain4j.beta.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-ovh-ai</artifactId>
                 <version>${langchain4j.beta.version}</version>
             </dependency>

--- a/langchain4j-open-ai-realtime/README.md
+++ b/langchain4j-open-ai-realtime/README.md
@@ -1,0 +1,86 @@
+# LangChain4j :: OpenAI Realtime
+
+Inbound WebSocket gateway that speaks OpenAI Realtime–shaped events, with an outbound
+WebSocket to OpenAI Realtime. Tools are registered at build time; the gateway runs the
+function-call loop on the server.
+
+```
+Browser ── inbound WS (OpenAI-like events) ──► Gateway ── outbound WS ──► OpenAI Realtime
+```
+
+## Differences from a pure OpenAI Realtime client
+
+1. **Tools schema is authoritative from the app registry**  
+   Schema and executors come from `ToolSpecification` + `ToolExecutor` pairs registered when
+   building the gateway. The client may omit `session.update.session.tools` to enable the
+   **full** registry. If the client sends a tools list, it is treated as a **name whitelist**
+   only; schemas are still taken from the registry. Unknown tool names fail that
+   `session.update` (downlink `error`; outbound is not updated with a partial tools set).
+
+2. **Function-call loop runs on the server**  
+   On outbound `response.done` (or equivalent) with `function_call` items, the gateway
+   executes registered tools, sends `conversation.item.create` (`function_call_output`),
+   then a single `response.create`. Clients must not send `function_call_output`.
+
+3. **Inbound Bearer is used for outbound OpenAI (mode B)**  
+   The inbound `Authorization: Bearer <openai-api-key-or-ek_...>` header is forwarded as-is
+   on the outbound Realtime connection. Suitable for local/dev and trusted networks.
+
+4. **Barge-in is client-driven**  
+   - **Stop playback**: when the client receives `input_audio_buffer.speech_started`, it
+     should clear local audio playback.  
+   - **Truncate**: the client sends `conversation.item.truncate` (it knows how much audio
+     was already played). The gateway does **not** auto-truncate.
+
+Either side disconnecting closes the other (symmetric session lifecycle).
+
+## Minimal example
+
+```java
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.model.openai.realtime.OpenAiRealtimeGateway;
+
+public class WeatherTools {
+    @Tool("Get the weather for a city")
+    public String getWeather(String city) {
+        return "sunny in " + city;
+    }
+}
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        try (OpenAiRealtimeGateway gateway = OpenAiRealtimeGateway.builder()
+                .host("127.0.0.1")
+                .port(8080)
+                .tools(new WeatherTools())
+                .build()) {
+            gateway.start();
+            System.out.println("Connect WS clients to " + gateway.wsUri());
+            // Client: Authorization: Bearer <OPENAI_API_KEY>
+            // Client: send session.update (tools optional), then audio / response.create
+            Thread.currentThread().join();
+        }
+    }
+}
+```
+
+WebSocket client (sketch):
+
+```text
+ws://127.0.0.1:8080/
+Authorization: Bearer sk-...
+
+→ {"type":"session.update","session":{"type":"realtime","instructions":"..."}}
+→ {"type":"input_audio_buffer.append","audio":"<base64 pcm>..."}
+→ {"type":"input_audio_buffer.commit"}
+→ {"type":"response.create"}
+```
+
+## Optional integration test
+
+`OpenAiRealtimeSessionIT` is run by Failsafe (`verify`) and only when `OPENAI_API_KEY` is set;
+otherwise it is skipped. Unit tests:
+
+```bash
+./mvnw -pl langchain4j-open-ai-realtime -am -Denforcer.skip=true test
+```

--- a/langchain4j-open-ai-realtime/pom.xml
+++ b/langchain4j-open-ai-realtime/pom.xml
@@ -22,6 +22,13 @@
             <version>1.20.0-SNAPSHOT</version>
         </dependency>
 
+        <!-- ToolExecutor lives in langchain4j (not core) -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.20.0-SNAPSHOT</version>
+        </dependency>
+
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>

--- a/langchain4j-open-ai-realtime/pom.xml
+++ b/langchain4j-open-ai-realtime/pom.xml
@@ -1,32 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-parent</artifactId>
-        <version>1.20.0-beta30-SNAPSHOT</version>
+        <version>1.21.0-beta31-SNAPSHOT</version>
         <relativePath>../langchain4j-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>langchain4j-open-ai-realtime</artifactId>
     <name>LangChain4j :: Integration :: OpenAI Realtime</name>
 
+    <properties>
+        <java-websocket.version>1.5.7</java-websocket.version>
+    </properties>
+
     <dependencies>
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.21.0-SNAPSHOT</version>
         </dependency>
 
-        <!-- ToolExecutor lives in langchain4j (not core) -->
+        <!-- ToolExecutor / @Tool live in langchain4j (not core) -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.21.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -37,7 +39,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.7</version>
+            <version>${java-websocket.version}</version>
         </dependency>
 
         <dependency>
@@ -53,7 +55,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.21.0-SNAPSHOT</version>
             <classifier>tests</classifier>
             <type>test-jar</type>
             <scope>test</scope>

--- a/langchain4j-open-ai-realtime/pom.xml
+++ b/langchain4j-open-ai-realtime/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.20.0-beta30-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-open-ai-realtime</artifactId>
+    <name>LangChain4j :: Integration :: OpenAI Realtime</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.20.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.20.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/OpenAiRealtimeGateway.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/OpenAiRealtimeGateway.java
@@ -1,0 +1,120 @@
+package dev.langchain4j.model.openai.realtime;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.openai.realtime.gateway.RealtimeGatewayConfig;
+import dev.langchain4j.model.openai.realtime.gateway.RealtimeGatewayServer;
+import dev.langchain4j.model.openai.realtime.session.OkHttpRealtimeTransport;
+import dev.langchain4j.model.openai.realtime.session.RealtimeTransport;
+import dev.langchain4j.model.openai.realtime.tools.RealtimeToolRegistry;
+import dev.langchain4j.service.tool.AiServiceTool;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolService;
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+
+/**
+ * Public entry point for the OpenAI Realtime inbound WebSocket gateway.
+ */
+public final class OpenAiRealtimeGateway implements AutoCloseable {
+
+    private final RealtimeGatewayServer server;
+
+    private OpenAiRealtimeGateway(RealtimeGatewayServer server) {
+        this.server = server;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void start() {
+        server.start();
+    }
+
+    public void stop() {
+        server.stop();
+    }
+
+    public URI wsUri() {
+        return server.wsUri();
+    }
+
+    public int port() {
+        return server.port();
+    }
+
+    @Override
+    public void close() {
+        stop();
+    }
+
+    public static final class Builder {
+
+        private String host = "127.0.0.1";
+        private int port = 0;
+        private Map<ToolSpecification, ToolExecutor> tools = Collections.emptyMap();
+        private Executor toolExecutor;
+        private Function<String, RealtimeTransport> outboundTransportFactory;
+
+        public Builder host(String host) {
+            this.host = Objects.requireNonNull(host, "host");
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder tools(Map<ToolSpecification, ToolExecutor> tools) {
+            this.tools = Objects.requireNonNull(tools, "tools");
+            return this;
+        }
+
+        /**
+         * Registers tools scanned from an object with {@code @Tool}-annotated methods.
+         */
+        public Builder tools(Object objectWithTools) {
+            Objects.requireNonNull(objectWithTools, "objectWithTools");
+            List<AiServiceTool> discovered = ToolService.findTools(objectWithTools);
+            Map<ToolSpecification, ToolExecutor> map = new LinkedHashMap<>();
+            for (AiServiceTool tool : discovered) {
+                map.put(tool.toolSpecification(), tool.toolExecutor());
+            }
+            return tools(map);
+        }
+
+        public Builder toolExecutor(Executor toolExecutor) {
+            this.toolExecutor = Objects.requireNonNull(toolExecutor, "toolExecutor");
+            return this;
+        }
+
+        /**
+         * Factory for outbound Realtime transports. Defaults to {@link OkHttpRealtimeTransport}.
+         * Tests may inject {@code FakeRealtimeTransport}.
+         */
+        public Builder outboundTransportFactory(Function<String, RealtimeTransport> outboundTransportFactory) {
+            this.outboundTransportFactory =
+                    Objects.requireNonNull(outboundTransportFactory, "outboundTransportFactory");
+            return this;
+        }
+
+        public OpenAiRealtimeGateway build() {
+            Executor executor =
+                    toolExecutor != null ? toolExecutor : Executors.newCachedThreadPool();
+            Function<String, RealtimeTransport> transportFactory = outboundTransportFactory != null
+                    ? outboundTransportFactory
+                    : apiKey -> new OkHttpRealtimeTransport();
+            RealtimeGatewayConfig config = new RealtimeGatewayConfig(
+                    host, port, RealtimeToolRegistry.from(tools), executor, transportFactory);
+            return new OpenAiRealtimeGateway(new RealtimeGatewayServer(config));
+        }
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/OpenAiRealtimeGateway.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/OpenAiRealtimeGateway.java
@@ -107,13 +107,12 @@ public final class OpenAiRealtimeGateway implements AutoCloseable {
         }
 
         public OpenAiRealtimeGateway build() {
-            Executor executor =
-                    toolExecutor != null ? toolExecutor : Executors.newCachedThreadPool();
+            Executor executor = toolExecutor != null ? toolExecutor : Executors.newCachedThreadPool();
             Function<String, RealtimeTransport> transportFactory = outboundTransportFactory != null
                     ? outboundTransportFactory
                     : apiKey -> new OkHttpRealtimeTransport();
-            RealtimeGatewayConfig config = new RealtimeGatewayConfig(
-                    host, port, RealtimeToolRegistry.from(tools), executor, transportFactory);
+            RealtimeGatewayConfig config =
+                    new RealtimeGatewayConfig(host, port, RealtimeToolRegistry.from(tools), executor, transportFactory);
             return new OpenAiRealtimeGateway(new RealtimeGatewayServer(config));
         }
     }

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayConfig.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayConfig.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.model.openai.realtime.gateway;
+
+import dev.langchain4j.model.openai.realtime.session.RealtimeTransport;
+import dev.langchain4j.model.openai.realtime.tools.RealtimeToolRegistry;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+/**
+ * Bind address and shared runtime settings for {@link RealtimeGatewayServer}.
+ */
+public final class RealtimeGatewayConfig {
+
+    private final String host;
+    private final int port;
+    private final RealtimeToolRegistry toolRegistry;
+    private final Executor toolExecutor;
+    private final Function<String, RealtimeTransport> outboundTransportFactory;
+
+    public RealtimeGatewayConfig(
+            String host,
+            int port,
+            RealtimeToolRegistry toolRegistry,
+            Executor toolExecutor,
+            Function<String, RealtimeTransport> outboundTransportFactory) {
+        this.host = Objects.requireNonNull(host, "host");
+        this.port = port;
+        this.toolRegistry = Objects.requireNonNull(toolRegistry, "toolRegistry");
+        this.toolExecutor = Objects.requireNonNull(toolExecutor, "toolExecutor");
+        this.outboundTransportFactory =
+                Objects.requireNonNull(outboundTransportFactory, "outboundTransportFactory");
+    }
+
+    public String host() {
+        return host;
+    }
+
+    public int port() {
+        return port;
+    }
+
+    public RealtimeToolRegistry toolRegistry() {
+        return toolRegistry;
+    }
+
+    public Executor toolExecutor() {
+        return toolExecutor;
+    }
+
+    public Function<String, RealtimeTransport> outboundTransportFactory() {
+        return outboundTransportFactory;
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayConfig.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayConfig.java
@@ -27,8 +27,7 @@ public final class RealtimeGatewayConfig {
         this.port = port;
         this.toolRegistry = Objects.requireNonNull(toolRegistry, "toolRegistry");
         this.toolExecutor = Objects.requireNonNull(toolExecutor, "toolExecutor");
-        this.outboundTransportFactory =
-                Objects.requireNonNull(outboundTransportFactory, "outboundTransportFactory");
+        this.outboundTransportFactory = Objects.requireNonNull(outboundTransportFactory, "outboundTransportFactory");
     }
 
     public String host() {

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServer.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServer.java
@@ -133,6 +133,7 @@ public final class RealtimeGatewayServer {
                             if (session != null) {
                                 session.onOutboundClosed(code, reason);
                             }
+                            closeInboundQuietly(conn, 1011, "Outbound closed");
                         }
 
                         @Override
@@ -141,6 +142,7 @@ public final class RealtimeGatewayServer {
                             if (session != null) {
                                 session.onOutboundFailure(t);
                             }
+                            closeInboundQuietly(conn, 1011, "Outbound failed");
                         }
                     })
                     .build();
@@ -197,6 +199,17 @@ public final class RealtimeGatewayServer {
                 conn.send(message);
             } catch (Exception e) {
                 log.debug("Failed to send inbound message", e);
+            }
+        }
+
+        private static void closeInboundQuietly(WebSocket conn, int code, String reason) {
+            if (conn == null || !conn.isOpen()) {
+                return;
+            }
+            try {
+                conn.close(code, reason);
+            } catch (Exception e) {
+                log.debug("Failed to close inbound WebSocket", e);
             }
         }
 

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServer.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServer.java
@@ -1,0 +1,215 @@
+package dev.langchain4j.model.openai.realtime.gateway;
+
+import dev.langchain4j.model.openai.realtime.session.OpenAiRealtimeSession;
+import dev.langchain4j.model.openai.realtime.session.OpenAiRealtimeSessionListener;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Inbound WebSocket server: one client connection maps to one outbound Realtime session.
+ */
+public final class RealtimeGatewayServer {
+
+    private static final Logger log = LoggerFactory.getLogger(RealtimeGatewayServer.class);
+
+    private final RealtimeGatewayConfig config;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private volatile ServerImpl server;
+
+    public RealtimeGatewayServer(RealtimeGatewayConfig config) {
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    public void start() {
+        if (!started.compareAndSet(false, true)) {
+            throw new IllegalStateException("gateway server already started");
+        }
+        CountDownLatch ready = new CountDownLatch(1);
+        ServerImpl impl = new ServerImpl(new InetSocketAddress(config.host(), config.port()), config, ready);
+        this.server = impl;
+        impl.setReuseAddr(true);
+        impl.start();
+        try {
+            if (!ready.await(10, TimeUnit.SECONDS)) {
+                stopQuietly();
+                throw new IllegalStateException("gateway server failed to start within timeout");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            stopQuietly();
+            throw new IllegalStateException("interrupted while starting gateway server", e);
+        }
+        log.info("Realtime gateway listening on {}", wsUri());
+    }
+
+    public void stop() {
+        if (!started.compareAndSet(true, false)) {
+            return;
+        }
+        stopQuietly();
+    }
+
+    public URI wsUri() {
+        ServerImpl impl = server;
+        if (impl == null || !started.get()) {
+            throw new IllegalStateException("gateway server is not started");
+        }
+        return URI.create("ws://" + config.host() + ":" + impl.getPort() + "/");
+    }
+
+    public int port() {
+        ServerImpl impl = server;
+        if (impl == null || !started.get()) {
+            throw new IllegalStateException("gateway server is not started");
+        }
+        return impl.getPort();
+    }
+
+    private void stopQuietly() {
+        ServerImpl impl = server;
+        server = null;
+        if (impl != null) {
+            try {
+                impl.stop(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                log.debug("Error stopping gateway server", e);
+            }
+        }
+    }
+
+    private static final class ServerImpl extends WebSocketServer {
+
+        private final RealtimeGatewayConfig config;
+        private final CountDownLatch ready;
+
+        ServerImpl(InetSocketAddress address, RealtimeGatewayConfig config, CountDownLatch ready) {
+            super(address);
+            this.config = config;
+            this.ready = ready;
+        }
+
+        @Override
+        public void onStart() {
+            ready.countDown();
+        }
+
+        @Override
+        public void onOpen(WebSocket conn, ClientHandshake handshake) {
+            String apiKey = extractBearerToken(handshake.getFieldValue("Authorization"));
+            if (apiKey == null) {
+                log.warn("Rejecting inbound connection without Authorization Bearer");
+                conn.close(1008, "Missing Authorization Bearer");
+                return;
+            }
+
+            AtomicReference<RealtimeGatewaySession> gatewayRef = new AtomicReference<>();
+            OpenAiRealtimeSession outbound = OpenAiRealtimeSession.builder()
+                    .transport(config.outboundTransportFactory().apply(apiKey))
+                    .apiKey(apiKey)
+                    .listener(new OpenAiRealtimeSessionListener() {
+                        @Override
+                        public void onEvent(String json) {
+                            RealtimeGatewaySession session = gatewayRef.get();
+                            if (session != null) {
+                                session.onOutboundEvent(json);
+                            }
+                        }
+
+                        @Override
+                        public void onClosed(int code, String reason) {
+                            RealtimeGatewaySession session = gatewayRef.get();
+                            if (session != null) {
+                                session.onOutboundClosed(code, reason);
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t) {
+                            RealtimeGatewaySession session = gatewayRef.get();
+                            if (session != null) {
+                                session.onOutboundFailure(t);
+                            }
+                        }
+                    })
+                    .build();
+
+            RealtimeGatewaySession gatewaySession = new RealtimeGatewaySession(
+                    outbound,
+                    config.toolRegistry(),
+                    config.toolExecutor(),
+                    message -> sendToClient(conn, message));
+            gatewayRef.set(gatewaySession);
+            conn.setAttachment(gatewaySession);
+
+            try {
+                outbound.connect();
+            } catch (RuntimeException e) {
+                log.warn("Failed to open outbound Realtime session", e);
+                gatewaySession.close();
+                conn.close(1011, "Outbound connect failed");
+            }
+        }
+
+        @Override
+        public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+            RealtimeGatewaySession session = conn.getAttachment();
+            if (session != null) {
+                session.onClientClosed();
+            }
+        }
+
+        @Override
+        public void onMessage(WebSocket conn, String message) {
+            RealtimeGatewaySession session = conn.getAttachment();
+            if (session != null) {
+                session.onClientMessage(message);
+            }
+        }
+
+        @Override
+        public void onError(WebSocket conn, Exception ex) {
+            log.warn("Inbound WebSocket error", ex);
+            if (conn != null) {
+                RealtimeGatewaySession session = conn.getAttachment();
+                if (session != null) {
+                    session.close();
+                }
+            }
+        }
+
+        private static void sendToClient(WebSocket conn, String message) {
+            if (conn == null || !conn.isOpen()) {
+                return;
+            }
+            try {
+                conn.send(message);
+            } catch (Exception e) {
+                log.debug("Failed to send inbound message", e);
+            }
+        }
+
+        private static String extractBearerToken(String authorization) {
+            if (authorization == null || authorization.isBlank()) {
+                return null;
+            }
+            String value = authorization.trim();
+            if (value.length() > 7 && value.regionMatches(true, 0, "Bearer ", 0, 7)) {
+                String token = value.substring(7).trim();
+                return token.isEmpty() ? null : token;
+            }
+            return null;
+        }
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServer.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServer.java
@@ -148,10 +148,7 @@ public final class RealtimeGatewayServer {
                     .build();
 
             RealtimeGatewaySession gatewaySession = new RealtimeGatewaySession(
-                    outbound,
-                    config.toolRegistry(),
-                    config.toolExecutor(),
-                    message -> sendToClient(conn, message));
+                    outbound, config.toolRegistry(), config.toolExecutor(), message -> sendToClient(conn, message));
             gatewayRef.set(gatewaySession);
             conn.setAttachment(gatewaySession);
 

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySession.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySession.java
@@ -83,6 +83,32 @@ public final class RealtimeGatewaySession implements AutoCloseable {
         inboundSink.accept(json);
     }
 
+    /**
+     * Outbound WebSocket closed. Notifies the inbound client once, then closes local state.
+     * Safe if invoked again after {@link #close()} (no re-notify / no recursion).
+     */
+    public void onOutboundClosed(int code, String reason) {
+        if (closed.get()) {
+            return;
+        }
+        String detail = reason == null || reason.isBlank() ? "" : " " + reason;
+        inboundSink.accept(errorEvent("Outbound connection closed: " + code + detail));
+        close();
+    }
+
+    /**
+     * Outbound failure. Notifies the inbound client once, then closes local state.
+     */
+    public void onOutboundFailure(Throwable t) {
+        if (closed.get()) {
+            return;
+        }
+        Objects.requireNonNull(t, "t");
+        String message = t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage();
+        inboundSink.accept(errorEvent("Outbound connection failed: " + message));
+        close();
+    }
+
     public void onClientClosed() {
         close();
     }

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySession.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySession.java
@@ -59,7 +59,8 @@ public final class RealtimeGatewaySession implements AutoCloseable {
                 return;
             }
             if (isClientFunctionCallOutput(root, type)) {
-                inboundSink.accept(errorEvent("Clients must not send function_call_output; the gateway executes tools"));
+                inboundSink.accept(
+                        errorEvent("Clients must not send function_call_output; the gateway executes tools"));
                 return;
             }
             outbound.sendEvent(json);

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySession.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySession.java
@@ -1,0 +1,138 @@
+package dev.langchain4j.model.openai.realtime.gateway;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.model.openai.realtime.session.OpenAiRealtimeSession;
+import dev.langchain4j.model.openai.realtime.tools.RealtimeToolLoop;
+import dev.langchain4j.model.openai.realtime.tools.RealtimeToolRegistry;
+import dev.langchain4j.model.openai.realtime.tools.SessionUpdateToolsRewriter;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * One-to-one bridge between an inbound client and an outbound {@link OpenAiRealtimeSession}:
+ * rewrites {@code session.update} tools, runs the server-side tool loop, and forwards events.
+ */
+public final class RealtimeGatewaySession implements AutoCloseable {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final OpenAiRealtimeSession outbound;
+    private final SessionUpdateToolsRewriter rewriter;
+    private final RealtimeToolLoop toolLoop;
+    private final Consumer<String> inboundSink;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public RealtimeGatewaySession(
+            OpenAiRealtimeSession outbound,
+            RealtimeToolRegistry registry,
+            Executor toolExecutor,
+            Consumer<String> inboundSink) {
+        this.outbound = Objects.requireNonNull(outbound, "outbound");
+        Objects.requireNonNull(registry, "registry");
+        Objects.requireNonNull(toolExecutor, "toolExecutor");
+        this.inboundSink = Objects.requireNonNull(inboundSink, "inboundSink");
+        this.rewriter = new SessionUpdateToolsRewriter(registry);
+        this.toolLoop = new RealtimeToolLoop(registry, outbound::sendEvent, toolExecutor);
+    }
+
+    /**
+     * Handle a text frame from the inbound client.
+     */
+    public void onClientMessage(String json) {
+        Objects.requireNonNull(json, "json");
+        if (closed.get()) {
+            return;
+        }
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(json);
+            if (root == null || !root.isObject()) {
+                outbound.sendEvent(json);
+                return;
+            }
+            String type = textOrEmpty(root, "type");
+            if ("session.update".equals(type)) {
+                handleSessionUpdate(json);
+                return;
+            }
+            if (isClientFunctionCallOutput(root, type)) {
+                inboundSink.accept(errorEvent("Clients must not send function_call_output; the gateway executes tools"));
+                return;
+            }
+            outbound.sendEvent(json);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to handle client message", e);
+        }
+    }
+
+    /**
+     * Handle a text event from the outbound OpenAI Realtime session.
+     * Invoked via the session listener (wire with {@code gatewayRef} in tests / server).
+     */
+    public void onOutboundEvent(String json) {
+        Objects.requireNonNull(json, "json");
+        if (closed.get()) {
+            return;
+        }
+        toolLoop.onServerEvent(json);
+        inboundSink.accept(json);
+    }
+
+    public void onClientClosed() {
+        close();
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        outbound.close();
+    }
+
+    private void handleSessionUpdate(String json) {
+        try {
+            String rewritten = rewriter.rewrite(json);
+            outbound.sendEvent(rewritten);
+        } catch (IllegalArgumentException e) {
+            String message = e.getMessage() == null ? "Invalid session.update" : e.getMessage();
+            inboundSink.accept(errorEvent(message));
+        }
+    }
+
+    private static boolean isClientFunctionCallOutput(JsonNode root, String type) {
+        if ("function_call_output".equals(type)) {
+            return true;
+        }
+        if ("conversation.item.create".equals(type)) {
+            return "function_call_output".equals(root.path("item").path("type").asText());
+        }
+        return false;
+    }
+
+    private static String errorEvent(String message) {
+        ObjectNode error = OBJECT_MAPPER.createObjectNode();
+        error.put("message", message == null ? "" : message);
+        ObjectNode event = OBJECT_MAPPER.createObjectNode();
+        event.put("type", "error");
+        event.set("error", error);
+        try {
+            return OBJECT_MAPPER.writeValueAsString(event);
+        } catch (Exception e) {
+            return "{\"type\":\"error\",\"error\":{\"message\":\"error\"}}";
+        }
+    }
+
+    private static String textOrEmpty(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return "";
+        }
+        return value.asText();
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OkHttpRealtimeTransport.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OkHttpRealtimeTransport.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+import java.util.Map;
+import java.util.Objects;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+
+/**
+ * OkHttp-based {@link RealtimeTransport} for OpenAI Realtime WebSocket.
+ */
+public final class OkHttpRealtimeTransport implements RealtimeTransport {
+
+    private final OkHttpClient client;
+    private volatile WebSocket webSocket;
+
+    public OkHttpRealtimeTransport() {
+        this(new OkHttpClient());
+    }
+
+    public OkHttpRealtimeTransport(OkHttpClient client) {
+        this.client = Objects.requireNonNull(client, "client");
+    }
+
+    @Override
+    public void connect(String url, Map<String, String> headers, RealtimeTransportListener listener) {
+        Objects.requireNonNull(url, "url");
+        Objects.requireNonNull(headers, "headers");
+        Objects.requireNonNull(listener, "listener");
+
+        Request.Builder requestBuilder = new Request.Builder().url(url);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            requestBuilder.header(entry.getKey(), entry.getValue());
+        }
+
+        webSocket = client.newWebSocket(requestBuilder.build(), new WebSocketListener() {
+            @Override
+            public void onOpen(WebSocket webSocket, Response response) {
+                listener.onOpen();
+            }
+
+            @Override
+            public void onMessage(WebSocket webSocket, String text) {
+                listener.onTextMessage(text);
+            }
+
+            @Override
+            public void onClosing(WebSocket webSocket, int code, String reason) {
+                webSocket.close(code, reason);
+            }
+
+            @Override
+            public void onClosed(WebSocket webSocket, int code, String reason) {
+                listener.onClosed(code, reason);
+            }
+
+            @Override
+            public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+                listener.onFailure(t);
+            }
+        });
+    }
+
+    @Override
+    public void sendText(String message) {
+        WebSocket ws = webSocket;
+        if (ws == null) {
+            throw new IllegalStateException("not connected");
+        }
+        ws.send(message);
+    }
+
+    @Override
+    public void close() {
+        WebSocket ws = webSocket;
+        if (ws != null) {
+            ws.close(1000, "closed");
+            webSocket = null;
+        }
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OkHttpRealtimeTransport.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OkHttpRealtimeTransport.java
@@ -20,7 +20,7 @@ public final class OkHttpRealtimeTransport implements RealtimeTransport {
         this(new OkHttpClient());
     }
 
-    public OkHttpRealtimeTransport(OkHttpClient client) {
+    OkHttpRealtimeTransport(OkHttpClient client) {
         this.client = Objects.requireNonNull(client, "client");
     }
 

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSession.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSession.java
@@ -1,0 +1,183 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Outbound OpenAI Realtime WebSocket session: connect, serialized send, and inbound JSON events.
+ */
+public final class OpenAiRealtimeSession implements AutoCloseable {
+
+    private static final String DEFAULT_MODEL = "gpt-realtime-2.1";
+    private static final String DEFAULT_BASE_URL = "wss://api.openai.com/v1/realtime";
+
+    private final RealtimeTransport transport;
+    private final String apiKey;
+    private final String model;
+    private final String baseUrl;
+    private final OpenAiRealtimeSessionListener listener;
+    private final String safetyIdentifier;
+
+    private final BlockingQueue<String> outboundQueue = new LinkedBlockingQueue<>();
+    private final AtomicBoolean writerRunning = new AtomicBoolean(false);
+    private volatile Thread writerThread;
+
+    private OpenAiRealtimeSession(Builder builder) {
+        this.transport = Objects.requireNonNull(builder.transport, "transport");
+        this.apiKey = Objects.requireNonNull(builder.apiKey, "apiKey");
+        this.model = builder.model == null || builder.model.isBlank() ? DEFAULT_MODEL : builder.model;
+        this.baseUrl = builder.baseUrl;
+        this.listener = Objects.requireNonNull(builder.listener, "listener");
+        this.safetyIdentifier = builder.safetyIdentifier;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void connect() {
+        startWriter();
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Authorization", "Bearer " + apiKey);
+        if (safetyIdentifier != null && !safetyIdentifier.isBlank()) {
+            headers.put("OpenAI-Safety-Identifier", safetyIdentifier);
+        }
+        transport.connect(buildUrl(), headers, new RealtimeTransportListener() {
+            @Override
+            public void onOpen() {
+                // no-op: session readiness is connection completion
+            }
+
+            @Override
+            public void onTextMessage(String text) {
+                listener.onEvent(text);
+            }
+
+            @Override
+            public void onClosed(int code, String reason) {
+                listener.onClosed(code, reason);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                listener.onFailure(t);
+            }
+        });
+    }
+
+    /**
+     * Enqueues a client event JSON string; writes are serialized on a single writer thread.
+     */
+    public void sendEvent(String json) {
+        Objects.requireNonNull(json, "json");
+        if (!writerRunning.get()) {
+            throw new IllegalStateException("session is not connected");
+        }
+        outboundQueue.offer(json);
+    }
+
+    @Override
+    public void close() {
+        stopWriter();
+        transport.close();
+    }
+
+    private String buildUrl() {
+        if (baseUrl != null && !baseUrl.isBlank()) {
+            if (baseUrl.contains("model=")) {
+                return baseUrl;
+            }
+            String sep = baseUrl.contains("?") ? "&" : "?";
+            return baseUrl + sep + "model=" + model;
+        }
+        return DEFAULT_BASE_URL + "?model=" + model;
+    }
+
+    private void startWriter() {
+        if (!writerRunning.compareAndSet(false, true)) {
+            return;
+        }
+        Thread thread = new Thread(this::writeLoop, "openai-realtime-outbound-writer");
+        thread.setDaemon(true);
+        writerThread = thread;
+        thread.start();
+    }
+
+    private void writeLoop() {
+        try {
+            while (writerRunning.get() || !outboundQueue.isEmpty()) {
+                String message = outboundQueue.poll(100, TimeUnit.MILLISECONDS);
+                if (message != null) {
+                    transport.sendText(message);
+                } else if (!writerRunning.get()) {
+                    break;
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void stopWriter() {
+        writerRunning.set(false);
+        Thread thread = writerThread;
+        if (thread != null) {
+            thread.interrupt();
+            try {
+                thread.join(TimeUnit.SECONDS.toMillis(2));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            writerThread = null;
+        }
+    }
+
+    public static final class Builder {
+
+        private RealtimeTransport transport;
+        private String apiKey;
+        private String model = DEFAULT_MODEL;
+        private String baseUrl;
+        private OpenAiRealtimeSessionListener listener;
+        private String safetyIdentifier;
+
+        public Builder transport(RealtimeTransport transport) {
+            this.transport = transport;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder model(String model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder listener(OpenAiRealtimeSessionListener listener) {
+            this.listener = listener;
+            return this;
+        }
+
+        public Builder safetyIdentifier(String safetyIdentifier) {
+            this.safetyIdentifier = safetyIdentifier;
+            return this;
+        }
+
+        public OpenAiRealtimeSession build() {
+            return new OpenAiRealtimeSession(this);
+        }
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionListener.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionListener.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+/**
+ * Application callbacks for an {@link OpenAiRealtimeSession}.
+ */
+public interface OpenAiRealtimeSessionListener {
+
+    void onEvent(String json);
+
+    default void onClosed(int code, String reason) {}
+
+    default void onFailure(Throwable t) {}
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/RealtimeTransport.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/RealtimeTransport.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+import java.util.Map;
+
+/**
+ * Pluggable outbound WebSocket transport for OpenAI Realtime.
+ */
+public interface RealtimeTransport extends AutoCloseable {
+
+    void connect(String url, Map<String, String> headers, RealtimeTransportListener listener);
+
+    void sendText(String message);
+
+    @Override
+    void close();
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/RealtimeTransportListener.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/session/RealtimeTransportListener.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+/**
+ * Callbacks from {@link RealtimeTransport}.
+ */
+public interface RealtimeTransportListener {
+
+    void onOpen();
+
+    void onTextMessage(String text);
+
+    void onClosed(int code, String reason);
+
+    void onFailure(Throwable t);
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJson.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJson.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,6 +16,7 @@ import java.util.Objects;
  * Maps {@link ToolSpecification} to OpenAI Realtime function-tool JSON
  * (flat {@code type/name/description/parameters}, not Chat Completions nested shape).
  */
+@Internal
 public final class OpenAiRealtimeToolJson {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJson.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJson.java
@@ -1,0 +1,47 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Maps {@link ToolSpecification} to OpenAI Realtime function-tool JSON
+ * (flat {@code type/name/description/parameters}, not Chat Completions nested shape).
+ */
+public final class OpenAiRealtimeToolJson {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private OpenAiRealtimeToolJson() {}
+
+    public static ObjectNode toFunctionTool(ToolSpecification toolSpecification) {
+        Objects.requireNonNull(toolSpecification, "toolSpecification");
+
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        node.put("type", "function");
+        node.put("name", toolSpecification.name());
+        if (toolSpecification.description() != null) {
+            node.put("description", toolSpecification.description());
+        }
+        node.set("parameters", OBJECT_MAPPER.valueToTree(toOpenAiParameters(toolSpecification)));
+        return node;
+    }
+
+    private static Map<String, Object> toOpenAiParameters(ToolSpecification toolSpecification) {
+        if (toolSpecification.parameters() != null) {
+            return toMap(toolSpecification.parameters());
+        }
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("type", "object");
+        map.put("properties", new HashMap<>());
+        map.put("required", new ArrayList<>());
+        return map;
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeOutboundWriter.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeOutboundWriter.java
@@ -1,0 +1,10 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+/**
+ * Sends outbound Realtime client events (JSON) to the OpenAI WebSocket.
+ */
+@FunctionalInterface
+public interface RealtimeOutboundWriter {
+
+    void send(String json);
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoop.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoop.java
@@ -1,0 +1,153 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Server-side function-call loop: on {@code response.done} with function calls,
+ * execute tools in parallel, emit {@code function_call_output} items, then one {@code response.create}.
+ */
+public final class RealtimeToolLoop {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final RealtimeToolRegistry registry;
+    private final RealtimeOutboundWriter writer;
+    private final Executor toolExecutor;
+
+    public RealtimeToolLoop(
+            RealtimeToolRegistry registry, RealtimeOutboundWriter writer, Executor toolExecutor) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.writer = Objects.requireNonNull(writer, "writer");
+        this.toolExecutor = Objects.requireNonNull(toolExecutor, "toolExecutor");
+    }
+
+    /**
+     * @return true if handled (had function_call(s) and ran loop)
+     */
+    public boolean onServerEvent(String json) {
+        Objects.requireNonNull(json, "json");
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(json);
+            if (root == null || !root.isObject()) {
+                return false;
+            }
+            JsonNode typeNode = root.get("type");
+            if (typeNode == null || !"response.done".equals(typeNode.asText())) {
+                return false;
+            }
+            JsonNode output = root.path("response").path("output");
+            if (!output.isArray()) {
+                return false;
+            }
+
+            List<JsonNode> functionCalls = new ArrayList<>();
+            for (JsonNode item : output) {
+                if (item != null && "function_call".equals(item.path("type").asText())) {
+                    functionCalls.add(item);
+                }
+            }
+            if (functionCalls.isEmpty()) {
+                return false;
+            }
+
+            List<CompletableFuture<FunctionCallOutcome>> futures = new ArrayList<>(functionCalls.size());
+            for (JsonNode call : functionCalls) {
+                futures.add(CompletableFuture.supplyAsync(() -> executeCall(call), toolExecutor));
+            }
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+            for (CompletableFuture<FunctionCallOutcome> future : futures) {
+                FunctionCallOutcome outcome = future.join();
+                writer.send(toFunctionCallOutputEvent(outcome.callId, outcome.output));
+            }
+            writer.send("{\"type\":\"response.create\"}");
+            return true;
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to handle realtime server event", e);
+        }
+    }
+
+    private FunctionCallOutcome executeCall(JsonNode call) {
+        String callId = textOrEmpty(call, "call_id");
+        String name = textOrEmpty(call, "name");
+        String arguments = textOrNull(call, "arguments");
+        if (arguments == null) {
+            arguments = "{}";
+        }
+
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id(callId)
+                .name(name)
+                .arguments(arguments)
+                .build();
+
+        ToolExecutor executor = registry.findExecutor(name);
+        if (executor == null) {
+            return new FunctionCallOutcome(callId, "{\"error\":\"tool not found: " + name + "\"}");
+        }
+        try {
+            String result = executor.execute(request, null);
+            return new FunctionCallOutcome(callId, result == null ? "" : result);
+        } catch (Exception e) {
+            String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            return new FunctionCallOutcome(callId, "{\"error\":\"" + escapeJson(message) + "\"}");
+        }
+    }
+
+    private static String toFunctionCallOutputEvent(String callId, String output) {
+        try {
+            ObjectNode item = OBJECT_MAPPER.createObjectNode();
+            item.put("type", "function_call_output");
+            item.put("call_id", callId);
+            item.put("output", output == null ? "" : output);
+
+            ObjectNode event = OBJECT_MAPPER.createObjectNode();
+            event.put("type", "conversation.item.create");
+            event.set("item", item);
+            return OBJECT_MAPPER.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize function_call_output", e);
+        }
+    }
+
+    private static String textOrEmpty(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return "";
+        }
+        return value.asText();
+    }
+
+    private static String textOrNull(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        return value.asText();
+    }
+
+    private static String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static final class FunctionCallOutcome {
+        final String callId;
+        final String output;
+
+        FunctionCallOutcome(String callId, String output) {
+            this.callId = callId;
+            this.output = output;
+        }
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoop.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoop.java
@@ -23,8 +23,7 @@ public final class RealtimeToolLoop {
     private final RealtimeOutboundWriter writer;
     private final Executor toolExecutor;
 
-    public RealtimeToolLoop(
-            RealtimeToolRegistry registry, RealtimeOutboundWriter writer, Executor toolExecutor) {
+    public RealtimeToolLoop(RealtimeToolRegistry registry, RealtimeOutboundWriter writer, Executor toolExecutor) {
         this.registry = Objects.requireNonNull(registry, "registry");
         this.writer = Objects.requireNonNull(writer, "writer");
         this.toolExecutor = Objects.requireNonNull(toolExecutor, "toolExecutor");

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolRegistry.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolRegistry.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Registry of tools available to the Realtime gateway, keyed by tool name.
+ */
+public final class RealtimeToolRegistry {
+
+    private final Map<String, ToolSpecification> specsByName;
+    private final Map<String, ToolExecutor> executorsByName;
+
+    private RealtimeToolRegistry(
+            Map<String, ToolSpecification> specsByName, Map<String, ToolExecutor> executorsByName) {
+        this.specsByName = specsByName;
+        this.executorsByName = executorsByName;
+    }
+
+    public static RealtimeToolRegistry from(Map<ToolSpecification, ToolExecutor> tools) {
+        Objects.requireNonNull(tools, "tools");
+        Map<String, ToolSpecification> specsByName = new LinkedHashMap<>();
+        Map<String, ToolExecutor> executorsByName = new LinkedHashMap<>();
+        for (Map.Entry<ToolSpecification, ToolExecutor> entry : tools.entrySet()) {
+            ToolSpecification spec = Objects.requireNonNull(entry.getKey(), "toolSpecification");
+            ToolExecutor executor = Objects.requireNonNull(entry.getValue(), "toolExecutor");
+            String name = Objects.requireNonNull(spec.name(), "toolSpecification.name");
+            if (specsByName.containsKey(name)) {
+                throw new IllegalArgumentException("Duplicate tool name: " + name);
+            }
+            specsByName.put(name, spec);
+            executorsByName.put(name, executor);
+        }
+        return new RealtimeToolRegistry(specsByName, executorsByName);
+    }
+
+    public ToolExecutor findExecutor(String name) {
+        return executorsByName.get(name);
+    }
+
+    public ToolSpecification findSpecification(String name) {
+        return specsByName.get(name);
+    }
+
+    public List<ToolSpecification> allSpecifications() {
+        return unmodifiableList(new ArrayList<>(specsByName.values()));
+    }
+
+    public Set<String> names() {
+        return unmodifiableSet(specsByName.keySet());
+    }
+}

--- a/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/SessionUpdateToolsRewriter.java
+++ b/langchain4j-open-ai-realtime/src/main/java/dev/langchain4j/model/openai/realtime/tools/SessionUpdateToolsRewriter.java
@@ -1,0 +1,99 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Rewrites {@code session.update} tools from client name whitelist to registry schemas.
+ */
+public final class SessionUpdateToolsRewriter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final RealtimeToolRegistry registry;
+
+    public SessionUpdateToolsRewriter(RealtimeToolRegistry registry) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+    }
+
+    public String rewrite(String inboundJson) {
+        Objects.requireNonNull(inboundJson, "inboundJson");
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(inboundJson);
+            if (!root.isObject()) {
+                return inboundJson;
+            }
+            JsonNode typeNode = root.get("type");
+            if (typeNode == null || !"session.update".equals(typeNode.asText())) {
+                return inboundJson;
+            }
+
+            ObjectNode rootObject = (ObjectNode) root;
+            JsonNode sessionNode = rootObject.get("session");
+            ObjectNode session;
+            if (sessionNode != null && sessionNode.isObject()) {
+                session = (ObjectNode) sessionNode;
+            } else {
+                session = rootObject.putObject("session");
+            }
+            JsonNode toolsNode = session.get("tools");
+
+            List<ToolSpecification> specs;
+            if (toolsNode == null || toolsNode.isNull() || (toolsNode.isArray() && toolsNode.isEmpty())) {
+                specs = registry.allSpecifications();
+            } else if (!toolsNode.isArray()) {
+                throw new IllegalArgumentException("session.tools must be an array");
+            } else {
+                specs = resolveWhitelist((ArrayNode) toolsNode);
+            }
+
+            ArrayNode rewritten = OBJECT_MAPPER.createArrayNode();
+            for (ToolSpecification spec : specs) {
+                rewritten.add(OpenAiRealtimeToolJson.toFunctionTool(spec));
+            }
+            session.set("tools", rewritten);
+            return OBJECT_MAPPER.writeValueAsString(rootObject);
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to rewrite session.update tools", e);
+        }
+    }
+
+    private List<ToolSpecification> resolveWhitelist(ArrayNode toolsNode) {
+        List<ToolSpecification> specs = new ArrayList<>();
+        for (JsonNode toolNode : toolsNode) {
+            String name = extractToolName(toolNode);
+            ToolSpecification spec = registry.findSpecification(name);
+            if (spec == null) {
+                throw new IllegalArgumentException("Unknown tool name: " + name);
+            }
+            specs.add(spec);
+        }
+        return specs;
+    }
+
+    private static String extractToolName(JsonNode toolNode) {
+        if (toolNode == null || !toolNode.isObject()) {
+            throw new IllegalArgumentException("Each session.tools entry must be an object");
+        }
+        JsonNode nameNode = toolNode.get("name");
+        if (nameNode != null && !nameNode.isNull() && nameNode.isTextual()) {
+            return nameNode.asText();
+        }
+        JsonNode functionNode = toolNode.get("function");
+        if (functionNode != null && functionNode.isObject()) {
+            JsonNode nestedName = functionNode.get("name");
+            if (nestedName != null && !nestedName.isNull() && nestedName.isTextual()) {
+                return nestedName.asText();
+            }
+        }
+        throw new IllegalArgumentException("Tool entry is missing name");
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServerTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServerTest.java
@@ -175,20 +175,20 @@ class RealtimeGatewayServerTest {
 
         awaitSent(fake, 3);
         List<String> outboundCopy = new ArrayList<>(fake.sent);
-        assertThat(outboundCopy.stream().filter(s -> s.contains("function_call_output"))).hasSize(2);
+        assertThat(outboundCopy.stream().filter(s -> s.contains("function_call_output")))
+                .hasSize(2);
         assertThat(outboundCopy.stream().filter(s -> s.contains("\"type\":\"response.create\"")))
                 .hasSize(1);
 
         awaitCondition(() -> inbound.stream().anyMatch(s -> s.contains("response.done")), 5);
-        assertThat(inbound.stream()
-                        .anyMatch(s -> {
-                            try {
-                                return "response.done"
-                                        .equals(OBJECT_MAPPER.readTree(s).path("type").asText());
-                            } catch (Exception e) {
-                                return false;
-                            }
-                        }))
+        assertThat(inbound.stream().anyMatch(s -> {
+                    try {
+                        return "response.done"
+                                .equals(OBJECT_MAPPER.readTree(s).path("type").asText());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                }))
                 .isTrue();
     }
 
@@ -201,27 +201,20 @@ class RealtimeGatewayServerTest {
                         .required("city")
                         .build())
                 .build();
-        ToolSpecification ping = ToolSpecification.builder()
-                .name("ping")
-                .description("Ping")
-                .build();
+        ToolSpecification ping =
+                ToolSpecification.builder().name("ping").description("Ping").build();
         Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
         tools.put(weather, (req, mem) -> "sunny");
         tools.put(ping, (req, mem) -> "pong");
         return tools;
     }
 
-    private static WebSocketClient newClient(
-            URI uri, String apiKey, CountDownLatch open, List<String> messages) {
+    private static WebSocketClient newClient(URI uri, String apiKey, CountDownLatch open, List<String> messages) {
         return newClient(uri, apiKey, open, messages, null);
     }
 
     private static WebSocketClient newClient(
-            URI uri,
-            String apiKey,
-            CountDownLatch open,
-            List<String> messages,
-            CountDownLatch closed) {
+            URI uri, String apiKey, CountDownLatch open, List<String> messages, CountDownLatch closed) {
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put("Authorization", "Bearer " + apiKey);
         return new WebSocketClient(uri, headers) {
@@ -249,8 +242,7 @@ class RealtimeGatewayServerTest {
 
     private static String loadFixture(String name) throws Exception {
         String path = "realtime/fixtures/" + name;
-        try (InputStream in =
-                RealtimeGatewayServerTest.class.getClassLoader().getResourceAsStream(path)) {
+        try (InputStream in = RealtimeGatewayServerTest.class.getClassLoader().getResourceAsStream(path)) {
             assertThat(in).as("fixture %s", path).isNotNull();
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServerTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServerTest.java
@@ -96,6 +96,62 @@ class RealtimeGatewayServerTest {
     }
 
     @Test
+    void outboundClosed_closesInboundWebSocket() throws Exception {
+        FakeRealtimeTransport fake = new FakeRealtimeTransport();
+        gateway = OpenAiRealtimeGateway.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .tools(sampleTools())
+                .toolExecutor(Runnable::run)
+                .outboundTransportFactory(apiKey -> fake)
+                .build();
+        gateway.start();
+
+        List<String> inbound = new CopyOnWriteArrayList<>();
+        CountDownLatch open = new CountDownLatch(1);
+        CountDownLatch closed = new CountDownLatch(1);
+        client = newClient(gateway.wsUri(), "sk-test", open, inbound, closed);
+        assertThat(client.connectBlocking(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(open.await(5, TimeUnit.SECONDS)).isTrue();
+        awaitCondition(() -> fake.listener != null, 5);
+
+        fake.simulateClosed(1000, "bye");
+
+        assertThat(closed.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(inbound.stream().anyMatch(s -> s.contains("Outbound connection closed")))
+                .isTrue();
+        assertThat(client.isOpen()).isFalse();
+    }
+
+    @Test
+    void outboundFailure_closesInboundWebSocket() throws Exception {
+        FakeRealtimeTransport fake = new FakeRealtimeTransport();
+        gateway = OpenAiRealtimeGateway.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .tools(sampleTools())
+                .toolExecutor(Runnable::run)
+                .outboundTransportFactory(apiKey -> fake)
+                .build();
+        gateway.start();
+
+        List<String> inbound = new CopyOnWriteArrayList<>();
+        CountDownLatch open = new CountDownLatch(1);
+        CountDownLatch closed = new CountDownLatch(1);
+        client = newClient(gateway.wsUri(), "sk-test", open, inbound, closed);
+        assertThat(client.connectBlocking(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(open.await(5, TimeUnit.SECONDS)).isTrue();
+        awaitCondition(() -> fake.listener != null, 5);
+
+        fake.simulateFailure(new RuntimeException("boom"));
+
+        assertThat(closed.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(inbound.stream().anyMatch(s -> s.contains("Outbound connection failed")))
+                .isTrue();
+        assertThat(client.isOpen()).isFalse();
+    }
+
+    @Test
     void responseDoneWithFunctionCall_loopsAndForwardsToClient() throws Exception {
         FakeRealtimeTransport fake = new FakeRealtimeTransport();
         gateway = OpenAiRealtimeGateway.builder()
@@ -157,6 +213,15 @@ class RealtimeGatewayServerTest {
 
     private static WebSocketClient newClient(
             URI uri, String apiKey, CountDownLatch open, List<String> messages) {
+        return newClient(uri, apiKey, open, messages, null);
+    }
+
+    private static WebSocketClient newClient(
+            URI uri,
+            String apiKey,
+            CountDownLatch open,
+            List<String> messages,
+            CountDownLatch closed) {
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put("Authorization", "Bearer " + apiKey);
         return new WebSocketClient(uri, headers) {
@@ -171,7 +236,11 @@ class RealtimeGatewayServerTest {
             }
 
             @Override
-            public void onClose(int code, String reason, boolean remote) {}
+            public void onClose(int code, String reason, boolean remote) {
+                if (closed != null) {
+                    closed.countDown();
+                }
+            }
 
             @Override
             public void onError(Exception ex) {}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServerTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewayServerTest.java
@@ -1,0 +1,206 @@
+package dev.langchain4j.model.openai.realtime.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.openai.realtime.OpenAiRealtimeGateway;
+import dev.langchain4j.model.openai.realtime.session.FakeRealtimeTransport;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class RealtimeGatewayServerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private OpenAiRealtimeGateway gateway;
+    private WebSocketClient client;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) {
+            client.closeBlocking();
+            client = null;
+        }
+        if (gateway != null) {
+            gateway.stop();
+            gateway = null;
+        }
+    }
+
+    @Test
+    void connectsWithBearerAuthorization() throws Exception {
+        FakeRealtimeTransport fake = new FakeRealtimeTransport();
+        gateway = OpenAiRealtimeGateway.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .tools(sampleTools())
+                .toolExecutor(Runnable::run)
+                .outboundTransportFactory(apiKey -> fake)
+                .build();
+        gateway.start();
+
+        CountDownLatch open = new CountDownLatch(1);
+        client = newClient(gateway.wsUri(), "sk-test", open, new CopyOnWriteArrayList<>());
+        assertThat(client.connectBlocking(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(open.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(client.isOpen()).isTrue();
+
+        awaitCondition(() -> fake.listener != null, 5);
+        assertThat(fake.connectedHeaders.get("Authorization")).isEqualTo("Bearer sk-test");
+    }
+
+    @Test
+    void sessionUpdateWithoutTools_rewritesToFullRegistry() throws Exception {
+        FakeRealtimeTransport fake = new FakeRealtimeTransport();
+        gateway = OpenAiRealtimeGateway.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .tools(sampleTools())
+                .toolExecutor(Runnable::run)
+                .outboundTransportFactory(apiKey -> fake)
+                .build();
+        gateway.start();
+
+        CountDownLatch open = new CountDownLatch(1);
+        client = newClient(gateway.wsUri(), "sk-test", open, new CopyOnWriteArrayList<>());
+        assertThat(client.connectBlocking(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(open.await(5, TimeUnit.SECONDS)).isTrue();
+        awaitCondition(() -> fake.listener != null, 5);
+
+        client.send("{\"type\":\"session.update\",\"session\":{\"type\":\"realtime\"}}");
+
+        awaitSent(fake, 1);
+        JsonNode root = OBJECT_MAPPER.readTree(fake.sent.get(0));
+        assertThat(root.path("type").asText()).isEqualTo("session.update");
+        JsonNode tools = root.path("session").path("tools");
+        assertThat(tools).hasSize(2);
+        List<String> names = new ArrayList<>();
+        tools.forEach(n -> names.add(n.path("name").asText()));
+        assertThat(names).containsExactly("get_weather", "ping");
+    }
+
+    @Test
+    void responseDoneWithFunctionCall_loopsAndForwardsToClient() throws Exception {
+        FakeRealtimeTransport fake = new FakeRealtimeTransport();
+        gateway = OpenAiRealtimeGateway.builder()
+                .host("127.0.0.1")
+                .port(0)
+                .tools(sampleTools())
+                .toolExecutor(Runnable::run)
+                .outboundTransportFactory(apiKey -> fake)
+                .build();
+        gateway.start();
+
+        List<String> inbound = new CopyOnWriteArrayList<>();
+        CountDownLatch open = new CountDownLatch(1);
+        client = newClient(gateway.wsUri(), "sk-test", open, inbound);
+        assertThat(client.connectBlocking(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(open.await(5, TimeUnit.SECONDS)).isTrue();
+        awaitCondition(() -> fake.listener != null, 5);
+
+        String responseDone = loadFixture("response-done-two-function-calls.json");
+        fake.simulateText(responseDone);
+
+        awaitSent(fake, 3);
+        List<String> outboundCopy = new ArrayList<>(fake.sent);
+        assertThat(outboundCopy.stream().filter(s -> s.contains("function_call_output"))).hasSize(2);
+        assertThat(outboundCopy.stream().filter(s -> s.contains("\"type\":\"response.create\"")))
+                .hasSize(1);
+
+        awaitCondition(() -> inbound.stream().anyMatch(s -> s.contains("response.done")), 5);
+        assertThat(inbound.stream()
+                        .anyMatch(s -> {
+                            try {
+                                return "response.done"
+                                        .equals(OBJECT_MAPPER.readTree(s).path("type").asText());
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        }))
+                .isTrue();
+    }
+
+    private static Map<ToolSpecification, ToolExecutor> sampleTools() {
+        ToolSpecification weather = ToolSpecification.builder()
+                .name("get_weather")
+                .description("Get weather")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+        ToolSpecification ping = ToolSpecification.builder()
+                .name("ping")
+                .description("Ping")
+                .build();
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(weather, (req, mem) -> "sunny");
+        tools.put(ping, (req, mem) -> "pong");
+        return tools;
+    }
+
+    private static WebSocketClient newClient(
+            URI uri, String apiKey, CountDownLatch open, List<String> messages) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Authorization", "Bearer " + apiKey);
+        return new WebSocketClient(uri, headers) {
+            @Override
+            public void onOpen(ServerHandshake handshakedata) {
+                open.countDown();
+            }
+
+            @Override
+            public void onMessage(String message) {
+                messages.add(message);
+            }
+
+            @Override
+            public void onClose(int code, String reason, boolean remote) {}
+
+            @Override
+            public void onError(Exception ex) {}
+        };
+    }
+
+    private static String loadFixture(String name) throws Exception {
+        String path = "realtime/fixtures/" + name;
+        try (InputStream in =
+                RealtimeGatewayServerTest.class.getClassLoader().getResourceAsStream(path)) {
+            assertThat(in).as("fixture %s", path).isNotNull();
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void awaitSent(FakeRealtimeTransport transport, int expected) throws Exception {
+        awaitCondition(() -> transport.sent.size() >= expected, 5);
+        assertThat(transport.sent.size()).isGreaterThanOrEqualTo(expected);
+    }
+
+    private static void awaitCondition(java.util.function.BooleanSupplier condition, int seconds)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        assertThat(condition.getAsBoolean()).isTrue();
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySessionTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySessionTest.java
@@ -1,0 +1,162 @@
+package dev.langchain4j.model.openai.realtime.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.openai.realtime.session.FakeRealtimeTransport;
+import dev.langchain4j.model.openai.realtime.session.OpenAiRealtimeSession;
+import dev.langchain4j.model.openai.realtime.tools.RealtimeToolRegistry;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RealtimeGatewaySessionTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private FakeRealtimeTransport transport;
+    private OpenAiRealtimeSession outbound;
+    private RealtimeGatewaySession gateway;
+    private List<String> clientMessages;
+    private RealtimeToolRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        transport = new FakeRealtimeTransport();
+        clientMessages = new CopyOnWriteArrayList<>();
+
+        ToolSpecification weather = ToolSpecification.builder()
+                .name("get_weather")
+                .description("Get weather")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+        ToolSpecification ping = ToolSpecification.builder()
+                .name("ping")
+                .description("Ping")
+                .build();
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(weather, (req, mem) -> "sunny");
+        tools.put(ping, (req, mem) -> "pong");
+        registry = RealtimeToolRegistry.from(tools);
+
+        AtomicReference<RealtimeGatewaySession> gatewayRef = new AtomicReference<>();
+        outbound = OpenAiRealtimeSession.builder()
+                .transport(transport)
+                .apiKey("sk-test")
+                .listener(json -> gatewayRef.get().onOutboundEvent(json))
+                .build();
+        gateway = new RealtimeGatewaySession(outbound, registry, Runnable::run, clientMessages::add);
+        gatewayRef.set(gateway);
+        outbound.connect();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (gateway != null) {
+            gateway.close();
+        }
+    }
+
+    @Test
+    void sessionUpdate_rewritesToolsBeforeOutbound() throws Exception {
+        String inbound =
+                """
+                {"type":"session.update","session":{"type":"realtime","tools":[{"type":"function","name":"ping"}]}}
+                """;
+
+        gateway.onClientMessage(inbound);
+
+        awaitSent(transport, 1);
+        JsonNode root = OBJECT_MAPPER.readTree(transport.sent.get(0));
+        assertThat(root.path("type").asText()).isEqualTo("session.update");
+        JsonNode tools = root.path("session").path("tools");
+        assertThat(tools).hasSize(1);
+        assertThat(tools.get(0).path("name").asText()).isEqualTo("ping");
+        assertThat(tools.get(0).path("description").asText()).isEqualTo("Ping");
+        assertThat(clientMessages).isEmpty();
+    }
+
+    @Test
+    void sessionUpdate_unknownTool_sendsErrorAndNoOutbound() throws Exception {
+        String inbound =
+                """
+                {"type":"session.update","session":{"tools":[{"type":"function","name":"unknown_tool"}]}}
+                """;
+
+        gateway.onClientMessage(inbound);
+
+        Thread.sleep(50L);
+        assertThat(transport.sent).isEmpty();
+        assertThat(clientMessages).hasSize(1);
+        JsonNode error = OBJECT_MAPPER.readTree(clientMessages.get(0));
+        assertThat(error.path("type").asText()).isEqualTo("error");
+        assertThat(error.path("error").path("message").asText()).contains("unknown_tool");
+    }
+
+    @Test
+    void clientFunctionCallOutput_isIgnored() throws Exception {
+        String inbound =
+                """
+                {"type":"conversation.item.create","item":{"type":"function_call_output","call_id":"call_1","output":"hack"}}
+                """;
+
+        gateway.onClientMessage(inbound);
+
+        Thread.sleep(50L);
+        assertThat(transport.sent).isEmpty();
+        assertThat(clientMessages).hasSize(1);
+        JsonNode error = OBJECT_MAPPER.readTree(clientMessages.get(0));
+        assertThat(error.path("type").asText()).isEqualTo("error");
+        assertThat(error.path("error").path("message").asText()).containsIgnoringCase("function_call_output");
+    }
+
+    @Test
+    void responseDoneWithFunctionCall_runsLoopAndForwardsEvents() throws Exception {
+        String responseDone = loadFixture("response-done-two-function-calls.json");
+
+        transport.simulateText(responseDone);
+
+        awaitSent(transport, 3);
+        List<String> outboundCopy = new ArrayList<>(transport.sent);
+        assertThat(outboundCopy.stream().filter(s -> s.contains("function_call_output"))).hasSize(2);
+        assertThat(outboundCopy.stream().filter(s -> s.contains("\"type\":\"response.create\""))).hasSize(1);
+
+        assertThat(clientMessages).hasSize(1);
+        assertThat(OBJECT_MAPPER.readTree(clientMessages.get(0)).path("type").asText())
+                .isEqualTo("response.done");
+    }
+
+    private static String loadFixture(String name) throws Exception {
+        String path = "realtime/fixtures/" + name;
+        try (InputStream in =
+                RealtimeGatewaySessionTest.class.getClassLoader().getResourceAsStream(path)) {
+            assertThat(in).as("fixture %s", path).isNotNull();
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void awaitSent(FakeRealtimeTransport transport, int expected)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (transport.sent.size() < expected && System.nanoTime() < deadline) {
+            Thread.sleep(10L);
+        }
+        assertThat(transport.sent).hasSize(expected);
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySessionTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySessionTest.java
@@ -8,6 +8,7 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.openai.realtime.session.FakeRealtimeTransport;
 import dev.langchain4j.model.openai.realtime.session.OpenAiRealtimeSession;
+import dev.langchain4j.model.openai.realtime.session.OpenAiRealtimeSessionListener;
 import dev.langchain4j.model.openai.realtime.tools.RealtimeToolRegistry;
 import dev.langchain4j.service.tool.ToolExecutor;
 import java.io.InputStream;
@@ -59,7 +60,22 @@ class RealtimeGatewaySessionTest {
         outbound = OpenAiRealtimeSession.builder()
                 .transport(transport)
                 .apiKey("sk-test")
-                .listener(json -> gatewayRef.get().onOutboundEvent(json))
+                .listener(new OpenAiRealtimeSessionListener() {
+                    @Override
+                    public void onEvent(String json) {
+                        gatewayRef.get().onOutboundEvent(json);
+                    }
+
+                    @Override
+                    public void onClosed(int code, String reason) {
+                        gatewayRef.get().onOutboundClosed(code, reason);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        gatewayRef.get().onOutboundFailure(t);
+                    }
+                })
                 .build();
         gateway = new RealtimeGatewaySession(outbound, registry, Runnable::run, clientMessages::add);
         gatewayRef.set(gateway);
@@ -140,6 +156,36 @@ class RealtimeGatewaySessionTest {
         assertThat(clientMessages).hasSize(1);
         assertThat(OBJECT_MAPPER.readTree(clientMessages.get(0)).path("type").asText())
                 .isEqualTo("response.done");
+    }
+
+    @Test
+    void onOutboundFailure_sendsErrorAndCloses() throws Exception {
+        gateway.onOutboundFailure(new RuntimeException("upstream boom"));
+
+        assertThat(clientMessages).hasSize(1);
+        JsonNode error = OBJECT_MAPPER.readTree(clientMessages.get(0));
+        assertThat(error.path("type").asText()).isEqualTo("error");
+        assertThat(error.path("error").path("message").asText()).contains("upstream boom");
+        assertThat(transport.closed).isTrue();
+
+        gateway.onOutboundFailure(new RuntimeException("again"));
+        assertThat(clientMessages).hasSize(1);
+    }
+
+    @Test
+    void onOutboundClosed_sendsErrorAndCloses() throws Exception {
+        gateway.onOutboundClosed(1006, "abnormal closure");
+
+        assertThat(clientMessages).hasSize(1);
+        JsonNode error = OBJECT_MAPPER.readTree(clientMessages.get(0));
+        assertThat(error.path("type").asText()).isEqualTo("error");
+        assertThat(error.path("error").path("message").asText())
+                .contains("1006")
+                .contains("abnormal closure");
+        assertThat(transport.closed).isTrue();
+
+        gateway.onOutboundClosed(1000, "ok");
+        assertThat(clientMessages).hasSize(1);
     }
 
     private static String loadFixture(String name) throws Exception {

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySessionTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/gateway/RealtimeGatewaySessionTest.java
@@ -47,10 +47,8 @@ class RealtimeGatewaySessionTest {
                         .required("city")
                         .build())
                 .build();
-        ToolSpecification ping = ToolSpecification.builder()
-                .name("ping")
-                .description("Ping")
-                .build();
+        ToolSpecification ping =
+                ToolSpecification.builder().name("ping").description("Ping").build();
         Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
         tools.put(weather, (req, mem) -> "sunny");
         tools.put(ping, (req, mem) -> "pong");
@@ -91,8 +89,7 @@ class RealtimeGatewaySessionTest {
 
     @Test
     void sessionUpdate_rewritesToolsBeforeOutbound() throws Exception {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"session.update","session":{"type":"realtime","tools":[{"type":"function","name":"ping"}]}}
                 """;
 
@@ -110,8 +107,7 @@ class RealtimeGatewaySessionTest {
 
     @Test
     void sessionUpdate_unknownTool_sendsErrorAndNoOutbound() throws Exception {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"session.update","session":{"tools":[{"type":"function","name":"unknown_tool"}]}}
                 """;
 
@@ -127,8 +123,7 @@ class RealtimeGatewaySessionTest {
 
     @Test
     void clientFunctionCallOutput_isIgnored() throws Exception {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"conversation.item.create","item":{"type":"function_call_output","call_id":"call_1","output":"hack"}}
                 """;
 
@@ -150,8 +145,10 @@ class RealtimeGatewaySessionTest {
 
         awaitSent(transport, 3);
         List<String> outboundCopy = new ArrayList<>(transport.sent);
-        assertThat(outboundCopy.stream().filter(s -> s.contains("function_call_output"))).hasSize(2);
-        assertThat(outboundCopy.stream().filter(s -> s.contains("\"type\":\"response.create\""))).hasSize(1);
+        assertThat(outboundCopy.stream().filter(s -> s.contains("function_call_output")))
+                .hasSize(2);
+        assertThat(outboundCopy.stream().filter(s -> s.contains("\"type\":\"response.create\"")))
+                .hasSize(1);
 
         assertThat(clientMessages).hasSize(1);
         assertThat(OBJECT_MAPPER.readTree(clientMessages.get(0)).path("type").asText())
@@ -190,15 +187,13 @@ class RealtimeGatewaySessionTest {
 
     private static String loadFixture(String name) throws Exception {
         String path = "realtime/fixtures/" + name;
-        try (InputStream in =
-                RealtimeGatewaySessionTest.class.getClassLoader().getResourceAsStream(path)) {
+        try (InputStream in = RealtimeGatewaySessionTest.class.getClassLoader().getResourceAsStream(path)) {
             assertThat(in).as("fixture %s", path).isNotNull();
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 
-    private static void awaitSent(FakeRealtimeTransport transport, int expected)
-            throws InterruptedException {
+    private static void awaitSent(FakeRealtimeTransport transport, int expected) throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
         while (transport.sent.size() < expected && System.nanoTime() < deadline) {
             Thread.sleep(10L);

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/FakeRealtimeTransport.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/FakeRealtimeTransport.java
@@ -1,0 +1,45 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory {@link RealtimeTransport} for unit tests.
+ */
+public final class FakeRealtimeTransport implements RealtimeTransport {
+
+    public final List<String> sent = Collections.synchronizedList(new ArrayList<>());
+
+    public volatile String connectedUrl;
+    public volatile Map<String, String> connectedHeaders;
+    public volatile RealtimeTransportListener listener;
+    public volatile boolean closed;
+
+    @Override
+    public void connect(String url, Map<String, String> headers, RealtimeTransportListener listener) {
+        this.connectedUrl = url;
+        this.connectedHeaders = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
+        this.listener = listener;
+        listener.onOpen();
+    }
+
+    @Override
+    public void sendText(String message) {
+        sent.add(message);
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    public void simulateText(String text) {
+        if (listener == null) {
+            throw new IllegalStateException("not connected");
+        }
+        listener.onTextMessage(text);
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/FakeRealtimeTransport.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/FakeRealtimeTransport.java
@@ -42,4 +42,18 @@ public final class FakeRealtimeTransport implements RealtimeTransport {
         }
         listener.onTextMessage(text);
     }
+
+    public void simulateClosed(int code, String reason) {
+        if (listener == null) {
+            throw new IllegalStateException("not connected");
+        }
+        listener.onClosed(code, reason);
+    }
+
+    public void simulateFailure(Throwable t) {
+        if (listener == null) {
+            throw new IllegalStateException("not connected");
+        }
+        listener.onFailure(t);
+    }
 }

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionIT.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionIT.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Short live session against OpenAI Realtime. Skipped when {@code OPENAI_API_KEY} is unset.
+ */
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiRealtimeSessionIT {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void connects_and_receivesSessionCreated_thenSessionUpdated() throws Exception {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        CountDownLatch sessionCreated = new CountDownLatch(1);
+        CountDownLatch sessionUpdated = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CopyOnWriteArrayList<String> events = new CopyOnWriteArrayList<>();
+
+        OpenAiRealtimeSession session = OpenAiRealtimeSession.builder()
+                .transport(new OkHttpRealtimeTransport())
+                .apiKey(apiKey)
+                .listener(new OpenAiRealtimeSessionListener() {
+                    @Override
+                    public void onEvent(String json) {
+                        events.add(json);
+                        try {
+                            String type = OBJECT_MAPPER.readTree(json).path("type").asText();
+                            if ("session.created".equals(type)) {
+                                sessionCreated.countDown();
+                            } else if ("session.updated".equals(type)) {
+                                sessionUpdated.countDown();
+                            }
+                        } catch (Exception ignored) {
+                            // keep collecting raw events
+                        }
+                    }
+
+                    @Override
+                    public void onClosed(int code, String reason) {
+                        // no-op
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        failure.set(t);
+                        sessionCreated.countDown();
+                        sessionUpdated.countDown();
+                    }
+                })
+                .build();
+
+        try {
+            session.connect();
+            assertThat(sessionCreated.await(30, TimeUnit.SECONDS))
+                    .as("session.created; failure=%s events=%s", failure.get(), events)
+                    .isTrue();
+            assertThat(failure.get()).isNull();
+
+            session.sendEvent("{\"type\":\"session.update\",\"session\":{\"type\":\"realtime\","
+                    + "\"instructions\":\"Say hi in one short sentence.\"}}");
+
+            assertThat(sessionUpdated.await(30, TimeUnit.SECONDS))
+                    .as("session.updated; failure=%s events=%s", failure.get(), events)
+                    .isTrue();
+            assertThat(failure.get()).isNull();
+
+            boolean sawUpdated = events.stream().anyMatch(e -> {
+                try {
+                    JsonNode root = OBJECT_MAPPER.readTree(e);
+                    return "session.updated".equals(root.path("type").asText());
+                } catch (Exception ex) {
+                    return false;
+                }
+            });
+            assertThat(sawUpdated).isTrue();
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionIT.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionIT.java
@@ -35,7 +35,8 @@ class OpenAiRealtimeSessionIT {
                     public void onEvent(String json) {
                         events.add(json);
                         try {
-                            String type = OBJECT_MAPPER.readTree(json).path("type").asText();
+                            String type =
+                                    OBJECT_MAPPER.readTree(json).path("type").asText();
                             if ("session.created".equals(type)) {
                                 sessionCreated.countDown();
                             } else if ("session.updated".equals(type)) {

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionTest.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.model.openai.realtime.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class OpenAiRealtimeSessionTest {
+
+    private OpenAiRealtimeSession session;
+
+    @AfterEach
+    void tearDown() {
+        if (session != null) {
+            session.close();
+        }
+    }
+
+    @Test
+    void connect_setsAuthorizationHeader() {
+        FakeRealtimeTransport transport = new FakeRealtimeTransport();
+        session = OpenAiRealtimeSession.builder()
+                .transport(transport)
+                .apiKey("sk-test")
+                .model("gpt-realtime-2.1")
+                .listener(json -> {})
+                .safetyIdentifier("safety-1")
+                .build();
+
+        session.connect();
+
+        assertThat(transport.connectedUrl)
+                .isEqualTo("wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1");
+        assertThat(transport.connectedHeaders)
+                .containsEntry("Authorization", "Bearer sk-test")
+                .containsEntry("OpenAI-Safety-Identifier", "safety-1");
+    }
+
+    @Test
+    void sendEvent_isSerializedOnSingleWriter() throws Exception {
+        FakeRealtimeTransport transport = new FakeRealtimeTransport();
+        session = OpenAiRealtimeSession.builder()
+                .transport(transport)
+                .apiKey("sk-test")
+                .model("gpt-realtime-2.1")
+                .listener(json -> {})
+                .build();
+        session.connect();
+
+        String event1 = "{\"type\":\"session.update\",\"session\":{\"type\":\"realtime\"}}";
+        String event2 = "{\"type\":\"response.create\"}";
+        String event3 = "{\"type\":\"input_audio_buffer.commit\"}";
+        session.sendEvent(event1);
+        session.sendEvent(event2);
+        session.sendEvent(event3);
+
+        awaitSent(transport, 3);
+        assertThat(transport.sent).containsExactly(event1, event2, event3);
+    }
+
+    @Test
+    void inboundServerMessage_notifiesListener() {
+        FakeRealtimeTransport transport = new FakeRealtimeTransport();
+        List<String> events = new CopyOnWriteArrayList<>();
+        session = OpenAiRealtimeSession.builder()
+                .transport(transport)
+                .apiKey("sk-test")
+                .model("gpt-realtime-2.1")
+                .listener(events::add)
+                .build();
+        session.connect();
+
+        String json = "{\"type\":\"session.created\"}";
+        transport.simulateText(json);
+
+        assertThat(events).containsExactly(json);
+    }
+
+    private static void awaitSent(FakeRealtimeTransport transport, int expected) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (transport.sent.size() < expected && System.nanoTime() < deadline) {
+            Thread.sleep(10L);
+        }
+        assertThat(transport.sent).hasSize(expected);
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/session/OpenAiRealtimeSessionTest.java
@@ -32,8 +32,7 @@ class OpenAiRealtimeSessionTest {
 
         session.connect();
 
-        assertThat(transport.connectedUrl)
-                .isEqualTo("wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1");
+        assertThat(transport.connectedUrl).isEqualTo("wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1");
         assertThat(transport.connectedHeaders)
                 .containsEntry("Authorization", "Bearer sk-test")
                 .containsEntry("OpenAI-Safety-Identifier", "safety-1");

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJsonTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJsonTest.java
@@ -1,0 +1,50 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import org.junit.jupiter.api.Test;
+
+class OpenAiRealtimeToolJsonTest {
+
+    @Test
+    void toFunctionTool_mapsNameDescriptionParameters() {
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("get_weather")
+                .description("Get weather")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+
+        ObjectNode node = OpenAiRealtimeToolJson.toFunctionTool(spec);
+
+        assertThat(node.get("type").asText()).isEqualTo("function");
+        assertThat(node.get("name").asText()).isEqualTo("get_weather");
+        assertThat(node.get("description").asText()).isEqualTo("Get weather");
+        assertThat(node.get("parameters").get("type").asText()).isEqualTo("object");
+        assertThat(node.get("parameters").get("properties").get("city").get("type").asText())
+                .isEqualTo("string");
+        assertThat(node.get("parameters").get("required").get(0).asText()).isEqualTo("city");
+        // Realtime shape is flat — not Chat Completions nested function{}
+        assertThat(node.has("function")).isFalse();
+    }
+
+    @Test
+    void toFunctionTool_nullParameters_usesEmptyObjectSchema() {
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("ping")
+                .description("Ping")
+                .build();
+
+        ObjectNode node = OpenAiRealtimeToolJson.toFunctionTool(spec);
+
+        assertThat(node.get("type").asText()).isEqualTo("function");
+        assertThat(node.get("name").asText()).isEqualTo("ping");
+        assertThat(node.get("parameters").get("type").asText()).isEqualTo("object");
+        assertThat(node.get("parameters").get("properties").isEmpty()).isTrue();
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJsonTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/OpenAiRealtimeToolJsonTest.java
@@ -26,7 +26,11 @@ class OpenAiRealtimeToolJsonTest {
         assertThat(node.get("name").asText()).isEqualTo("get_weather");
         assertThat(node.get("description").asText()).isEqualTo("Get weather");
         assertThat(node.get("parameters").get("type").asText()).isEqualTo("object");
-        assertThat(node.get("parameters").get("properties").get("city").get("type").asText())
+        assertThat(node.get("parameters")
+                        .get("properties")
+                        .get("city")
+                        .get("type")
+                        .asText())
                 .isEqualTo("string");
         assertThat(node.get("parameters").get("required").get(0).asText()).isEqualTo("city");
         // Realtime shape is flat — not Chat Completions nested function{}
@@ -35,10 +39,8 @@ class OpenAiRealtimeToolJsonTest {
 
     @Test
     void toFunctionTool_nullParameters_usesEmptyObjectSchema() {
-        ToolSpecification spec = ToolSpecification.builder()
-                .name("ping")
-                .description("Ping")
-                .build();
+        ToolSpecification spec =
+                ToolSpecification.builder().name("ping").description("Ping").build();
 
         ObjectNode node = OpenAiRealtimeToolJson.toFunctionTool(spec);
 

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoopTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoopTest.java
@@ -24,10 +24,8 @@ class RealtimeToolLoopTest {
             .name("get_weather")
             .description("weather")
             .build();
-    private final ToolSpecification pingSpec = ToolSpecification.builder()
-            .name("ping")
-            .description("ping")
-            .build();
+    private final ToolSpecification pingSpec =
+            ToolSpecification.builder().name("ping").description("ping").build();
 
     @Test
     void parallelFunctionCalls_emitOutputsThenSingleResponseCreate() throws Exception {
@@ -41,8 +39,10 @@ class RealtimeToolLoopTest {
         boolean handled = loop.onServerEvent(loadFixture("response-done-two-function-calls.json"));
 
         assertThat(handled).isTrue();
-        assertThat(sent.stream().filter(s -> s.contains("function_call_output"))).hasSize(2);
-        assertThat(sent.stream().filter(s -> s.contains("\"type\":\"response.create\""))).hasSize(1);
+        assertThat(sent.stream().filter(s -> s.contains("function_call_output")))
+                .hasSize(2);
+        assertThat(sent.stream().filter(s -> s.contains("\"type\":\"response.create\"")))
+                .hasSize(1);
 
         JsonNode weatherOut = findOutputByCallId(sent, "call_weather");
         assertThat(weatherOut.path("item").path("output").asText()).isEqualTo("sunny");
@@ -68,11 +68,9 @@ class RealtimeToolLoopTest {
         };
         Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
         tools.put(weatherSpec, boom);
-        RealtimeToolLoop loop =
-                new RealtimeToolLoop(RealtimeToolRegistry.from(tools), sent::add, Runnable::run);
+        RealtimeToolLoop loop = new RealtimeToolLoop(RealtimeToolRegistry.from(tools), sent::add, Runnable::run);
 
-        String event =
-                """
+        String event = """
                 {"type":"response.done","response":{"id":"resp_1","output":[{"type":"function_call","name":"get_weather","arguments":"{}","call_id":"call_boom"}]}}
                 """;
         boolean handled = loop.onServerEvent(event);
@@ -90,11 +88,9 @@ class RealtimeToolLoopTest {
     @Test
     void hallucinatedToolName_emitsErrorOutput() throws Exception {
         List<String> sent = Collections.synchronizedList(new ArrayList<>());
-        RealtimeToolLoop loop =
-                new RealtimeToolLoop(RealtimeToolRegistry.from(Map.of()), sent::add, Runnable::run);
+        RealtimeToolLoop loop = new RealtimeToolLoop(RealtimeToolRegistry.from(Map.of()), sent::add, Runnable::run);
 
-        String event =
-                """
+        String event = """
                 {"type":"response.done","response":{"id":"resp_1","output":[{"type":"function_call","name":"no_such_tool","arguments":"{}","call_id":"call_missing"}]}}
                 """;
         boolean handled = loop.onServerEvent(event);
@@ -110,11 +106,9 @@ class RealtimeToolLoopTest {
     @Test
     void responseDoneWithoutFunctionCall_returnsFalse() {
         List<String> sent = Collections.synchronizedList(new ArrayList<>());
-        RealtimeToolLoop loop =
-                new RealtimeToolLoop(RealtimeToolRegistry.from(Map.of()), sent::add, Runnable::run);
+        RealtimeToolLoop loop = new RealtimeToolLoop(RealtimeToolRegistry.from(Map.of()), sent::add, Runnable::run);
 
-        String event =
-                """
+        String event = """
                 {"type":"response.done","response":{"id":"resp_1","output":[{"type":"message","role":"assistant"}]}}
                 """;
         boolean handled = loop.onServerEvent(event);

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoopTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolLoopTest.java
@@ -1,0 +1,144 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class RealtimeToolLoopTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ToolSpecification weatherSpec = ToolSpecification.builder()
+            .name("get_weather")
+            .description("weather")
+            .build();
+    private final ToolSpecification pingSpec = ToolSpecification.builder()
+            .name("ping")
+            .description("ping")
+            .build();
+
+    @Test
+    void parallelFunctionCalls_emitOutputsThenSingleResponseCreate() throws Exception {
+        List<String> sent = Collections.synchronizedList(new ArrayList<>());
+        RealtimeOutboundWriter writer = sent::add;
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(weatherSpec, (r, m) -> "sunny");
+        tools.put(pingSpec, (r, m) -> "pong");
+        RealtimeToolLoop loop = new RealtimeToolLoop(RealtimeToolRegistry.from(tools), writer, Runnable::run);
+
+        boolean handled = loop.onServerEvent(loadFixture("response-done-two-function-calls.json"));
+
+        assertThat(handled).isTrue();
+        assertThat(sent.stream().filter(s -> s.contains("function_call_output"))).hasSize(2);
+        assertThat(sent.stream().filter(s -> s.contains("\"type\":\"response.create\""))).hasSize(1);
+
+        JsonNode weatherOut = findOutputByCallId(sent, "call_weather");
+        assertThat(weatherOut.path("item").path("output").asText()).isEqualTo("sunny");
+        JsonNode pingOut = findOutputByCallId(sent, "call_ping");
+        assertThat(pingOut.path("item").path("output").asText()).isEqualTo("pong");
+
+        int lastOutputIdx = IntStream.range(0, sent.size())
+                .filter(i -> sent.get(i).contains("function_call_output"))
+                .max()
+                .orElseThrow();
+        int responseCreateIdx = IntStream.range(0, sent.size())
+                .filter(i -> sent.get(i).contains("\"type\":\"response.create\""))
+                .findFirst()
+                .orElseThrow();
+        assertThat(responseCreateIdx).isGreaterThan(lastOutputIdx);
+    }
+
+    @Test
+    void executorException_stillEmitsOutputAndResponseCreate() throws Exception {
+        List<String> sent = Collections.synchronizedList(new ArrayList<>());
+        ToolExecutor boom = (r, m) -> {
+            throw new RuntimeException("fail");
+        };
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(weatherSpec, boom);
+        RealtimeToolLoop loop =
+                new RealtimeToolLoop(RealtimeToolRegistry.from(tools), sent::add, Runnable::run);
+
+        String event =
+                """
+                {"type":"response.done","response":{"id":"resp_1","output":[{"type":"function_call","name":"get_weather","arguments":"{}","call_id":"call_boom"}]}}
+                """;
+        boolean handled = loop.onServerEvent(event);
+
+        assertThat(handled).isTrue();
+        assertThat(sent).hasSize(2);
+        JsonNode outputEvent = OBJECT_MAPPER.readTree(sent.get(0));
+        assertThat(outputEvent.path("type").asText()).isEqualTo("conversation.item.create");
+        assertThat(outputEvent.path("item").path("type").asText()).isEqualTo("function_call_output");
+        assertThat(outputEvent.path("item").path("call_id").asText()).isEqualTo("call_boom");
+        assertThat(outputEvent.path("item").path("output").asText()).contains("fail");
+        assertThat(OBJECT_MAPPER.readTree(sent.get(1)).path("type").asText()).isEqualTo("response.create");
+    }
+
+    @Test
+    void hallucinatedToolName_emitsErrorOutput() throws Exception {
+        List<String> sent = Collections.synchronizedList(new ArrayList<>());
+        RealtimeToolLoop loop =
+                new RealtimeToolLoop(RealtimeToolRegistry.from(Map.of()), sent::add, Runnable::run);
+
+        String event =
+                """
+                {"type":"response.done","response":{"id":"resp_1","output":[{"type":"function_call","name":"no_such_tool","arguments":"{}","call_id":"call_missing"}]}}
+                """;
+        boolean handled = loop.onServerEvent(event);
+
+        assertThat(handled).isTrue();
+        assertThat(sent).hasSize(2);
+        JsonNode outputEvent = OBJECT_MAPPER.readTree(sent.get(0));
+        assertThat(outputEvent.path("item").path("call_id").asText()).isEqualTo("call_missing");
+        assertThat(outputEvent.path("item").path("output").asText()).contains("no_such_tool");
+        assertThat(OBJECT_MAPPER.readTree(sent.get(1)).path("type").asText()).isEqualTo("response.create");
+    }
+
+    @Test
+    void responseDoneWithoutFunctionCall_returnsFalse() {
+        List<String> sent = Collections.synchronizedList(new ArrayList<>());
+        RealtimeToolLoop loop =
+                new RealtimeToolLoop(RealtimeToolRegistry.from(Map.of()), sent::add, Runnable::run);
+
+        String event =
+                """
+                {"type":"response.done","response":{"id":"resp_1","output":[{"type":"message","role":"assistant"}]}}
+                """;
+        boolean handled = loop.onServerEvent(event);
+
+        assertThat(handled).isFalse();
+        assertThat(sent).isEmpty();
+    }
+
+    private static String loadFixture(String name) throws Exception {
+        String path = "realtime/fixtures/" + name;
+        try (InputStream in = RealtimeToolLoopTest.class.getClassLoader().getResourceAsStream(path)) {
+            assertThat(in).as("fixture %s", path).isNotNull();
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static JsonNode findOutputByCallId(List<String> sent, String callId) throws Exception {
+        for (String json : sent) {
+            JsonNode node = OBJECT_MAPPER.readTree(json);
+            if ("function_call_output".equals(node.path("item").path("type").asText())
+                    && callId.equals(node.path("item").path("call_id").asText())) {
+                return node;
+            }
+        }
+        throw new AssertionError("No function_call_output for call_id=" + callId);
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolRegistryTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/RealtimeToolRegistryTest.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RealtimeToolRegistryTest {
+
+    @Test
+    void lookupByName_returnsExecutorAndSpecification() {
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("get_weather")
+                .description("weather")
+                .build();
+        ToolExecutor executor = (req, mem) -> "sunny";
+
+        RealtimeToolRegistry registry = RealtimeToolRegistry.from(Map.of(spec, executor));
+
+        assertThat(registry.findExecutor("get_weather")).isSameAs(executor);
+        assertThat(registry.findSpecification("get_weather")).isEqualTo(spec);
+        assertThat(registry.allSpecifications()).containsExactly(spec);
+        assertThat(registry.names()).containsExactly("get_weather");
+    }
+
+    @Test
+    void unknownName_returnsNull() {
+        RealtimeToolRegistry registry = RealtimeToolRegistry.from(Map.of());
+
+        assertThat(registry.findExecutor("nope")).isNull();
+        assertThat(registry.findSpecification("nope")).isNull();
+    }
+
+    @Test
+    void duplicateName_isRejected() {
+        ToolSpecification first = ToolSpecification.builder()
+                .name("get_weather")
+                .description("first")
+                .build();
+        ToolSpecification second = ToolSpecification.builder()
+                .name("get_weather")
+                .description("second")
+                .build();
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(first, (req, mem) -> "a");
+        tools.put(second, (req, mem) -> "b");
+
+        assertThatThrownBy(() -> RealtimeToolRegistry.from(tools))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("get_weather");
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/SessionUpdateToolsRewriterTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/SessionUpdateToolsRewriterTest.java
@@ -1,0 +1,125 @@
+package dev.langchain4j.model.openai.realtime.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SessionUpdateToolsRewriterTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private SessionUpdateToolsRewriter rewriter;
+
+    @BeforeEach
+    void setUp() {
+        ToolSpecification weather = ToolSpecification.builder()
+                .name("get_weather")
+                .description("Get weather")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+        ToolSpecification ping = ToolSpecification.builder()
+                .name("ping")
+                .description("Ping")
+                .build();
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(weather, (req, mem) -> "sunny");
+        tools.put(ping, (req, mem) -> "pong");
+        rewriter = new SessionUpdateToolsRewriter(RealtimeToolRegistry.from(tools));
+    }
+
+    @Test
+    void omitTools_usesFullRegistry() throws Exception {
+        String inbound =
+                """
+                {"type":"session.update","session":{"type":"realtime","instructions":"hi"}}
+                """;
+
+        String outbound = rewriter.rewrite(inbound);
+
+        JsonNode root = OBJECT_MAPPER.readTree(outbound);
+        assertThat(root.get("type").asText()).isEqualTo("session.update");
+        assertThat(root.path("session").path("instructions").asText()).isEqualTo("hi");
+        assertThat(root.path("session").path("type").asText()).isEqualTo("realtime");
+        JsonNode tools = root.path("session").path("tools");
+        assertThat(tools).hasSize(2);
+        assertThat(tools.get(0).get("name").asText()).isEqualTo("get_weather");
+        assertThat(tools.get(1).get("name").asText()).isEqualTo("ping");
+        assertThat(tools.get(0).get("parameters").get("properties").has("city")).isTrue();
+    }
+
+    @Test
+    void emptyToolsArray_usesFullRegistry() throws Exception {
+        String inbound =
+                """
+                {"type":"session.update","session":{"tools":[]}}
+                """;
+
+        String outbound = rewriter.rewrite(inbound);
+
+        assertThat(OBJECT_MAPPER.readTree(outbound).path("session").path("tools")).hasSize(2);
+    }
+
+    @Test
+    void whitelist_filtersByName() throws Exception {
+        String inbound =
+                """
+                {"type":"session.update","session":{"type":"realtime","tools":[{"type":"function","name":"ping"}]}}
+                """;
+
+        String outbound = rewriter.rewrite(inbound);
+
+        JsonNode tools = OBJECT_MAPPER.readTree(outbound).path("session").path("tools");
+        assertThat(tools).hasSize(1);
+        assertThat(tools.get(0).get("name").asText()).isEqualTo("ping");
+        assertThat(tools.get(0).get("description").asText()).isEqualTo("Ping");
+    }
+
+    @Test
+    void whitelist_supportsNestedFunctionName() throws Exception {
+        String inbound =
+                """
+                {"type":"session.update","session":{"tools":[{"type":"function","function":{"name":"get_weather"}}]}}
+                """;
+
+        String outbound = rewriter.rewrite(inbound);
+
+        JsonNode tools = OBJECT_MAPPER.readTree(outbound).path("session").path("tools");
+        assertThat(tools).hasSize(1);
+        assertThat(tools.get(0).get("name").asText()).isEqualTo("get_weather");
+        assertThat(tools.get(0).has("function")).isFalse();
+    }
+
+    @Test
+    void unknownName_throws() {
+        String inbound =
+                """
+                {"type":"session.update","session":{"tools":[{"type":"function","name":"unknown_tool"}]}}
+                """;
+
+        assertThatThrownBy(() -> rewriter.rewrite(inbound))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown_tool");
+    }
+
+    @Test
+    void nonSessionUpdate_returnsUnchanged() {
+        String inbound =
+                """
+                {"type":"response.create","response":{}}
+                """;
+
+        assertThat(rewriter.rewrite(inbound)).isEqualTo(inbound);
+    }
+}

--- a/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/SessionUpdateToolsRewriterTest.java
+++ b/langchain4j-open-ai-realtime/src/test/java/dev/langchain4j/model/openai/realtime/tools/SessionUpdateToolsRewriterTest.java
@@ -29,10 +29,8 @@ class SessionUpdateToolsRewriterTest {
                         .required("city")
                         .build())
                 .build();
-        ToolSpecification ping = ToolSpecification.builder()
-                .name("ping")
-                .description("Ping")
-                .build();
+        ToolSpecification ping =
+                ToolSpecification.builder().name("ping").description("Ping").build();
         Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
         tools.put(weather, (req, mem) -> "sunny");
         tools.put(ping, (req, mem) -> "pong");
@@ -41,8 +39,7 @@ class SessionUpdateToolsRewriterTest {
 
     @Test
     void omitTools_usesFullRegistry() throws Exception {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"session.update","session":{"type":"realtime","instructions":"hi"}}
                 """;
 
@@ -61,20 +58,19 @@ class SessionUpdateToolsRewriterTest {
 
     @Test
     void emptyToolsArray_usesFullRegistry() throws Exception {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"session.update","session":{"tools":[]}}
                 """;
 
         String outbound = rewriter.rewrite(inbound);
 
-        assertThat(OBJECT_MAPPER.readTree(outbound).path("session").path("tools")).hasSize(2);
+        assertThat(OBJECT_MAPPER.readTree(outbound).path("session").path("tools"))
+                .hasSize(2);
     }
 
     @Test
     void whitelist_filtersByName() throws Exception {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"session.update","session":{"type":"realtime","tools":[{"type":"function","name":"ping"}]}}
                 """;
 
@@ -88,8 +84,7 @@ class SessionUpdateToolsRewriterTest {
 
     @Test
     void whitelist_supportsNestedFunctionName() throws Exception {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"session.update","session":{"tools":[{"type":"function","function":{"name":"get_weather"}}]}}
                 """;
 
@@ -103,8 +98,7 @@ class SessionUpdateToolsRewriterTest {
 
     @Test
     void unknownName_throws() {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"session.update","session":{"tools":[{"type":"function","name":"unknown_tool"}]}}
                 """;
 
@@ -115,8 +109,7 @@ class SessionUpdateToolsRewriterTest {
 
     @Test
     void nonSessionUpdate_returnsUnchanged() {
-        String inbound =
-                """
+        String inbound = """
                 {"type":"response.create","response":{}}
                 """;
 

--- a/langchain4j-open-ai-realtime/src/test/resources/realtime/fixtures/response-done-two-function-calls.json
+++ b/langchain4j-open-ai-realtime/src/test/resources/realtime/fixtures/response-done-two-function-calls.json
@@ -1,0 +1,22 @@
+{
+  "type": "response.done",
+  "event_id": "event_1",
+  "response": {
+    "id": "resp_1",
+    "status": "completed",
+    "output": [
+      {
+        "type": "function_call",
+        "name": "get_weather",
+        "arguments": "{\"city\":\"SF\"}",
+        "call_id": "call_weather"
+      },
+      {
+        "type": "function_call",
+        "name": "ping",
+        "arguments": "{}",
+        "call_id": "call_ping"
+      }
+    ]
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <module>langchain4j-ovh-ai</module>
         <module>langchain4j-open-ai</module>
         <module>langchain4j-open-ai-official</module>
+        <module>langchain4j-open-ai-realtime</module>
         <module>langchain4j-google-ai-gemini</module>
         <module>langchain4j-google-genai</module>
         <module>langchain4j-vertex-ai</module>


### PR DESCRIPTION
## Summary
- Add experimental module `langchain4j-open-ai-realtime`: inbound OpenAI-like Realtime WebSocket gateway + outbound Realtime session (server WebSocket).
- Server-side tools loop using langchain4j `ToolSpecification` + `ToolExecutor` (app-registered pairs are authoritative; client may omit `tools` to enable all).
- Design/plan docs under `docs/superpowers/`; README documents differences vs raw OpenAI Realtime clients.

Related to #5810 — this PR addresses the **OpenAI Realtime voice-to-voice path** (audio in/out via gateway), not a cross-provider `SpeechToSpeechModel` / `AudioChatModel` abstraction.

## Test plan
- [x] `mvnw -pl langchain4j-open-ai-realtime -Denforcer.skip=true test` (29 unit tests)
- [x] `mvnw -pl langchain4j-open-ai-realtime -Denforcer.skip=true verify` (incl. revapi)
- [ ] Optional live IT with `OPENAI_API_KEY` set (`OpenAiRealtimeSessionIT`)
- [ ] Manual: start `OpenAiRealtimeGateway`, connect WS client with Bearer, `session.update`, verify tool loop / audio event passthrough