### PR TITLE
1.19.1 MCP backports

### DIFF
--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -542,6 +542,23 @@ long subId = mcpClient.subscribeToResources(List.of("file:///status", "file:///c
 mcpClient.unsubscribeFromResources(subId);
 ```
 
+The server has to confirm a subscription before it may send anything on it, so
+`subscribeToResources` blocks until that confirmation arrives. If the server rejects the
+subscription, declines the requested URIs, or stays silent, the call throws instead of
+returning a subscription ID that would never deliver anything. Use `resourcesTimeout` to
+control how long the client waits for the confirmation:
+
+```java
+McpClient mcpClient = DefaultMcpClient.builder()
+    .transport(transport)
+    .resourcesTimeout(Duration.ofSeconds(10))  // default: 60 seconds
+    .build();
+```
+
+Because the call blocks, do not invoke it from inside an `onResourceUpdated` callback:
+those callbacks run on the thread that reads messages from the server, which is the same
+thread that would have to deliver the confirmation.
+
 For list-change notifications (tool list, prompt list, resource list changes),
 the client subscribes automatically by default. You can control this via
 builder flags:

--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
@@ -1,8 +1,7 @@
 package dev.langchain4j.mcp.client.transport.docker;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
@@ -37,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DockerMcpTransport implements McpTransport {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(DockerMcpTransport.class);
 
     private final String dockerHost;
@@ -169,48 +167,44 @@ public class DockerMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> initialize(McpInitializeRequest operation) {
+    public CompletableFuture<String> sendInitializeRequest(McpInitializeRequest operation) {
         try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(operation);
-            String initializationNotification = OBJECT_MAPPER.writeValueAsString(new McpInitializationNotification());
-            final CompletableFuture<JsonNode> execute = execute(requestString, operation.getId());
+            String requestString = McpJson.serialize(operation);
+            String initializationNotification = McpJson.serialize(new McpInitializationNotification());
+            final CompletableFuture<String> execute = execute(requestString, operation.getId());
             return execute.thenCompose(originalResponse -> {
-                final CompletableFuture<JsonNode> execute1 = execute(initializationNotification, null);
+                final CompletableFuture<String> execute1 = execute(initializationNotification, null);
                 return execute1.thenCompose(nullNode -> CompletableFuture.completedFuture(originalResponse));
             });
-        } catch (JsonProcessingException e) {
+        } catch (IllegalArgumentException e) {
             return CompletableFuture.failedFuture(e);
         }
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
-        return executeOperationWithResponse(new McpCallContext(null, operation));
+    public CompletableFuture<String> sendRequest(McpClientMessage operation) {
+        return sendRequest(new McpCallContext(null, operation));
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+    public CompletableFuture<String> sendRequest(McpCallContext context) {
         try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(context.message());
+            String requestString = McpJson.serialize(context.message());
             return execute(requestString, context.message().getId());
-        } catch (JsonProcessingException e) {
+        } catch (IllegalArgumentException e) {
             return CompletableFuture.failedFuture(e);
         }
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpClientMessage operation) {
-        executeOperationWithoutResponse(new McpCallContext(null, operation));
+    public void sendMessage(McpClientMessage operation) {
+        sendMessage(new McpCallContext(null, operation));
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpCallContext context) {
-        try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(context.message());
-            execute(requestString, null);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+    public void sendMessage(McpCallContext context) {
+        String requestString = McpJson.serialize(context.message());
+        execute(requestString, null);
     }
 
     @Override
@@ -241,10 +235,10 @@ public class DockerMcpTransport implements McpTransport {
         dockerClient.removeContainerCmd(containerId).exec();
     }
 
-    private CompletableFuture<JsonNode> execute(String request, Long id) {
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+    private CompletableFuture<String> execute(String request, Long id) {
+        CompletableFuture<String> future = new CompletableFuture<>();
         if (id != null) {
-            messageHandler.startOperation(id, future);
+            messageHandler.expectResponse(id, future);
         }
 
         PipedOutputStream out = null;
@@ -294,7 +288,7 @@ public class DockerMcpTransport implements McpTransport {
     }
 
     private void awaitResponseAndDetach(
-            DockerResultCallback callback, CompletableFuture<JsonNode> future, Closeable... toClose) {
+            DockerResultCallback callback, CompletableFuture<String> future, Closeable... toClose) {
         try {
             if (!callback.awaitCompletion(responseTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
                 String message = "The MCP server in container %s did not respond within %s"
@@ -484,4 +478,55 @@ public class DockerMcpTransport implements McpTransport {
             return new DockerMcpTransport(this);
         }
     }
+
+    /**
+     * @deprecated use {@link #sendInitializeRequest(McpInitializeRequest)} instead, which does not
+     * expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+        return McpJson.map(sendInitializeRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request) {
+        return McpJson.map(sendRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+        return McpJson.map(sendRequest(context), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage request) {
+        sendMessage(request);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
+        sendMessage(context);
+    }
+
 }

--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.mcp.client.transport.docker;
 
-import dev.langchain4j.mcp.client.transport.McpJson;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
@@ -17,6 +16,7 @@ import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -255,7 +256,7 @@ public class DockerMcpTransport implements McpTransport {
                     .exec(new DockerResultCallback(logEvents, logger, messageHandler));
             callback.awaitStarted(attachTimeout.toMillis(), TimeUnit.MILLISECONDS);
 
-            out.write((request + "\n").getBytes());
+            out.write((request + "\n").getBytes(StandardCharsets.UTF_8));
             out.flush();
 
             if (id != null) {
@@ -528,5 +529,4 @@ public class DockerMcpTransport implements McpTransport {
     public void executeOperationWithoutResponse(McpCallContext context) {
         sendMessage(context);
     }
-
 }

--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
@@ -2,8 +2,6 @@ package dev.langchain4j.mcp.client.transport.docker;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
@@ -16,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 class DockerResultCallback extends ResultCallback.Adapter<Frame> {
     private static final Logger LOG = LoggerFactory.getLogger(DockerResultCallback.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger DEFAULT_TRAFFIC_LOG = LoggerFactory.getLogger("MCP");
     private static final Pattern NEWLINE_PATTERN = Pattern.compile("([^\\r\\n]+)[\\r\\n]+");
 
@@ -80,12 +77,10 @@ class DockerResultCallback extends ResultCallback.Adapter<Frame> {
             trafficLog.debug("< {}", message);
         }
 
-        try {
-            messageHandler.handle(OBJECT_MAPPER.readTree(message));
-            logAggregator.setLength(0);
-            countDownLatch.countDown();
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        // onMessage throws if the line is not valid JSON, which leaves the latch up so that
+        // awaitResponseAndDetach reports the server as unresponsive rather than detaching cleanly
+        messageHandler.onMessage(message);
+        logAggregator.setLength(0);
+        countDownLatch.countDown();
     }
 }

--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -36,7 +37,7 @@ class DockerResultCallback extends ResultCallback.Adapter<Frame> {
 
     @Override
     public void onNext(Frame frame) {
-        String frameStr = new String(frame.getPayload());
+        String frameStr = new String(frame.getPayload(), StandardCharsets.UTF_8);
         if (frame.getStreamType() == StreamType.STDERR) {
             LOG.debug("[STDERR] {}", frameStr);
         } else if (frame.getStreamType() == StreamType.STDOUT) {

--- a/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallbackTest.java
+++ b/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallbackTest.java
@@ -34,4 +34,15 @@ class DockerResultCallbackTest {
             verifyNoInteractions(messageHandler);
         }
     }
+
+    @Test
+    void shouldDecodeDockerFramesAsUtf8() {
+        McpOperationHandler messageHandler = mock(McpOperationHandler.class);
+        DockerResultCallback callback = new DockerResultCallback(false, messageHandler);
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"caf\u00e9 \ud55c\uae00 \ud83d\ude80\"}";
+
+        callback.onNext(new Frame(StreamType.STDOUT, (message + "\n").getBytes(UTF_8)));
+
+        verify(messageHandler).onMessage(message + "\n");
+    }
 }

--- a/langchain4j-mcp/revapi.json
+++ b/langchain4j-mcp/revapi.json
@@ -46,6 +46,183 @@
           "code": "java.class.removed",
           "old": "class dev.langchain4j.mcp.client.transport.http.SseEventListener",
           "justification": "Legacy HTTP transport has been removed"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "class dev.langchain4j.mcp.protocol.McpCallToolResult.Content",
+          "justification": "Content only modelled text items and had no callers outside a serialization test. MCP content is open-ended, so entries are now plain maps, matching the McpToolResultConverter contract. McpCallToolResult is annotated @Internal, whose javadoc states it may change at any time without notice. The tool-result path now deserializes into this type instead of navigating a Jackson tree, which is what removes Jackson from the parsing code."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolResult.Result",
+          "justification": "McpCallToolResult is annotated @Internal, whose javadoc states it may change at any time without notice. The tool-result path now deserializes into this type instead of navigating a Jackson tree, which is what removes Jackson from the parsing code."
+        },
+        {
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolResult.Result",
+          "justification": "McpCallToolResult is annotated @Internal, whose javadoc states it may change at any time without notice. The tool-result path now deserializes into this type instead of navigating a Jackson tree, which is what removes Jackson from the parsing code."
+        },
+        {
+          "code": "java.annotation.added",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonCreator",
+          "justification": "Added so the protocol types can be deserialized, which is what allows the read path to use them instead of tree navigation. Scoped to the protocol package so it does not blanket-ignore annotation changes elsewhere in the module.",
+          "package": "dev.langchain4j.mcp.protocol"
+        },
+        {
+          "code": "java.annotation.added",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonProperty",
+          "justification": "Names the creator parameters for the same reason. Scoped to the protocol package so it does not blanket-ignore annotation changes elsewhere in the module.",
+          "package": "dev.langchain4j.mcp.protocol"
+        },
+        {
+          "code": "java.annotation.added",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Protocol types must tolerate fields added by future MCP revisions. Scoped to the protocol package so it does not blanket-ignore annotation changes elsewhere in the module.",
+          "package": "dev.langchain4j.mcp.protocol"
+        },
+        {
+          "code": "java.annotation.removed",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonCreator",
+          "classQualifiedName": "dev.langchain4j.mcp.client.logging.McpLogMessage",
+          "justification": "The Jackson creator moved to the constructor taking the payload as a plain value, so that McpLogMessage no longer stores a JsonNode. The JsonNode constructor is still available, deprecated, and delegates to it."
+        },
+        {
+          "code": "java.annotation.removed",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonProperty",
+          "classQualifiedName": "dev.langchain4j.mcp.client.logging.McpLogMessage",
+          "justification": "The Jackson creator moved to the constructor taking the payload as a plain value, so that McpLogMessage no longer stores a JsonNode. The JsonNode constructor is still available, deprecated, and delegates to it."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolParams",
+          "methodName": "getRequestState",
+          "justification": "requestState is opaque state the server sends and the client echoes back unchanged, so it is carried as a plain value rather than a JsonNode. These params types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()/getUri()."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolParams",
+          "methodName": "setRequestState",
+          "justification": "requestState is opaque state the server sends and the client echoes back unchanged, so it is carried as a plain value rather than a JsonNode. These params types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()/getUri()."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpGetPromptParams",
+          "methodName": "getRequestState",
+          "justification": "requestState is opaque state the server sends and the client echoes back unchanged, so it is carried as a plain value rather than a JsonNode. These params types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()/getUri()."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpGetPromptParams",
+          "methodName": "setRequestState",
+          "justification": "requestState is opaque state the server sends and the client echoes back unchanged, so it is carried as a plain value rather than a JsonNode. These params types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()/getUri()."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpReadResourceParams",
+          "methodName": "getRequestState",
+          "justification": "requestState is opaque state the server sends and the client echoes back unchanged, so it is carried as a plain value rather than a JsonNode. These params types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()/getUri()."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpReadResourceParams",
+          "methodName": "setRequestState",
+          "justification": "requestState is opaque state the server sends and the client echoes back unchanged, so it is carried as a plain value rather than a JsonNode. These params types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()/getUri()."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolParams",
+          "methodName": "<init>",
+          "justification": "Tool-call arguments are carried as a plain Map rather than a Jackson ObjectNode. A Jackson 3 mapper cannot serialize a Jackson 2 ObjectNode: it does not fail, it bean-serializes the node, so the arguments silently become {\"array\":false,\"bigDecimal\":false,...}. Transports outside LangChain4j serialize the outgoing message with their own mapper, so this type had to stop exposing a Jackson type for them to be able to move to Jackson 3. Both types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolParams",
+          "methodName": "getArguments",
+          "justification": "Tool-call arguments are carried as a plain Map rather than a Jackson ObjectNode. A Jackson 3 mapper cannot serialize a Jackson 2 ObjectNode: it does not fail, it bean-serializes the node, so the arguments silently become {\"array\":false,\"bigDecimal\":false,...}. Transports outside LangChain4j serialize the outgoing message with their own mapper, so this type had to stop exposing a Jackson type for them to be able to move to Jackson 3. Both types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolParams",
+          "methodName": "setArguments",
+          "justification": "Tool-call arguments are carried as a plain Map rather than a Jackson ObjectNode. A Jackson 3 mapper cannot serialize a Jackson 2 ObjectNode: it does not fail, it bean-serializes the node, so the arguments silently become {\"array\":false,\"bigDecimal\":false,...}. Transports outside LangChain4j serialize the outgoing message with their own mapper, so this type had to stop exposing a Jackson type for them to be able to move to Jackson 3. Both types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.protocol.McpCallToolRequest",
+          "methodName": "<init>",
+          "justification": "Tool-call arguments are carried as a plain Map rather than a Jackson ObjectNode. A Jackson 3 mapper cannot serialize a Jackson 2 ObjectNode: it does not fail, it bean-serializes the node, so the arguments silently become {\"array\":false,\"bigDecimal\":false,...}. Transports outside LangChain4j serialize the outgoing message with their own mapper, so this type had to stop exposing a Jackson type for them to be able to move to Jackson 3. Both types are @Internal, whose javadoc states they may change at any time; quarkus-langchain4j uses them but only for getName()."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.client.transport.McpOperationHandler",
+          "methodName": "<init>",
+          "justification": "The handler now keeps a single map of pending operations, keyed by request id and holding the response as raw JSON text, so that cancellation and the client's cleanup act on every in-flight operation regardless of which transport API registered it. Only the type argument changes; the erased signature is unchanged, so this is binary compatible. The constructor is called only by DefaultMcpClient - transports receive an already-built handler through McpTransport.start, which was checked against quarkus-langchain4j rather than assumed."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpImplementation",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpResource",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpResourceTemplate",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpPrompt",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpPromptArgument",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpIcon",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpPromptMessage",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpGetPromptResult",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.client.McpReadResourceResult",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "justification": "Unknown-property tolerance is declared on the type so that it does not depend on the configuration of whichever ObjectMapper deserializes it. MCP adds fields in a backwards-compatible way, so a server may send fields this client does not model yet. Adding an annotation changes no signature and is binary and source compatible."
+        },
+        {
+          "code": "java.method.parameterTypeParameterChanged",
+          "classQualifiedName": "dev.langchain4j.mcp.transport.stdio.JsonRpcIoHandler",
+          "methodName": "<init>",
+          "justification": "The stdio reader now hands whole lines to the operation handler instead of parsing them into a Jackson tree first, so that the stdio transport uses the raw-JSON API like the other transports and JsonRpcIoHandler no longer carries Jackson in its signature or its own ObjectMapper. Only the type argument changes; the erased signature is unchanged, so this is binary compatible. The only caller is StdioMcpTransport; quarkus-langchain4j does not reference this class."
+        },
+        {
+          "code": "java.annotation.added",
+          "classQualifiedName": "dev.langchain4j.mcp.transport.stdio.JsonRpcIoHandler",
+          "annotationType": "dev.langchain4j.Internal",
+          "justification": "JsonRpcIoHandler is the stdio transport's newline framing; only StdioMcpTransport constructs it and quarkus-langchain4j does not reference it. Marking it @Internal records that, and matches the constructor change already recorded below. Adding an annotation changes no signature and is binary and source compatible."
         }
       ]
     }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -14,8 +14,8 @@ import dev.langchain4j.mcp.client.logging.DefaultMcpLogMessageHandler;
 import dev.langchain4j.mcp.client.logging.McpLogMessageHandler;
 import dev.langchain4j.mcp.client.progress.McpProgressHandler;
 import dev.langchain4j.mcp.client.transport.McpHeaderEncoding;
-import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpCallToolParams;
 import dev.langchain4j.mcp.protocol.McpCallToolRequest;
@@ -183,8 +183,8 @@ public class DefaultMcpClient implements McpClient {
             cachePromptList = getOrDefault(builder.cachePromptList, Boolean.TRUE);
             onResourceUpdated = builder.onResourceUpdated;
             if (builder.toolResultConverter != null && builder.toolResultExtractor != null) {
-                throw new IllegalArgumentException("Set either toolResultConverter or the deprecated "
-                        + "toolResultExtractor, not both");
+                throw new IllegalArgumentException(
+                        "Set either toolResultConverter or the deprecated " + "toolResultExtractor, not both");
             }
             toolResultConverter = builder.toolResultExtractor != null
                     ? new LegacyToolResultConverterAdapter(builder.toolResultExtractor)
@@ -425,8 +425,7 @@ public class DefaultMcpClient implements McpClient {
 
         return new McpInitializeResult(
                 discovered.getId(),
-                new McpInitializeResult.Result(
-                        null, result.getCapabilities(), serverInfo, result.getInstructions()));
+                new McpInitializeResult.Result(null, result.getCapabilities(), serverInfo, result.getInstructions()));
     }
 
     private void initializeModern(String versionToAdvertise, boolean isProbe) {
@@ -458,8 +457,8 @@ public class DefaultMcpClient implements McpClient {
                         error.getData() == null ? null : McpJson.serialize(error.getData()));
             }
             log.debug("MCP server discover result: {}", response.get("result"));
-            McpServerDiscoverResponse.Result discovered =
-                    McpJson.deserialize(response, McpServerDiscoverResponse.class).getResult();
+            McpServerDiscoverResponse.Result discovered = McpJson.deserialize(response, McpServerDiscoverResponse.class)
+                    .getResult();
             initializeResult = toInitializeResultFromDiscover(response, discovered);
             modernProtocol = true;
             McpDiscoverResult discoverResult = toDiscoverResult(discovered);
@@ -492,7 +491,8 @@ public class DefaultMcpClient implements McpClient {
         }
 
         McpServerInfo serverInfo = null;
-        Object serverInfoValue = result.getMeta() == null ? null : result.getMeta().get(MCP_SERVER_INFO_META_KEY);
+        Object serverInfoValue =
+                result.getMeta() == null ? null : result.getMeta().get(MCP_SERVER_INFO_META_KEY);
         if (serverInfoValue != null) {
             McpImplementation implementation = McpJson.convert(serverInfoValue, McpImplementation.class);
             serverInfo =
@@ -739,10 +739,8 @@ public class DefaultMcpClient implements McpClient {
         }
         final JsonNode finalResult = result;
         try {
-            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(
-                    finalResult, false, toolResultConverter);
-            notifyListeners(l -> l.afterExecuteTool(
-                    context, toolResult, McpJsonConversions.toMap(finalResult)));
+            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(finalResult, false, toolResultConverter);
+            notifyListeners(l -> l.afterExecuteTool(context, toolResult, McpJsonConversions.toMap(finalResult)));
             return toolResult;
         } catch (ToolExecutionException e) {
             if (e.errorCode() != null) {
@@ -753,8 +751,7 @@ public class DefaultMcpClient implements McpClient {
                 // -> we notify the listener with afterExecuteTool
                 notifyListeners(l -> l.afterExecuteTool(
                         context,
-                        ToolExecutionHelper.extractResult(
-                                finalResult, true, toolResultConverter),
+                        ToolExecutionHelper.extractResult(finalResult, true, toolResultConverter),
                         McpJsonConversions.toMap(finalResult)));
             }
             throw e;
@@ -809,10 +806,20 @@ public class DefaultMcpClient implements McpClient {
                     "resources/read");
             McpReadResourceResult resourceResult = ResourcesHelper.parseResourceContents(result);
             final JsonNode finalResult = result;
-            notifyListeners(l -> l.afterResourceGet(
-                    context, resourceResult, McpJsonConversions.toMap(finalResult)));
+            notifyListeners(l -> l.afterResourceGet(context, resourceResult, McpJsonConversions.toMap(finalResult)));
             return resourceResult;
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            notifyListeners(l -> l.onResourceGetError(context, timeout));
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            throw new RuntimeException(timeout);
+        } catch (ExecutionException e) {
             notifyListeners(l -> l.onResourceGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
@@ -862,10 +869,20 @@ public class DefaultMcpClient implements McpClient {
                     "prompts/get");
             McpGetPromptResult promptResult = PromptsHelper.parsePromptContents(result);
             final JsonNode finalResult = result;
-            notifyListeners(l -> l.afterPromptGet(
-                    context, promptResult, McpJsonConversions.toMap(finalResult)));
+            notifyListeners(l -> l.afterPromptGet(context, promptResult, McpJsonConversions.toMap(finalResult)));
             return promptResult;
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            notifyListeners(l -> l.onPromptGetError(context, timeout));
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            throw new RuntimeException(timeout);
+        } catch (ExecutionException e) {
             notifyListeners(l -> l.onPromptGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
@@ -963,12 +980,25 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforeResourceSubscribe(context));
         applyMeta(operation, context);
         long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
+        CompletableFuture<JsonNode> resultFuture = null;
         try {
-            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
+            resultFuture = executeViaTransport(context);
             JsonNode result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             McpErrorHelper.checkForErrors(result);
             notifyListeners(l -> l.afterResourceSubscribe(context));
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            RuntimeException re = new RuntimeException(timeout);
+            notifyListeners(l -> l.onResourceSubscribeError(context, re));
+            throw re;
+        } catch (ExecutionException e) {
             RuntimeException re = new RuntimeException(e);
             notifyListeners(l -> l.onResourceSubscribeError(context, re));
             throw re;
@@ -996,12 +1026,25 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforeResourceUnsubscribe(context));
         applyMeta(operation, context);
         long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
+        CompletableFuture<JsonNode> resultFuture = null;
         try {
-            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
+            resultFuture = executeViaTransport(context);
             JsonNode result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             McpErrorHelper.checkForErrors(result);
             notifyListeners(l -> l.afterResourceUnsubscribe(context));
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (TimeoutException timeout) {
+            if (resultFuture != null) {
+                resultFuture.cancel(true);
+            }
+            if (shouldSendCancellationNotification()) {
+                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+                applyMeta(cancellation, null);
+                transport.sendMessage(cancellation);
+            }
+            RuntimeException re = new RuntimeException(timeout);
+            notifyListeners(l -> l.onResourceUnsubscribeError(context, re));
+            throw re;
+        } catch (ExecutionException e) {
             RuntimeException re = new RuntimeException(e);
             notifyListeners(l -> l.onResourceUnsubscribeError(context, re));
             throw re;
@@ -1131,7 +1174,8 @@ public class DefaultMcpClient implements McpClient {
     private static boolean honoursResourceSubscriptions(Map<String, Object> acknowledgement) {
         Object params = acknowledgement.get("params");
         Object notifications = params instanceof Map ? ((Map<?, ?>) params).get("notifications") : null;
-        Object honoured = notifications instanceof Map ? ((Map<?, ?>) notifications).get("resourceSubscriptions") : null;
+        Object honoured =
+                notifications instanceof Map ? ((Map<?, ?>) notifications).get("resourceSubscriptions") : null;
         return honoured instanceof List<?> list && !list.isEmpty();
     }
 
@@ -1399,7 +1443,9 @@ public class DefaultMcpClient implements McpClient {
     private static String getNextCursor(JsonNode response) {
         McpPaginatedResult.Result result =
                 McpJson.deserialize(response, McpPaginatedResult.class).getResult();
-        if (result == null || result.getNextCursor() == null || result.getNextCursor().isEmpty()) {
+        if (result == null
+                || result.getNextCursor() == null
+                || result.getNextCursor().isEmpty()) {
             return null;
         }
         return result.getNextCursor();
@@ -1594,6 +1640,7 @@ public class DefaultMcpClient implements McpClient {
 
         @Deprecated(since = "1.20.0", forRemoval = true)
         private McpToolResultExtractor toolResultExtractor;
+
         private Integer multiRoundTripMaxRetries;
         private Boolean subscribeToToolListChanges;
         private Boolean subscribeToPromptListChanges;
@@ -1963,5 +2010,4 @@ public class DefaultMcpClient implements McpClient {
     private CompletableFuture<JsonNode> initializeViaTransport(McpInitializeRequest request) {
         return McpJson.map(transport.sendInitializeRequest(request), McpJson::parse);
     }
-
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -846,7 +846,7 @@ public class DefaultMcpClient implements McpClient {
             notifyListeners(l -> l.onResourceGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (McpException e) {
             notifyListeners(l -> l.onResourceGetError(context, e));
@@ -902,7 +902,7 @@ public class DefaultMcpClient implements McpClient {
             notifyListeners(l -> l.onPromptGetError(context, e));
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (McpException e) {
             notifyListeners(l -> l.onPromptGetError(context, e));

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -503,8 +503,8 @@ public class DefaultMcpClient implements McpClient {
         JsonNode serverInfoNode = result.path("_meta").path("io.modelcontextprotocol/serverInfo");
         if (!serverInfoNode.isMissingNode() && !serverInfoNode.isNull()) {
             McpImplementation implementation = OBJECT_MAPPER.convertValue(serverInfoNode, McpImplementation.class);
-            serverInfo = new McpServerInfo(
-                    implementation.getName(), implementation.getVersion(), implementation.getTitle());
+            serverInfo =
+                    new McpServerInfo(implementation.getName(), implementation.getVersion(), implementation.getTitle());
         }
 
         Map<String, Object> capabilities = Map.of();
@@ -1285,6 +1285,8 @@ public class DefaultMcpClient implements McpClient {
             } finally {
                 pendingOperations.remove(operation.getId());
             }
+            // An error response carries no "result", so it has to be raised before anything reads that field.
+            McpErrorHelper.checkForErrors(result);
             if (modernProtocol) {
                 String resultType = getResultType(result);
                 // servers may only send an InputRequiredResult in response to prompts/get, resources/read and

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -55,6 +55,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -141,6 +142,7 @@ public class DefaultMcpClient implements McpClient {
     private final boolean subscribeToPromptListChanges;
     private final boolean subscribeToResourceListChanges;
     private final Map<Long, CompletableFuture<JsonNode>> activeSubscriptions = new ConcurrentHashMap<>();
+    private final Map<Long, CompletableFuture<Map<String, Object>>> pendingSubscriptionAcks = new ConcurrentHashMap<>();
     private volatile CompletableFuture<JsonNode> listChangeSubscriptionFuture;
 
     public DefaultMcpClient(Builder builder) {
@@ -227,7 +229,14 @@ public class DefaultMcpClient implements McpClient {
                     },
                     () -> notifyListeners(l -> l.onServerPing()),
                     () -> notifyListeners(l -> l.onServerRootsList()),
-                    (requestId, reason) -> notifyListeners(l -> l.onNotificationCancelled(requestId, reason)));
+                    (requestId, reason) -> notifyListeners(l -> l.onNotificationCancelled(requestId, reason)),
+                    (subscriptionId, message) -> {
+                        CompletableFuture<Map<String, Object>> ackFuture =
+                                pendingSubscriptionAcks.remove(subscriptionId);
+                        if (ackFuture != null) {
+                            ackFuture.complete(message);
+                        }
+                    });
             transport.onFailure(() -> {
                 if (!closed) {
                     try {
@@ -1025,25 +1034,116 @@ public class DefaultMcpClient implements McpClient {
         McpCallContext context = new McpCallContext(null, request);
         notifyListeners(l -> l.beforeResourcesSubscribe(context, uris));
         applyMeta(request, context);
-        CompletableFuture<JsonNode> streamFuture = executeViaTransport(context);
+
+        // The server acknowledges the subscription with a separate notification
+        // (notifications/subscriptions/acknowledged), correlated by subscription ID.
+        // Register a future for it before sending the request, so the ack can never
+        // race ahead of us starting to listen for it.
+        CompletableFuture<Map<String, Object>> ackFuture = new CompletableFuture<>();
+        pendingSubscriptionAcks.put(subscriptionId, ackFuture);
+
+        CompletableFuture<JsonNode> streamFuture;
+        try {
+            streamFuture = executeViaTransport(context);
+        } catch (RuntimeException e) {
+            pendingSubscriptionAcks.remove(subscriptionId);
+            notifyListeners(l -> l.onResourcesSubscribeError(context, e));
+            throw e;
+        }
         activeSubscriptions.put(subscriptionId, streamFuture);
         streamFuture.whenComplete((result, error) -> {
             pendingOperations.remove(subscriptionId);
-            if (error != null && !closed) {
-                log.warn("Resource subscription {} failed", subscriptionId, error);
-                activeSubscriptions.remove(subscriptionId);
-            } else if (result != null && result.has("error") && !closed) {
-                log.warn(
-                        "Resource subscription {} rejected by server: {}",
-                        subscriptionId,
-                        errorMessageOf(result));
-                activeSubscriptions.remove(subscriptionId);
+            if (error != null) {
+                ackFuture.completeExceptionally(error);
+                if (!closed) {
+                    if (error instanceof CancellationException) {
+                        // Expected when the client itself gave up (timeout, unsubscribe, close)
+                        log.debug("Resource subscription {} was cancelled", subscriptionId);
+                    } else {
+                        log.warn("Resource subscription {} failed", subscriptionId, error);
+                    }
+                    activeSubscriptions.remove(subscriptionId);
+                }
+            } else if (result != null && result.has("error")) {
+                try {
+                    McpErrorHelper.checkForErrors(result);
+                } catch (RuntimeException e) {
+                    // Usually an McpException, but a malformed error object yields something else,
+                    // and the caller must be unblocked either way
+                    ackFuture.completeExceptionally(e);
+                }
+                if (!closed) {
+                    log.warn("Resource subscription {} rejected by server: {}", subscriptionId, errorMessageOf(result));
+                    activeSubscriptions.remove(subscriptionId);
+                }
+            } else {
+                if (!ackFuture.isDone()) {
+                    // A successful, non-error result means the server ended the subscription gracefully
+                    // (see the spec's Graceful Closure). That normally happens long after the
+                    // acknowledgement; arriving before it means the server never acknowledged at all.
+                    ackFuture.completeExceptionally(
+                            new IllegalStateException("The MCP server ended resource subscription " + subscriptionId
+                                    + " without ever acknowledging it"));
+                }
+                if (!closed) {
+                    activeSubscriptions.remove(subscriptionId);
+                }
             }
         });
 
-        notifyListeners(l -> l.afterResourcesSubscribe(context, subscriptionId, uris));
+        long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
+        try {
+            Map<String, Object> acknowledgement = ackFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            if (!honoursResourceSubscriptions(acknowledgement)) {
+                abandonSubscription(subscriptionId, streamFuture, "The server declined the resource subscriptions");
+                IllegalStateException e = new IllegalStateException("The MCP server acknowledged subscription "
+                        + subscriptionId + " but declined to honour the requested resource subscriptions: " + uris);
+                notifyListeners(l -> l.onResourcesSubscribeError(context, e));
+                throw e;
+            }
+            notifyListeners(l -> l.afterResourcesSubscribe(context, subscriptionId, uris));
+            return subscriptionId;
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            RuntimeException re = cause instanceof RuntimeException runtime ? runtime : new RuntimeException(cause);
+            notifyListeners(l -> l.onResourcesSubscribeError(context, re));
+            throw re;
+        } catch (CancellationException e) {
+            // The stream was cancelled before the acknowledgement arrived, e.g. by a concurrent
+            // unsubscribeFromResources() or a server-sent notifications/cancelled. CompletableFuture
+            // reports this one directly rather than wrapping it in an ExecutionException.
+            notifyListeners(l -> l.onResourcesSubscribeError(context, e));
+            throw e;
+        } catch (TimeoutException e) {
+            abandonSubscription(
+                    subscriptionId, streamFuture, "Timed out waiting for the server to acknowledge the subscription");
+            RuntimeException re = new RuntimeException(e);
+            notifyListeners(l -> l.onResourcesSubscribeError(context, re));
+            throw re;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } finally {
+            pendingSubscriptionAcks.remove(subscriptionId);
+        }
+    }
 
-        return subscriptionId;
+    private static boolean honoursResourceSubscriptions(Map<String, Object> acknowledgement) {
+        Object params = acknowledgement.get("params");
+        Object notifications = params instanceof Map ? ((Map<?, ?>) params).get("notifications") : null;
+        Object honoured = notifications instanceof Map ? ((Map<?, ?>) notifications).get("resourceSubscriptions") : null;
+        return honoured instanceof List<?> list && !list.isEmpty();
+    }
+
+    private void abandonSubscription(long subscriptionId, CompletableFuture<JsonNode> streamFuture, String reason) {
+        activeSubscriptions.remove(subscriptionId);
+        streamFuture.cancel(true);
+        if (transport.requiresCancellationNotification()) {
+            McpCancellationNotification cancellation = new McpCancellationNotification(subscriptionId, reason);
+            McpCallContext cancellationContext = new McpCallContext(null, cancellation);
+            applyMeta(cancellationContext.message(), cancellationContext);
+            transport.sendMessage(cancellationContext.message());
+        }
     }
 
     @Override
@@ -1313,6 +1413,13 @@ public class DefaultMcpClient implements McpClient {
         if (listChangeFuture != null) {
             listChangeFuture.cancel(true);
         }
+        // Unblock any subscribeToResources() call still waiting for a server acknowledgement.
+        // This has to happen before the streams are cancelled below, otherwise the cancellation
+        // completes those futures first and the caller sees a bare CancellationException instead.
+        pendingSubscriptionAcks
+                .values()
+                .forEach(f -> f.completeExceptionally(new IllegalStateException("MCP client was closed")));
+        pendingSubscriptionAcks.clear();
         // Cancel all active resource subscriptions
         activeSubscriptions.values().forEach(f -> f.cancel(true));
         activeSubscriptions.clear();

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -4,13 +4,7 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -21,6 +15,7 @@ import dev.langchain4j.mcp.client.logging.McpLogMessageHandler;
 import dev.langchain4j.mcp.client.progress.McpProgressHandler;
 import dev.langchain4j.mcp.client.transport.McpHeaderEncoding;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpCallToolParams;
 import dev.langchain4j.mcp.protocol.McpCallToolRequest;
@@ -29,6 +24,7 @@ import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpClientNotification;
 import dev.langchain4j.mcp.protocol.McpClientParams;
 import dev.langchain4j.mcp.protocol.McpClientRequest;
+import dev.langchain4j.mcp.protocol.McpErrorResponse;
 import dev.langchain4j.mcp.protocol.McpGetPromptParams;
 import dev.langchain4j.mcp.protocol.McpGetPromptRequest;
 import dev.langchain4j.mcp.protocol.McpImplementation;
@@ -39,12 +35,15 @@ import dev.langchain4j.mcp.protocol.McpListPromptsRequest;
 import dev.langchain4j.mcp.protocol.McpListResourceTemplatesRequest;
 import dev.langchain4j.mcp.protocol.McpListResourcesRequest;
 import dev.langchain4j.mcp.protocol.McpListToolsRequest;
+import dev.langchain4j.mcp.protocol.McpListToolsResult;
+import dev.langchain4j.mcp.protocol.McpPaginatedResult;
 import dev.langchain4j.mcp.protocol.McpPingRequest;
 import dev.langchain4j.mcp.protocol.McpReadResourceParams;
 import dev.langchain4j.mcp.protocol.McpReadResourceRequest;
 import dev.langchain4j.mcp.protocol.McpRootsListChangedNotification;
 import dev.langchain4j.mcp.protocol.McpServerDiscoverParams;
 import dev.langchain4j.mcp.protocol.McpServerDiscoverRequest;
+import dev.langchain4j.mcp.protocol.McpServerDiscoverResponse;
 import dev.langchain4j.mcp.protocol.McpSubscribeResourceRequest;
 import dev.langchain4j.mcp.protocol.McpSubscriptionsListenParams;
 import dev.langchain4j.mcp.protocol.McpSubscriptionsListenRequest;
@@ -89,9 +88,6 @@ public class DefaultMcpClient implements McpClient {
     static final String PROTOCOL_VERSION_LEGACY = "2025-11-25";
     static final String PROTOCOL_VERSION_LEGACY_OLD = "2024-11-05";
 
-    static final ObjectMapper OBJECT_MAPPER =
-            new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-
     private final AtomicLong idGenerator = new AtomicLong(0);
     private final McpTransport transport;
     private final String key;
@@ -105,9 +101,10 @@ public class DefaultMcpClient implements McpClient {
     private final Duration resourcesTimeout;
     private final Duration promptsTimeout;
     private final Duration pingTimeout;
-    private final JsonNode RESULT_TIMEOUT;
+    private static final String MCP_SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
+
     private final String toolExecutionTimeoutErrorMessage;
-    private final Map<Long, CompletableFuture<JsonNode>> pendingOperations = new ConcurrentHashMap<>();
+    private final Map<Long, CompletableFuture<String>> pendingOperations = new ConcurrentHashMap<>();
     private final McpOperationHandler messageHandler;
     private final McpLogMessageHandler logHandler;
     private final McpProgressHandler progressHandler;
@@ -136,7 +133,8 @@ public class DefaultMcpClient implements McpClient {
     private final Boolean cachePromptList;
     private final List<McpClientListener> listeners;
     private final McpMetaSupplier metaSupplier;
-    private final McpToolResultExtractor toolResultExtractor;
+    private final McpToolResultConverter toolResultConverter;
+
     private volatile @Nullable McpInitializeResult initializeResult;
     private final int multiRoundTripMaxRetries;
     private final boolean subscribeToToolListChanges;
@@ -182,13 +180,18 @@ public class DefaultMcpClient implements McpClient {
             cacheResourceList = getOrDefault(builder.cacheResourceList, Boolean.TRUE);
             cachePromptList = getOrDefault(builder.cachePromptList, Boolean.TRUE);
             onResourceUpdated = builder.onResourceUpdated;
-            toolResultExtractor = getOrDefault(builder.toolResultExtractor, new DefaultMcpToolResultExtractor());
+            if (builder.toolResultConverter != null && builder.toolResultExtractor != null) {
+                throw new IllegalArgumentException("Set either toolResultConverter or the deprecated "
+                        + "toolResultExtractor, not both");
+            }
+            toolResultConverter = builder.toolResultExtractor != null
+                    ? new LegacyToolResultConverterAdapter(builder.toolResultExtractor)
+                    : getOrDefault(builder.toolResultConverter, DefaultMcpToolResultConverter::new);
             multiRoundTripMaxRetries =
                     getOrDefault(builder.multiRoundTripMaxRetries, DEFAULT_MULTI_ROUND_TRIP_MAX_RETRIES);
             subscribeToToolListChanges = getOrDefault(builder.subscribeToToolListChanges, Boolean.TRUE);
             subscribeToPromptListChanges = getOrDefault(builder.subscribeToPromptListChanges, Boolean.TRUE);
             subscribeToResourceListChanges = getOrDefault(builder.subscribeToResourceListChanges, Boolean.TRUE);
-            RESULT_TIMEOUT = JsonNodeFactory.instance.objectNode();
             messageHandler = new McpOperationHandler(
                     pendingOperations,
                     mcpRoots::get,
@@ -225,12 +228,6 @@ public class DefaultMcpClient implements McpClient {
                     () -> notifyListeners(l -> l.onServerPing()),
                     () -> notifyListeners(l -> l.onServerRootsList()),
                     (requestId, reason) -> notifyListeners(l -> l.onNotificationCancelled(requestId, reason)));
-            ((ObjectNode) RESULT_TIMEOUT)
-                    .putObject("result")
-                    .putArray("content")
-                    .addObject()
-                    .put("type", "text")
-                    .put("text", toolExecutionTimeoutErrorMessage);
             transport.onFailure(() -> {
                 if (!closed) {
                     try {
@@ -322,33 +319,31 @@ public class DefaultMcpClient implements McpClient {
     }
 
     private void retryWithSupportedVersion(McpException e) {
-        JsonNode data = e.errorData();
-        if (data != null && data.has("supported")) {
-            JsonNode supported = data.get("supported");
-            if (supported.isArray()) {
-                // Prefer modern versions, fall back to legacy
-                String bestModern = null;
-                String bestLegacy = null;
-                for (JsonNode v : supported) {
-                    String version = v.asText();
-                    if (isModernVersion(version)) {
-                        if (bestModern == null || version.compareTo(bestModern) > 0) {
-                            bestModern = version;
-                        }
-                    } else {
-                        if (bestLegacy == null || version.compareTo(bestLegacy) > 0) {
-                            bestLegacy = version;
-                        }
+        Map<String, Object> data = e.errorDataAsMap();
+        if (data != null && data.get("supported") instanceof List) {
+            List<?> supported = (List<?>) data.get("supported");
+            // Prefer modern versions, fall back to legacy
+            String bestModern = null;
+            String bestLegacy = null;
+            for (Object v : supported) {
+                String version = String.valueOf(v);
+                if (isModernVersion(version)) {
+                    if (bestModern == null || version.compareTo(bestModern) > 0) {
+                        bestModern = version;
+                    }
+                } else {
+                    if (bestLegacy == null || version.compareTo(bestLegacy) > 0) {
+                        bestLegacy = version;
                     }
                 }
-                if (bestModern != null) {
-                    initializeModern(bestModern, false);
-                    return;
-                }
-                if (bestLegacy != null) {
-                    initializeLegacy(bestLegacy);
-                    return;
-                }
+            }
+            if (bestModern != null) {
+                initializeModern(bestModern, false);
+                return;
+            }
+            if (bestLegacy != null) {
+                initializeLegacy(bestLegacy);
+                return;
             }
         }
         throw new RuntimeException("Server does not support any compatible protocol version", e);
@@ -365,7 +360,7 @@ public class DefaultMcpClient implements McpClient {
         applyMeta(request, context);
         try {
             JsonNode capabilities =
-                    transport.initialize(request).get(initializationTimeout.toMillis(), TimeUnit.MILLISECONDS);
+                    initializeViaTransport(request).get(initializationTimeout.toMillis(), TimeUnit.MILLISECONDS);
             if (capabilities.get("result") != null) {
                 log.debug("MCP server capabilities: {}", capabilities.get("result"));
             }
@@ -399,48 +394,30 @@ public class DefaultMcpClient implements McpClient {
     }
 
     private static McpInitializeResult toInitializeResult(JsonNode response) {
-        JsonNode result = response.path("result");
-        JsonNode serverInfo = result.path("serverInfo");
-        JsonNode tools = result.path("capabilities").path("tools");
-
-        McpImplementation implementation = null;
-        if (!serverInfo.isMissingNode() && !serverInfo.isNull()) {
-            implementation = OBJECT_MAPPER.convertValue(serverInfo, McpImplementation.class);
-        }
-
-        McpInitializeResult.Capabilities capabilities = new McpInitializeResult.Capabilities(
-                new McpInitializeResult.Capabilities.Tools(toNullableBoolean(tools.get("listChanged"))));
-
-        return new McpInitializeResult(
-                toNullableLong(response.get("id")),
-                new McpInitializeResult.Result(
-                        result.path("protocolVersion").asText(null),
-                        capabilities,
-                        implementation,
-                        result.path("instructions").asText(null)));
+        return McpJson.deserialize(response, McpInitializeResult.class);
     }
 
-    private static McpInitializeResult toInitializeResultFromDiscover(JsonNode response) {
-        JsonNode result = response.path("result");
-        JsonNode serverInfoNode = result.path("_meta").path("io.modelcontextprotocol/serverInfo");
-        JsonNode capabilities = result.path("capabilities");
-        JsonNode tools = capabilities.path("tools");
-
-        McpImplementation serverInfo = null;
-        if (!serverInfoNode.isMissingNode() && !serverInfoNode.isNull()) {
-            serverInfo = OBJECT_MAPPER.convertValue(serverInfoNode, McpImplementation.class);
+    /**
+     * The discover result carries the same shape as an initialize result, except that the server
+     * info sits under a reserved '_meta' key and no protocol version is reported.
+     */
+    private static McpInitializeResult toInitializeResultFromDiscover(
+            JsonNode response, McpServerDiscoverResponse.Result discoveredResult) {
+        McpInitializeResult discovered = McpJson.deserialize(response, McpInitializeResult.class);
+        McpInitializeResult.Result result = discovered.getResult();
+        if (result == null) {
+            return discovered;
         }
 
-        McpInitializeResult.Capabilities caps = new McpInitializeResult.Capabilities(
-                new McpInitializeResult.Capabilities.Tools(toNullableBoolean(tools.get("listChanged"))));
+        Map<String, Object> meta = discoveredResult == null ? null : discoveredResult.getMeta();
+        Object serverInfoValue = meta == null ? null : meta.get(MCP_SERVER_INFO_META_KEY);
+        McpImplementation serverInfo =
+                serverInfoValue == null ? null : McpJson.convert(serverInfoValue, McpImplementation.class);
 
         return new McpInitializeResult(
-                toNullableLong(response.get("id")),
+                discovered.getId(),
                 new McpInitializeResult.Result(
-                        null, // protocolVersion not in discover result directly
-                        caps,
-                        serverInfo,
-                        result.path("instructions").asText(null)));
+                        null, result.getCapabilities(), serverInfo, result.getInstructions()));
     }
 
     private void initializeModern(String versionToAdvertise, boolean isProbe) {
@@ -460,18 +437,23 @@ public class DefaultMcpClient implements McpClient {
         applyMeta(request, context);
         CompletableFuture<JsonNode> resultFuture = null;
         try {
-            resultFuture = transport.executeOperationWithResponse(context);
+            resultFuture = executeViaTransport(context);
             Duration timeout = isProbe ? protocolDetectionTimeout : initializationTimeout;
             JsonNode response = resultFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-            if (response.has("error")) {
-                JsonNode error = response.get("error");
-                throw new McpException(
-                        error.get("code").asInt(), error.get("message").asText(), error.get("data"));
+            McpErrorResponse.Error error =
+                    McpJson.deserialize(response, McpErrorResponse.class).getError();
+            if (error != null) {
+                throw McpException.withErrorData(
+                        error.getCode(),
+                        error.getMessage(),
+                        error.getData() == null ? null : McpJson.serialize(error.getData()));
             }
             log.debug("MCP server discover result: {}", response.get("result"));
-            initializeResult = toInitializeResultFromDiscover(response);
+            McpServerDiscoverResponse.Result discovered =
+                    McpJson.deserialize(response, McpServerDiscoverResponse.class).getResult();
+            initializeResult = toInitializeResultFromDiscover(response, discovered);
             modernProtocol = true;
-            McpDiscoverResult discoverResult = toDiscoverResult(response);
+            McpDiscoverResult discoverResult = toDiscoverResult(discovered);
             notifyListeners(l -> l.afterServerDiscover(context, discoverResult));
             // Auto-start list-change subscriptions if enabled
             if (subscribeToToolListChanges || subscribeToPromptListChanges || subscribeToResourceListChanges) {
@@ -495,43 +477,25 @@ public class DefaultMcpClient implements McpClient {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private static McpDiscoverResult toDiscoverResult(JsonNode response) {
-        JsonNode result = response.path("result");
+    private static McpDiscoverResult toDiscoverResult(McpServerDiscoverResponse.Result result) {
+        if (result == null) {
+            return new McpDiscoverResult(List.of(), Map.of(), null, null, null);
+        }
 
         McpServerInfo serverInfo = null;
-        JsonNode serverInfoNode = result.path("_meta").path("io.modelcontextprotocol/serverInfo");
-        if (!serverInfoNode.isMissingNode() && !serverInfoNode.isNull()) {
-            McpImplementation implementation = OBJECT_MAPPER.convertValue(serverInfoNode, McpImplementation.class);
+        Object serverInfoValue = result.getMeta() == null ? null : result.getMeta().get(MCP_SERVER_INFO_META_KEY);
+        if (serverInfoValue != null) {
+            McpImplementation implementation = McpJson.convert(serverInfoValue, McpImplementation.class);
             serverInfo =
                     new McpServerInfo(implementation.getName(), implementation.getVersion(), implementation.getTitle());
         }
 
-        Map<String, Object> capabilities = Map.of();
-        JsonNode capabilitiesNode = result.path("capabilities");
-        if (capabilitiesNode.isObject()) {
-            capabilities = (Map<String, Object>) ToolExecutionHelper.toObject(capabilitiesNode);
-        }
-
-        List<String> versions = new ArrayList<>();
-        for (JsonNode version : result.path("supportedVersions")) {
-            versions.add(version.asText());
-        }
-
         return new McpDiscoverResult(
-                versions,
-                capabilities,
+                result.getSupportedVersions() == null ? List.of() : result.getSupportedVersions(),
+                result.getCapabilities() == null ? Map.of() : result.getCapabilities(),
                 serverInfo,
-                result.path("instructions").asText(null),
-                result.path("resultType").asText(null));
-    }
-
-    private static @Nullable Long toNullableLong(JsonNode node) {
-        return node == null || node.isNull() || !node.canConvertToLong() ? null : node.asLong();
-    }
-
-    private static @Nullable Boolean toNullableBoolean(JsonNode node) {
-        return node == null || node.isNull() ? null : node.asBoolean();
+                result.getInstructions(),
+                result.getResultType());
     }
 
     private void applyModernMeta(McpClientParams params, String versionToAdvertise) {
@@ -576,7 +540,7 @@ public class DefaultMcpClient implements McpClient {
         request.setParams(params);
         McpCallContext context = new McpCallContext(null, request);
         applyMeta(request, context);
-        CompletableFuture<JsonNode> future = transport.executeOperationWithResponse(context);
+        CompletableFuture<JsonNode> future = executeViaTransport(context);
         listChangeSubscriptionFuture = future;
         future.whenComplete((result, error) -> {
             pendingOperations.remove(operationId);
@@ -586,28 +550,40 @@ public class DefaultMcpClient implements McpClient {
         });
     }
 
-    private static String getResultType(JsonNode response) {
-        JsonNode result = response.path("result");
-        if (result.isMissingNode() || result.isNull()) {
+    private static McpServerDiscoverResponse.Result multiRoundTripResult(JsonNode response) {
+        return McpJson.deserialize(response, McpServerDiscoverResponse.class).getResult();
+    }
+
+    private static String resultTypeOf(McpServerDiscoverResponse.Result result) {
+        if (result == null || result.getResultType() == null) {
             return "complete";
         }
-        String resultType = result.path("resultType").asText(null);
-        return resultType != null ? resultType : "complete";
+        return result.getResultType();
     }
 
-    private static JsonNode getRequestState(JsonNode response) {
-        return response.path("result").path("requestState");
+    private static String getResultType(JsonNode response) {
+        return resultTypeOf(multiRoundTripResult(response));
     }
 
-    private static JsonNode getInputRequests(JsonNode response) {
-        return response.path("result").path("inputRequests");
+    /**
+     * Mirrors JsonNode.isEmpty(), for which only a non-empty array or object is non-empty: an
+     * absent value, an empty array, an empty object and any scalar all count as empty.
+     */
+    private static boolean isNotEmpty(Object value) {
+        if (value instanceof List) {
+            return !((List<?>) value).isEmpty();
+        }
+        if (value instanceof Map) {
+            return !((Map<?, ?>) value).isEmpty();
+        }
+        return false;
     }
 
     private JsonNode handleMultiRoundTrip(
             JsonNode initialResult,
             long timeoutMillis,
             InvocationContext invocationContext,
-            BiFunction<Long, JsonNode, McpClientRequest> retryRequestFactory,
+            BiFunction<Long, Object, McpClientRequest> retryRequestFactory,
             String operationName)
             throws ExecutionException, InterruptedException, TimeoutException {
         if (!modernProtocol) {
@@ -615,28 +591,29 @@ public class DefaultMcpClient implements McpClient {
         }
         JsonNode result = initialResult;
         int retryCount = 0;
-        while ("input_required".equals(getResultType(result))) {
+        McpServerDiscoverResponse.Result parsed = multiRoundTripResult(result);
+        while ("input_required".equals(resultTypeOf(parsed))) {
             if (retryCount >= multiRoundTripMaxRetries) {
                 throw new RuntimeException("Multi round-trip retry limit exceeded for " + operationName);
             }
-            JsonNode inputRequests = getInputRequests(result);
-            if (!inputRequests.isMissingNode() && !inputRequests.isEmpty()) {
+            if (isNotEmpty(parsed.getInputRequests())) {
                 throw new RuntimeException("Server sent inputRequests that the client cannot handle");
             }
-            JsonNode requestState = getRequestState(result);
-            if (requestState.isMissingNode() || requestState.isNull()) {
+            Object requestState = parsed.getRequestState();
+            if (requestState == null) {
                 throw new RuntimeException("Server sent input_required without requestState or inputRequests");
             }
             long retryOperationId = idGenerator.getAndIncrement();
             McpClientRequest retryOperation = retryRequestFactory.apply(retryOperationId, requestState);
             McpCallContext retryContext = new McpCallContext(invocationContext, retryOperation);
             applyMeta(retryOperation, retryContext);
-            CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(retryContext);
+            CompletableFuture<JsonNode> resultFuture = executeViaTransport(retryContext);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             pendingOperations.remove(retryOperationId);
+            parsed = multiRoundTripResult(result);
             retryCount++;
         }
-        String resultType = getResultType(result);
+        String resultType = resultTypeOf(parsed);
         if (!"complete".equals(resultType)) {
             throw new RuntimeException("Unexpected resultType for " + operationName + ": " + resultType);
         }
@@ -690,15 +667,15 @@ public class DefaultMcpClient implements McpClient {
     @Override
     public ToolExecutionResult executeTool(ToolExecutionRequest executionRequest, InvocationContext invocationContext) {
         assertNotClosed();
-        ObjectNode arguments = null;
+        Map<String, Object> arguments;
         try {
             String args = executionRequest.arguments();
             if (isNullOrBlank(args)) {
                 args = "{}";
             }
-            arguments = OBJECT_MAPPER.readValue(args, ObjectNode.class);
-        } catch (JsonProcessingException e) {
-            throw new ToolArgumentsException(e);
+            arguments = McpJson.toMap(args);
+        } catch (IllegalArgumentException e) {
+            throw new ToolArgumentsException(e.getCause() != null ? e.getCause() : e);
         }
         long operationId = idGenerator.getAndIncrement();
         String progressToken = progressHandler != null ? String.valueOf(operationId) : null;
@@ -713,10 +690,10 @@ public class DefaultMcpClient implements McpClient {
         try {
             notifyListeners(l -> l.beforeExecuteTool(context));
             applyMeta(operation, context);
-            resultFuture = transport.executeOperationWithResponse(context);
+            resultFuture = executeViaTransport(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
 
-            final ObjectNode finalArguments = arguments;
+            final Map<String, Object> finalArguments = arguments;
             result = handleMultiRoundTrip(
                     result,
                     timeoutMillis,
@@ -736,9 +713,12 @@ public class DefaultMcpClient implements McpClient {
             if (shouldSendCancellationNotification()) {
                 McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
                 applyMeta(cancellation, null);
-                transport.executeOperationWithoutResponse(cancellation);
+                transport.sendMessage(cancellation);
             }
-            return ToolExecutionHelper.extractResult(RESULT_TIMEOUT, false, toolResultExtractor);
+            // built on demand, not once at construction: a custom converter must not be invoked
+            // for a tool call that never happened
+            return toolResultConverter.convert(
+                    List.of(Map.of("type", "text", "text", toolExecutionTimeoutErrorMessage)), false);
         } catch (ExecutionException e) {
             notifyListeners(l -> l.onExecuteToolError(context, e));
             throw new ToolExecutionException(e.getCause());
@@ -750,9 +730,10 @@ public class DefaultMcpClient implements McpClient {
         }
         final JsonNode finalResult = result;
         try {
-            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(finalResult, false, toolResultExtractor);
+            ToolExecutionResult toolResult = ToolExecutionHelper.extractResult(
+                    finalResult, false, toolResultConverter);
             notifyListeners(l -> l.afterExecuteTool(
-                    context, toolResult, (Map<String, Object>) ToolExecutionHelper.toObject(finalResult)));
+                    context, toolResult, McpJsonConversions.toMap(finalResult)));
             return toolResult;
         } catch (ToolExecutionException e) {
             if (e.errorCode() != null) {
@@ -763,8 +744,9 @@ public class DefaultMcpClient implements McpClient {
                 // -> we notify the listener with afterExecuteTool
                 notifyListeners(l -> l.afterExecuteTool(
                         context,
-                        ToolExecutionHelper.extractResult(finalResult, true, toolResultExtractor),
-                        (Map<String, Object>) ToolExecutionHelper.toObject(finalResult)));
+                        ToolExecutionHelper.extractResult(
+                                finalResult, true, toolResultConverter),
+                        McpJsonConversions.toMap(finalResult)));
             }
             throw e;
         }
@@ -803,7 +785,7 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforeResourceGet(context));
         applyMeta(operation, context);
         try {
-            resultFuture = transport.executeOperationWithResponse(context);
+            resultFuture = executeViaTransport(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
 
             result = handleMultiRoundTrip(
@@ -819,7 +801,7 @@ public class DefaultMcpClient implements McpClient {
             McpReadResourceResult resourceResult = ResourcesHelper.parseResourceContents(result);
             final JsonNode finalResult = result;
             notifyListeners(l -> l.afterResourceGet(
-                    context, resourceResult, (Map<String, Object>) ToolExecutionHelper.toObject(finalResult)));
+                    context, resourceResult, McpJsonConversions.toMap(finalResult)));
             return resourceResult;
         } catch (ExecutionException | TimeoutException e) {
             notifyListeners(l -> l.onResourceGetError(context, e));
@@ -855,7 +837,7 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforePromptGet(context));
         applyMeta(operation, context);
         try {
-            resultFuture = transport.executeOperationWithResponse(context);
+            resultFuture = executeViaTransport(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
 
             final Map<String, Object> finalArguments = arguments == null ? Map.of() : arguments;
@@ -872,7 +854,7 @@ public class DefaultMcpClient implements McpClient {
             McpGetPromptResult promptResult = PromptsHelper.parsePromptContents(result);
             final JsonNode finalResult = result;
             notifyListeners(l -> l.afterPromptGet(
-                    context, promptResult, (Map<String, Object>) ToolExecutionHelper.toObject(finalResult)));
+                    context, promptResult, McpJsonConversions.toMap(finalResult)));
             return promptResult;
         } catch (ExecutionException | TimeoutException e) {
             notifyListeners(l -> l.onPromptGetError(context, e));
@@ -908,7 +890,7 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforePing(context));
         applyMeta(request, context);
         try {
-            CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(context);
+            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
             resultFuture.get(pingTimeout.toMillis(), TimeUnit.MILLISECONDS);
             notifyListeners(l -> l.afterPing(context));
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
@@ -927,7 +909,7 @@ public class DefaultMcpClient implements McpClient {
         notifyListeners(l -> l.beforePing(context));
         applyMeta(ping, context);
         try {
-            CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(context);
+            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
             resultFuture.get(pingTimeout.toMillis(), TimeUnit.MILLISECONDS);
             notifyListeners(l -> l.afterPing(context));
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
@@ -949,7 +931,7 @@ public class DefaultMcpClient implements McpClient {
         McpRootsListChangedNotification notification = new McpRootsListChangedNotification();
         McpCallContext context = new McpCallContext(null, notification);
         applyMeta(notification, context);
-        transport.executeOperationWithoutResponse(context);
+        transport.sendMessage(context);
         notifyListeners(l -> l.onRootsListChanged(context));
     }
 
@@ -973,7 +955,7 @@ public class DefaultMcpClient implements McpClient {
         applyMeta(operation, context);
         long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
         try {
-            CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(context);
+            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
             JsonNode result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             McpErrorHelper.checkForErrors(result);
             notifyListeners(l -> l.afterResourceSubscribe(context));
@@ -1006,7 +988,7 @@ public class DefaultMcpClient implements McpClient {
         applyMeta(operation, context);
         long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
         try {
-            CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(context);
+            CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
             JsonNode result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             McpErrorHelper.checkForErrors(result);
             notifyListeners(l -> l.afterResourceUnsubscribe(context));
@@ -1043,7 +1025,7 @@ public class DefaultMcpClient implements McpClient {
         McpCallContext context = new McpCallContext(null, request);
         notifyListeners(l -> l.beforeResourcesSubscribe(context, uris));
         applyMeta(request, context);
-        CompletableFuture<JsonNode> streamFuture = transport.executeOperationWithResponse(context);
+        CompletableFuture<JsonNode> streamFuture = executeViaTransport(context);
         activeSubscriptions.put(subscriptionId, streamFuture);
         streamFuture.whenComplete((result, error) -> {
             pendingOperations.remove(subscriptionId);
@@ -1054,7 +1036,7 @@ public class DefaultMcpClient implements McpClient {
                 log.warn(
                         "Resource subscription {} rejected by server: {}",
                         subscriptionId,
-                        result.path("error").path("message").asText());
+                        errorMessageOf(result));
                 activeSubscriptions.remove(subscriptionId);
             }
         });
@@ -1088,7 +1070,7 @@ public class DefaultMcpClient implements McpClient {
             // Send notifications/cancelled for transports that need it (e.g. stdio)
             if (context != null) {
                 applyMeta(context.message(), context);
-                transport.executeOperationWithoutResponse(context.message());
+                transport.sendMessage(context.message());
             }
         }
 
@@ -1166,7 +1148,9 @@ public class DefaultMcpClient implements McpClient {
                     toolExecutionTimeout,
                     invocationContext,
                     result -> ToolSpecificationHelper.toolSpecificationListFromMcpResponse(
-                            (ArrayNode) result.get("result").get("tools")));
+                            McpJson.deserialize(result, McpListToolsResult.class)
+                                    .getResult()
+                                    .getTools()));
             toolListRefs.set(list);
             notifyListeners(l -> l.afterToolsList(listenerContext, list));
             return list;
@@ -1278,7 +1262,7 @@ public class DefaultMcpClient implements McpClient {
             applyMeta(operation, context);
             JsonNode result;
             try {
-                CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(context);
+                CompletableFuture<JsonNode> resultFuture = executeViaTransport(context);
                 result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             } catch (ExecutionException | InterruptedException | TimeoutException e) {
                 throw new RuntimeException(e);
@@ -1306,15 +1290,19 @@ public class DefaultMcpClient implements McpClient {
         return allItems;
     }
 
+    private static String errorMessageOf(JsonNode response) {
+        McpErrorResponse.Error error =
+                McpJson.deserialize(response, McpErrorResponse.class).getError();
+        return error == null ? "" : error.getMessage();
+    }
+
     private static String getNextCursor(JsonNode response) {
-        JsonNode resultNode = response.get("result");
-        if (resultNode != null && resultNode.has("nextCursor")) {
-            String nextCursor = resultNode.get("nextCursor").asText();
-            if (!nextCursor.isEmpty()) {
-                return nextCursor;
-            }
+        McpPaginatedResult.Result result =
+                McpJson.deserialize(response, McpPaginatedResult.class).getResult();
+        if (result == null || result.getNextCursor() == null || result.getNextCursor().isEmpty()) {
+            return null;
         }
-        return null;
+        return result.getNextCursor();
     }
 
     @Override
@@ -1392,7 +1380,7 @@ public class DefaultMcpClient implements McpClient {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, String> buildMcpParamHeaders(String toolName, ObjectNode arguments) {
+    private Map<String, String> buildMcpParamHeaders(String toolName, Map<String, Object> arguments) {
         List<ToolSpecification> tools = toolListRefs.get();
         if (tools == null) {
             log.warn(
@@ -1420,18 +1408,16 @@ public class DefaultMcpClient implements McpClient {
         for (Map.Entry<String, String> entry : headerMappings.entrySet()) {
             String propertyPath = entry.getKey();
             String headerName = entry.getValue();
-            JsonNode value = resolvePropertyPath(arguments, propertyPath);
-            if (value == null || value.isNull() || value.isMissingNode()) {
-                continue;
-            }
+            Object value = resolvePropertyPath(arguments, propertyPath);
             String stringValue;
-            if (value.isTextual()) {
-                stringValue = value.asText();
-            } else if (value.isInt() || value.isLong()) {
-                stringValue = String.valueOf(value.asLong());
-            } else if (value.isBoolean()) {
-                stringValue = value.asBoolean() ? "true" : "false";
+            if (value instanceof String text) {
+                stringValue = text;
+            } else if (value instanceof Integer || value instanceof Long) {
+                stringValue = String.valueOf(((Number) value).longValue());
+            } else if (value instanceof Boolean bool) {
+                stringValue = bool ? "true" : "false";
             } else {
+                // nulls, floating-point and oversized numbers, objects and arrays are not sent as headers
                 continue;
             }
             result.put(headerName, McpHeaderEncoding.encode(stringValue));
@@ -1439,14 +1425,14 @@ public class DefaultMcpClient implements McpClient {
         return result.isEmpty() ? null : result;
     }
 
-    private static JsonNode resolvePropertyPath(ObjectNode root, String path) {
+    private static @Nullable Object resolvePropertyPath(Map<String, Object> root, String path) {
         String[] segments = path.split("\\.");
-        JsonNode current = root;
+        Object current = root;
         for (String segment : segments) {
-            if (current == null || current.isMissingNode() || !current.isObject()) {
+            if (!(current instanceof Map<?, ?> map)) {
                 return null;
             }
-            current = current.get(segment);
+            current = map.get(segment);
         }
         return current;
     }
@@ -1497,6 +1483,9 @@ public class DefaultMcpClient implements McpClient {
         private McpProgressHandler progressHandler;
         private McpMetaSupplier metaSupplier;
         private BiConsumer<McpClient, String> onResourceUpdated;
+        private McpToolResultConverter toolResultConverter;
+
+        @Deprecated(since = "1.20.0", forRemoval = true)
         private McpToolResultExtractor toolResultExtractor;
         private Integer multiRoundTripMaxRetries;
         private Boolean subscribeToToolListChanges;
@@ -1780,15 +1769,23 @@ public class DefaultMcpClient implements McpClient {
         }
 
         /**
-         * Sets the extractor used for MCP tool responses that return ordinary
-         * {@code CallToolResult.result.content[]} items.
-         * Responses with {@code structuredContent} are handled separately and
-         * are not affected by this setting.
-         * The default client only supports {@code structuredContent} and text
-         * content out of the box. More specialized extraction strategies, such as
-         * parsing text items and returning the first JSON object, can be implemented
-         * with a custom extractor.
+         * Sets the extractor used for MCP tool responses backed by {@code content[]}.
+         * Takes precedence over {@link #toolResultExtractor(McpToolResultExtractor)}.
          */
+        public Builder toolResultConverter(McpToolResultConverter toolResultConverter) {
+            this.toolResultConverter = ensureNotNull(toolResultConverter, "toolResultConverter");
+            return this;
+        }
+
+        /**
+         * Sets the extractor used for MCP tool responses that return ordinary
+         * {@code CallToolResult.result.content[]} items. Responses with
+         * {@code structuredContent} are handled separately and are not affected by this setting.
+         *
+         * @deprecated use {@link #toolResultConverter(McpToolResultConverter)}, which does not expose
+         * Jackson types. Setting both is rejected with an {@link IllegalArgumentException}.
+         */
+        @Deprecated(since = "1.20.0", forRemoval = true)
         public Builder toolResultExtractor(McpToolResultExtractor toolResultExtractor) {
             this.toolResultExtractor = ensureNotNull(toolResultExtractor, "toolResultExtractor");
             return this;
@@ -1847,4 +1844,17 @@ public class DefaultMcpClient implements McpClient {
             return new DefaultMcpClient(this);
         }
     }
+
+    private CompletableFuture<JsonNode> executeViaTransport(McpCallContext context) {
+        return McpJson.map(transport.sendRequest(context), McpJson::parse);
+    }
+
+    private CompletableFuture<JsonNode> executeViaTransport(McpClientMessage message) {
+        return McpJson.map(transport.sendRequest(message), McpJson::parse);
+    }
+
+    private CompletableFuture<JsonNode> initializeViaTransport(McpInitializeRequest request) {
+        return McpJson.map(transport.sendInitializeRequest(request), McpJson::parse);
+    }
+
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -617,7 +617,11 @@ public class DefaultMcpClient implements McpClient {
             McpCallContext retryContext = new McpCallContext(invocationContext, retryOperation);
             applyMeta(retryOperation, retryContext);
             CompletableFuture<JsonNode> resultFuture = executeViaTransport(retryContext);
-            result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            try {
+                result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException timeout) {
+                throw new McpOperationTimeoutException(retryOperationId, resultFuture, timeout);
+            }
             pendingOperations.remove(retryOperationId);
             parsed = multiRoundTripResult(result);
             retryCount++;
@@ -627,6 +631,39 @@ public class DefaultMcpClient implements McpClient {
             throw new RuntimeException("Unexpected resultType for " + operationName + ": " + resultType);
         }
         return result;
+    }
+
+    private void cancelTimedOutOperation(
+            TimeoutException timeout, long operationId, CompletableFuture<JsonNode> resultFuture) {
+        long timedOutOperationId = operationId;
+        CompletableFuture<JsonNode> timedOutResultFuture = resultFuture;
+        if (timeout instanceof McpOperationTimeoutException operationTimeout) {
+            timedOutOperationId = operationTimeout.operationId;
+            timedOutResultFuture = operationTimeout.resultFuture;
+        }
+        if (timedOutResultFuture != null) {
+            timedOutResultFuture.cancel(true);
+        }
+        pendingOperations.remove(timedOutOperationId);
+        if (shouldSendCancellationNotification()) {
+            McpCancellationNotification cancellation = new McpCancellationNotification(timedOutOperationId, "Timeout");
+            applyMeta(cancellation, null);
+            transport.sendMessage(cancellation);
+        }
+    }
+
+    private static class McpOperationTimeoutException extends TimeoutException {
+
+        private final long operationId;
+        private final CompletableFuture<JsonNode> resultFuture;
+
+        private McpOperationTimeoutException(
+                long operationId, CompletableFuture<JsonNode> resultFuture, TimeoutException cause) {
+            super(cause.getMessage());
+            this.operationId = operationId;
+            this.resultFuture = resultFuture;
+            initCause(cause);
+        }
     }
 
     @Override
@@ -716,14 +753,7 @@ public class DefaultMcpClient implements McpClient {
                     "tools/call");
         } catch (TimeoutException timeout) {
             notifyListeners(l -> l.onExecuteToolError(context, timeout));
-            if (resultFuture != null) {
-                resultFuture.cancel(true);
-            }
-            if (shouldSendCancellationNotification()) {
-                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
-                applyMeta(cancellation, null);
-                transport.sendMessage(cancellation);
-            }
+            cancelTimedOutOperation(timeout, operationId, resultFuture);
             // built on demand, not once at construction: a custom converter must not be invoked
             // for a tool call that never happened
             return toolResultConverter.convert(
@@ -810,14 +840,7 @@ public class DefaultMcpClient implements McpClient {
             return resourceResult;
         } catch (TimeoutException timeout) {
             notifyListeners(l -> l.onResourceGetError(context, timeout));
-            if (resultFuture != null) {
-                resultFuture.cancel(true);
-            }
-            if (shouldSendCancellationNotification()) {
-                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
-                applyMeta(cancellation, null);
-                transport.sendMessage(cancellation);
-            }
+            cancelTimedOutOperation(timeout, operationId, resultFuture);
             throw new RuntimeException(timeout);
         } catch (ExecutionException e) {
             notifyListeners(l -> l.onResourceGetError(context, e));
@@ -873,14 +896,7 @@ public class DefaultMcpClient implements McpClient {
             return promptResult;
         } catch (TimeoutException timeout) {
             notifyListeners(l -> l.onPromptGetError(context, timeout));
-            if (resultFuture != null) {
-                resultFuture.cancel(true);
-            }
-            if (shouldSendCancellationNotification()) {
-                McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
-                applyMeta(cancellation, null);
-                transport.sendMessage(cancellation);
-            }
+            cancelTimedOutOperation(timeout, operationId, resultFuture);
             throw new RuntimeException(timeout);
         } catch (ExecutionException e) {
             notifyListeners(l -> l.onPromptGetError(context, e));

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverter.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverter.java
@@ -1,0 +1,37 @@
+package dev.langchain4j.mcp.client;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Default converter for MCP tool responses backed by {@code content[]}.
+ * <p>
+ * It only supports {@code content} items of type {@code text}, joins multiple text
+ * fragments with newline characters, and stores the result in
+ * {@link ToolExecutionResult#resultText()}.
+ */
+public class DefaultMcpToolResultConverter implements McpToolResultConverter {
+
+    @Override
+    public ToolExecutionResult convert(List<Map<String, Object>> content, boolean isError) {
+        String resultText = content.stream().map(this::extractText).collect(Collectors.joining("\n"));
+
+        return ToolExecutionResult.builder()
+                .isError(isError)
+                .resultText(resultText)
+                .build();
+    }
+
+    private String extractText(Map<String, Object> contentItem) {
+        Object type = contentItem.get("type");
+        if (!"text".equals(type)) {
+            // Preserve the historical error message format from ToolExecutionHelper,
+            // where the JSON string value is rendered with quotes.
+            throw new RuntimeException("Unsupported content type: \"" + type + "\"");
+        }
+        Object text = contentItem.get("text");
+        return text == null ? "" : String.valueOf(text);
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpToolResultExtractor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpToolResultExtractor.java
@@ -12,7 +12,12 @@ import java.util.stream.StreamSupport;
  * {@code content} items of type {@code text}, joins multiple text fragments with
  * newline characters, and stores the result in {@link ToolExecutionResult#resultText()}.
  * It does not apply to responses that contain {@code structuredContent}.
+ *
+ * @deprecated use {@link DefaultMcpToolResultConverter} instead, which does not expose Jackson
+ * types.
  */
+@Deprecated(since = "1.20.0", forRemoval = true)
+@SuppressWarnings("removal")
 public class DefaultMcpToolResultExtractor implements McpToolResultExtractor {
 
     @Override

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/LegacyToolResultConverterAdapter.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/LegacyToolResultConverterAdapter.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.mcp.client;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Presents a user-supplied {@link McpToolResultExtractor} as an {@link McpToolResultConverter},
+ * so that the client has a single extraction path. The content is rendered back into a Jackson
+ * tree here, which is the cost of the deprecated interface and is confined to it.
+ */
+@Internal
+@SuppressWarnings("removal")
+class LegacyToolResultConverterAdapter implements McpToolResultConverter {
+
+    private final McpToolResultExtractor delegate;
+
+    LegacyToolResultConverterAdapter(McpToolResultExtractor delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ToolExecutionResult convert(List<Map<String, Object>> content, boolean isError) {
+        return delegate.extract(McpJson.parse(McpJson.serialize(content)), isError);
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
@@ -101,13 +101,34 @@ public interface McpClient extends AutoCloseable {
     void unsubscribeFromResource(String uri);
 
     /**
-     * Subscribes to resource content update notifications for the given URIs.
-     * Returns a subscription ID that can be used to unsubscribe later.
+     * Subscribes to resource content update notifications for the given URIs. Once subscribed,
+     * the server notifies the client whenever one of those resources changes; the notifications
+     * are delivered to the callback registered via {@code DefaultMcpClient.Builder#onResourceUpdated}.
+     * <p>
+     * The MCP specification requires the server to confirm a subscription before it sends anything
+     * on it, so this method blocks until that confirmation arrives and fails if it does not. When it
+     * returns normally, the subscription is established and the returned subscription ID can be
+     * passed to {@link #unsubscribeFromResources(long)} to stop receiving the notifications.
+     * How long the client waits for the confirmation is governed by
+     * {@code DefaultMcpClient.Builder#resourcesTimeout(Duration)}.
+     * <p>
+     * Because this method blocks, do not call it from inside a notification callback such as
+     * {@code onResourceUpdated}: those callbacks run on the thread that reads messages from the
+     * server, which is the same thread that would have to deliver the confirmation.
+     * <p>
      * Only available with MCP protocol version 2026-07-28 and later.
      *
      * @param uris the list of resource URIs to subscribe to
      * @return a subscription ID
      * @throws UnsupportedOperationException when using legacy protocol (2025-11-25)
+     * @throws McpException if the server rejects the subscription
+     * @throws IllegalStateException if the server confirms the subscription but declines to honour
+     *     the requested resource URIs, if it ends the subscription without ever confirming it, or if
+     *     the client is closed while the call is still waiting
+     * @throws java.util.concurrent.CancellationException if the subscription is cancelled before the
+     *     server confirms it, for example by a concurrent {@link #unsubscribeFromResources(long)}
+     * @throws RuntimeException if the underlying transport fails, or the server does not confirm the
+     *     subscription in time
      */
     default long subscribeToResources(List<String> uris) {
         throw new UnsupportedOperationException("subscribeToResources requires MCP protocol 2026-07-28 or later");

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
@@ -197,6 +197,13 @@ public interface McpClientListener {
     default void afterResourcesSubscribe(McpCallContext context, long subscriptionId, List<String> uris) {}
 
     /**
+     * Called when subscribing to resources fails, either because the server rejected the
+     * {@code subscriptions/listen} request or because it never acknowledged it in time.
+     * Only used with MCP protocol 2026-07-28 and later.
+     */
+    default void onResourcesSubscribeError(McpCallContext context, Throwable error) {}
+
+    /**
      * Called before unsubscribing from resources via subscription ID.
      * Only used with MCP protocol 2026-07-28 and later.
      *

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpErrorHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpErrorHelper.java
@@ -1,14 +1,20 @@
 package dev.langchain4j.mcp.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.protocol.McpErrorResponse;
 
 class McpErrorHelper {
 
     static void checkForErrors(JsonNode mcpMessage) {
-        if (mcpMessage.has("error")) {
-            JsonNode errorNode = mcpMessage.get("error");
-            throw new McpException(
-                    errorNode.get("code").asInt(), errorNode.get("message").asText());
+        if (!mcpMessage.has("error")) {
+            // the common case: skip building the whole response just to find no error
+            return;
+        }
+        McpErrorResponse.Error error =
+                McpJson.deserialize(mcpMessage, McpErrorResponse.class).getError();
+        if (error != null) {
+            throw new McpException(error.getCode(), error.getMessage());
         }
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpException.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpException.java
@@ -2,6 +2,8 @@ package dev.langchain4j.mcp.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.exception.LangChain4jException;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -11,17 +13,35 @@ public class McpException extends LangChain4jException {
 
     private final int errorCode;
     private final String errorMessage;
-    private final @Nullable JsonNode errorData;
+    private final @Nullable String errorDataAsJson;
 
     public McpException(int errorCode, String errorMessage) {
-        this(errorCode, errorMessage, null);
+        this(errorCode, errorMessage, (String) null);
     }
 
-    public McpException(int errorCode, String errorMessage, @Nullable JsonNode errorData) {
+    /**
+     * Creates an exception carrying the JSON-RPC {@code error.data} member as JSON text.
+     *
+     * <p>This is a factory rather than a constructor so that {@code new McpException(code, message, null)}
+     * keeps resolving to a single constructor and continues to compile.
+     */
+    public static McpException withErrorData(int errorCode, String errorMessage, @Nullable String errorDataAsJson) {
+        return new McpException(errorCode, errorMessage, errorDataAsJson);
+    }
+
+    private McpException(int errorCode, String errorMessage, @Nullable String errorDataAsJson) {
         super("Code: %d, message: %s".formatted(errorCode, errorMessage));
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
-        this.errorData = errorData;
+        this.errorDataAsJson = errorDataAsJson;
+    }
+
+    /**
+     * @deprecated use {@link #withErrorData(int, String, String)}, which does not expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    public McpException(int errorCode, String errorMessage, @Nullable JsonNode errorData) {
+        this(errorCode, errorMessage, errorData == null ? null : errorData.toString());
     }
 
     public int errorCode() {
@@ -32,7 +52,44 @@ public class McpException extends LangChain4jException {
         return errorMessage;
     }
 
+    /**
+     * Returns the JSON-RPC {@code error.data} member as JSON text.
+     */
+    public @Nullable String errorDataAsJson() {
+        return errorDataAsJson;
+    }
+
+    /**
+     * Returns the JSON-RPC {@code error.data} member as plain values, so callers do not need a
+     * JSON library.
+     *
+     * @return null when there is no {@code error.data}, and also when it is not a JSON object -
+     * JSON-RPC allows any value there. Use {@link #errorDataAsObject()} to read those.
+     */
+    public @Nullable Map<String, Object> errorDataAsMap() {
+        Object data = errorDataAsObject();
+        return data instanceof Map ? asMap(data) : null;
+    }
+
+    /**
+     * Returns the JSON-RPC {@code error.data} member as a plain JDK value: a {@link Map}, a
+     * {@link java.util.List}, a boxed primitive, or null. JSON-RPC allows {@code error.data} to be
+     * any value, so this is the accessor that can represent all of them.
+     */
+    public @Nullable Object errorDataAsObject() {
+        return errorDataAsJson == null ? null : McpJson.toValue(errorDataAsJson);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    /**
+     * @deprecated use {@link #errorDataAsMap()} or {@link #errorDataAsJson()}.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
     public @Nullable JsonNode errorData() {
-        return errorData;
+        return errorDataAsJson == null ? null : McpJson.parse(errorDataAsJson);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpGetPromptResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpGetPromptResult.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.mcp.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Objects;
 /**
  * The 'GetPromptResult' object from the MCP protocol schema.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpGetPromptResult {
 
     private final String description;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpIcon.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpIcon.java
@@ -1,12 +1,14 @@
 package dev.langchain4j.mcp.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
  * The 'Icon' object from the MCP protocol schema.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record McpIcon(
         @JsonProperty("mimeType") String mimeType,
         @JsonProperty("sizes") List<String> sizes,

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpJsonConversions.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpJsonConversions.java
@@ -1,0 +1,67 @@
+package dev.langchain4j.mcp.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.Internal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts Jackson's tree model into plain JDK values, so that MCP APIs can expose
+ * JSON payloads without requiring callers to depend on Jackson.
+ */
+@Internal
+public final class McpJsonConversions {
+
+    private McpJsonConversions() {}
+
+    public static Map<String, Object> toMap(JsonNode node) {
+        if (node == null || !node.isObject()) {
+            return null;
+        }
+        Map<String, Object> map = new LinkedHashMap<>();
+        node.properties().forEach(e -> map.put(e.getKey(), toValue(e.getValue())));
+        return map;
+    }
+
+    public static List<Map<String, Object>> toMaps(JsonNode arrayNode) {
+        if (arrayNode == null || !arrayNode.isArray()) {
+            return List.of();
+        }
+        List<Map<String, Object>> result = new ArrayList<>();
+        arrayNode.forEach(item -> result.add(toMap(item)));
+        return result;
+    }
+
+    public static Object toValue(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isObject()) {
+            return toMap(node);
+        }
+        if (node.isArray()) {
+            List<Object> values = new ArrayList<>();
+            node.forEach(item -> values.add(toValue(item)));
+            return values;
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.isBoolean()) {
+            return node.asBoolean();
+        }
+        if (node.isIntegralNumber()) {
+            if (node.canConvertToInt()) {
+                return node.asInt();
+            }
+            // asLong() silently truncates anything wider than a long
+            return node.canConvertToLong() ? node.asLong() : node.bigIntegerValue();
+        }
+        if (node.isFloatingPointNumber()) {
+            return node.asDouble();
+        }
+        return node.asText();
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpPrompt.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpPrompt.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.mcp.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import static dev.langchain4j.internal.Utils.copy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -13,6 +14,7 @@ import java.util.Objects;
  * It describes a declaration of a prompt, not its actual contents.
  * It contains a name, description and a list of arguments relevant for rendering an instance of the prompt.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpPrompt {
 
     private final String name;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpPromptArgument.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpPromptArgument.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.mcp.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -8,6 +9,7 @@ import java.util.Objects;
 /**
  * The 'PromptArgument' object from the MCP protocol schema.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpPromptArgument {
 
     private final String name;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpPromptMessage.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpPromptMessage.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.mcp.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -14,6 +15,7 @@ import java.util.Objects;
  * The 'PromptMessage' object from the MCP protocol schema.
  * This can be directly translated to a ChatMessage object from the LangChain4j API.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpPromptMessage {
 
     private final McpRole role;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpReadResourceResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpReadResourceResult.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.mcp.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Objects;
 /**
  * The 'ReadResourceResult' object from the MCP protocol schema.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpReadResourceResult {
 
     private final List<McpResourceContents> contents;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpResource.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpResource.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.mcp.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import static dev.langchain4j.internal.Utils.copy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -12,6 +13,7 @@ import java.util.Objects;
 /**
  * The 'Resource' object from the MCP protocol schema.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpResource {
     private final String uri;
     private final String name;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpResourceTemplate.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpResourceTemplate.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.mcp.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import static dev.langchain4j.internal.Utils.copy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -12,6 +13,7 @@ import java.util.Objects;
 /**
  * The 'ResourceTemplate' object from the MCP protocol schema.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpResourceTemplate {
 
     private final String uriTemplate;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpToolResultConverter.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpToolResultConverter.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.mcp.client;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts the content blocks of an MCP {@code CallToolResult} into the
+ * {@link ToolExecutionResult} the model sees. It is not invoked when the MCP server
+ * returns {@code structuredContent}, which is handled separately.
+ * <p>
+ * Content items are presented as plain maps, so implementations do not need a JSON library.
+ * A text item, for example, looks like {@code {"type": "text", "text": "..."}}.
+ * <p>
+ * The default client only supports {@code structuredContent} and text content out of the box.
+ * More specialized conversion strategies can be provided through
+ * {@link DefaultMcpClient.Builder#toolResultConverter(McpToolResultConverter)}.
+ */
+@FunctionalInterface
+public interface McpToolResultConverter {
+
+    /**
+     * @param content the content blocks of {@code CallToolResult}.
+     * @param isError whether the tool response is marked as an application-level error.
+     * @return the result to hand back to the caller, whose text is what the model sees.
+     */
+    ToolExecutionResult convert(List<Map<String, Object>> content, boolean isError);
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpToolResultExtractor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpToolResultExtractor.java
@@ -14,7 +14,10 @@ import dev.langchain4j.service.tool.ToolExecutionResult;
  * client only supports {@code structuredContent} and text content out of the box.
  * More specialized extraction strategies can be provided through
  * {@link DefaultMcpClient.Builder#toolResultExtractor(McpToolResultExtractor)}.
+ *
+ * @deprecated use {@link McpToolResultConverter}, which does not expose Jackson types.
  */
+@Deprecated(since = "1.20.0", forRemoval = true)
 public interface McpToolResultExtractor {
 
     /**

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/PromptsHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/PromptsHelper.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.mcp.client;
 
-import static dev.langchain4j.mcp.client.DefaultMcpClient.OBJECT_MAPPER;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.ArrayList;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.protocol.McpGetPromptResponse;
+import dev.langchain4j.mcp.protocol.McpListPromptsResult;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,26 +14,21 @@ class PromptsHelper {
 
     static List<McpPrompt> parsePromptRefs(JsonNode mcpMessage) {
         McpErrorHelper.checkForErrors(mcpMessage);
-        if (mcpMessage.has("result")) {
-            JsonNode resultNode = mcpMessage.get("result");
-            if (resultNode.has("prompts")) {
-                List<McpPrompt> promptRefs = new ArrayList<>();
-                for (JsonNode promptNode : resultNode.get("prompts")) {
-                    promptRefs.add(OBJECT_MAPPER.convertValue(promptNode, McpPrompt.class));
-                }
-                return promptRefs;
-            } else {
-                log.warn("Result does not contain 'prompts' element: {}", resultNode);
-                throw new IllegalResponseException("Result does not contain 'prompts' element");
-            }
-        } else {
+        McpListPromptsResult.Result result =
+                McpJson.deserialize(mcpMessage, McpListPromptsResult.class).getResult();
+        if (result == null) {
             log.warn("Result does not contain 'result' element: {}", mcpMessage);
             throw new IllegalResponseException("Result does not contain 'result' element");
         }
+        if (result.getPrompts() == null) {
+            log.warn("Result does not contain 'prompts' element: {}", mcpMessage);
+            throw new IllegalResponseException("Result does not contain 'prompts' element");
+        }
+        return result.getPrompts();
     }
 
     static McpGetPromptResult parsePromptContents(JsonNode mcpMessage) {
         McpErrorHelper.checkForErrors(mcpMessage);
-        return OBJECT_MAPPER.convertValue(mcpMessage.get("result"), McpGetPromptResult.class);
+        return McpJson.deserialize(mcpMessage, McpGetPromptResponse.class).getResult();
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ResourcesHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ResourcesHelper.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.mcp.client;
 
-import static dev.langchain4j.mcp.client.DefaultMcpClient.OBJECT_MAPPER;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.protocol.McpListResourceTemplatesResult;
+import dev.langchain4j.mcp.protocol.McpListResourcesResult;
+import dev.langchain4j.mcp.protocol.McpReadResourceResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
@@ -14,72 +16,53 @@ class ResourcesHelper {
 
     static List<McpResource> parseResourceRefs(JsonNode mcpMessage) {
         McpErrorHelper.checkForErrors(mcpMessage);
-        if (mcpMessage.has("result")) {
-            JsonNode resultNode = mcpMessage.get("result");
-            if (resultNode.has("resources")) {
-                List<McpResource> resourceRefs = new ArrayList<>();
-                for (JsonNode resourceNode : resultNode.get("resources")) {
-                    resourceRefs.add(OBJECT_MAPPER.convertValue(resourceNode, McpResource.class));
-                }
-                return resourceRefs;
-            } else {
-                log.warn("Result does not contain 'resources' element: {}", resultNode);
-                throw new IllegalResponseException("Result does not contain 'resources' element");
-            }
-        } else {
-            log.warn("Result does not contain 'result' element: {}", mcpMessage);
-            throw new IllegalResponseException("Result does not contain 'result' element");
-        }
-    }
-
-    static McpReadResourceResult parseResourceContents(JsonNode mcpMessage) {
-        McpErrorHelper.checkForErrors(mcpMessage);
-        if (mcpMessage.has("result")) {
-            JsonNode resultNode = mcpMessage.get("result");
-            if (resultNode.has("contents")) {
-                List<McpResourceContents> resourceContentsList = new ArrayList<>();
-                for (JsonNode resourceNode : resultNode.get("contents")) {
-                    String uri = resourceNode.get("uri").asText();
-                    String mimeType = resourceNode.get("mimeType") != null
-                            ? resourceNode.get("mimeType").asText()
-                            : null;
-                    if (resourceNode.has("text")) {
-                        resourceContentsList.add(new McpTextResourceContents(
-                                uri, resourceNode.get("text").asText(), mimeType));
-                    } else if (resourceNode.has("blob")) {
-                        resourceContentsList.add(new McpBlobResourceContents(
-                                uri, resourceNode.get("blob").asText(), mimeType));
-                    }
-                }
-                return new McpReadResourceResult(resourceContentsList);
-            } else {
-                log.warn("Result does not contain 'contents' element: {}", resultNode);
-                throw new IllegalResponseException("Result does not contain 'resources' element");
-            }
-        } else {
-            log.warn("Result does not contain 'result' element: {}", mcpMessage);
-            throw new IllegalResponseException("Result does not contain 'result' element");
-        }
+        McpListResourcesResult.Result result =
+                McpJson.deserialize(mcpMessage, McpListResourcesResult.class).getResult();
+        requireResult(result, mcpMessage);
+        return require(result.getResources(), "resources", mcpMessage);
     }
 
     static List<McpResourceTemplate> parseResourceTemplateRefs(JsonNode mcpMessage) {
         McpErrorHelper.checkForErrors(mcpMessage);
-        if (mcpMessage.has("result")) {
-            JsonNode resultNode = mcpMessage.get("result");
-            if (resultNode.has("resourceTemplates")) {
-                List<McpResourceTemplate> resourceTemplateRefs = new ArrayList<>();
-                for (JsonNode resourceTemplateNode : resultNode.get("resourceTemplates")) {
-                    resourceTemplateRefs.add(
-                            OBJECT_MAPPER.convertValue(resourceTemplateNode, McpResourceTemplate.class));
-                }
-                return resourceTemplateRefs;
-            } else {
-                log.warn("Result does not contain 'resourceTemplates' element: {}", resultNode);
-                throw new IllegalResponseException("Result does not contain 'resourceTemplates' element");
+        McpListResourceTemplatesResult.Result result =
+                McpJson.deserialize(mcpMessage, McpListResourceTemplatesResult.class).getResult();
+        requireResult(result, mcpMessage);
+        return require(result.getResourceTemplates(), "resourceTemplates", mcpMessage);
+    }
+
+    static McpReadResourceResult parseResourceContents(JsonNode mcpMessage) {
+        McpErrorHelper.checkForErrors(mcpMessage);
+        McpReadResourceResponse.Result result =
+                McpJson.deserialize(mcpMessage, McpReadResourceResponse.class).getResult();
+
+        requireResult(result, mcpMessage);
+        List<McpReadResourceResponse.Contents> contents = require(result.getContents(), "contents", mcpMessage);
+
+        List<McpResourceContents> resourceContentsList = new ArrayList<>();
+        for (McpReadResourceResponse.Contents item : contents) {
+            if (item.getText() != null) {
+                resourceContentsList.add(
+                        new McpTextResourceContents(item.getUri(), item.getText(), item.getMimeType()));
+            } else if (item.getBlob() != null) {
+                resourceContentsList.add(
+                        new McpBlobResourceContents(item.getUri(), item.getBlob(), item.getMimeType()));
             }
-        } else {
+        }
+        return new McpReadResourceResult(resourceContentsList);
+    }
+
+    private static void requireResult(Object result, JsonNode mcpMessage) {
+        if (result == null) {
             log.warn("Result does not contain 'result' element: {}", mcpMessage);
             throw new IllegalResponseException("Result does not contain 'result' element");
         }
+    }
+
+    private static <T> List<T> require(List<T> values, String element, JsonNode mcpMessage) {
+        if (values == null) {
+            log.warn("Result does not contain '{}' element: {}", element, mcpMessage);
+            throw new IllegalResponseException("Result does not contain '" + element + "' element");
+        }
+        return values;
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.protocol.McpCallToolResult;
+import dev.langchain4j.mcp.protocol.McpErrorResponse;
 import dev.langchain4j.service.tool.ToolExecutionResult;
-import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 class ToolExecutionHelper {
 
@@ -23,44 +25,50 @@ class ToolExecutionHelper {
      * {@link ToolExecutionResult#attributes()} and are not sent to the LLM.
      */
     static ToolExecutionResult extractResult(
-            JsonNode result, boolean ignoreApplicationLevelErrors, McpToolResultExtractor toolResultExtractor) {
-        if (result.has("result")) {
-            JsonNode resultNode = result.get("result");
-            if (resultNode.has("structuredContent")
-                    && !resultNode.get("structuredContent").isNull()) {
-                JsonNode content = resultNode.get("structuredContent");
-                if (isError(resultNode) && !ignoreApplicationLevelErrors) {
-                    throw new ToolExecutionException(content.toString());
+            JsonNode response, boolean ignoreApplicationLevelErrors, McpToolResultConverter toolResultConverter) {
+
+        McpCallToolResult.Result result =
+                McpJson.deserialize(response, McpCallToolResult.class).getResult();
+
+        if (result != null) {
+            boolean applicationError = Boolean.TRUE.equals(result.getIsError());
+            Map<String, Object> attributes = toolAttributes(result.getMeta());
+
+            if (result.getStructuredContent() != null) {
+                String resultText = McpJson.serialize(result.getStructuredContent());
+                if (applicationError && !ignoreApplicationLevelErrors) {
+                    throw new ToolExecutionException(resultText);
                 }
                 return ToolExecutionResult.builder()
-                        .result(toObject(content))
-                        .resultText(content.toString())
-                        .isError(isError(resultNode))
-                        .attributes(extractMeta(resultNode))
+                        .result(result.getStructuredContent())
+                        .resultText(resultText)
+                        .isError(applicationError)
+                        .attributes(attributes)
                         .build();
-            } else if (resultNode.has("content")) {
-                boolean applicationError = isError(resultNode);
+            }
+
+            if (result.getContent() != null) {
                 ToolExecutionResult toolExecutionResult =
-                        toolResultExtractor.extract(resultNode.get("content"), applicationError);
+                        toolResultConverter.convert(result.getContent(), applicationError);
                 if (applicationError && !ignoreApplicationLevelErrors) {
-                    throw new ToolExecutionException(errorMessage(toolExecutionResult, resultNode.get("content")));
+                    throw new ToolExecutionException(errorMessage(toolExecutionResult, result.getContent()));
                 }
-                return withAttributes(toolExecutionResult, extractMeta(resultNode));
-            } else {
-                throw new RuntimeException("Result does not contain 'content' element: " + result);
+                return withAttributes(toolExecutionResult, attributes);
             }
-        } else {
-            if (result.has("error")) {
-                String errorMessage = extractErrorMessage(result.get("error"));
-                Integer errorCode = extractErrorCode(result.get("error"));
-                if (errorCode != null && errorCode == ERROR_CODE_INVALID_PARAMETERS) {
-                    throw new ToolArgumentsException(errorMessage, errorCode);
-                } else {
-                    throw new ToolExecutionException(errorMessage, errorCode);
-                }
-            }
-            throw new RuntimeException("Result contains neither 'result' nor 'error' element: " + result);
+
+            throw new RuntimeException("Result does not contain 'content' element: " + response);
         }
+
+        McpErrorResponse.Error error =
+                McpJson.deserialize(response, McpErrorResponse.class).getError();
+        if (error != null) {
+            if (error.getCode() == ERROR_CODE_INVALID_PARAMETERS) {
+                throw new ToolArgumentsException(error.getMessage(), error.getCode());
+            }
+            throw new ToolExecutionException(error.getMessage(), error.getCode());
+        }
+
+        throw new RuntimeException("Result contains neither 'result' nor 'error' element: " + response);
     }
 
     /**
@@ -68,17 +76,16 @@ class ToolExecutionHelper {
      * Keys reserved by the MCP specification, such as 'io.modelcontextprotocol/serverInfo',
      * are skipped, as they describe the protocol interaction and not the tool result.
      */
-    private static Map<String, Object> extractMeta(JsonNode resultNode) {
-        JsonNode meta = resultNode.get("_meta");
-        if (meta == null || !meta.isObject()) {
+    private static Map<String, Object> toolAttributes(Map<String, Object> meta) {
+        if (meta == null) {
             return Map.of();
         }
         Map<String, Object> attributes = new HashMap<>();
-        for (Map.Entry<String, JsonNode> property : meta.properties()) {
-            if (!isReservedByMcp(property.getKey())) {
-                attributes.put(property.getKey(), toObject(property.getValue()));
+        meta.forEach((key, value) -> {
+            if (!isReservedByMcp(key)) {
+                attributes.put(key, value);
             }
-        }
+        });
         return attributes;
     }
 
@@ -97,7 +104,7 @@ class ToolExecutionHelper {
     }
 
     /**
-     * Adds the given attributes to a {@link ToolExecutionResult} produced by a {@link McpToolResultExtractor}.
+     * Adds the given attributes to a {@link ToolExecutionResult} produced by a {@link McpToolResultConverter}.
      * Attributes set by the extractor take precedence.
      */
     private static ToolExecutionResult withAttributes(ToolExecutionResult result, Map<String, Object> attributes) {
@@ -109,7 +116,7 @@ class ToolExecutionHelper {
         return result.toBuilder().attributes(mergedAttributes).build();
     }
 
-    private static String errorMessage(ToolExecutionResult toolExecutionResult, JsonNode content) {
+    private static String errorMessage(ToolExecutionResult toolExecutionResult, List<Map<String, Object>> content) {
         String contentsText = toolExecutionResult.resultContents().stream()
                 .filter(TextContent.class::isInstance)
                 .map(TextContent.class::cast)
@@ -121,7 +128,7 @@ class ToolExecutionHelper {
         if (toolExecutionResult.result() != null) {
             return toolExecutionResult.result().toString();
         }
-        String rawContentText = StreamSupport.stream(content.spliterator(), false)
+        String rawContentText = content.stream()
                 .map(ToolExecutionHelper::textFromContentItem)
                 .filter(text -> !text.isEmpty())
                 .collect(Collectors.joining("\n"));
@@ -131,71 +138,13 @@ class ToolExecutionHelper {
         return "";
     }
 
-    private static String textFromContentItem(JsonNode contentItem) {
-        JsonNode type = contentItem.get("type");
-        JsonNode text = contentItem.get("text");
-        if (type != null && "text".equals(type.asText()) && text != null) {
-            return text.asText();
+    private static String textFromContentItem(Map<String, Object> contentItem) {
+        Object type = contentItem.get("type");
+        Object text = contentItem.get("text");
+        if ("text".equals(type) && text != null) {
+            return String.valueOf(text);
         }
         return "";
     }
 
-    /**
-     * Converts any JsonNode into a recursive Map using basic Java types
-     */
-    static Object toObject(JsonNode content) {
-        return switch (content.getNodeType()) {
-            case BOOLEAN -> content.asBoolean();
-            case NUMBER ->
-                switch (content.numberType()) {
-                    case INT -> content.asInt();
-                    case LONG -> content.asLong();
-                    case BIG_INTEGER -> content.bigIntegerValue();
-                    case FLOAT, DOUBLE, BIG_DECIMAL -> content.asDouble();
-                };
-            case STRING -> content.asText();
-            case NULL -> null;
-            case ARRAY ->
-                StreamSupport.stream(content.spliterator(), true)
-                        .map(element -> toObject(element))
-                        .collect(Collectors.toList());
-            case OBJECT -> {
-                Map<String, Object> map = new HashMap<>();
-                for (Map.Entry<String, JsonNode> property : content.properties()) {
-                    map.put(property.getKey(), toObject(property.getValue()));
-                }
-                yield map;
-            }
-            case BINARY -> {
-                try {
-                    yield content.binaryValue();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            case POJO -> new Object(); // shouldn't happen
-            case MISSING -> new Object(); // shouldn't happen
-        };
-    }
-
-    private static boolean isError(JsonNode resultNode) {
-        if (resultNode.has("isError")) {
-            return resultNode.get("isError").asBoolean();
-        }
-        return false;
-    }
-
-    private static String extractErrorMessage(JsonNode errorNode) {
-        if (errorNode.has("message")) {
-            return errorNode.get("message").asText("");
-        }
-        return "";
-    }
-
-    private static Integer extractErrorCode(JsonNode errorNode) {
-        if (errorNode.has("code")) {
-            return errorNode.get("code").asInt();
-        }
-        return null;
-    }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -2,13 +2,8 @@ package dev.langchain4j.mcp.client;
 
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.*;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
@@ -26,31 +21,28 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class ToolSpecificationHelper {
 
     private static final Logger log = LoggerFactory.getLogger(ToolSpecificationHelper.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<List<McpIcon>> MCP_ICON_LIST_TYPE = new TypeReference<>() {};
     private static final Set<String> ALLOWED_HEADER_PARAM_TYPES = Set.of("string", "integer", "boolean");
 
     /**
      * Converts the 'tools' element from a ListToolsResult MCP message
      * to a list of ToolSpecification objects.
      */
-    static List<ToolSpecification> toolSpecificationListFromMcpResponse(ArrayNode array) {
+    static List<ToolSpecification> toolSpecificationListFromMcpResponse(List<Map<String, Object>> tools) {
         List<ToolSpecification> result = new ArrayList<>();
-        for (JsonNode tool : array) {
-            String toolName = tool.get("name").asText();
+        for (Map<String, Object> tool : tools) {
+            String toolName = string(tool.get("name"));
             final ToolSpecification.Builder builder = ToolSpecification.builder();
             builder.name(toolName);
-            if (tool.has("description")) {
-                builder.description(tool.get("description").asText());
+            if (tool.containsKey("description")) {
+                builder.description(string(tool.get("description")));
             }
-            JsonNode inputSchema = tool.get("inputSchema");
+            Map<String, Object> inputSchema = object(tool.get("inputSchema"));
             builder.parameters((JsonObjectSchema) jsonNodeToJsonSchemaElement(inputSchema));
             Map<String, String> paramHeaders = extractAndValidateMcpParamHeaders(inputSchema, toolName);
             if (paramHeaders == null) {
@@ -59,20 +51,20 @@ class ToolSpecificationHelper {
             if (!paramHeaders.isEmpty()) {
                 builder.addMetadata(MCP_PARAM_HEADERS, paramHeaders);
             }
-            if (tool.has("annotations")) {
-                processMcpToolAnnotations(tool.get("annotations"), builder);
+            if (tool.containsKey("annotations")) {
+                processMcpToolAnnotations(object(tool.get("annotations")), builder);
             }
-            if (tool.has("_meta")) {
-                processMcpToolMetadata(tool.get("_meta"), builder);
+            if (tool.containsKey("_meta")) {
+                processMcpToolMetadata(object(tool.get("_meta")), builder);
             }
-            if (tool.has("title")) {
-                builder.addMetadata(TITLE, tool.get("title").asText());
+            if (tool.containsKey("title")) {
+                builder.addMetadata(TITLE, string(tool.get("title")));
             }
-            if (tool.has("outputSchema")) {
-                builder.addMetadata(OUTPUT_SCHEMA, OBJECT_MAPPER.convertValue(tool.get("outputSchema"), Object.class));
+            if (tool.containsKey("outputSchema")) {
+                builder.addMetadata(OUTPUT_SCHEMA, tool.get("outputSchema"));
             }
-            if (tool.has("icons")) {
-                builder.addMetadata(ICONS, OBJECT_MAPPER.convertValue(tool.get("icons"), MCP_ICON_LIST_TYPE));
+            if (tool.containsKey("icons")) {
+                builder.addMetadata(ICONS, toIcons(tool.get("icons")));
             }
             result.add(builder.build());
         }
@@ -83,108 +75,104 @@ class ToolSpecificationHelper {
      * Converts the 'inputSchema' element (inside the 'Tool' type in the MCP schema)
      * to a JsonSchemaElement object that describes the tool's arguments.
      */
-    static JsonSchemaElement jsonNodeToJsonSchemaElement(JsonNode node) {
+    static JsonSchemaElement jsonNodeToJsonSchemaElement(Map<String, Object> node) {
         // MCP SEP-2106 allows composition keywords such as anyOf alongside type "object", and the tool
         // inputSchema root is always type "object". JsonObjectSchema cannot represent a schema-level anyOf,
         // so an object-typed node is parsed as an object (its anyOf constraint is not carried over) rather
         // than as a JsonAnyOfSchema that the root would then fail to cast.
-        if (node.has("anyOf") && !isObjectType(node)) {
+        if (node.containsKey("anyOf") && !isObjectType(node)) {
             JsonAnyOfSchema.Builder anyOf = JsonAnyOfSchema.builder();
-            JsonSchemaElement[] types = StreamSupport.stream(node.get("anyOf").spliterator(), false)
-                    .map(ToolSpecificationHelper::jsonNodeToJsonSchemaElement)
+            JsonSchemaElement[] types = array(node.get("anyOf")).stream()
+                    .map(item -> jsonNodeToJsonSchemaElement(object(item)))
                     .toArray(JsonSchemaElement[]::new);
             anyOf.anyOf(types);
-            if (node.has("description")) {
-                anyOf.description(node.get("description").asText());
+            if (node.containsKey("description")) {
+                anyOf.description(string(node.get("description")));
             }
             return anyOf.build();
         }
-        if (node.has("$ref")) {
-            String referenceKey = extractReferenceKey(node.get("$ref").asText());
+        if (node.containsKey("$ref")) {
+            String referenceKey = extractReferenceKey(string(node.get("$ref")));
             if (referenceKey != null) {
                 return JsonReferenceSchema.builder().reference(referenceKey).build();
             }
         }
-        JsonNode typeNode = node.get("type");
+        Object typeNode = node.get("type");
         // If no type is specified, default to object schema
-        if (typeNode == null
-                || (node.get("type").getNodeType() == JsonNodeType.STRING
-                        && node.get("type").asText().equals("object"))) {
+        if (typeNode == null || "object".equals(typeNode)) {
             JsonObjectSchema.Builder builder = JsonObjectSchema.builder();
-            if (node.has("description")) {
-                builder.description(node.get("description").asText());
+            if (node.containsKey("description")) {
+                builder.description(string(node.get("description")));
             }
-            if (node.has("properties")) {
-                ObjectNode propertiesObject = (ObjectNode) node.get("properties");
-                for (Map.Entry<String, JsonNode> property : propertiesObject.properties()) {
-                    builder.addProperty(property.getKey(), jsonNodeToJsonSchemaElement(property.getValue()));
+            if (node.containsKey("properties")) {
+                for (Map.Entry<String, Object> property : object(node.get("properties")).entrySet()) {
+                    builder.addProperty(property.getKey(), jsonNodeToJsonSchemaElement(object(property.getValue())));
                 }
             }
-            if (node.has("required")) {
-                builder.required(toStringArray((ArrayNode) node.get("required")));
+            if (node.containsKey("required")) {
+                builder.required(toStringArray(node.get("required")));
             }
-            if (node.has("additionalProperties")) {
-                builder.additionalProperties(node.get("additionalProperties").asBoolean(false));
+            if (node.containsKey("additionalProperties")) {
+                builder.additionalProperties(bool(node.get("additionalProperties")));
             }
             // Handle $defs (draft 2019-09+) and definitions (draft-07)
-            JsonNode defsNode = node.has("$defs") ? node.get("$defs") : node.get("definitions");
+            Object defsNode = node.containsKey("$defs") ? node.get("$defs") : node.get("definitions");
             if (defsNode != null) {
                 Map<String, JsonSchemaElement> definitions = new LinkedHashMap<>();
-                for (Map.Entry<String, JsonNode> entry : ((ObjectNode) defsNode).properties()) {
-                    definitions.put(entry.getKey(), jsonNodeToJsonSchemaElement(entry.getValue()));
+                for (Map.Entry<String, Object> entry : object(defsNode).entrySet()) {
+                    definitions.put(entry.getKey(), jsonNodeToJsonSchemaElement(object(entry.getValue())));
                 }
                 builder.definitions(definitions);
             }
             return builder.build();
-        } else if (node.get("type").getNodeType() == JsonNodeType.STRING) {
-            String nodeType = node.get("type").asText();
+        } else if (typeNode instanceof String) {
+            String nodeType = (String) typeNode;
             if (nodeType.equals("string")) {
-                if (node.has("enum")) {
+                if (node.containsKey("enum")) {
                     JsonEnumSchema.Builder builder = JsonEnumSchema.builder();
-                    if (node.has("description")) {
-                        builder.description(node.get("description").asText());
+                    if (node.containsKey("description")) {
+                        builder.description(string(node.get("description")));
                     }
-                    builder.enumValues(toStringArray((ArrayNode) node.get("enum")));
+                    builder.enumValues(toStringArray(node.get("enum")));
                     return builder.build();
                 } else {
                     JsonStringSchema.Builder builder = JsonStringSchema.builder();
-                    if (node.has("description")) {
-                        builder.description(node.get("description").asText());
+                    if (node.containsKey("description")) {
+                        builder.description(string(node.get("description")));
                     }
                     return builder.build();
                 }
             } else if (nodeType.equals("number")) {
                 JsonNumberSchema.Builder builder = JsonNumberSchema.builder();
-                if (node.has("description")) {
-                    builder.description(node.get("description").asText());
+                if (node.containsKey("description")) {
+                    builder.description(string(node.get("description")));
                 }
                 return builder.build();
             } else if (nodeType.equals("integer")) {
                 JsonIntegerSchema.Builder builder = JsonIntegerSchema.builder();
-                if (node.has("description")) {
-                    builder.description(node.get("description").asText());
+                if (node.containsKey("description")) {
+                    builder.description(string(node.get("description")));
                 }
                 return builder.build();
             } else if (nodeType.equals("boolean")) {
                 JsonBooleanSchema.Builder builder = JsonBooleanSchema.builder();
-                if (node.has("description")) {
-                    builder.description(node.get("description").asText());
+                if (node.containsKey("description")) {
+                    builder.description(string(node.get("description")));
                 }
                 return builder.build();
             } else if (nodeType.equals("array")) {
                 JsonArraySchema.Builder builder = JsonArraySchema.builder();
-                if (node.has("description")) {
-                    builder.description(node.get("description").asText());
+                if (node.containsKey("description")) {
+                    builder.description(string(node.get("description")));
                 }
-                if (node.has("items")) {
+                if (node.containsKey("items")) {
                     // if 'items' is an empty array, or missing altogether,
                     // we leave the "items" field unset,
                     // which means it will be serialized as "items": {},
                     // which means "any value"
-                    if (!node.get("items").isArray()
-                            || (node.get("items").isArray()
-                                    && !node.get("items").isEmpty())) {
-                        builder.items(jsonNodeToJsonSchemaElement(node.get("items")));
+                    Object items = node.get("items");
+                    if (!(items instanceof List) || !((List<?>) items).isEmpty()) {
+                        builder.items(jsonNodeToJsonSchemaElement(object(items)));
                     }
                 }
                 return builder.build();
@@ -218,29 +206,26 @@ class ToolSpecificationHelper {
             //   ]
             // }
             JsonAnyOfSchema.Builder anyOf = JsonAnyOfSchema.builder();
-            JsonSchemaElement[] types = StreamSupport.stream(node.get("type").spliterator(), false)
+            JsonSchemaElement[] types = array(typeNode).stream()
                     .map(ToolSpecificationHelper::toTypeElement)
                     .toArray(JsonSchemaElement[]::new);
             anyOf.anyOf(types);
-            if (node.has("description")) {
-                anyOf.description(node.get("description").asText());
+            if (node.containsKey("description")) {
+                anyOf.description(string(node.get("description")));
             }
             return anyOf.build();
         }
     }
 
-    private static boolean isObjectType(JsonNode node) {
-        JsonNode typeNode = node.get("type");
-        return typeNode != null
-                && typeNode.getNodeType() == JsonNodeType.STRING
-                && typeNode.asText().equals("object");
+    private static boolean isObjectType(Map<String, Object> node) {
+        return "object".equals(node.get("type"));
     }
 
-    private static JsonSchemaElement toTypeElement(JsonNode node) {
-        if (!node.isTextual()) {
+    private static JsonSchemaElement toTypeElement(Object node) {
+        if (!(node instanceof String)) {
             throw new IllegalArgumentException(node + " is not a string");
         }
-        switch (node.textValue()) {
+        switch ((String) node) {
             case "string":
                 return JsonStringSchema.builder().build();
             case "number":
@@ -256,7 +241,7 @@ class ToolSpecificationHelper {
             case "null":
                 return new JsonNullSchema();
             default:
-                throw new IllegalArgumentException("Unsupported type: " + node.textValue());
+                throw new IllegalArgumentException("Unsupported type: " + node);
         }
     }
 
@@ -276,46 +261,44 @@ class ToolSpecificationHelper {
         return null;
     }
 
-    private static String[] toStringArray(ArrayNode jsonArray) {
-        String[] result = new String[jsonArray.size()];
-        for (int i = 0; i < jsonArray.size(); i++) {
-            result[i] = jsonArray.get(i).asText();
+    private static String[] toStringArray(Object jsonArray) {
+        List<Object> values = array(jsonArray);
+        String[] result = new String[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            result[i] = string(values.get(i));
         }
         return result;
     }
 
-    private static void processMcpToolAnnotations(JsonNode annotations, ToolSpecification.Builder builder) {
-        if (annotations.has(DESTRUCTIVE_HINT)) {
+    private static void processMcpToolAnnotations(Map<String, Object> annotations, ToolSpecification.Builder builder) {
+        if (annotations.containsKey(DESTRUCTIVE_HINT)) {
             builder.addMetadata(
-                    DESTRUCTIVE_HINT, annotations.get(DESTRUCTIVE_HINT).asBoolean());
+                    DESTRUCTIVE_HINT, bool(annotations.get(DESTRUCTIVE_HINT)));
         }
-        if (annotations.has(IDEMPOTENT_HINT)) {
+        if (annotations.containsKey(IDEMPOTENT_HINT)) {
             builder.addMetadata(
-                    IDEMPOTENT_HINT, annotations.get(IDEMPOTENT_HINT).asBoolean());
+                    IDEMPOTENT_HINT, bool(annotations.get(IDEMPOTENT_HINT)));
         }
-        if (annotations.has(OPEN_WORLD_HINT)) {
+        if (annotations.containsKey(OPEN_WORLD_HINT)) {
             builder.addMetadata(
-                    OPEN_WORLD_HINT, annotations.get(OPEN_WORLD_HINT).asBoolean());
+                    OPEN_WORLD_HINT, bool(annotations.get(OPEN_WORLD_HINT)));
         }
-        if (annotations.has(READ_ONLY_HINT)) {
-            builder.addMetadata(READ_ONLY_HINT, annotations.get(READ_ONLY_HINT).asBoolean());
+        if (annotations.containsKey(READ_ONLY_HINT)) {
+            builder.addMetadata(READ_ONLY_HINT, bool(annotations.get(READ_ONLY_HINT)));
         }
         // note that the TITLE_ANNOTATION constant doesn't contain 'title' to disambiguate it with the other title that
         // is
         // stored directly in the Tool object
-        if (annotations.has("title")) {
-            builder.addMetadata(TITLE_ANNOTATION, annotations.get("title").asText());
+        if (annotations.containsKey("title")) {
+            builder.addMetadata(TITLE_ANNOTATION, string(annotations.get("title")));
         }
     }
 
-    private static void processMcpToolMetadata(JsonNode meta, ToolSpecification.Builder builder) {
-        for (Map.Entry<String, JsonNode> property : meta.properties()) {
-            // convert the value to a nested Map (independent of Jackson) and store it in the metadata
-            builder.addMetadata(property.getKey(), OBJECT_MAPPER.convertValue(property.getValue(), Object.class));
-        }
+    private static void processMcpToolMetadata(Map<String, Object> meta, ToolSpecification.Builder builder) {
+        meta.forEach(builder::addMetadata);
     }
 
-    static Map<String, String> extractAndValidateMcpParamHeaders(JsonNode schema, String toolName) {
+    static Map<String, String> extractAndValidateMcpParamHeaders(Map<String, Object> schema, String toolName) {
         Map<String, String> result = new LinkedHashMap<>();
         Set<String> seenHeaderNamesLower = new HashSet<>();
         List<String> errors = new ArrayList<>();
@@ -333,30 +316,28 @@ class ToolSpecificationHelper {
             "items", "prefixItems", "additionalProperties", "oneOf", "anyOf", "allOf", "not", "if", "then", "else");
 
     private static void extractAndValidateMcpParamHeaders(
-            JsonNode schema,
+            Map<String, Object> schema,
             String pathPrefix,
             Map<String, String> result,
             Set<String> seenHeaderNamesLower,
             List<String> errors) {
         checkForbiddenSubtrees(schema, errors);
-        JsonNode properties = schema.path("properties");
-        if (properties.isMissingNode() || !properties.isObject()) {
-            return;
-        }
-        for (Map.Entry<String, JsonNode> entry : properties.properties()) {
-            JsonNode propSchema = entry.getValue();
+        Map<String, Object> properties = object(schema.get("properties"));
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            // a non-object property schema yields an empty map, which simply declares no header
+            Map<String, Object> propSchema = object(entry.getValue());
             String propertyPath = pathPrefix.isEmpty() ? entry.getKey() : pathPrefix + "." + entry.getKey();
-            JsonNode headerAnnotation = propSchema.get("x-mcp-header");
+            Object headerAnnotation = propSchema.get("x-mcp-header");
             if (headerAnnotation != null) {
-                if (!headerAnnotation.isTextual()) {
+                if (!(headerAnnotation instanceof String)) {
                     errors.add("x-mcp-header value must be a string, but property '" + propertyPath + "' declares "
-                            + headerAnnotation.getNodeType().name().toLowerCase());
+                            + jsonTypeName(headerAnnotation));
                 } else {
                     validateMcpParamHeader(
-                            headerAnnotation.asText(), propSchema, propertyPath, result, seenHeaderNamesLower, errors);
+                            (String) headerAnnotation, propSchema, propertyPath, result, seenHeaderNamesLower, errors);
                 }
             }
-            if (propSchema.has("properties")) {
+            if (propSchema.containsKey("properties")) {
                 extractAndValidateMcpParamHeaders(propSchema, propertyPath, result, seenHeaderNamesLower, errors);
             } else {
                 checkForbiddenSubtrees(propSchema, errors);
@@ -366,7 +347,7 @@ class ToolSpecificationHelper {
 
     private static void validateMcpParamHeader(
             String headerName,
-            JsonNode propSchema,
+            Map<String, Object> propSchema,
             String propertyPath,
             Map<String, String> result,
             Set<String> seenHeaderNamesLower,
@@ -397,18 +378,18 @@ class ToolSpecificationHelper {
      * so a header-carrying property has to be checked against every declared type.
      * "null" is skipped: it only marks the property as optional.
      */
-    private static List<String> declaredTypes(JsonNode propSchema) {
-        JsonNode type = propSchema.get("type");
+    private static List<String> declaredTypes(Map<String, Object> propSchema) {
+        Object type = propSchema.get("type");
         if (type == null) {
             return List.of();
         }
         List<String> types = new ArrayList<>();
-        if (type.isTextual()) {
-            types.add(type.asText());
-        } else if (type.isArray()) {
-            for (JsonNode t : type) {
-                if (t.isTextual()) {
-                    types.add(t.asText());
+        if (type instanceof String) {
+            types.add((String) type);
+        } else if (type instanceof List) {
+            for (Object t : (List<?>) type) {
+                if (t instanceof String) {
+                    types.add((String) t);
                 }
             }
         }
@@ -416,9 +397,9 @@ class ToolSpecificationHelper {
         return types;
     }
 
-    private static void checkForbiddenSubtrees(JsonNode schema, List<String> errors) {
+    private static void checkForbiddenSubtrees(Map<String, Object> schema, List<String> errors) {
         for (String keyword : FORBIDDEN_SCHEMA_KEYWORDS) {
-            JsonNode node = schema.get(keyword);
+            Object node = schema.get(keyword);
             if (node != null && containsHeaderAnnotation(node)) {
                 errors.add("x-mcp-header found inside '" + keyword
                         + "' (annotations must be statically reachable via properties keys only)");
@@ -426,18 +407,19 @@ class ToolSpecificationHelper {
         }
     }
 
-    private static boolean containsHeaderAnnotation(JsonNode node) {
-        if (node.isObject()) {
-            if (node.has("x-mcp-header")) {
+    private static boolean containsHeaderAnnotation(Object node) {
+        if (node instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) node;
+            if (map.containsKey("x-mcp-header")) {
                 return true;
             }
-            for (JsonNode child : node) {
+            for (Object child : map.values()) {
                 if (containsHeaderAnnotation(child)) {
                     return true;
                 }
             }
-        } else if (node.isArray()) {
-            for (JsonNode child : node) {
+        } else if (node instanceof List) {
+            for (Object child : (List<?>) node) {
                 if (containsHeaderAnnotation(child)) {
                     return true;
                 }
@@ -461,4 +443,73 @@ class ToolSpecificationHelper {
         }
         return "!#$%&'*+-.^_`|~".indexOf(c) >= 0;
     }
+
+    // --- JSON value accessors, over plain JDK types rather than a JSON library ---
+
+    /**
+     * Mirrors JsonNode.asBoolean(false), which also accepts the strings "true" and "false".
+     */
+    private static boolean bool(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue() != 0;
+        }
+        // TextNode.asBoolean() accepts only the exact, trimmed token
+        return value instanceof String && "true".equals(((String) value).trim());
+    }
+
+    /**
+     * Mirrors JsonNode.asText(), which renders scalars but yields "" for objects and arrays
+     * rather than their Java toString form.
+     */
+    private static String string(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Map || value instanceof List) {
+            return "";
+        }
+        return String.valueOf(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> object(Object value) {
+        // mirrors JsonNode.path(): anything that is not an object is treated as an empty one,
+        // so a boolean schema or a tuple-form 'items' degrades instead of failing
+        return value instanceof Map ? (Map<String, Object>) value : Map.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> array(Object value) {
+        return value instanceof List ? (List<Object>) value : List.of();
+    }
+
+    private static List<McpIcon> toIcons(Object value) {
+        return McpJson.convertList(value, McpIcon.class);
+    }
+
+    /**
+     * Mirrors the JSON type names Jackson reports, so validation messages are unchanged.
+     */
+    private static String jsonTypeName(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof String) {
+            return "string";
+        }
+        if (value instanceof Boolean) {
+            return "boolean";
+        }
+        if (value instanceof Number) {
+            return "number";
+        }
+        if (value instanceof List) {
+            return "array";
+        }
+        return "object";
+    }
+
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -105,7 +105,8 @@ class ToolSpecificationHelper {
                 builder.description(string(node.get("description")));
             }
             if (node.containsKey("properties")) {
-                for (Map.Entry<String, Object> property : object(node.get("properties")).entrySet()) {
+                for (Map.Entry<String, Object> property :
+                        object(node.get("properties")).entrySet()) {
                     builder.addProperty(property.getKey(), jsonNodeToJsonSchemaElement(object(property.getValue())));
                 }
             }
@@ -113,7 +114,17 @@ class ToolSpecificationHelper {
                 builder.required(toStringArray(node.get("required")));
             }
             if (node.containsKey("additionalProperties")) {
-                builder.additionalProperties(bool(node.get("additionalProperties")));
+                Object additionalProperties = node.get("additionalProperties");
+                if (additionalProperties instanceof Map) {
+                    // A schema-typed additionalProperties (e.g. {"type": "string"}) means additional
+                    // properties ARE allowed, just constrained to that schema. JsonObjectSchema only
+                    // models this as a boolean, so it must be treated as "allowed" (true) rather than
+                    // being collapsed to false, which would wrongly tell the model to reject every
+                    // extra property.
+                    builder.additionalProperties(true);
+                } else {
+                    builder.additionalProperties(bool(additionalProperties));
+                }
             }
             // Handle $defs (draft 2019-09+) and definitions (draft-07)
             Object defsNode = node.containsKey("$defs") ? node.get("$defs") : node.get("definitions");
@@ -272,16 +283,13 @@ class ToolSpecificationHelper {
 
     private static void processMcpToolAnnotations(Map<String, Object> annotations, ToolSpecification.Builder builder) {
         if (annotations.containsKey(DESTRUCTIVE_HINT)) {
-            builder.addMetadata(
-                    DESTRUCTIVE_HINT, bool(annotations.get(DESTRUCTIVE_HINT)));
+            builder.addMetadata(DESTRUCTIVE_HINT, bool(annotations.get(DESTRUCTIVE_HINT)));
         }
         if (annotations.containsKey(IDEMPOTENT_HINT)) {
-            builder.addMetadata(
-                    IDEMPOTENT_HINT, bool(annotations.get(IDEMPOTENT_HINT)));
+            builder.addMetadata(IDEMPOTENT_HINT, bool(annotations.get(IDEMPOTENT_HINT)));
         }
         if (annotations.containsKey(OPEN_WORLD_HINT)) {
-            builder.addMetadata(
-                    OPEN_WORLD_HINT, bool(annotations.get(OPEN_WORLD_HINT)));
+            builder.addMetadata(OPEN_WORLD_HINT, bool(annotations.get(OPEN_WORLD_HINT)));
         }
         if (annotations.containsKey(READ_ONLY_HINT)) {
             builder.addMetadata(READ_ONLY_HINT, bool(annotations.get(READ_ONLY_HINT)));
@@ -511,5 +519,4 @@ class ToolSpecificationHelper {
         }
         return "object";
     }
-
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -222,6 +222,9 @@ class ToolSpecificationHelper {
                     .map(ToolSpecificationHelper::toTypeElement)
                     .toArray(JsonSchemaElement[]::new);
             anyOf.anyOf(types);
+            if (node.has("description")) {
+                anyOf.description(node.get("description").asText());
+            }
             return anyOf.build();
         }
     }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/DefaultMcpLogMessageHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/DefaultMcpLogMessageHandler.java
@@ -14,14 +14,14 @@ public class DefaultMcpLogMessageHandler implements McpLogMessageHandler {
     @Override
     public void handleLogMessage(McpLogMessage message) {
         if (message.level() == null) {
-            log.warn("Received MCP log message with unknown level: {}", message.data());
+            log.warn("Received MCP log message with unknown level: {}", message.dataAsJson());
             return;
         }
         switch (message.level()) {
-            case DEBUG -> log.debug("MCP logger: {}: {}", message.logger(), message.data());
-            case INFO, NOTICE -> log.info("MCP logger: {}: {}", message.logger(), message.data());
-            case WARNING -> log.warn("MCP logger: {}: {}", message.logger(), message.data());
-            case ERROR, CRITICAL, ALERT, EMERGENCY -> log.error("MCP logger: {}: {}", message.logger(), message.data());
+            case DEBUG -> log.debug("MCP logger: {}: {}", message.logger(), message.dataAsJson());
+            case INFO, NOTICE -> log.info("MCP logger: {}: {}", message.logger(), message.dataAsJson());
+            case WARNING -> log.warn("MCP logger: {}: {}", message.logger(), message.dataAsJson());
+            case ERROR, CRITICAL, ALERT, EMERGENCY -> log.error("MCP logger: {}: {}", message.logger(), message.dataAsJson());
         }
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLogLevel.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLogLevel.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.mcp.client.logging;
 
+import java.util.Locale;
+
 /**
  * Log level of an MCP log message.
  */
@@ -18,7 +20,7 @@ public enum McpLogLevel {
             return null;
         }
         try {
-            return valueOf(val.toUpperCase());
+            return valueOf(val.toUpperCase(Locale.ROOT));
         } catch (Exception e) {
             return null;
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLogMessage.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLogMessage.java
@@ -3,20 +3,22 @@ package dev.langchain4j.mcp.client.logging;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-
+import dev.langchain4j.mcp.client.McpJsonConversions;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import java.util.Map;
 import java.util.Objects;
 
 public class McpLogMessage {
 
     private final McpLogLevel level;
     private final String logger;
-    private final JsonNode data;
+    private final Object data;
 
     @JsonCreator
     public McpLogMessage(
             @JsonProperty("level") McpLogLevel level,
             @JsonProperty("logger") String logger,
-            @JsonProperty("data") JsonNode data
+            @JsonProperty("data") Object data
     ) {
         this.level = level;
         this.logger = logger;
@@ -24,14 +26,34 @@ public class McpLogMessage {
     }
 
     /**
-     * Parses a McpLogMessage from the contents of the 'params' object inside a 'notifications/message' message.
+     * @deprecated use {@link #McpLogMessage(McpLogLevel, String, Object)}, which does not expose
+     * Jackson types.
      */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    public McpLogMessage(McpLogLevel level, String logger, JsonNode data) {
+        this(level, logger, (Object) (data == null ? null : McpJsonConversions.toValue(data)));
+    }
+
+    /**
+     * Parses a McpLogMessage from the contents of the 'params' object inside a 'notifications/message'
+     * message, presented as plain values.
+     */
+    public static McpLogMessage fromMap(Map<String, Object> params) {
+        Object levelValue = params.get("level");
+        McpLogLevel level = McpLogLevel.from(levelValue == null ? null : String.valueOf(levelValue));
+        Object logger = params.get("logger");
+        return new McpLogMessage(level, logger == null ? null : String.valueOf(logger), params.get("data"));
+    }
+
+    /**
+     * Parses a McpLogMessage from the contents of the 'params' object inside a 'notifications/message'
+     * message.
+     *
+     * @deprecated use {@link #fromMap(Map)}, which does not expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
     public static McpLogMessage fromJson(JsonNode json) {
-        McpLogLevel level = McpLogLevel.from(json.get("level").asText());
-        JsonNode loggerNode = json.get("logger");
-        String logger = loggerNode != null ? loggerNode.asText() : null;
-        JsonNode data = json.get("data");
-        return new McpLogMessage(level, logger, data);
+        return fromMap(McpJsonConversions.toMap(json));
     }
 
     public McpLogLevel level() {
@@ -42,8 +64,39 @@ public class McpLogMessage {
         return logger;
     }
 
-    public JsonNode data() {
+    /**
+     * Returns the log payload as JSON text.
+     */
+    public String dataAsJson() {
+        return data == null ? null : McpJson.serialize(data);
+    }
+
+    /**
+     * Returns the log payload as a plain map, so consumers do not need a JSON library.
+     *
+     * @return null when the payload is not a JSON object. MCP allows any JSON-serializable value
+     * here and a plain string is common, so use {@link #dataAsObject()} to read those.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> dataAsMap() {
+        return data instanceof Map ? (Map<String, Object>) data : null;
+    }
+
+    /**
+     * Returns the log payload as a plain JDK value: a {@link String}, a {@link Map}, a
+     * {@link java.util.List}, a boxed primitive, or null. MCP defines the payload as any
+     * JSON-serializable value, so this is the accessor that can represent all of them.
+     */
+    public Object dataAsObject() {
         return data;
+    }
+
+    /**
+     * @deprecated use {@link #dataAsMap()} or {@link #dataAsJson()}.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    public JsonNode data() {
+        return data == null ? null : McpJson.parse(McpJson.serialize(data));
     }
 
     @Override

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressNotification.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.mcp.client.progress;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.McpJsonConversions;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -23,14 +25,45 @@ public class McpProgressNotification {
 
     /**
      * Parses a McpProgressNotification from the contents of the 'params' object
-     * inside a 'notifications/progress' message.
+     * inside a 'notifications/progress' message, presented as plain values.
      */
+    public static McpProgressNotification fromMap(Map<String, Object> params) {
+        Object progressToken = params.get("progressToken");
+        Object progress = params.get("progress");
+        Object total = params.get("total");
+        Object message = params.get("message");
+        Double totalValue = toDouble(total);
+        Double progressValue = toDouble(progress);
+        return new McpProgressNotification(
+                progressToken == null ? null : String.valueOf(progressToken),
+                progressValue == null ? 0d : progressValue,
+                totalValue,
+                message == null ? null : String.valueOf(message));
+    }
+
+    /**
+     * Mirrors JsonNode.asDouble(), which also parses numeric strings.
+     */
+    private static Double toDouble(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Double.parseDouble((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @deprecated use {@link #fromMap(Map)}, which does not expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
     public static McpProgressNotification fromJson(JsonNode params) {
-        String progressToken = params.path("progressToken").asText(null);
-        double progress = params.path("progress").asDouble();
-        Double total = params.has("total") ? params.get("total").asDouble() : null;
-        String message = params.has("message") ? params.get("message").asText() : null;
-        return new McpProgressNotification(progressToken, progress, total, message);
+        return fromMap(McpJsonConversions.toMap(params));
     }
 
     public String progressToken() {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpJson.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpJson.java
@@ -1,0 +1,130 @@
+package dev.langchain4j.mcp.client.transport;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.Internal;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Bridges between JSON text and Jackson's tree model while both the
+ * deprecated {@code JsonNode}-based transport API and its replacement coexist.
+ */
+@Internal
+public final class McpJson {
+
+    /**
+     * A server may send fields this client does not model yet — MCP adds them in a backwards-compatible
+     * way, such as the {@code title} that 2025-06-18 put on every named object — so unknown properties
+     * are ignored rather than treated as errors.
+     */
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private McpJson() {}
+
+    /**
+     * Deserializes an MCP message into a protocol type.
+     */
+    public static <T> T deserialize(JsonNode message, Class<T> type) {
+        return OBJECT_MAPPER.convertValue(message, type);
+    }
+
+    /**
+     * Reads any JSON value as plain JDK types: a {@link Map}, a {@link java.util.List}, a boxed
+     * primitive, or null for a JSON null.
+     *
+     * @throws IllegalArgumentException if the text is not valid JSON.
+     */
+    public static Object toValue(String json) {
+        try {
+            return OBJECT_MAPPER.readValue(json, Object.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to parse MCP message: " + json, e);
+        }
+    }
+
+    /**
+     * Reads a JSON object as plain values.
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> toMap(String json) {
+        try {
+            return OBJECT_MAPPER.readValue(json, Map.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to parse MCP message: " + json, e);
+        }
+    }
+
+    /**
+     * Re-reads an already-decoded JSON value as the given type.
+     */
+    public static <T> T convert(Object value, Class<T> type) {
+        return OBJECT_MAPPER.convertValue(value, type);
+    }
+
+    /**
+     * Re-reads an already-decoded JSON array as a list of the given element type.
+     */
+    public static <T> List<T> convertList(Object value, Class<T> elementType) {
+        return OBJECT_MAPPER.convertValue(
+                value, OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, elementType));
+    }
+
+    /**
+     * Serializes an outbound MCP message. A null message renders as null rather than as the
+     * JSON null literal, so that an absent payload stays absent.
+     */
+    public static String serialize(Object message) {
+        if (message == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(message);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize MCP message", e);
+        }
+    }
+
+    public static JsonNode parse(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse MCP message: " + json, e);
+        }
+    }
+
+    /**
+     * Maps a future's value while keeping cancellation linked to the source. A plain
+     * {@code thenApply} would not propagate cancellation upstream, which would leave the
+     * transport's response stream open after the client cancels the operation.
+     */
+    public static <T, R> CompletableFuture<R> map(CompletableFuture<T> source, Function<T, R> mapper) {
+        CompletableFuture<R> mapped = new CompletableFuture<>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                source.cancel(mayInterruptIfRunning);
+                return super.cancel(mayInterruptIfRunning);
+            }
+        };
+        source.whenComplete((value, error) -> {
+            if (error != null) {
+                mapped.completeExceptionally(error);
+            } else {
+                try {
+                    mapped.complete(mapper.apply(value));
+                } catch (Throwable t) {
+                    mapped.completeExceptionally(t);
+                }
+            }
+        });
+        return mapped;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
@@ -43,6 +43,7 @@ public class McpOperationHandler {
     private final Runnable onServerPing;
     private final Runnable onServerRootsList;
     private final BiConsumer<Long, String> onServerCancelled;
+    private final BiConsumer<Long, Map<String, Object>> onSubscriptionAcknowledged;
 
     public McpOperationHandler(
             Map<Long, CompletableFuture<String>> pendingOperations,
@@ -56,7 +57,8 @@ public class McpOperationHandler {
             McpProgressHandler progressHandler,
             Runnable onServerPing,
             Runnable onServerRootsList,
-            BiConsumer<Long, String> onServerCancelled) {
+            BiConsumer<Long, String> onServerCancelled,
+            BiConsumer<Long, Map<String, Object>> onSubscriptionAcknowledged) {
         this.pendingOperations = pendingOperations;
         this.transport = transport;
         this.logMessageConsumer = logMessageConsumer;
@@ -69,6 +71,7 @@ public class McpOperationHandler {
         this.onServerPing = onServerPing;
         this.onServerRootsList = onServerRootsList;
         this.onServerCancelled = onServerCancelled;
+        this.onSubscriptionAcknowledged = onSubscriptionAcknowledged;
     }
 
     /**
@@ -186,7 +189,7 @@ public class McpOperationHandler {
                 handleCancelledNotification(message);
                 break;
             case NOTIFICATION_SUBSCRIPTIONS_ACKNOWLEDGED:
-                log.debug("Subscriptions acknowledged: {}", message);
+                handleSubscriptionAcknowledgedNotification(message);
                 break;
             default:
                 log.warn("Received unknown message: {}", message);
@@ -240,6 +243,21 @@ public class McpOperationHandler {
             log.warn("Received resource updated notification without uri: {}", message);
         } else if (onResourceUpdate != null) {
             onResourceUpdate.accept(String.valueOf(uri));
+        }
+    }
+
+    private void handleSubscriptionAcknowledgedNotification(Map<String, Object> message) {
+        Map<String, Object> params = params(message);
+        Object meta = params == null ? null : params.get("_meta");
+        Long subscriptionId = meta instanceof Map
+                ? toLong(((Map<?, ?>) meta).get("io.modelcontextprotocol/subscriptionId"))
+                : null;
+        if (subscriptionId == null) {
+            log.warn("Received subscriptions acknowledged notification without a subscription ID: {}", message);
+            return;
+        }
+        if (onSubscriptionAcknowledged != null) {
+            onSubscriptionAcknowledged.accept(subscriptionId, message);
         }
     }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
@@ -19,14 +19,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles incoming messages from the MCP server. Transport implementations
- * should call the "handle" method on each received message. A transport also has
- * to call "startOperation" before starting an operation that requires a response
- * to register its ID in the map of pending operations.
+ * Handles incoming messages from the MCP server.
+ *
+ * <p>A transport calls {@link #onMessage(String)} for every message it receives, and
+ * {@link #expectResponse(Long, java.util.concurrent.CompletableFuture)} before sending a request,
+ * to register the id whose response it is waiting for.
+ *
+ * <p>The {@code handle} and {@code startOperation} methods do the same through Jackson's
+ * {@code JsonNode} and are deprecated.
  */
 public class McpOperationHandler {
 
-    private final Map<Long, CompletableFuture<JsonNode>> pendingOperations;
+    private final Map<Long, CompletableFuture<String>> pendingOperations;
     private static final Logger log = LoggerFactory.getLogger(McpOperationHandler.class);
     private final McpTransport transport;
     private final Consumer<McpLogMessage> logMessageConsumer;
@@ -41,7 +45,7 @@ public class McpOperationHandler {
     private final BiConsumer<Long, String> onServerCancelled;
 
     public McpOperationHandler(
-            Map<Long, CompletableFuture<JsonNode>> pendingOperations,
+            Map<Long, CompletableFuture<String>> pendingOperations,
             Supplier<List<McpRoot>> roots,
             McpTransport transport,
             Consumer<McpLogMessage> logMessageConsumer,
@@ -67,40 +71,76 @@ public class McpOperationHandler {
         this.onServerCancelled = onServerCancelled;
     }
 
+    /**
+     * Handles an inbound message from the server.
+     *
+     * @deprecated use {@link #onMessage(String)} instead, which does not expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
     public void handle(JsonNode message) {
-        if (message.has("id")) {
-            handleMessageWithId(message);
-        } else if (message.has("method")) {
+        onMessage(McpJson.serialize(message));
+    }
+
+    /**
+     * Handles an inbound message from the server, taken exactly as it arrived on the wire, so that
+     * a transport does not have to parse it first.
+     *
+     * <p>Valid JSON that is not a JSON-RPC object - a batch array, a scalar, a bare null - is
+     * ignored. Text that is not valid JSON at all throws, so that the transport can decide: fail
+     * the pending operation, or log and keep reading.
+     *
+     * @throws IllegalArgumentException if the message is not valid JSON.
+     */
+    @SuppressWarnings("unchecked")
+    public void onMessage(String json) {
+        // Malformed input is the caller's decision, not this method's: a transport whose response
+        // body is unreadable has to fail the pending operation, while a stream reader only logs it
+        // and carries on. Both behaved that way before the parse moved in here.
+        Object parsed = McpJson.toValue(json);
+        if (!(parsed instanceof Map)) {
+            // valid JSON, but not a JSON-RPC object - a batch array, a bare null or a scalar.
+            // The tree model ignored these rather than failing, so they stay ignored.
+            log.warn("Received a message that is not a JSON-RPC object: {}", json);
+            return;
+        }
+        Map<String, Object> message = (Map<String, Object>) parsed;
+        if (message.containsKey("id")) {
+            handleMessageWithId(message, json);
+        } else if (message.containsKey("method")) {
             handleNotification(message);
         }
     }
 
-    private void handleMessageWithId(JsonNode message) {
-        long messageId = message.get("id").asLong();
-        if (message.has("result") || message.has("error")) {
+    private void handleMessageWithId(Map<String, Object> message, String json) {
+        Long messageId = toLong(message.get("id"));
+        if (messageId == null) {
+            log.warn("Received message with an unusable id: {}", message);
+            return;
+        }
+        if (message.containsKey("result") || message.containsKey("error")) {
             // response to a client-initiated operation
-            CompletableFuture<JsonNode> op = pendingOperations.remove(messageId);
+            CompletableFuture<String> op = pendingOperations.remove(messageId);
             if (op != null) {
-                op.complete(message);
+                op.complete(json);
             } else {
                 log.warn("Received response for unknown message id: {}", messageId);
             }
-        } else if (message.has("method")) {
+        } else if (message.containsKey("method")) {
             // server-initiated request requiring a response
-            McpServerMethod method = McpServerMethod.from(message.get("method").asText());
+            McpServerMethod method = McpServerMethod.from(String.valueOf(message.get("method")));
             if (method == null) {
                 log.warn("Received response for unknown message id: {}", messageId);
                 return;
             }
             switch (method) {
                 case PING:
-                    transport.executeOperationWithoutResponse(new McpPingResponse(messageId));
+                    transport.sendMessage(new McpPingResponse(messageId));
                     if (onServerPing != null) {
                         onServerPing.run();
                     }
                     break;
                 case ROOTS_LIST:
-                    transport.executeOperationWithoutResponse(new McpRootsListResponse(messageId, roots.get()));
+                    transport.sendMessage(new McpRootsListResponse(messageId, roots.get()));
                     if (onServerRootsList != null) {
                         onServerRootsList.run();
                     }
@@ -113,8 +153,8 @@ public class McpOperationHandler {
         }
     }
 
-    private void handleNotification(JsonNode message) {
-        McpServerMethod method = McpServerMethod.from(message.get("method").asText());
+    private void handleNotification(Map<String, Object> message) {
+        McpServerMethod method = McpServerMethod.from(String.valueOf(message.get("method")));
         if (method == null) {
             log.warn("Received unknown message: {}", message);
             return;
@@ -153,15 +193,16 @@ public class McpOperationHandler {
         }
     }
 
-    private void handleCancelledNotification(JsonNode message) {
-        JsonNode params = message.get("params");
-        if (params == null || !params.has("requestId")) {
+    private void handleCancelledNotification(Map<String, Object> message) {
+        Map<String, Object> params = params(message);
+        Long requestId = params == null ? null : toLong(params.get("requestId"));
+        if (requestId == null) {
             log.warn("Received cancelled notification without requestId: {}", message);
             return;
         }
-        long requestId = params.get("requestId").asLong();
-        String reason = params.has("reason") ? params.get("reason").asText() : null;
-        CompletableFuture<JsonNode> pending = pendingOperations.remove(requestId);
+        Object reasonValue = params.get("reason");
+        String reason = reasonValue == null ? null : String.valueOf(reasonValue);
+        CompletableFuture<String> pending = pendingOperations.remove(requestId);
         if (pending != null) {
             String message1 = reason != null
                     ? "Request " + requestId + " was cancelled by the server: " + reason
@@ -178,39 +219,94 @@ public class McpOperationHandler {
         }
     }
 
-    private void handleLogMessage(JsonNode message) {
-        if (message.has("params")) {
+    private void handleLogMessage(Map<String, Object> message) {
+        Map<String, Object> params = params(message);
+        if (params != null) {
             if (logMessageConsumer != null) {
-                logMessageConsumer.accept(McpLogMessage.fromJson(message.get("params")));
+                logMessageConsumer.accept(McpLogMessage.fromMap(params));
             }
         } else {
             log.warn("Received log message without params: {}", message);
         }
     }
 
-    private void handleResourceUpdatedNotification(JsonNode message) {
-        if (onResourceUpdate != null
-                && message.has("params")
-                && message.get("params").has("uri")) {
-            String uri = message.get("params").get("uri").asText();
-            onResourceUpdate.accept(uri);
-        } else if (message.has("params") && !message.get("params").has("uri")) {
+    private void handleResourceUpdatedNotification(Map<String, Object> message) {
+        Map<String, Object> params = params(message);
+        if (params == null) {
+            return;
+        }
+        Object uri = params.get("uri");
+        if (uri == null) {
             log.warn("Received resource updated notification without uri: {}", message);
+        } else if (onResourceUpdate != null) {
+            onResourceUpdate.accept(String.valueOf(uri));
         }
     }
 
-    private void handleProgressNotification(JsonNode message) {
-        if (progressHandler != null && message.has("params")) {
-            progressHandler.onProgress(McpProgressNotification.fromJson(message.get("params")));
+    private void handleProgressNotification(Map<String, Object> message) {
+        Map<String, Object> params = params(message);
+        if (progressHandler != null && params != null) {
+            progressHandler.onProgress(McpProgressNotification.fromMap(params));
         }
     }
 
+    /**
+     * JSON-RPC allows an id to be a number or a string, and Jackson coerced both, so both are
+     * accepted here too.
+     */
+    private static Long toLong(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong(((String) value).trim());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> params(Map<String, Object> message) {
+        Object params = message.get("params");
+        return params instanceof Map ? (Map<String, Object>) params : null;
+    }
+
+    /**
+     * Registers a client-initiated request whose response is awaited.
+     *
+     * @deprecated use {@link #expectResponse(Long, CompletableFuture)} instead, which does not
+     * expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
     public void startOperation(Long id, CompletableFuture<JsonNode> future) {
+        CompletableFuture<String> jsonFuture = new CompletableFuture<>();
+        jsonFuture.whenComplete((json, error) -> {
+            if (error != null) {
+                future.completeExceptionally(error);
+                return;
+            }
+            try {
+                future.complete(McpJson.parse(json));
+            } catch (RuntimeException e) {
+                future.completeExceptionally(e);
+            }
+        });
+        expectResponse(id, jsonFuture);
+    }
+
+    /**
+     * Registers a client-initiated request whose response is awaited; the future is completed with
+     * the response as unparsed JSON text.
+     */
+    public void expectResponse(Long id, CompletableFuture<String> future) {
         pendingOperations.put(id, future);
     }
 
     public synchronized void cancelAllPendingOperations(String reason) {
-        for (CompletableFuture<JsonNode> future : pendingOperations.values()) {
+        for (CompletableFuture<String> future : pendingOperations.values()) {
             future.completeExceptionally(
                     new IllegalStateException("Operation cancelled due to transport failure: " + reason));
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
@@ -7,6 +7,21 @@ import dev.langchain4j.mcp.protocol.McpInitializeRequest;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * The transport contract between the MCP client and a server connection.
+ *
+ * <p>Each method exists in two forms: a current one, and a deprecated one that uses Jackson's
+ * {@code JsonNode}. The bridge between them runs one way only: the current method delegates to the
+ * deprecated one, so a transport written against the old API keeps working, but the deprecated one
+ * <b>throws</b> rather than delegating back. Two mutually-delegating defaults would recurse if an
+ * implementation overrode neither, and this way that mistake fails immediately instead.
+ *
+ * <p>New implementations should override the current forms - {@code sendInitializeRequest},
+ * {@code sendRequest} and {@code sendMessage} - which are the ones the client calls. A transport
+ * migrating from the deprecated forms has to move <b>its own internal calls at the same time</b>:
+ * those keep compiling and then throw at runtime, often somewhere the exception is swallowed.
+ * Building with {@code -Xlint:removal -Werror} finds them mechanically.
+ */
 public interface McpTransport extends Closeable {
 
     /**
@@ -22,30 +37,107 @@ public interface McpTransport extends Closeable {
      * be used. This has to be called AFTER the "start" method.
      * Only used with the legacy MCP protocol (versions up to 2025-11-25).
      * Modern protocol uses {@code server/discover} instead.
+     *
+     * @deprecated implement {@link #sendInitializeRequest(McpInitializeRequest)} instead, which does
+     * not expose Jackson types. This default throws; it does not delegate, because two
+     * mutually-delegating defaults would recurse.
      */
-    CompletableFuture<JsonNode> initialize(McpInitializeRequest request);
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    default CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+        throw new UnsupportedOperationException(
+                "Implement sendInitializeRequest(McpInitializeRequest) instead of initialize(McpInitializeRequest)");
+    }
+
+    /**
+     * Sends the MCP {@code InitializeRequest} and returns the server's response as unparsed JSON
+     * text, so that a transport does not need a JSON library. Only used with the legacy MCP
+     * protocol (versions up to 2025-11-25); the modern protocol uses {@code server/discover}.
+     */
+    default CompletableFuture<String> sendInitializeRequest(McpInitializeRequest request) {
+        return McpJson.map(initialize(request), McpJson::serialize);
+    }
 
     /**
      * Executes an operation that expects a response from the server.
+     *
+     * @deprecated implement {@link #sendRequest(McpClientMessage)} instead, which does not expose
+     * Jackson types. This default throws; it does not delegate, because two mutually-delegating
+     * defaults would recurse.
      */
-    CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request);
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    default CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request) {
+        throw new UnsupportedOperationException("Implement sendRequest(McpClientMessage) instead"
+                + " of executeOperationWithResponse(McpClientMessage)");
+    }
+
+    /**
+     * Sends a JSON-RPC request and returns the server's response as unparsed JSON text.
+     */
+    default CompletableFuture<String> sendRequest(McpClientMessage request) {
+        return McpJson.map(executeOperationWithResponse(request), McpJson::serialize);
+    }
 
     /**
      * Executes an operation that expects a response from the server.
+     *
+     * @deprecated implement {@link #sendRequest(McpCallContext)} instead, which does not expose
+     * Jackson types. This default throws; it does not delegate, because two mutually-delegating
+     * defaults would recurse.
      */
-    CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context);
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    default CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+        throw new UnsupportedOperationException("Implement sendRequest(McpCallContext) instead"
+                + " of executeOperationWithResponse(McpCallContext)");
+    }
 
     /**
-     * Sends a message that does not expect a response from the server - either a
-     * client-initiated notification or a response to a server-initiated request.
+     * Sends a JSON-RPC request and returns the server's response as unparsed JSON text.
      */
-    void executeOperationWithoutResponse(McpClientMessage request);
+    default CompletableFuture<String> sendRequest(McpCallContext context) {
+        return McpJson.map(executeOperationWithResponse(context), McpJson::serialize);
+    }
 
     /**
-     * Sends a message that does not expect a response from the server - either a
-     * client-initiated notification or a response to a server-initiated request.
+     * Sends a message that does not expect a reply.
+     *
+     * @deprecated implement {@link #sendMessage(McpClientMessage)} instead, which is named for what MCP calls
+     * it. This default throws; it does not delegate, because two mutually-delegating defaults
+     * would recurse.
      */
-    void executeOperationWithoutResponse(McpCallContext context);
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    default void executeOperationWithoutResponse(McpClientMessage request) {
+        throw new UnsupportedOperationException(
+                "Implement sendMessage(McpClientMessage) instead of executeOperationWithoutResponse(McpClientMessage)");
+    }
+
+    /**
+     * Sends a message that does not expect a reply - in MCP terms a notification, or a
+     * response to a server-initiated request.
+     */
+    default void sendMessage(McpClientMessage request) {
+        executeOperationWithoutResponse(request);
+    }
+
+    /**
+     * Sends a message that does not expect a reply.
+     *
+     * @deprecated implement {@link #sendMessage(McpCallContext)} instead, which is named for what MCP calls
+     * it. This default throws; it does not delegate, because two mutually-delegating defaults
+     * would recurse.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    default void executeOperationWithoutResponse(McpCallContext context) {
+        throw new UnsupportedOperationException(
+                "Implement sendMessage(McpCallContext) instead of executeOperationWithoutResponse(McpCallContext)");
+    }
+
+    /**
+     * Sends a message that does not expect a reply - in MCP terms a notification, or a
+     * response to a server-initiated request.
+     */
+    default void sendMessage(McpCallContext context) {
+        executeOperationWithoutResponse(context);
+    }
 
     /**
      * Performs transport-specific health checks, if applicable. This is called

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
@@ -1,7 +1,5 @@
 package dev.langchain4j.mcp.client.transport.http;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
@@ -16,7 +14,7 @@ class SseSubscriber implements Flow.Subscriber<String> {
      * Future for the result of the operation that this SSE subscriber was created for.
      * If this is a subsidiary SSE subscriber for the long-lived GET channel (therefore, no operation), this will be null.
      */
-    private final CompletableFuture<JsonNode> future;
+    private final CompletableFuture<String> future;
 
     private final Logger logger;
     private final boolean logResponses;
@@ -32,7 +30,7 @@ class SseSubscriber implements Flow.Subscriber<String> {
      * Constructor for a regular (non-subsidiary) SSE subscriber, used for POST response streams.
      */
     SseSubscriber(
-            CompletableFuture<JsonNode> future,
+            CompletableFuture<String> future,
             boolean logResponses,
             McpOperationHandler operationHandler,
             Logger logger,
@@ -104,9 +102,9 @@ class SseSubscriber implements Flow.Subscriber<String> {
         subscription.request(1);
         if (item.startsWith("data:")) {
             try {
-                operationHandler.handle(StreamableHttpMcpTransport.OBJECT_MAPPER.readTree(item.substring(5)));
-            } catch (JsonProcessingException e) {
-                logger.warn("Failed to parse SSE event: " + item, e);
+                operationHandler.onMessage(item.substring(5));
+            } catch (RuntimeException e) {
+                logger.warn("Failed to handle SSE event: " + item, e);
             }
         } else if (item.startsWith("id:") && lastEventId != null) {
             lastEventId.set(item.substring(3).trim());

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
@@ -93,6 +93,11 @@ class SseSubscriber implements Flow.Subscriber<String> {
 
     @Override
     public void onNext(String item) {
+        if (future != null && future.isCancelled()) {
+            // the operation was cancelled (e.g. by unsubscribeFromResources), so events that are
+            // still in flight on this stream must not reach the operation handler anymore
+            return;
+        }
         if (logResponses && !item.trim().isEmpty()) {
             logger.info("SSE event received: " + item);
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -3,15 +3,14 @@ package dev.langchain4j.mcp.client.transport.http;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpHeaderEncoding;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -48,8 +47,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
     private final boolean logResponses;
     private final boolean logRequests;
     private final Logger trafficLog;
-    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private final AtomicReference<CompletableFuture<JsonNode>> initializeInProgress = new AtomicReference<>(null);
+    private final AtomicReference<CompletableFuture<String>> initializeInProgress = new AtomicReference<>(null);
     private volatile McpOperationHandler operationHandler;
     private final HttpClient httpClient;
     private final SSLContext sslContext;
@@ -101,9 +99,9 @@ public class StreamableHttpMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> initialize(McpInitializeRequest operation) {
+    public CompletableFuture<String> sendInitializeRequest(McpInitializeRequest operation) {
         this.initializeRequest = operation;
-        CompletableFuture<JsonNode> completableFuture = execute(new McpCallContext(null, operation), false);
+        CompletableFuture<String> completableFuture = execute(new McpCallContext(null, operation), false);
         initializeInProgress.set(completableFuture);
         return completableFuture
                 .thenCompose(originalResponse -> {
@@ -122,9 +120,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
                 });
     }
 
-    private HttpRequest createRequest(McpJsonRpcMessage message, McpCallContext callContext)
-            throws JsonProcessingException {
-        String body = OBJECT_MAPPER.writeValueAsString(message);
+    private HttpRequest createRequest(McpJsonRpcMessage message, McpCallContext callContext) {
+        String body = McpJson.serialize(message);
         HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofString(body);
         if (logRequests) {
             trafficLog.info("Request: {}", body);
@@ -137,7 +134,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
                 builder.header("MCP-Protocol-Version", protocolVersionHeader);
             }
             // Extract method from JSON-RPC message
-            JsonNode bodyNode = OBJECT_MAPPER.readTree(body);
+            JsonNode bodyNode = McpJson.parse(body);
             String method = bodyNode.path("method").asText(null);
             if (method != null) {
                 builder.header("Mcp-Method", method);
@@ -179,22 +176,22 @@ public class StreamableHttpMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
-        return executeOperationWithResponse(new McpCallContext(null, operation));
+    public CompletableFuture<String> sendRequest(McpClientMessage operation) {
+        return sendRequest(new McpCallContext(null, operation));
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+    public CompletableFuture<String> sendRequest(McpCallContext context) {
         return execute(context, false);
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpClientMessage operation) {
-        executeOperationWithoutResponse(new McpCallContext(null, operation));
+    public void sendMessage(McpClientMessage operation) {
+        sendMessage(new McpCallContext(null, operation));
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpCallContext context) {
+    public void sendMessage(McpCallContext context) {
         execute(context, false);
     }
 
@@ -252,10 +249,10 @@ public class StreamableHttpMcpTransport implements McpTransport {
         this.protocolVersionHeader = protocolVersion;
     }
 
-    private CompletableFuture<JsonNode> execute(McpCallContext context, boolean isRetry) {
+    private CompletableFuture<String> execute(McpCallContext context, boolean isRetry) {
         Long id = context.message().getId();
         if (!(context.message() instanceof McpInitializeRequest)) {
-            CompletableFuture<JsonNode> reinitializeInProgress = this.initializeInProgress.get();
+            CompletableFuture<String> reinitializeInProgress = this.initializeInProgress.get();
             if (reinitializeInProgress != null) {
                 reinitializeInProgress.join();
             }
@@ -263,12 +260,12 @@ public class StreamableHttpMcpTransport implements McpTransport {
         HttpRequest request = null;
         try {
             request = createRequest(context.message(), context);
-        } catch (JsonProcessingException e) {
+        } catch (IllegalArgumentException e) {
             return CompletableFuture.failedFuture(e);
         }
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        CompletableFuture<String> future = new CompletableFuture<>();
         if (id != null) {
-            operationHandler.startOperation(id, future);
+            operationHandler.expectResponse(id, future);
         }
 
         httpClient
@@ -333,10 +330,9 @@ public class StreamableHttpMcpTransport implements McpTransport {
                                             future.complete(null);
                                         }
                                         try {
-                                            JsonNode node = OBJECT_MAPPER.readTree(responseBody);
-                                            operationHandler.handle(node);
+                                            operationHandler.onMessage(responseBody);
                                             return null;
-                                        } catch (IOException e) {
+                                        } catch (RuntimeException e) {
                                             future.completeExceptionally(e);
                                             return null;
                                         }
@@ -629,4 +625,55 @@ public class StreamableHttpMcpTransport implements McpTransport {
             return new StreamableHttpMcpTransport(this);
         }
     }
+
+    /**
+     * @deprecated use {@link #sendInitializeRequest(McpInitializeRequest)} instead, which does not
+     * expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+        return McpJson.map(sendInitializeRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request) {
+        return McpJson.map(sendRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+        return McpJson.map(sendRequest(context), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage request) {
+        sendMessage(request);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
+        sendMessage(context);
+    }
+
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -9,8 +9,8 @@ import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpHeaderEncoding;
-import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -289,6 +289,11 @@ public class StreamableHttpMcpTransport implements McpTransport {
                                             future.completeExceptionally(t);
                                             return null;
                                         });
+                            } else {
+                                // Reinitialization did not help; fail instead of leaving the caller hanging
+                                future.completeExceptionally(new RuntimeException(
+                                        "Session expired again after reinitialization: server returned status code "
+                                                + responseInfo.statusCode()));
                             }
                         } else {
                             future.completeExceptionally(
@@ -675,5 +680,4 @@ public class StreamableHttpMcpTransport implements McpTransport {
     public void executeOperationWithoutResponse(McpCallContext context) {
         sendMessage(context);
     }
-
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +24,8 @@ class ProcessStderrHandler implements Runnable, Closeable {
 
     @Override
     public void run() {
-        try (InputStreamReader inputStreamReader = new InputStreamReader(process.getErrorStream())) {
+        try (InputStreamReader inputStreamReader =
+                new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8)) {
             try (BufferedReader reader = new BufferedReader(inputStreamReader)) {
                 String line;
                 while ((line = reader.readLine()) != null) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -3,12 +3,11 @@ package dev.langchain4j.mcp.client.transport.stdio;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -33,7 +32,6 @@ public class StdioMcpTransport implements McpTransport {
     private volatile JsonRpcIoHandler jsonRpcIoHandler;
     private final boolean logEvents;
     private final Logger logger;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(StdioMcpTransport.class);
     private volatile McpOperationHandler messageHandler;
     private volatile ProcessStderrHandler stderrHandler;
@@ -75,53 +73,49 @@ public class StdioMcpTransport implements McpTransport {
             throw new RuntimeException(e);
         }
         jsonRpcIoHandler = new JsonRpcIoHandler(
-                process.getInputStream(), process.getOutputStream(), messageHandler::handle, logEvents, logger);
+                process.getInputStream(), process.getOutputStream(), messageHandler::onMessage, logEvents, logger);
         stderrHandler = new ProcessStderrHandler(process);
         executorService.submit(jsonRpcIoHandler);
         executorService.submit(stderrHandler);
     }
 
     @Override
-    public CompletableFuture<JsonNode> initialize(McpInitializeRequest operation) {
+    public CompletableFuture<String> sendInitializeRequest(McpInitializeRequest operation) {
         try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(operation);
-            String initializationNotification = OBJECT_MAPPER.writeValueAsString(new McpInitializationNotification());
+            String requestString = McpJson.serialize(operation);
+            String initializationNotification = McpJson.serialize(new McpInitializationNotification());
             return execute(requestString, operation.getId())
                     .thenCompose(originalResponse -> execute(initializationNotification, null)
                             .thenCompose(nullNode -> CompletableFuture.completedFuture(originalResponse)));
-        } catch (JsonProcessingException e) {
+        } catch (IllegalArgumentException e) {
             return CompletableFuture.failedFuture(e);
         }
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
-        return executeOperationWithResponse(new McpCallContext(null, operation));
+    public CompletableFuture<String> sendRequest(McpClientMessage operation) {
+        return sendRequest(new McpCallContext(null, operation));
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+    public CompletableFuture<String> sendRequest(McpCallContext context) {
         try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(context.message());
+            String requestString = McpJson.serialize(context.message());
             return execute(requestString, context.message().getId());
-        } catch (JsonProcessingException e) {
+        } catch (IllegalArgumentException e) {
             return CompletableFuture.failedFuture(e);
         }
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpClientMessage operation) {
-        executeOperationWithoutResponse(new McpCallContext(null, operation));
+    public void sendMessage(McpClientMessage operation) {
+        sendMessage(new McpCallContext(null, operation));
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpCallContext context) {
-        try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(context.message());
-            execute(requestString, null);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+    public void sendMessage(McpCallContext context) {
+        String requestString = McpJson.serialize(context.message());
+        execute(requestString, null);
     }
 
     @Override
@@ -187,10 +181,10 @@ public class StdioMcpTransport implements McpTransport {
         return new Builder();
     }
 
-    private CompletableFuture<JsonNode> execute(String request, Long id) {
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+    private CompletableFuture<String> execute(String request, Long id) {
+        CompletableFuture<String> future = new CompletableFuture<>();
         if (id != null) {
-            messageHandler.startOperation(id, future);
+            messageHandler.expectResponse(id, future);
         }
         try {
             jsonRpcIoHandler.submit(request);
@@ -263,4 +257,55 @@ public class StdioMcpTransport implements McpTransport {
             return new StdioMcpTransport(this);
         }
     }
+
+    /**
+     * @deprecated use {@link #sendInitializeRequest(McpInitializeRequest)} instead, which does not
+     * expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+        return McpJson.map(sendInitializeRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request) {
+        return McpJson.map(sendRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+        return McpJson.map(sendRequest(context), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage request) {
+        sendMessage(request);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
+        sendMessage(context);
+    }
+
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpListener.java
@@ -1,7 +1,5 @@
 package dev.langchain4j.mcp.client.transport.websocket;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +7,6 @@ import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletionStage;
 
-import static dev.langchain4j.mcp.client.transport.websocket.WebSocketMcpTransport.OBJECT_MAPPER;
 
 public class WebSocketMcpListener implements WebSocket.Listener {
 
@@ -51,9 +48,8 @@ public class WebSocketMcpListener implements WebSocket.Listener {
                 trafficLogger.info("< " + completeMessage);
             }
             try {
-                JsonNode jsonNode = OBJECT_MAPPER.readTree(completeMessage);
-                operationHandler.handle(jsonNode);
-            } catch (JsonProcessingException e) {
+                operationHandler.onMessage(completeMessage);
+            } catch (RuntimeException e) {
                 logger.warn("Failed to parse JSON message: {}", completeMessage, e);
             }
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
@@ -4,11 +4,11 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -38,7 +38,6 @@ public class WebSocketMcpTransport implements McpTransport {
     private final boolean logResponses;
     private final boolean logRequests;
     private final Logger trafficLog;
-    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private volatile McpOperationHandler operationHandler;
     private volatile McpInitializeRequest initializeRequest;
     private final Duration connectTimeout;
@@ -147,9 +146,9 @@ public class WebSocketMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> initialize(McpInitializeRequest operation) {
+    public CompletableFuture<String> sendInitializeRequest(McpInitializeRequest operation) {
         this.initializeRequest = operation;
-        CompletableFuture<JsonNode> completableFuture =
+        CompletableFuture<String> completableFuture =
                 execute(new McpCallContext(null, operation), Optional.empty(), operation.getId());
         return completableFuture
                 .thenCompose(originalResponse -> {
@@ -161,22 +160,22 @@ public class WebSocketMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request) {
-        return executeOperationWithResponse(new McpCallContext(null, request));
+    public CompletableFuture<String> sendRequest(McpClientMessage request) {
+        return sendRequest(new McpCallContext(null, request));
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+    public CompletableFuture<String> sendRequest(McpCallContext context) {
         return execute(context, Optional.empty(), context.message().getId());
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpClientMessage request) {
-        executeOperationWithoutResponse(new McpCallContext(null, request));
+    public void sendMessage(McpClientMessage request) {
+        sendMessage(new McpCallContext(null, request));
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpCallContext context) {
+    public void sendMessage(McpCallContext context) {
         execute(context, Optional.empty(), null);
     }
 
@@ -226,17 +225,17 @@ public class WebSocketMcpTransport implements McpTransport {
         }
     }
 
-    private CompletableFuture<JsonNode> execute(McpCallContext context, Optional<WebSocket> webSocket, Long id) {
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+    private CompletableFuture<String> execute(McpCallContext context, Optional<WebSocket> webSocket, Long id) {
+        CompletableFuture<String> future = new CompletableFuture<>();
         if (closed) {
             future.completeExceptionally(new IllegalStateException("Transport is closed"));
             return future;
         }
         if (id != null) {
-            operationHandler.startOperation(id, future);
+            operationHandler.expectResponse(id, future);
         }
         try {
-            String messageJson = OBJECT_MAPPER.writeValueAsString(context.message());
+            String messageJson = McpJson.serialize(context.message());
             WebSocket wsToUse = webSocket.orElseGet(() -> getWebSocket());
             if (logRequests) {
                 trafficLog.info("> " + messageJson);
@@ -346,4 +345,55 @@ public class WebSocketMcpTransport implements McpTransport {
             return new WebSocketMcpTransport(this);
         }
     }
+
+    /**
+     * @deprecated use {@link #sendInitializeRequest(McpInitializeRequest)} instead, which does not
+     * expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+        return McpJson.map(sendInitializeRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request) {
+        return McpJson.map(sendRequest(request), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendRequest(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+        return McpJson.map(sendRequest(context), McpJson::parse);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpClientMessage)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage request) {
+        sendMessage(request);
+    }
+
+    /**
+     * @deprecated use {@link #sendMessage(McpCallContext)} instead, which does not expose Jackson
+     * types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
+        sendMessage(context);
+    }
+
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
-import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
@@ -241,8 +241,10 @@ public class WebSocketMcpTransport implements McpTransport {
                 trafficLog.info("> " + messageJson);
             }
             synchronized (wsToUse) {
-                wsToUse.sendText(messageJson, true).thenAccept(ws -> {
-                    if (id == null) {
+                wsToUse.sendText(messageJson, true).whenComplete((ws, error) -> {
+                    if (error != null) {
+                        future.completeExceptionally(error);
+                    } else if (id == null) {
                         // for operations without an ID, consider them done immediately after the message was sent
                         future.complete(null);
                     }
@@ -395,5 +397,4 @@ public class WebSocketMcpTransport implements McpTransport {
     public void executeOperationWithoutResponse(McpCallContext context) {
         sendMessage(context);
     }
-
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolParams.java
@@ -1,8 +1,6 @@
 package dev.langchain4j.mcp.protocol;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.Internal;
 import java.util.Map;
 
@@ -15,17 +13,17 @@ public class McpCallToolParams extends McpClientParams {
     private String name;
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    private ObjectNode arguments;
+    private Map<String, Object> arguments;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Map<String, Object> inputResponses;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private JsonNode requestState;
+    private Object requestState;
 
     public McpCallToolParams() {}
 
-    public McpCallToolParams(String name, ObjectNode arguments) {
+    public McpCallToolParams(String name, Map<String, Object> arguments) {
         this.name = name;
         this.arguments = arguments;
     }
@@ -38,11 +36,11 @@ public class McpCallToolParams extends McpClientParams {
         this.name = name;
     }
 
-    public ObjectNode getArguments() {
+    public Map<String, Object> getArguments() {
         return arguments;
     }
 
-    public void setArguments(ObjectNode arguments) {
+    public void setArguments(Map<String, Object> arguments) {
         this.arguments = arguments;
     }
 
@@ -54,11 +52,11 @@ public class McpCallToolParams extends McpClientParams {
         this.inputResponses = inputResponses;
     }
 
-    public JsonNode getRequestState() {
+    public Object getRequestState() {
         return requestState;
     }
 
-    public void setRequestState(JsonNode requestState) {
+    public void setRequestState(Object requestState) {
         this.requestState = requestState;
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.Internal;
 import java.util.Map;
 
@@ -10,11 +9,11 @@ import java.util.Map;
 @Internal
 public class McpCallToolRequest extends McpClientRequest {
 
-    public McpCallToolRequest(Long id, String toolName, ObjectNode arguments) {
+    public McpCallToolRequest(Long id, String toolName, Map<String, Object> arguments) {
         this(id, toolName, arguments, null);
     }
 
-    public McpCallToolRequest(Long id, String toolName, ObjectNode arguments, String progressToken) {
+    public McpCallToolRequest(Long id, String toolName, Map<String, Object> arguments, String progressToken) {
         super(id, McpClientMethod.TOOLS_CALL);
         McpCallToolParams params = new McpCallToolParams(toolName, arguments);
         if (progressToken != null) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolResult.java
@@ -1,18 +1,24 @@
 package dev.langchain4j.mcp.protocol;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.Internal;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Corresponds to the {@code CallToolResult} type from the MCP schema.
  */
 @Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpCallToolResult extends McpJsonRpcMessage {
 
     private final Result result;
 
-    public McpCallToolResult(Long id, Result result) {
+    @JsonCreator
+    public McpCallToolResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
         super(id);
         this.result = result;
     }
@@ -22,19 +28,31 @@ public class McpCallToolResult extends McpJsonRpcMessage {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Result {
 
-        private final List<Content> content;
+        private final List<Map<String, Object>> content;
         private final Object structuredContent;
         private final Boolean isError;
+        private final Map<String, Object> meta;
 
-        public Result(List<Content> content, Object structuredContent, Boolean isError) {
+        public Result(List<Map<String, Object>> content, Object structuredContent, Boolean isError) {
+            this(content, structuredContent, isError, null);
+        }
+
+        @JsonCreator
+        public Result(
+                @JsonProperty("content") List<Map<String, Object>> content,
+                @JsonProperty("structuredContent") Object structuredContent,
+                @JsonProperty("isError") Boolean isError,
+                @JsonProperty("_meta") Map<String, Object> meta) {
             this.content = content;
             this.structuredContent = structuredContent;
             this.isError = isError;
+            this.meta = meta;
         }
 
-        public List<Content> getContent() {
+        public List<Map<String, Object>> getContent() {
             return content;
         }
 
@@ -45,24 +63,10 @@ public class McpCallToolResult extends McpJsonRpcMessage {
         public Boolean getIsError() {
             return isError;
         }
-    }
 
-    public static class Content {
-
-        private final String type;
-        private final String text;
-
-        public Content(String type, String text) {
-            this.type = type;
-            this.text = text;
-        }
-
-        public String getType() {
-            return type;
-        }
-
-        public String getText() {
-            return text;
+        @JsonProperty("_meta")
+        public Map<String, Object> getMeta() {
+            return meta;
         }
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpErrorResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpErrorResponse.java
@@ -1,17 +1,22 @@
 package dev.langchain4j.mcp.protocol;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.Internal;
 
 /**
  * Corresponds to the {@code JSONRPCError} type from the MCP schema.
  */
 @Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpErrorResponse extends McpJsonRpcMessage {
 
     private final Error error;
 
-    public McpErrorResponse(Long id, Error error) {
+    @JsonCreator
+    public McpErrorResponse(@JsonProperty("id") Long id, @JsonProperty("error") Error error) {
         super(id);
         this.error = error;
     }
@@ -21,13 +26,18 @@ public class McpErrorResponse extends McpJsonRpcMessage {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Error {
 
         private final int code;
         private final String message;
         private final Object data;
 
-        public Error(int code, String message, Object data) {
+        @JsonCreator
+        public Error(
+                @JsonProperty("code") int code,
+                @JsonProperty("message") String message,
+                @JsonProperty("data") Object data) {
             this.code = code;
             this.message = message;
             this.data = data;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptParams.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.mcp.protocol;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.Internal;
 import java.util.Map;
 
@@ -20,7 +19,7 @@ public class McpGetPromptParams extends McpClientParams {
     private Map<String, Object> inputResponses;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private JsonNode requestState;
+    private Object requestState;
 
     public McpGetPromptParams() {}
 
@@ -53,11 +52,11 @@ public class McpGetPromptParams extends McpClientParams {
         this.inputResponses = inputResponses;
     }
 
-    public JsonNode getRequestState() {
+    public Object getRequestState() {
         return requestState;
     }
 
-    public void setRequestState(JsonNode requestState) {
+    public void setRequestState(Object requestState) {
         this.requestState = requestState;
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptResponse.java
@@ -1,0 +1,31 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+import dev.langchain4j.mcp.client.McpGetPromptResult;
+
+/**
+ * Corresponds to the {@code GetPromptResult} type from the MCP schema.
+ *
+ * <p>Named for the response rather than the result because {@link McpGetPromptResult} already
+ * exists as the client-facing type.
+ */
+@Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpGetPromptResponse extends McpJsonRpcMessage {
+
+    private final McpGetPromptResult result;
+
+    @JsonCreator
+    public McpGetPromptResponse(
+            @JsonProperty("id") Long id, @JsonProperty("result") McpGetPromptResult result) {
+        super(id);
+        this.result = result;
+    }
+
+    public McpGetPromptResult getResult() {
+        return result;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpImplementation.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpImplementation.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.mcp.protocol;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
@@ -8,6 +9,7 @@ import dev.langchain4j.Internal;
  */
 @Internal
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpImplementation {
 
     private String name;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeResult.java
@@ -1,6 +1,9 @@
 package dev.langchain4j.mcp.protocol;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.Internal;
 import org.jspecify.annotations.Nullable;
 
@@ -8,11 +11,13 @@ import org.jspecify.annotations.Nullable;
  * Corresponds to the {@code InitializeResult} type from the MCP schema.
  */
 @Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpInitializeResult extends McpJsonRpcMessage {
 
     private final Result result;
 
-    public McpInitializeResult(Long id, Result result) {
+    @JsonCreator
+    public McpInitializeResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
         super(id);
         this.result = result;
     }
@@ -22,6 +27,7 @@ public class McpInitializeResult extends McpJsonRpcMessage {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Result {
 
         private final String protocolVersion;
@@ -29,15 +35,17 @@ public class McpInitializeResult extends McpJsonRpcMessage {
         private final McpImplementation serverInfo;
         private final @Nullable String instructions;
 
-        public Result(String protocolVersion, Capabilities capabilities, McpImplementation serverInfo) {
+        public Result(
+                String protocolVersion, Capabilities capabilities, McpImplementation serverInfo) {
             this(protocolVersion, capabilities, serverInfo, null);
         }
 
+        @JsonCreator
         public Result(
-                String protocolVersion,
-                Capabilities capabilities,
-                McpImplementation serverInfo,
-                @Nullable String instructions) {
+                @JsonProperty("protocolVersion") String protocolVersion,
+                @JsonProperty("capabilities") Capabilities capabilities,
+                @JsonProperty("serverInfo") McpImplementation serverInfo,
+                @JsonProperty("instructions") @Nullable String instructions) {
             this.protocolVersion = protocolVersion;
             this.capabilities = capabilities;
             this.serverInfo = serverInfo;
@@ -61,11 +69,13 @@ public class McpInitializeResult extends McpJsonRpcMessage {
         }
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Capabilities {
 
         private final Tools tools;
 
-        public Capabilities(Tools tools) {
+        @JsonCreator
+        public Capabilities(@JsonProperty("tools") Tools tools) {
             this.tools = tools;
         }
 
@@ -74,11 +84,13 @@ public class McpInitializeResult extends McpJsonRpcMessage {
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Tools {
 
             private final Boolean listChanged;
 
-            public Tools(Boolean listChanged) {
+            @JsonCreator
+            public Tools(@JsonProperty("listChanged") Boolean listChanged) {
                 this.listChanged = listChanged;
             }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListPromptsResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListPromptsResult.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+import dev.langchain4j.mcp.client.McpPrompt;
+import java.util.List;
+
+/**
+ * Corresponds to the {@code ListPromptsResult} type from the MCP schema.
+ */
+@Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpListPromptsResult extends McpJsonRpcMessage {
+
+    private final Result result;
+
+    @JsonCreator
+    public McpListPromptsResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
+        super(id);
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+
+        private final List<McpPrompt> prompts;
+        private final String nextCursor;
+
+        @JsonCreator
+        public Result(
+                @JsonProperty("prompts") List<McpPrompt> prompts,
+                @JsonProperty("nextCursor") String nextCursor) {
+            this.prompts = prompts;
+            this.nextCursor = nextCursor;
+        }
+
+        public List<McpPrompt> getPrompts() {
+            return prompts;
+        }
+
+        public String getNextCursor() {
+            return nextCursor;
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourceTemplatesResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourceTemplatesResult.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+import dev.langchain4j.mcp.client.McpResourceTemplate;
+import java.util.List;
+
+/**
+ * Corresponds to the {@code ListResourceTemplatesResult} type from the MCP schema.
+ */
+@Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpListResourceTemplatesResult extends McpJsonRpcMessage {
+
+    private final Result result;
+
+    @JsonCreator
+    public McpListResourceTemplatesResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
+        super(id);
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+
+        private final List<McpResourceTemplate> resourceTemplates;
+        private final String nextCursor;
+
+        @JsonCreator
+        public Result(
+                @JsonProperty("resourceTemplates") List<McpResourceTemplate> resourceTemplates,
+                @JsonProperty("nextCursor") String nextCursor) {
+            this.resourceTemplates = resourceTemplates;
+            this.nextCursor = nextCursor;
+        }
+
+        public List<McpResourceTemplate> getResourceTemplates() {
+            return resourceTemplates;
+        }
+
+        public String getNextCursor() {
+            return nextCursor;
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourcesResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourcesResult.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+import dev.langchain4j.mcp.client.McpResource;
+import java.util.List;
+
+/**
+ * Corresponds to the {@code ListResourcesResult} type from the MCP schema.
+ */
+@Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpListResourcesResult extends McpJsonRpcMessage {
+
+    private final Result result;
+
+    @JsonCreator
+    public McpListResourcesResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
+        super(id);
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+
+        private final List<McpResource> resources;
+        private final String nextCursor;
+
+        @JsonCreator
+        public Result(
+                @JsonProperty("resources") List<McpResource> resources,
+                @JsonProperty("nextCursor") String nextCursor) {
+            this.resources = resources;
+            this.nextCursor = nextCursor;
+        }
+
+        public List<McpResource> getResources() {
+            return resources;
+        }
+
+        public String getNextCursor() {
+            return nextCursor;
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsResult.java
@@ -1,6 +1,9 @@
 package dev.langchain4j.mcp.protocol;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.Internal;
 import java.util.List;
 import java.util.Map;
@@ -9,11 +12,13 @@ import java.util.Map;
  * Corresponds to the {@code ListToolsResult} type from the MCP schema.
  */
 @Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpListToolsResult extends McpJsonRpcMessage {
 
     private final Result result;
 
-    public McpListToolsResult(Long id, Result result) {
+    @JsonCreator
+    public McpListToolsResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
         super(id);
         this.result = result;
     }
@@ -23,12 +28,16 @@ public class McpListToolsResult extends McpJsonRpcMessage {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Result {
 
         private final List<Map<String, Object>> tools;
         private final String nextCursor;
 
-        public Result(List<Map<String, Object>> tools, String nextCursor) {
+        @JsonCreator
+        public Result(
+                @JsonProperty("tools") List<Map<String, Object>> tools,
+                @JsonProperty("nextCursor") String nextCursor) {
             this.tools = tools;
             this.nextCursor = nextCursor;
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPaginatedResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPaginatedResult.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+
+/**
+ * The pagination envelope shared by every {@code list} operation in the MCP schema. Only the
+ * cursor is modelled, so that paging can be read from any list response without caring which
+ * kind of list it carries.
+ */
+@Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpPaginatedResult extends McpJsonRpcMessage {
+
+    private final Result result;
+
+    @JsonCreator
+    public McpPaginatedResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
+        super(id);
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+
+        private final String nextCursor;
+
+        @JsonCreator
+        public Result(@JsonProperty("nextCursor") String nextCursor) {
+            this.nextCursor = nextCursor;
+        }
+
+        public String getNextCursor() {
+            return nextCursor;
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceParams.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.mcp.protocol;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.Internal;
 import java.util.Map;
 import java.util.Objects;
@@ -18,7 +17,7 @@ public class McpReadResourceParams extends McpClientParams {
     private Map<String, Object> inputResponses;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private JsonNode requestState;
+    private Object requestState;
 
     public McpReadResourceParams() {}
 
@@ -43,11 +42,11 @@ public class McpReadResourceParams extends McpClientParams {
         this.inputResponses = inputResponses;
     }
 
-    public JsonNode getRequestState() {
+    public Object getRequestState() {
         return requestState;
     }
 
-    public void setRequestState(JsonNode requestState) {
+    public void setRequestState(Object requestState) {
         this.requestState = requestState;
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceResponse.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+import java.util.List;
+
+/**
+ * Corresponds to the {@code ReadResourceResult} type from the MCP schema.
+ *
+ * <p>A content entry carries either {@code text} or {@code blob}; which one decides the
+ * {@code McpResourceContents} subtype the client exposes.
+ */
+@Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpReadResourceResponse extends McpJsonRpcMessage {
+
+    private final Result result;
+
+    @JsonCreator
+    public McpReadResourceResponse(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
+        super(id);
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+
+        private final List<Contents> contents;
+
+        @JsonCreator
+        public Result(@JsonProperty("contents") List<Contents> contents) {
+            this.contents = contents;
+        }
+
+        public List<Contents> getContents() {
+            return contents;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Contents {
+
+        private final String uri;
+        private final String mimeType;
+        private final String text;
+        private final String blob;
+
+        @JsonCreator
+        public Contents(
+                @JsonProperty("uri") String uri,
+                @JsonProperty("mimeType") String mimeType,
+                @JsonProperty("text") String text,
+                @JsonProperty("blob") String blob) {
+            this.uri = uri;
+            this.mimeType = mimeType;
+            this.text = text;
+            this.blob = blob;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public String getMimeType() {
+            return mimeType;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public String getBlob() {
+            return blob;
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpServerDiscoverResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpServerDiscoverResponse.java
@@ -1,0 +1,92 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Corresponds to the result of {@code server/discover} in the modern MCP protocol.
+ *
+ * <p>Also covers the fields a multi-round-trip response carries, since those arrive in the same
+ * {@code result} object.
+ */
+@Internal
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpServerDiscoverResponse extends McpJsonRpcMessage {
+
+    private final Result result;
+
+    @JsonCreator
+    public McpServerDiscoverResponse(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
+        super(id);
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+
+        private final List<String> supportedVersions;
+        private final Map<String, Object> capabilities;
+        private final Map<String, Object> meta;
+        private final String instructions;
+        private final String resultType;
+        private final Object requestState;
+        private final Object inputRequests;
+
+        @JsonCreator
+        public Result(
+                @JsonProperty("supportedVersions") List<String> supportedVersions,
+                @JsonProperty("capabilities") Map<String, Object> capabilities,
+                @JsonProperty("_meta") Map<String, Object> meta,
+                @JsonProperty("instructions") String instructions,
+                @JsonProperty("resultType") String resultType,
+                @JsonProperty("requestState") Object requestState,
+                @JsonProperty("inputRequests") Object inputRequests) {
+            this.supportedVersions = supportedVersions;
+            this.capabilities = capabilities;
+            this.meta = meta;
+            this.instructions = instructions;
+            this.resultType = resultType;
+            this.requestState = requestState;
+            this.inputRequests = inputRequests;
+        }
+
+        public List<String> getSupportedVersions() {
+            return supportedVersions;
+        }
+
+        public Map<String, Object> getCapabilities() {
+            return capabilities;
+        }
+
+        @JsonProperty("_meta")
+        public Map<String, Object> getMeta() {
+            return meta;
+        }
+
+        public String getInstructions() {
+            return instructions;
+        }
+
+        public String getResultType() {
+            return resultType;
+        }
+
+        public Object getRequestState() {
+            return requestState;
+        }
+
+        public Object getInputRequests() {
+            return inputRequests;
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/registryclient/model/McpMeta.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/registryclient/model/McpMeta.java
@@ -2,6 +2,8 @@ package dev.langchain4j.mcp.registryclient.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.McpJsonConversions;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class McpMeta {
@@ -16,6 +18,22 @@ public class McpMeta {
         return official;
     }
 
+    /**
+     * Returns publisher-provided metadata as plain values, so consumers do not need a JSON library.
+     */
+    public Map<String, Object> publisherProvided() {
+        if (publisherProvided == null) {
+            return null;
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        publisherProvided.forEach((k, v) -> result.put(k, McpJsonConversions.toValue(v)));
+        return result;
+    }
+
+    /**
+     * @deprecated use {@link #publisherProvided()}, which does not expose Jackson types.
+     */
+    @Deprecated(since = "1.20.0", forRemoval = true)
     public Map<String, JsonNode> getPublisherProvided() {
         return publisherProvided;
     }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/GetResourceToolExecutor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/GetResourceToolExecutor.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.mcp.resourcesastools;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.exception.ToolExecutionException;
@@ -12,6 +11,7 @@ import dev.langchain4j.mcp.client.McpTextResourceContents;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -29,15 +29,15 @@ class GetResourceToolExecutor implements ToolExecutor {
     @Override
     public ToolExecutionResult executeWithContext(
             ToolExecutionRequest toolExecutionRequest, InvocationContext context) {
-        ObjectNode arguments = parseArguments(toolExecutionRequest);
-        if (!arguments.has("mcpServer")) {
+        Map<String, Object> arguments = parseArguments(toolExecutionRequest);
+        if (!arguments.containsKey("mcpServer")) {
             throw new ToolArgumentsException("ERROR: missing argument 'mcpServer'");
         }
-        String mcpServerKey = arguments.get("mcpServer").asText();
-        if (!arguments.has("uri")) {
+        String mcpServerKey = String.valueOf(arguments.get("mcpServer"));
+        if (!arguments.containsKey("uri")) {
             throw new ToolArgumentsException("ERROR: missing argument 'uri'");
         }
-        String uri = arguments.get("uri").asText();
+        String uri = String.valueOf(arguments.get("uri"));
         Optional<McpClient> client = mcpClients.stream()
                 .filter(mcpClient -> mcpClient.key().equals(mcpServerKey))
                 .findFirst();
@@ -63,9 +63,10 @@ class GetResourceToolExecutor implements ToolExecutor {
         return executeWithContext(toolExecutionRequest, null).resultText();
     }
 
-    private static ObjectNode parseArguments(ToolExecutionRequest toolExecutionRequest) {
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parseArguments(ToolExecutionRequest toolExecutionRequest) {
         try {
-            return Json.fromJson(toolExecutionRequest.arguments(), ObjectNode.class);
+            return Json.fromJson(toolExecutionRequest.arguments(), Map.class);
         } catch (Exception e) {
             throw new ToolArgumentsException(e.getCause());
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
@@ -2,9 +2,7 @@ package dev.langchain4j.mcp.transport.stdio;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.Internal;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
 import java.io.BufferedReader;
 import java.io.Closeable;
@@ -17,27 +15,27 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Internal
 public class JsonRpcIoHandler implements Runnable, Closeable {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(JsonRpcIoHandler.class);
 
     private final InputStream input;
     private final PrintStream out;
     private final boolean logEvents;
     private final Logger trafficLog;
-    private final Consumer<JsonNode> messageHandler;
+    private final Consumer<String> messageHandler;
     private volatile boolean closed = false;
 
     public JsonRpcIoHandler(
-            InputStream input, OutputStream output, Consumer<JsonNode> messageHandler, boolean logEvents) {
+            InputStream input, OutputStream output, Consumer<String> messageHandler, boolean logEvents) {
         this(input, output, messageHandler, logEvents, null);
     }
 
     public JsonRpcIoHandler(
             InputStream input,
             OutputStream output,
-            Consumer<JsonNode> messageHandler,
+            Consumer<String> messageHandler,
             boolean logEvents,
             Logger logger) {
         this.input = input;
@@ -56,9 +54,10 @@ public class JsonRpcIoHandler implements Runnable, Closeable {
                     trafficLog.debug("< {}", line);
                 }
                 try {
-                    messageHandler.accept(OBJECT_MAPPER.readTree(line));
-                } catch (JsonProcessingException e) {
-                    log.warn("Ignoring message received because it is not valid JSON: {}", line);
+                    messageHandler.accept(line);
+                } catch (RuntimeException e) {
+                    // one bad message must not end the read loop and strand the subprocess
+                    log.warn("Ignoring message that could not be handled: {}", line, e);
                 }
             }
         } catch (IOException e) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,21 +34,17 @@ public class JsonRpcIoHandler implements Runnable, Closeable {
     }
 
     public JsonRpcIoHandler(
-            InputStream input,
-            OutputStream output,
-            Consumer<String> messageHandler,
-            boolean logEvents,
-            Logger logger) {
+            InputStream input, OutputStream output, Consumer<String> messageHandler, boolean logEvents, Logger logger) {
         this.input = input;
         this.logEvents = logEvents;
         this.messageHandler = messageHandler;
-        this.out = new PrintStream(output, true);
+        this.out = new PrintStream(output, true, StandardCharsets.UTF_8);
         this.trafficLog = getOrDefault(logger, McpLoggers.traffic());
     }
 
     @Override
     public void run() {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (logEvents) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -3,7 +3,9 @@ package dev.langchain4j.mcp.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -31,6 +33,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -972,12 +978,20 @@ public class DefaultMcpClientTest {
     @Test
     public void activeSubscriptions_cleared_after_unsubscribe() throws Exception {
         McpTransport transport = getModernMcpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
 
         // The subscription request gets a future that never completes (simulating an open SSE stream)
         CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
         when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
-                .thenReturn(sseStream);
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    handlerRef
+                            .get()
+                            .handle(buildSubscriptionAcknowledgedNotification(
+                                    ctx.message().getId(), "file:///test"));
+                    return sseStream;
+                });
 
         DefaultMcpClient client = createMcpClient(transport);
         long subscriptionId = client.subscribeToResources(List.of("file:///test"));
@@ -990,13 +1004,52 @@ public class DefaultMcpClientTest {
     }
 
     @Test
-    public void unsubscribe_over_http_does_not_send_cancellation_notification() throws Exception {
-        McpTransport transport = getModernHttpTransportMock();
+    public void activeSubscriptions_cleared_after_graceful_server_closure() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
 
         CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
         when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
-                .thenReturn(sseStream);
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    handlerRef
+                            .get()
+                            .handle(buildSubscriptionAcknowledgedNotification(
+                                    ctx.message().getId(), "file:///test"));
+                    return sseStream;
+                });
+
+        DefaultMcpClient client = createMcpClient(transport);
+        long subscriptionId = client.subscribeToResources(List.of("file:///test"));
+        assertThat(getActiveSubscriptions(client)).containsKey(subscriptionId);
+
+        // The server ends the subscription gracefully, e.g. during its own shutdown
+        // (see the spec's Graceful Closure) - the original subscriptions/listen request
+        // finally gets its (empty) response, well after it was acknowledged.
+        ObjectNode gracefulClosure = JsonNodeFactory.instance.objectNode();
+        gracefulClosure.putObject("result").put("resultType", "complete");
+        sseStream.complete(gracefulClosure);
+
+        assertThat(getActiveSubscriptions(client)).doesNotContainKey(subscriptionId);
+    }
+
+    @Test
+    public void unsubscribe_over_http_does_not_send_cancellation_notification() throws Exception {
+        McpTransport transport = getModernHttpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    handlerRef
+                            .get()
+                            .handle(buildSubscriptionAcknowledgedNotification(
+                                    ctx.message().getId(), "file:///test"));
+                    return sseStream;
+                });
 
         DefaultMcpClient client = new DefaultMcpClient.Builder()
                 .transport(transport)
@@ -1016,11 +1069,19 @@ public class DefaultMcpClientTest {
     @Test
     public void unsubscribe_over_stdio_sends_cancellation_notification() throws Exception {
         McpTransport transport = getModernStdioTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
 
         CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
         when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
-                .thenReturn(sseStream);
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    handlerRef
+                            .get()
+                            .handle(buildSubscriptionAcknowledgedNotification(
+                                    ctx.message().getId(), "file:///test"));
+                    return sseStream;
+                });
 
         DefaultMcpClient client = new DefaultMcpClient.Builder()
                 .transport(transport)
@@ -1038,10 +1099,11 @@ public class DefaultMcpClientTest {
     }
 
     @Test
-    public void activeSubscriptions_cleared_after_server_rejection() throws Exception {
+    public void subscribeToResources_throws_mcp_exception_on_immediate_server_rejection() throws Exception {
         McpTransport transport = getModernMcpTransportMock();
 
-        // The subscription request completes immediately with a JSON-RPC error
+        // The subscription request completes immediately with a JSON-RPC error, before any
+        // notifications/subscriptions/acknowledged notification is ever sent
         ObjectNode errorResponse = JsonNodeFactory.instance.objectNode();
         ObjectNode error = errorResponse.putObject("error");
         error.put("code", -32602);
@@ -1051,17 +1113,17 @@ public class DefaultMcpClientTest {
                 .thenReturn(CompletableFuture.completedFuture(errorResponse));
 
         DefaultMcpClient client = createMcpClient(transport);
-        long subscriptionId = client.subscribeToResources(List.of("file:///nonexistent"));
 
-        // The whenComplete handler runs asynchronously — wait for it
-        Map<Long, ?> activeSubscriptions = getActiveSubscriptions(client);
-        org.awaitility.Awaitility.await()
-                .atMost(java.time.Duration.ofSeconds(2))
-                .untilAsserted(() -> assertThat(activeSubscriptions).doesNotContainKey(subscriptionId));
+        // The rejection must surface as an exception to the caller, not just a logged warning
+        assertThatThrownBy(() -> client.subscribeToResources(List.of("file:///nonexistent")))
+                .isInstanceOf(McpException.class)
+                .hasMessageContaining("Unknown resource URI");
+
+        assertThat(getActiveSubscriptions(client)).isEmpty();
     }
 
     @Test
-    public void activeSubscriptions_cleared_after_transport_error() throws Exception {
+    public void subscribeToResources_throws_on_transport_error_before_acknowledgement() throws Exception {
         McpTransport transport = getModernMcpTransportMock();
 
         // The subscription request fails with a transport error
@@ -1072,12 +1134,409 @@ public class DefaultMcpClientTest {
                 .thenReturn(failed);
 
         DefaultMcpClient client = createMcpClient(transport);
+
+        assertThatThrownBy(() -> client.subscribeToResources(List.of("file:///test")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Connection refused");
+
+        assertThat(getActiveSubscriptions(client)).isEmpty();
+    }
+
+    @Test
+    public void subscribeToResources_returns_only_after_server_acknowledges() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+
+        // Simulates an open SSE stream that stays open for the lifetime of the subscription
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    // The server acknowledges the subscription right after accepting the request
+                    handlerRef
+                            .get()
+                            .handle(buildSubscriptionAcknowledgedNotification(
+                                    ctx.message().getId(), "file:///test"));
+                    return sseStream;
+                });
+
+        DefaultMcpClient client = createMcpClient(transport);
         long subscriptionId = client.subscribeToResources(List.of("file:///test"));
 
-        Map<Long, ?> activeSubscriptions = getActiveSubscriptions(client);
-        org.awaitility.Awaitility.await()
-                .atMost(java.time.Duration.ofSeconds(2))
-                .untilAsserted(() -> assertThat(activeSubscriptions).doesNotContainKey(subscriptionId));
+        assertThat(getActiveSubscriptions(client)).containsKey(subscriptionId);
+    }
+
+    /**
+     * Unlike the test above, the acknowledgement here is deliberately delayed and delivered
+     * from a separate thread, so this test can actually distinguish "blocks until acknowledged"
+     * from an implementation that (bug) returns immediately regardless of the ack.
+     */
+    @Test
+    public void subscribeToResources_blocks_until_server_sends_delayed_acknowledgement() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+        AtomicReference<Long> capturedSubscriptionId = new AtomicReference<>();
+
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    capturedSubscriptionId.set(ctx.message().getId());
+                    // No acknowledgement is sent yet - the test sends it later, explicitly
+                    return sseStream;
+                });
+
+        DefaultMcpClient client = createMcpClient(transport);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Long> subscribeFuture = executor.submit(() -> client.subscribeToResources(List.of("file:///test")));
+
+            // The call must still be blocked, since no acknowledgement has been sent
+            Thread.sleep(200);
+            assertThat(subscribeFuture.isDone()).isFalse();
+
+            handlerRef
+                    .get()
+                    .handle(buildSubscriptionAcknowledgedNotification(capturedSubscriptionId.get(), "file:///test"));
+
+            long subscriptionId = subscribeFuture.get(2, java.util.concurrent.TimeUnit.SECONDS);
+            assertThat(subscriptionId).isEqualTo(capturedSubscriptionId.get());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void late_acknowledgement_after_timeout_is_a_safe_no_op() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+        AtomicReference<Long> capturedSubscriptionId = new AtomicReference<>();
+
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    capturedSubscriptionId.set(ctx.message().getId());
+                    return sseStream;
+                });
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .build();
+
+        assertThatThrownBy(() -> client.subscribeToResources(List.of("file:///test")))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(java.util.concurrent.TimeoutException.class);
+
+        // The server's acknowledgement finally arrives, well after the client gave up.
+        // It must be ignored rather than throw or resurrect the timed-out subscription.
+        assertThatCode(() -> handlerRef
+                        .get()
+                        .handle(buildSubscriptionAcknowledgedNotification(
+                                capturedSubscriptionId.get(), "file:///test")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void close_unblocks_a_pending_subscribeToResources_call() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+
+        // The stream never completes and the server never acknowledges
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(sseStream);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                // long enough that only close() (not the timeout) can unblock the call below
+                .resourcesTimeout(java.time.Duration.ofSeconds(30))
+                .build();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Long> subscribeFuture = executor.submit(() -> client.subscribeToResources(List.of("file:///test")));
+            Thread.sleep(200);
+            assertThat(subscribeFuture.isDone()).isFalse();
+
+            client.close();
+
+            // Not merely an IllegalStateException: cancelling the stream would complete the
+            // acknowledgement with a CancellationException, which extends IllegalStateException
+            // and would therefore satisfy a laxer assertion while telling the caller nothing
+            assertThatThrownBy(() -> subscribeFuture.get(2, java.util.concurrent.TimeUnit.SECONDS))
+                    .rootCause()
+                    .isExactlyInstanceOf(IllegalStateException.class)
+                    .hasMessage("MCP client was closed");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void subscribeToResources_throws_if_server_never_acknowledges() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+
+        // The stream stays open but the server never sends notifications/subscriptions/acknowledged
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(sseStream);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .build();
+
+        // Without a wait-for-acknowledgement fix, this call would return immediately
+        // instead of timing out
+        assertThatThrownBy(() -> client.subscribeToResources(List.of("file:///test")))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(java.util.concurrent.TimeoutException.class);
+
+        assertThat(getActiveSubscriptions(client)).isEmpty();
+        assertThat(sseStream.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void subscribeToResources_throws_when_server_declines_the_requested_resources() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    // The server acknowledges the subscription, but the acknowledgement carries none
+                    // of the requested resource subscriptions, meaning it will never send updates
+                    handlerRef
+                            .get()
+                            .handle(buildSubscriptionAcknowledgedNotification(
+                                    ctx.message().getId()));
+                    return sseStream;
+                });
+
+        List<Throwable> reportedErrors = new ArrayList<>();
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .listener(new McpClientListener() {
+                    @Override
+                    public void onResourcesSubscribeError(McpCallContext context, Throwable error) {
+                        reportedErrors.add(error);
+                    }
+                })
+                .build();
+
+        assertThatThrownBy(() -> client.subscribeToResources(List.of("file:///test")))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("declined to honour");
+
+        assertThat(reportedErrors).hasSize(1);
+        assertThat(getActiveSubscriptions(client)).isEmpty();
+        assertThat(getPendingSubscriptionAcks(client)).isEmpty();
+        assertThat(sseStream.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void subscribeToResources_fails_fast_when_server_ends_subscription_without_acknowledging() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(sseStream);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                // long enough that a timeout, rather than the closure below, would fail the test
+                .resourcesTimeout(java.time.Duration.ofSeconds(30))
+                .build();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Long> subscribeFuture = executor.submit(() -> client.subscribeToResources(List.of("file:///test")));
+            Thread.sleep(200);
+            assertThat(subscribeFuture.isDone()).isFalse();
+
+            // The server closes the subscription (see the spec's Graceful Closure) without ever
+            // having acknowledged it, so the caller must not keep waiting for an acknowledgement
+            ObjectNode gracefulClosure = JsonNodeFactory.instance.objectNode();
+            gracefulClosure.putObject("result").put("resultType", "complete");
+            sseStream.complete(gracefulClosure);
+
+            assertThatThrownBy(() -> subscribeFuture.get(2, java.util.concurrent.TimeUnit.SECONDS))
+                    .rootCause()
+                    .isExactlyInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("without ever acknowledging it");
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(getActiveSubscriptions(client)).isEmpty();
+        assertThat(getPendingSubscriptionAcks(client)).isEmpty();
+    }
+
+    @Test
+    public void subscribeToResources_reports_cancellation_before_acknowledgement_to_listener() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(sseStream);
+
+        List<Throwable> reportedErrors = new ArrayList<>();
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .resourcesTimeout(java.time.Duration.ofSeconds(30))
+                .listener(new McpClientListener() {
+                    @Override
+                    public void onResourcesSubscribeError(McpCallContext context, Throwable error) {
+                        reportedErrors.add(error);
+                    }
+                })
+                .build();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Long> subscribeFuture = executor.submit(() -> client.subscribeToResources(List.of("file:///test")));
+            Thread.sleep(200);
+            assertThat(subscribeFuture.isDone()).isFalse();
+
+            // Cancelling the stream is what unsubscribeFromResources() and a server-sent
+            // notifications/cancelled both end up doing
+            sseStream.cancel(true);
+
+            assertThatThrownBy(() -> subscribeFuture.get(2, java.util.concurrent.TimeUnit.SECONDS))
+                    .rootCause()
+                    .isInstanceOf(java.util.concurrent.CancellationException.class);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(reportedErrors).hasSize(1);
+        assertThat(getPendingSubscriptionAcks(client)).isEmpty();
+    }
+
+    @Test
+    public void subscribeToResources_does_not_leak_when_transport_throws_synchronously() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenThrow(new IllegalStateException("Transport is reconnecting"));
+
+        List<Throwable> reportedErrors = new ArrayList<>();
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .listener(new McpClientListener() {
+                    @Override
+                    public void onResourcesSubscribeError(McpCallContext context, Throwable error) {
+                        reportedErrors.add(error);
+                    }
+                })
+                .build();
+
+        assertThatThrownBy(() -> client.subscribeToResources(List.of("file:///test")))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Transport is reconnecting");
+
+        assertThat(reportedErrors).hasSize(1);
+        assertThat(getPendingSubscriptionAcks(client)).isEmpty();
+        assertThat(getActiveSubscriptions(client)).isEmpty();
+    }
+
+    @Test
+    public void subscribeToResources_throws_on_malformed_server_rejection() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+
+        // A rejection whose error object lacks the mandatory "code" and "message" fields.
+        // Parsing it fails, but the caller still has to be unblocked rather than wait out the timeout
+        ObjectNode malformedError = JsonNodeFactory.instance.objectNode();
+        malformedError.putObject("error");
+
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(CompletableFuture.completedFuture(malformedError));
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                // long enough that the call timing out, instead of failing, would fail the test
+                .resourcesTimeout(java.time.Duration.ofSeconds(5))
+                .build();
+
+        // Which exception the malformed error produces is an implementation detail; what matters is
+        // that the caller is told promptly instead of waiting out resourcesTimeout
+        long startedAt = System.nanoTime();
+        Throwable thrown = catchThrowable(() -> client.subscribeToResources(List.of("file:///test")));
+        java.time.Duration elapsed = java.time.Duration.ofNanos(System.nanoTime() - startedAt);
+
+        assertThat(thrown).isNotNull();
+        assertThat(elapsed).isLessThan(java.time.Duration.ofSeconds(2));
+
+        assertThat(getActiveSubscriptions(client)).isEmpty();
+        assertThat(getPendingSubscriptionAcks(client)).isEmpty();
+    }
+
+    @Test
+    public void pendingSubscriptionAcks_cleared_after_successful_subscribe() throws Exception {
+        McpTransport transport = getModernMcpTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+
+        CompletableFuture<JsonNode> sseStream = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenAnswer(invocation -> {
+                    McpCallContext ctx = invocation.getArgument(0);
+                    handlerRef
+                            .get()
+                            .handle(buildSubscriptionAcknowledgedNotification(
+                                    ctx.message().getId(), "file:///test"));
+                    return sseStream;
+                });
+
+        DefaultMcpClient client = createMcpClient(transport);
+        client.subscribeToResources(List.of("file:///test"));
+
+        assertThat(getPendingSubscriptionAcks(client)).isEmpty();
     }
 
     @Test
@@ -1175,6 +1634,50 @@ public class DefaultMcpClientTest {
         java.lang.reflect.Field field = DefaultMcpClient.class.getDeclaredField("activeSubscriptions");
         field.setAccessible(true);
         return (Map<Long, ?>) field.get(client);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Long, ?> getPendingSubscriptionAcks(DefaultMcpClient client) throws Exception {
+        java.lang.reflect.Field field = DefaultMcpClient.class.getDeclaredField("pendingSubscriptionAcks");
+        field.setAccessible(true);
+        return (Map<Long, ?>) field.get(client);
+    }
+
+    /**
+     * Captures the {@link McpOperationHandler} that the client hands to {@code transport.start(...)},
+     * so that tests can simulate server-initiated notifications (e.g. subscription acknowledgements).
+     * Must be called before the transport is passed to {@link DefaultMcpClient.Builder#build()}.
+     */
+    private static AtomicReference<McpOperationHandler> captureMessageHandler(McpTransport transport) {
+        AtomicReference<McpOperationHandler> handlerRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+                    handlerRef.set(invocation.getArgument(0));
+                    return null;
+                })
+                .when(transport)
+                .start(any(McpOperationHandler.class));
+        return handlerRef;
+    }
+
+    /**
+     * Builds the acknowledgement a spec-compliant server sends as the first message on a
+     * subscription stream. {@code honouredUris} are the resource subscriptions the server agreed
+     * to honour; passing none simulates a server that acknowledges but declines them all.
+     */
+    private static ObjectNode buildSubscriptionAcknowledgedNotification(long subscriptionId, String... honouredUris) {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("jsonrpc", "2.0");
+        node.put("method", "notifications/subscriptions/acknowledged");
+        ObjectNode params = node.putObject("params");
+        params.putObject("_meta").put("io.modelcontextprotocol/subscriptionId", subscriptionId);
+        ObjectNode notifications = params.putObject("notifications");
+        if (honouredUris.length > 0) {
+            ArrayNode resourceSubscriptions = notifications.putArray("resourceSubscriptions");
+            for (String uri : honouredUris) {
+                resourceSubscriptions.add(uri);
+            }
+        }
+        return node;
     }
 
     private static record ToolDefinition(String name, String description, ToolArg... args) {}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -24,6 +24,8 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpCancellationNotification;
+import dev.langchain4j.mcp.protocol.McpCancellationParams;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpClientRequest;
 import dev.langchain4j.mcp.protocol.McpListToolsParams;
@@ -697,6 +699,59 @@ public class DefaultMcpClientTest {
 
         // 4 calls: discover, first tool call, retry
         verify(transport, times(3)).executeOperationWithResponse(any(McpCallContext.class));
+    }
+
+    @Test
+    public void mrtr_retry_timeout_cancels_retry_request_and_notifies_server() throws Exception {
+        McpTransport transport = getModernStdioTransportMock();
+        AtomicReference<McpOperationHandler> handlerRef = captureMessageHandler(transport);
+        CompletableFuture<String> retryNeverCompletes = new CompletableFuture<>();
+
+        when(transport.sendRequest(any(McpCallContext.class)))
+                .thenReturn(
+                        CompletableFuture.completedFuture(getDiscoverResult().toString()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        buildInputRequiredResponse(true, false).toString()))
+                .thenAnswer(invocation -> {
+                    McpCallContext retryContext = invocation.getArgument(0);
+                    Long retryRequestId = retryContext.message().getId();
+                    handlerRef.get().expectResponse(retryRequestId, retryNeverCompletes);
+                    return retryNeverCompletes;
+                });
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .toolExecutionTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        try {
+            client.executeTool(
+                    ToolExecutionRequest.builder().name("test").arguments("{}").build());
+
+            ArgumentCaptor<McpCallContext> requestCaptor = ArgumentCaptor.forClass(McpCallContext.class);
+            verify(transport, times(3)).sendRequest(requestCaptor.capture());
+            Long retryRequestId =
+                    ((McpClientRequest) requestCaptor.getAllValues().get(2).message()).getId();
+
+            java.lang.reflect.Field pendingOperationsField =
+                    DefaultMcpClient.class.getDeclaredField("pendingOperations");
+            pendingOperationsField.setAccessible(true);
+            Map<?, ?> pendingOperations = (Map<?, ?>) pendingOperationsField.get(client);
+            assertThat(pendingOperations.containsKey(retryRequestId)).isFalse();
+            assertThat(retryNeverCompletes.isCancelled()).isTrue();
+
+            ArgumentCaptor<McpClientMessage> cancellationCaptor = ArgumentCaptor.forClass(McpClientMessage.class);
+            verify(transport).sendMessage(cancellationCaptor.capture());
+            McpCancellationNotification cancellation = (McpCancellationNotification) cancellationCaptor.getValue();
+            McpCancellationParams params = (McpCancellationParams) cancellation.getParams();
+            assertThat(params.getRequestId()).isEqualTo(retryRequestId);
+        } finally {
+            client.close();
+        }
     }
 
     @Test

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -191,6 +191,24 @@ public class DefaultMcpClientTest {
     }
 
     @Test
+    public void should_throw_mcp_exception_when_tool_list_is_refused() throws Exception {
+        // given
+        final McpTransport transport = getMinimalMcpTransportMock();
+        final DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+        final ObjectNode errorResponse = JsonNodeFactory.instance.objectNode();
+        errorResponse.put("jsonrpc", "2.0").put("id", 1);
+        errorResponse.putObject("error").put("code", -32600).put("message", "You are not allowed to use these tools");
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(errorResponse));
+
+        // when + then: the server's reason reaches the caller instead of a NullPointerException
+        assertThatThrownBy(client::listTools)
+                .isInstanceOf(McpException.class)
+                .hasMessageContaining("You are not allowed to use these tools");
+    }
+
+    @Test
     public void should_cache_tool_list() throws Exception {
         // given
         final McpTransport transport = getMinimalMcpTransportMock();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -880,6 +880,11 @@ public class DefaultMcpClientTest {
 
     private static McpTransport getMinimalMcpTransportMock() {
         McpTransport transport = mock(McpTransport.class);
+        // exercise the default bridge: a legacy transport that implements only the
+        // deprecated JsonNode methods must still satisfy the raw-JSON contract
+        when(transport.sendInitializeRequest(any())).thenCallRealMethod();
+        when(transport.sendRequest(any(McpCallContext.class))).thenCallRealMethod();
+        when(transport.sendRequest(any(McpClientMessage.class))).thenCallRealMethod();
         when(transport.requiresCancellationNotification()).thenReturn(true);
         ObjectNode emptyJsonNode = JsonNodeFactory.instance.objectNode();
         when(transport.initialize(any())).thenReturn(CompletableFuture.completedFuture(emptyJsonNode));
@@ -897,6 +902,11 @@ public class DefaultMcpClientTest {
 
     private static McpTransport getModernStdioTransportMock() {
         McpTransport transport = mock(McpTransport.class);
+        // exercise the default bridge: a legacy transport that implements only the
+        // deprecated JsonNode methods must still satisfy the raw-JSON contract
+        when(transport.sendInitializeRequest(any())).thenCallRealMethod();
+        when(transport.sendRequest(any(McpCallContext.class))).thenCallRealMethod();
+        when(transport.sendRequest(any(McpClientMessage.class))).thenCallRealMethod();
         when(transport.requiresCancellationNotification()).thenReturn(true);
         ObjectNode discoverResult = getDiscoverResult();
         when(transport.executeOperationWithResponse(any(McpCallContext.class)))
@@ -906,6 +916,11 @@ public class DefaultMcpClientTest {
 
     private static McpTransport getModernHttpTransportMock() {
         McpTransport transport = mock(McpTransport.class);
+        // exercise the default bridge: a legacy transport that implements only the
+        // deprecated JsonNode methods must still satisfy the raw-JSON contract
+        when(transport.sendInitializeRequest(any())).thenCallRealMethod();
+        when(transport.sendRequest(any(McpCallContext.class))).thenCallRealMethod();
+        when(transport.sendRequest(any(McpClientMessage.class))).thenCallRealMethod();
         when(transport.requiresCancellationNotification()).thenReturn(false);
         ObjectNode discoverResult = getDiscoverResult();
         when(transport.executeOperationWithResponse(any(McpCallContext.class)))
@@ -915,6 +930,11 @@ public class DefaultMcpClientTest {
 
     private static McpTransport getLegacyHttpTransportMock() {
         McpTransport transport = mock(McpTransport.class);
+        // exercise the default bridge: a legacy transport that implements only the
+        // deprecated JsonNode methods must still satisfy the raw-JSON contract
+        when(transport.sendInitializeRequest(any())).thenCallRealMethod();
+        when(transport.sendRequest(any(McpCallContext.class))).thenCallRealMethod();
+        when(transport.sendRequest(any(McpClientMessage.class))).thenCallRealMethod();
         when(transport.requiresCancellationNotification()).thenReturn(false);
         ObjectNode emptyJsonNode = JsonNodeFactory.instance.objectNode();
         when(transport.initialize(any())).thenReturn(CompletableFuture.completedFuture(emptyJsonNode));
@@ -990,7 +1010,7 @@ public class DefaultMcpClientTest {
         client.unsubscribeFromResources(subscriptionId);
 
         assertThat(sseStream.isCancelled()).isTrue();
-        verify(transport, never()).executeOperationWithoutResponse(any(McpClientMessage.class));
+        verify(transport, never()).sendMessage(any(McpClientMessage.class));
     }
 
     @Test
@@ -1014,7 +1034,7 @@ public class DefaultMcpClientTest {
         client.unsubscribeFromResources(subscriptionId);
 
         assertThat(sseStream.isCancelled()).isTrue();
-        verify(transport, times(1)).executeOperationWithoutResponse(any(McpClientMessage.class));
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
     }
 
     @Test
@@ -1082,7 +1102,7 @@ public class DefaultMcpClientTest {
                 ToolExecutionRequest.builder().name("slowTool").arguments("{}").build());
 
         assertThat(neverCompletes.isCancelled()).isTrue();
-        verify(transport, never()).executeOperationWithoutResponse(any(McpClientMessage.class));
+        verify(transport, never()).sendMessage(any(McpClientMessage.class));
     }
 
     @Test
@@ -1102,7 +1122,7 @@ public class DefaultMcpClientTest {
                 ToolExecutionRequest.builder().name("slowTool").arguments("{}").build());
 
         assertThat(neverCompletes.isCancelled()).isTrue();
-        verify(transport, times(1)).executeOperationWithoutResponse(any(McpClientMessage.class));
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
     }
 
     @Test
@@ -1127,7 +1147,7 @@ public class DefaultMcpClientTest {
                 ToolExecutionRequest.builder().name("slowTool").arguments("{}").build());
 
         assertThat(neverCompletes.isCancelled()).isTrue();
-        verify(transport, times(1)).executeOperationWithoutResponse(any(McpClientMessage.class));
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
     }
 
     @Test
@@ -1147,7 +1167,7 @@ public class DefaultMcpClientTest {
                 ToolExecutionRequest.builder().name("slowTool").arguments("{}").build());
 
         assertThat(neverCompletes.isCancelled()).isTrue();
-        verify(transport, times(1)).executeOperationWithoutResponse(any(McpClientMessage.class));
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
     }
 
     @SuppressWarnings("unchecked")

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -1629,6 +1629,92 @@ public class DefaultMcpClientTest {
         verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
     }
 
+    @Test
+    public void resource_read_timeout_cancels_pending_request_and_sends_cancellation_notification() {
+        McpTransport transport = getModernStdioTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        assertThatThrownBy(() -> client.readResource("test://resource")).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
+    public void resource_read_timeout_over_http_cancels_without_cancellation_notification() {
+        McpTransport transport = getModernHttpTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(getDiscoverResult()))
+                .thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        assertThatThrownBy(() -> client.readResource("test://resource")).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, never()).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
+    public void prompt_get_timeout_cancels_pending_request_and_sends_cancellation_notification() {
+        McpTransport transport = getLegacyHttpTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class))).thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .promptsTimeout(java.time.Duration.ofMillis(100))
+                .build();
+
+        assertThatThrownBy(() -> client.getPrompt("test", Map.of())).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
+    }
+
+    @Test
+    public void resource_subscribe_timeout_cancels_pending_request_and_sends_cancellation_notification() {
+        McpTransport transport = getLegacyHttpTransportMock();
+
+        CompletableFuture<JsonNode> neverCompletes = new CompletableFuture<>();
+        when(transport.executeOperationWithResponse(any(McpCallContext.class))).thenReturn(neverCompletes);
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .resourcesTimeout(java.time.Duration.ofMillis(100))
+                .build();
+
+        assertThatThrownBy(() -> client.subscribeToResource("test://resource")).isInstanceOf(RuntimeException.class);
+
+        assertThat(neverCompletes.isCancelled()).isTrue();
+        verify(transport, times(1)).sendMessage(any(McpClientMessage.class));
+    }
+
     @SuppressWarnings("unchecked")
     private static Map<Long, ?> getActiveSubscriptions(DefaultMcpClient client) throws Exception {
         java.lang.reflect.Field field = DefaultMcpClient.class.getDeclaredField("activeSubscriptions");

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverterTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpToolResultConverterTest.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DefaultMcpToolResultConverterTest {
+
+    private final DefaultMcpToolResultConverter extractor = new DefaultMcpToolResultConverter();
+
+    @Test
+    void extracts_single_text_item() {
+        ToolExecutionResult result = extractor.convert(List.of(Map.of("type", "text", "text", "hello")), false);
+
+        assertThat(result.resultText()).isEqualTo("hello");
+        assertThat(result.isError()).isFalse();
+    }
+
+    @Test
+    void joins_multiple_text_items_with_newlines() {
+        ToolExecutionResult result = extractor.convert(
+                List.of(Map.of("type", "text", "text", "a"), Map.of("type", "text", "text", "b")), false);
+
+        assertThat(result.resultText()).isEqualTo("a\nb");
+    }
+
+    @Test
+    void propagates_application_level_error_flag() {
+        ToolExecutionResult result = extractor.convert(List.of(Map.of("type", "text", "text", "boom")), true);
+
+        assertThat(result.isError()).isTrue();
+    }
+
+    @Test
+    void rejects_unsupported_content_type() {
+        assertThatThrownBy(() -> extractor.convert(List.of(Map.of("type", "image", "data", "xxx")), false))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Unsupported content type");
+    }
+
+    @Test
+    void is_a_functional_interface_so_it_can_be_a_lambda() {
+        McpToolResultConverter lambda = (content, isError) -> ToolExecutionResult.builder()
+                .resultText("items=" + content.size())
+                .isError(isError)
+                .build();
+
+        assertThat(lambda.convert(List.of(Map.of("type", "text", "text", "x")), false)
+                        .resultText())
+                .isEqualTo("items=1");
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpJsonConversionsTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpJsonConversionsTest.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.mcp.client.transport.McpJson;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The tree-to-plain-values conversion feeds listener callbacks and the deprecated JsonNode APIs,
+ * so it has to preserve values exactly and agree with the mapper-based path.
+ */
+class McpJsonConversionsTest {
+
+    private static final String JSON =
+            """
+            {"big":123456789012345678901234567890,"long":9007199254740993,"int":5,"d":1.5,"s":"x","b":true,"n":null}""";
+
+    @Test
+    void an_integer_too_wide_for_a_long_should_not_be_truncated() {
+        assertThat(McpJsonConversions.toMap(McpJson.parse(JSON)))
+                .containsEntry("big", new BigInteger("123456789012345678901234567890"));
+    }
+
+    @Test
+    void integral_values_should_keep_their_narrowest_exact_type() {
+        var map = McpJsonConversions.toMap(McpJson.parse(JSON));
+        assertThat(map).containsEntry("int", 5);
+        assertThat(map).containsEntry("long", 9007199254740993L);
+    }
+
+    @Test
+    void it_should_agree_with_the_mapper_based_conversion() {
+        assertThat(McpJsonConversions.toMap(McpJson.parse(JSON))).isEqualTo(McpJson.toMap(JSON));
+    }
+
+    @Test
+    void scalars_and_nulls_should_round_trip() {
+        var map = McpJsonConversions.toMap(McpJson.parse(JSON));
+        assertThat(map).containsEntry("d", 1.5).containsEntry("s", "x").containsEntry("b", true);
+        assertThat(map).containsKey("n");
+        assertThat(map.get("n")).isNull();
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpMetadataParsingTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpMetadataParsingTest.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.mcp.client;
 
-import static dev.langchain4j.mcp.client.DefaultMcpClient.OBJECT_MAPPER;
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.ICONS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ class McpMetadataParsingTest {
 
     @Test
     void resourceWithMetadataAndIcons() throws Exception {
-        JsonNode json = OBJECT_MAPPER.readTree(
+        JsonNode json = McpJson.parse(
                 // language=json
                 """
                         {
@@ -51,7 +51,7 @@ class McpMetadataParsingTest {
 
     @Test
     void resourceTemplateWithMetadataAndIcons() throws Exception {
-        JsonNode json = OBJECT_MAPPER.readTree(
+        JsonNode json = McpJson.parse(
                 // language=json
                 """
                         {
@@ -91,7 +91,7 @@ class McpMetadataParsingTest {
 
     @Test
     void promptWithMetadataAndIcons() throws Exception {
-        JsonNode json = OBJECT_MAPPER.readTree(
+        JsonNode json = McpJson.parse(
                 // language=json
                 """
                         {
@@ -132,7 +132,7 @@ class McpMetadataParsingTest {
 
     @Test
     void metadataIsEmptyWhenMetaAndIconsAreAbsent() throws Exception {
-        JsonNode resourcesJson = OBJECT_MAPPER.readTree(
+        JsonNode resourcesJson = McpJson.parse(
                 // language=json
                 """
                         {
@@ -146,7 +146,7 @@ class McpMetadataParsingTest {
                           }
                         }
                         """);
-        JsonNode resourceTemplatesJson = OBJECT_MAPPER.readTree(
+        JsonNode resourceTemplatesJson = McpJson.parse(
                 // language=json
                 """
                         {
@@ -160,7 +160,7 @@ class McpMetadataParsingTest {
                           }
                         }
                         """);
-        JsonNode promptsJson = OBJECT_MAPPER.readTree(
+        JsonNode promptsJson = McpJson.parse(
                 // language=json
                 """
                         {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpPayloadAccessorTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpPayloadAccessorTest.java
@@ -1,0 +1,76 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import dev.langchain4j.mcp.client.logging.McpLogLevel;
+import dev.langchain4j.mcp.client.logging.McpLogMessage;
+import dev.langchain4j.mcp.protocol.McpInitializeResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JSON-RPC allows {@code error.data} to be any value and MCP allows a log payload to be any
+ * JSON-serializable value, so the accessors have to cope with more than an object.
+ */
+class McpPayloadAccessorTest {
+
+    @Test
+    void errorDataAsMap_should_return_null_rather_than_throw_for_a_non_object() {
+        for (String data : new String[] {"\"boom\"", "[1,2]", "42", "true", "null"}) {
+            McpException e = McpException.withErrorData(1, "m", data);
+            assertThatCode(e::errorDataAsMap).as(data).doesNotThrowAnyException();
+            assertThat(e.errorDataAsMap()).as(data).isNull();
+        }
+    }
+
+    @Test
+    void errorDataAsObject_should_expose_values_that_are_not_objects() {
+        assertThat(McpException.withErrorData(1, "m", "\"boom\"").errorDataAsObject()).isEqualTo("boom");
+        assertThat(McpException.withErrorData(1, "m", "42").errorDataAsObject()).isEqualTo(42);
+        assertThat(McpException.withErrorData(1, "m", "[1,2]").errorDataAsObject()).isEqualTo(java.util.List.of(1, 2));
+        assertThat(McpException.withErrorData(1, "m", "{\"k\":1}").errorDataAsMap()).containsEntry("k", 1);
+        assertThat(McpException.withErrorData(1, "m", null).errorDataAsObject()).isNull();
+    }
+
+    @Test
+    void logMessage_should_expose_a_scalar_payload() {
+        // the common case: a server logs a plain string, which is not a map
+        McpLogMessage message = new McpLogMessage(McpLogLevel.INFO, "lg", "plain text line");
+
+        assertThat(message.dataAsMap()).isNull();
+        assertThat(message.dataAsObject()).isEqualTo("plain text line");
+        assertThat(message.dataAsJson()).isEqualTo("\"plain text line\"");
+    }
+
+    @Test
+    void initialize_instructions_should_not_depend_on_a_jackson_default() {
+        // ALLOW_FINAL_FIELDS_AS_MUTATORS is on by default in Jackson 2 and off in Jackson 3, so a
+        // final field bound behind the getter rather than through the creator would silently
+        // become null on the very migration this API exists to enable.
+        String response =
+                """
+                {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},
+                 "serverInfo":{"name":"s","version":"1"},"instructions":"hello"}}""";
+
+        JsonMapper strict = JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS)
+                .build();
+
+        assertThatCode(() -> {
+                    McpInitializeResult result = strict.readValue(response, McpInitializeResult.class);
+                    assertThat(result.getResult().getInstructions()).isEqualTo("hello");
+                })
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void a_map_payload_still_reads_as_a_map() {
+        McpLogMessage message = new McpLogMessage(McpLogLevel.INFO, "lg", Map.of("k", "v"));
+        assertThat(message.dataAsMap()).containsEntry("k", "v");
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpSchemaCoercionTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpSchemaCoercionTest.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.transport.McpJson;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reading the tool list as plain values rather than a Jackson tree dropped the coercions
+ * JsonNode accessors performed. These pin the behaviour the tree model had.
+ */
+class McpSchemaCoercionTest {
+
+    @SuppressWarnings("unchecked")
+    private static ToolSpecification firstTool(String toolsArrayJson) {
+        List<Map<String, Object>> tools = (List<Map<String, Object>>)
+                McpJson.toMap("{\"tools\":" + toolsArrayJson + "}").get("tools");
+        return ToolSpecificationHelper.toolSpecificationListFromMcpResponse(tools).get(0);
+    }
+
+    @Test
+    void annotation_hints_should_accept_a_string_as_JsonNode_asBoolean_did() {
+        ToolSpecification tool = firstTool(
+                """
+                [{"name":"t","description":"d","inputSchema":{"type":"object"},
+                 "annotations":{"readOnlyHint":"true","destructiveHint":"false"}}]""");
+
+        assertThat(tool.metadata()).containsEntry("readOnlyHint", true);
+        assertThat(tool.metadata()).containsEntry("destructiveHint", false);
+    }
+
+    @Test
+    void annotation_hints_should_accept_a_number_as_JsonNode_asBoolean_did() {
+        ToolSpecification tool = firstTool(
+                """
+                [{"name":"t","description":"d","inputSchema":{"type":"object"},
+                 "annotations":{"idempotentHint":1,"openWorldHint":0}}]""");
+
+        assertThat(tool.metadata()).containsEntry("idempotentHint", true);
+        assertThat(tool.metadata()).containsEntry("openWorldHint", false);
+    }
+
+    @Test
+    void a_boolean_schema_should_degrade_to_an_empty_object_schema() {
+        assertThatCode(() -> firstTool(
+                        """
+                        [{"name":"t","description":"d",
+                         "inputSchema":{"type":"object","properties":{"anything":true}}}]"""))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void tuple_form_items_should_degrade_rather_than_fail() {
+        assertThatCode(() -> firstTool(
+                        """
+                        [{"name":"t","description":"d","inputSchema":{"type":"object",
+                         "properties":{"pair":{"type":"array","items":[{"type":"string"},{"type":"number"}]}}}}]"""))
+                .doesNotThrowAnyException();
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpToolResultMetaParsingTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpToolResultMetaParsingTest.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.mcp.client;
 
-import static dev.langchain4j.mcp.client.DefaultMcpClient.OBJECT_MAPPER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.util.List;
 import java.util.Map;
@@ -11,11 +11,13 @@ import org.junit.jupiter.api.Test;
 
 class McpToolResultMetaParsingTest {
 
-    private final McpToolResultExtractor extractor = new DefaultMcpToolResultExtractor();
+    private final McpToolResultConverter extractor = new DefaultMcpToolResultConverter();
+    private final McpToolResultConverter legacyExtractor =
+            new LegacyToolResultConverterAdapter(new DefaultMcpToolResultExtractor());
 
     @Test
     void should_map_meta_of_text_result_into_attributes() throws Exception {
-        JsonNode response = OBJECT_MAPPER.readTree(
+        JsonNode response = McpJson.parse(
                 // language=json
                 """
                         {
@@ -50,7 +52,7 @@ class McpToolResultMetaParsingTest {
 
     @Test
     void should_map_meta_of_structured_content_result_into_attributes() throws Exception {
-        JsonNode response = OBJECT_MAPPER.readTree(
+        JsonNode response = McpJson.parse(
                 // language=json
                 """
                         {
@@ -75,7 +77,7 @@ class McpToolResultMetaParsingTest {
 
     @Test
     void should_return_no_attributes_when_there_is_no_meta() throws Exception {
-        JsonNode response = OBJECT_MAPPER.readTree(
+        JsonNode response = McpJson.parse(
                 // language=json
                 """
                         {
@@ -99,7 +101,7 @@ class McpToolResultMetaParsingTest {
 
     @Test
     void should_keep_meta_of_error_result_when_application_level_errors_are_ignored() throws Exception {
-        JsonNode response = OBJECT_MAPPER.readTree(
+        JsonNode response = McpJson.parse(
                 // language=json
                 """
                         {
@@ -129,7 +131,7 @@ class McpToolResultMetaParsingTest {
 
     @Test
     void should_give_precedence_to_attributes_set_by_the_extractor() throws Exception {
-        JsonNode response = OBJECT_MAPPER.readTree(
+        JsonNode response = McpJson.parse(
                 // language=json
                 """
                         {
@@ -156,7 +158,7 @@ class McpToolResultMetaParsingTest {
                 .attributes(Map.of("source", "extractor"))
                 .build();
 
-        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, customExtractor);
+        ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, new LegacyToolResultConverterAdapter(customExtractor));
 
         assertThat(result.resultText()).isEqualTo("custom");
         assertThat(result.attributes())
@@ -166,7 +168,7 @@ class McpToolResultMetaParsingTest {
 
     @Test
     void should_skip_meta_keys_reserved_by_mcp() throws Exception {
-        JsonNode response = OBJECT_MAPPER.readTree(
+        JsonNode response = McpJson.parse(
                 // language=json
                 """
                         {
@@ -197,5 +199,26 @@ class McpToolResultMetaParsingTest {
         ToolExecutionResult result = ToolExecutionHelper.extractResult(response, false, extractor);
 
         assertThat(result.attributes()).containsOnlyKeys("com.example.mcp/traceId", "traceId");
+    }
+
+    @Test
+    void the_default_and_the_legacy_extractor_should_agree_on_a_text_content_result() {
+        JsonNode response = McpJson.parse(
+                """
+                {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"hello"}]}}""");
+
+        assertThat(ToolExecutionHelper.extractResult(response, false, extractor).resultText())
+                .isEqualTo(ToolExecutionHelper.extractResult(response, false, legacyExtractor)
+                        .resultText())
+                .isEqualTo("hello");
+    }
+
+    @Test
+    void a_text_item_without_text_should_not_yield_the_literal_string_null() {
+        JsonNode response = McpJson.parse("""
+                {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text"}]}}""");
+
+        assertThat(ToolExecutionHelper.extractResult(response, false, extractor).resultText())
+                .isEmpty();
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpUnknownFieldToleranceTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/McpUnknownFieldToleranceTest.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.mcp.client.transport.McpJson;
+import dev.langchain4j.mcp.protocol.McpInitializeResult;
+import dev.langchain4j.mcp.protocol.McpListPromptsResult;
+import dev.langchain4j.mcp.protocol.McpListResourcesResult;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MCP adds fields in a backwards-compatible way — 2025-06-18 gave every named object a 'title' —
+ * so a server may legitimately send fields this client does not model. Reading a response must
+ * ignore them rather than fail, at every level of the document.
+ */
+@SuppressWarnings("unchecked")
+class McpUnknownFieldToleranceTest {
+
+    @Test
+    void initialize_should_tolerate_an_unknown_field_on_serverInfo() {
+        String response =
+                """
+                {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},
+                 "serverInfo":{"name":"s","version":"1","websiteUrl":"https://example.com"}}}""";
+
+        McpInitializeResult result = McpJson.deserialize(McpJson.parse(response), McpInitializeResult.class);
+
+        assertThat(result.getResult().getServerInfo().getName()).isEqualTo("s");
+    }
+
+    @Test
+    void listResources_should_tolerate_title_on_a_resource() {
+        String response =
+                """
+                {"jsonrpc":"2.0","id":1,"result":{"resources":[
+                 {"uri":"file:///a","name":"n","title":"T","size":12,"annotations":{"audience":["user"]}}]}}""";
+
+        McpListResourcesResult result = McpJson.deserialize(McpJson.parse(response), McpListResourcesResult.class);
+
+        assertThat(result.getResult().getResources()).singleElement().satisfies(r -> assertThat(r.name())
+                .isEqualTo("n"));
+    }
+
+    @Test
+    void listPrompts_should_tolerate_title_on_a_prompt() {
+        String response =
+                """
+                {"jsonrpc":"2.0","id":1,"result":{"prompts":[{"name":"p","title":"T","description":"d"}]}}""";
+
+        McpListPromptsResult result = McpJson.deserialize(McpJson.parse(response), McpListPromptsResult.class);
+
+        assertThat(result.getResult().getPrompts()).singleElement().satisfies(p -> assertThat(p.name())
+                .isEqualTo("p"));
+    }
+
+    @Test
+    void listTools_should_tolerate_an_unknown_field_on_an_icon() {
+        String toolsArray =
+                """
+                [{"name":"t","description":"d","inputSchema":{"type":"object"},
+                 "icons":[{"src":"https://example.com/i.png","mimeType":"image/png","futureIconField":1}]}]""";
+
+        assertThatCode(() -> ToolSpecificationHelper.toolSpecificationListFromMcpResponse(
+                        (java.util.List<java.util.Map<String, Object>>)
+                                McpJson.toMap("{\"tools\":" + toolsArray + "}").get("tools")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void unknown_fields_should_be_tolerated_at_envelope_and_result_level_too() {
+        String response =
+                """
+                {"jsonrpc":"2.0","id":1,"someFutureTopLevel":true,
+                 "result":{"nextCursor":"c","someFutureResultField":1,"resources":[{"uri":"file:///a","name":"n"}]}}""";
+
+        assertThatCode(() -> McpJson.deserialize(McpJson.parse(response), McpListResourcesResult.class))
+                .doesNotThrowAnyException();
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/PromptContentConversionTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/PromptContentConversionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.Content;
@@ -24,7 +25,7 @@ class PromptContentConversionTest {
                 """
                 {"jsonrpc":"2.0","id":111,"result":{"messages":[{"role":"user","content":{"text":"Hello","type":"text"}}]}}
                 """;
-        JsonNode responseJsonNode = DefaultMcpClient.OBJECT_MAPPER.readTree(response);
+        JsonNode responseJsonNode = McpJson.parse(response);
         McpGetPromptResult promptResponse = PromptsHelper.parsePromptContents(responseJsonNode);
 
         ChatMessage chatMessage = promptResponse.messages().get(0).toChatMessage();
@@ -39,7 +40,7 @@ class PromptContentConversionTest {
                 """
                 {"jsonrpc":"2.0","id":123,"result":{"messages":[{"role":"assistant","content":{"text":"Hello","type":"text"}}]}}
                 """;
-        JsonNode responseJsonNode = DefaultMcpClient.OBJECT_MAPPER.readTree(response);
+        JsonNode responseJsonNode = McpJson.parse(response);
         McpGetPromptResult promptResponse = PromptsHelper.parsePromptContents(responseJsonNode);
 
         ChatMessage chatMessage = promptResponse.messages().get(0).toChatMessage();
@@ -54,7 +55,7 @@ class PromptContentConversionTest {
                 """
                 {"jsonrpc":"2.0","id":1,"result":{"messages":[{"role":"user","content":{"data":"aaa","mimeType":"image/png","type":"image"}}]}}
                 """;
-        JsonNode responseJsonNode = DefaultMcpClient.OBJECT_MAPPER.readTree(response);
+        JsonNode responseJsonNode = McpJson.parse(response);
         McpGetPromptResult promptResponse = PromptsHelper.parsePromptContents(responseJsonNode);
 
         ChatMessage chatMessage = promptResponse.messages().get(0).toChatMessage();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.math.BigInteger;
 import java.util.Map;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 public class StructuredContentParsingTest {
 
-    ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     public void testComplexObject() throws JsonProcessingException {
@@ -37,9 +37,10 @@ public class StructuredContentParsingTest {
                   }
                 }
                 """;
-        JsonNode responseNode = objectMapper.readTree(response);
+        JsonNode responseNode = McpJson.parse(response);
         McpToolResultExtractor extractor = mock(McpToolResultExtractor.class);
-        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false, extractor);
+        ToolExecutionResult toolExecutionResult =
+                ToolExecutionHelper.extractResult(responseNode, false, new LegacyToolResultConverterAdapter(extractor));
         assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
         Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
         assertThat(map).hasSize(4);
@@ -72,10 +73,11 @@ public class StructuredContentParsingTest {
                 }
                 """;
 
-        JsonNode responseNode = objectMapper.readTree(response);
+        JsonNode responseNode = McpJson.parse(response);
         McpToolResultExtractor extractor = mock(McpToolResultExtractor.class);
 
-        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false, extractor);
+        ToolExecutionResult toolExecutionResult =
+                ToolExecutionHelper.extractResult(responseNode, false, new LegacyToolResultConverterAdapter(extractor));
 
         assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
         Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
@@ -101,10 +103,11 @@ public class StructuredContentParsingTest {
                 }
                 """;
 
-        JsonNode responseNode = objectMapper.readTree(response);
+        JsonNode responseNode = McpJson.parse(response);
         McpToolResultExtractor extractor = mock(McpToolResultExtractor.class);
 
-        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false, extractor);
+        ToolExecutionResult toolExecutionResult =
+                ToolExecutionHelper.extractResult(responseNode, false, new LegacyToolResultConverterAdapter(extractor));
 
         assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
         Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
@@ -127,10 +130,11 @@ public class StructuredContentParsingTest {
                 }
                 """;
 
-        JsonNode responseNode = objectMapper.readTree(response);
+        JsonNode responseNode = McpJson.parse(response);
         McpToolResultExtractor extractor = mock(McpToolResultExtractor.class);
 
-        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false, extractor);
+        ToolExecutionResult toolExecutionResult =
+                ToolExecutionHelper.extractResult(responseNode, false, new LegacyToolResultConverterAdapter(extractor));
 
         assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
         Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
@@ -158,10 +162,11 @@ public class StructuredContentParsingTest {
                 }
                 """;
 
-        JsonNode responseNode = objectMapper.readTree(response);
+        JsonNode responseNode = McpJson.parse(response);
         McpToolResultExtractor extractor = mock(McpToolResultExtractor.class);
 
-        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false, extractor);
+        ToolExecutionResult toolExecutionResult =
+                ToolExecutionHelper.extractResult(responseNode, false, new LegacyToolResultConverterAdapter(extractor));
 
         assertThat(toolExecutionResult.result()).isEqualTo(Map.of("source", "structured"));
         assertThat(toolExecutionResult.resultText()).isEqualTo("{\"source\":\"structured\"}");

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -255,6 +255,33 @@ class ToolSpecificationHelperTest {
     }
 
     @Test
+    void arrayTypePreservesDescription() throws JsonProcessingException {
+        // A property whose "type" is a union array (like ["string", "null"]) goes through the
+        // type-array branch of jsonNodeToJsonSchemaElement, which builds a JsonAnyOfSchema.
+        // The node's own "description" must be carried onto that anyOf schema, just like the
+        // dedicated anyOf branch does. Otherwise LLMs lose the parameter's purpose entirely.
+        String text = """
+                [{
+                  "name": "query",
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": ["string", "null"],
+                        "description": "Filter by status (nullable)"
+                      }
+                    }
+                  }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
+        JsonAnyOfSchema status = (JsonAnyOfSchema) parameters.properties().get("status");
+        assertThat(status.description()).isEqualTo("Filter by status (nullable)");
+    }
+
+    @Test
     void arrayWithAnyOf() throws JsonProcessingException {
         // trimmed version of the tool from @modelcontextprotocol/server-github
         String text =

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -12,7 +12,6 @@ import static dev.langchain4j.mcp.client.McpToolMetadataKeys.TITLE_ANNOTATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.mcp.client.transport.McpJson;
@@ -32,7 +31,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ToolSpecificationHelperTest {
-
 
     @Test
     void toolWithSimpleParams() throws JsonProcessingException {
@@ -278,6 +276,33 @@ class ToolSpecificationHelperTest {
         JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
         JsonAnyOfSchema status = (JsonAnyOfSchema) parameters.properties().get("status");
         assertThat(status.description()).isEqualTo("Filter by status (nullable)");
+    }
+
+    @Test
+    void objectSchemaWithSchemaTypedAdditionalPropertiesAllowsExtraProperties() throws JsonProcessingException {
+        // "additionalProperties" may be a schema object (common in real MCP schemas) to say "extra
+        // properties are allowed, each matching this schema". JsonObjectSchema only models it as a
+        // boolean, so this must map to "allowed" (true) rather than being collapsed to false, which
+        // would wrongly tell the model to reject any extra property.
+        String text = """
+                [{
+                  "name": "query",
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "filters": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"}
+                      }
+                    }
+                  }
+                }]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        JsonObjectSchema filters = (JsonObjectSchema)
+                toolSpecifications.get(0).parameters().properties().get("filters");
+        assertThat(filters.additionalProperties()).isEqualTo(true);
     }
 
     @Test
@@ -1354,5 +1379,4 @@ class ToolSpecificationHelperTest {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -13,9 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.JsonSchemaElementUtils;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 
 class ToolSpecificationHelperTest {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     void toolWithSimpleParams() throws JsonProcessingException {
@@ -84,7 +83,7 @@ class ToolSpecificationHelperTest {
                       }
                     } ]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications).hasSize(1);
         ToolSpecification toolSpecification = toolSpecifications.get(0);
@@ -154,7 +153,7 @@ class ToolSpecificationHelperTest {
                   }
                 ]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications).hasSize(1);
         ToolSpecification toolSpecification = toolSpecifications.get(0);
@@ -195,7 +194,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications).hasSize(1);
         ToolSpecification toolSpecification = toolSpecifications.get(0);
@@ -238,7 +237,7 @@ class ToolSpecificationHelperTest {
                           }
                         }]
                         """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications).hasSize(1);
         ToolSpecification toolSpecification = toolSpecifications.get(0);
@@ -274,7 +273,7 @@ class ToolSpecificationHelperTest {
                   }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
         JsonAnyOfSchema status = (JsonAnyOfSchema) parameters.properties().get("status");
@@ -352,7 +351,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
 
         assertThat(toolSpecifications).hasSize(1);
@@ -407,7 +406,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
 
         assertThat(toolSpecifications).hasSize(1);
@@ -441,7 +440,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
 
         assertThat(toolSpecifications).hasSize(1);
@@ -471,7 +470,7 @@ class ToolSpecificationHelperTest {
                    }
                  }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications.get(0).parameters().properties().get("value"))
                 .isInstanceOf(JsonObjectSchema.class);
@@ -516,7 +515,7 @@ class ToolSpecificationHelperTest {
                   }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications.get(0).parameters().properties().get("fieldSelections"))
                 .isInstanceOf(JsonAnyOfSchema.class);
@@ -551,7 +550,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
 
         assertThat(toolSpecifications).hasSize(1);
@@ -580,7 +579,7 @@ class ToolSpecificationHelperTest {
                     "title": "A title in the root tool object"
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
                 .get(0)
                 .metadata();
@@ -622,7 +621,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
                 .get(0)
                 .metadata();
@@ -655,7 +654,7 @@ class ToolSpecificationHelperTest {
                     ]
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
                 .get(0)
                 .metadata();
@@ -675,7 +674,7 @@ class ToolSpecificationHelperTest {
                     "inputSchema": {}
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
                 .get(0)
                 .metadata();
@@ -701,7 +700,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
                 .get(0)
                 .metadata();
@@ -751,7 +750,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications).hasSize(1);
         ToolSpecification toolSpecification = toolSpecifications.get(0);
@@ -810,7 +809,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications).hasSize(1);
 
@@ -860,7 +859,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications).hasSize(1);
 
@@ -909,7 +908,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
 
@@ -941,7 +940,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
 
@@ -971,7 +970,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
 
@@ -1006,7 +1005,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).hasSize(1);
         Map<String, String> headers =
@@ -1038,7 +1037,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         Map<String, String> headers =
                 (Map<String, String>) tools.get(0).metadata().get(MCP_PARAM_HEADERS);
@@ -1060,7 +1059,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools.get(0).metadata()).doesNotContainKey(MCP_PARAM_HEADERS);
     }
@@ -1083,7 +1082,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1106,7 +1105,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1133,7 +1132,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1156,7 +1155,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1179,7 +1178,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1202,7 +1201,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1225,7 +1224,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).hasSize(1);
         assertThat(tools.get(0).metadata().get(MCP_PARAM_HEADERS)).isEqualTo(Map.of("tenant", "X-Tenant"));
@@ -1258,7 +1257,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).hasSize(1);
         assertThat(tools.get(0).name()).isEqualTo("good_tool");
@@ -1285,7 +1284,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1312,7 +1311,7 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
@@ -1342,8 +1341,18 @@ class ToolSpecificationHelperTest {
                     }
                 }]
                 """;
-        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<Map<String, Object>> json = toolList(text);
         List<ToolSpecification> tools = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(tools).isEmpty();
     }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> toolList(String json) {
+        try {
+            return McpJson.deserialize(McpJson.parse(json), List.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolResultExtractorStdioLegacyIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolResultExtractorStdioLegacyIT.java
@@ -12,6 +12,7 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpToolResultExtractor;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
 import dev.langchain4j.service.tool.ToolExecutionResult;
@@ -25,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 class McpToolResultExtractorStdioLegacyIT {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static DefaultMcpClient client;
 
@@ -47,8 +47,8 @@ class McpToolResultExtractorStdioLegacyIT {
 
                 if ("text".equals(type) && content.size() == 1) {
                     try {
-                        Map<String, Object> map = OBJECT_MAPPER.convertValue(
-                                OBJECT_MAPPER.readTree(
+                        Map<String, Object> map = McpJson.convert(
+                                McpJson.parse(
                                         content.get(0).get("text").asText()),
                                 Map.class);
                         return ToolExecutionResult.builder()

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/logging/McpLogLevelTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/logging/McpLogLevelTest.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.mcp.client.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * and single-threaded to avoid races with the otherwise parallel test suite.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class McpLogLevelTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ"})
+    void should_parse_log_level_independently_of_default_locale(String languageTag) {
+        withDefaultLocale(
+                languageTag, () -> assertThat(McpLogLevel.from("info")).isEqualTo(McpLogLevel.INFO));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "unknown"})
+    void should_return_null_for_invalid_value(String value) {
+        assertThat(McpLogLevel.from(value)).isNull();
+    }
+
+    private static void withDefaultLocale(String languageTag, Runnable action) {
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
+            action.run();
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/logging/McpLogMessageTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/logging/McpLogMessageTest.java
@@ -2,9 +2,9 @@ package dev.langchain4j.mcp.client.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import org.junit.jupiter.api.Test;
 
 class McpLogMessageTest {
@@ -32,11 +32,6 @@ class McpLogMessageTest {
     }
 
     private static JsonNode toJsonNode(String json) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            return mapper.readTree(json);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        return McpJson.parse(json);
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerRobustnessTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerRobustnessTest.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.mcp.client.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The dispatch frame is read as plain values rather than a Jackson tree, so the coercions
+ * Jackson used to apply have to be reproduced. These cover the cases that differ.
+ */
+class McpOperationHandlerRobustnessTest {
+
+    private McpOperationHandler handler() {
+        return new McpOperationHandler(
+                new ConcurrentHashMap<>(),
+                List::of,
+                Mockito.mock(McpTransport.class),
+                m -> {},
+                () -> {},
+                () -> {},
+                () -> {},
+                u -> {},
+                null,
+                null,
+                null,
+                null);
+    }
+
+    @Test
+    void completes_an_operation_whose_id_arrives_as_a_json_string() {
+        // JSON-RPC allows an id to be a string as well as a number
+        McpOperationHandler handler = handler();
+        CompletableFuture<String> pending = new CompletableFuture<>();
+        handler.expectResponse(42L, pending);
+
+        handler.onMessage("{\"id\":\"42\",\"result\":{}}");
+
+        assertThat(pending).isCompleted();
+    }
+
+    @Test
+    void completes_an_operation_whose_id_arrives_as_a_number() {
+        McpOperationHandler handler = handler();
+        CompletableFuture<String> pending = new CompletableFuture<>();
+        handler.expectResponse(7L, pending);
+
+        handler.onMessage("{\"id\":7,\"result\":{}}");
+
+        assertThat(pending).isCompleted();
+    }
+
+    @Test
+    void ignores_a_batch_array_rather_than_failing() {
+        assertThatCode(() -> handler().onMessage("[{\"id\":1,\"result\":{}}]"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void a_malformed_payload_should_throw_so_the_transport_can_decide() {
+        // the caller decides: a response body that cannot be read fails the pending operation,
+        // while a stream reader logs it and carries on. Swallowing it here left the streamable-HTTP
+        // and Docker transports with a future nobody completed.
+        assertThatThrownBy(() -> handler().onMessage("not json"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void ignores_an_unusable_id_rather_than_failing() {
+        assertThatCode(() -> handler().onMessage("{\"id\":{},\"result\":{}}"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void valid_json_that_is_not_a_jsonrpc_object_should_be_ignored() {
+        // the tree model ignored these rather than failing, so they stay ignored
+        assertThatCode(() -> handler().onMessage("null")).doesNotThrowAnyException();
+        assertThatCode(() -> handler().onMessage("42")).doesNotThrowAnyException();
+        assertThatCode(() -> handler().onMessage("\"a string\"")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void an_empty_body_should_throw_like_any_other_unreadable_input() {
+        assertThatThrownBy(() -> handler().onMessage("")).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerRobustnessTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerRobustnessTest.java
@@ -29,6 +29,7 @@ class McpOperationHandlerRobustnessTest {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -15,12 +16,11 @@ import org.mockito.Mockito;
 
 class McpOperationHandlerTest {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     void should_complete_pending_operation_exceptionally_on_server_cancelled() throws JsonProcessingException {
-        Map<Long, CompletableFuture<JsonNode>> pending = new ConcurrentHashMap<>();
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        Map<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+        CompletableFuture<String> future = new CompletableFuture<>();
         pending.put(42L, future);
 
         AtomicReference<Long> cancelledId = new AtomicReference<>();
@@ -42,7 +42,7 @@ class McpOperationHandlerTest {
                     cancelledReason.set(reason);
                 });
 
-        JsonNode notification = OBJECT_MAPPER.readTree("""
+        JsonNode notification = McpJson.parse("""
                 {
                   "jsonrpc": "2.0",
                   "method": "notifications/cancelled",
@@ -72,7 +72,7 @@ class McpOperationHandlerTest {
 
     @Test
     void should_invoke_listener_even_when_request_id_is_unknown() throws JsonProcessingException {
-        Map<Long, CompletableFuture<JsonNode>> pending = new ConcurrentHashMap<>();
+        Map<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
         AtomicReference<Long> cancelledId = new AtomicReference<>();
         AtomicReference<String> cancelledReason = new AtomicReference<>();
         McpOperationHandler handler = new McpOperationHandler(
@@ -92,7 +92,7 @@ class McpOperationHandlerTest {
                     cancelledReason.set(reason);
                 });
 
-        JsonNode notification = OBJECT_MAPPER.readTree("""
+        JsonNode notification = McpJson.parse("""
                 {
                   "jsonrpc": "2.0",
                   "method": "notifications/cancelled",
@@ -110,8 +110,8 @@ class McpOperationHandlerTest {
 
     @Test
     void should_ignore_cancelled_notification_without_request_id() throws JsonProcessingException {
-        Map<Long, CompletableFuture<JsonNode>> pending = new ConcurrentHashMap<>();
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        Map<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+        CompletableFuture<String> future = new CompletableFuture<>();
         pending.put(99L, future);
 
         AtomicReference<Long> cancelledId = new AtomicReference<>();
@@ -129,7 +129,7 @@ class McpOperationHandlerTest {
                 () -> {},
                 (id, reason) -> cancelledId.set(id));
 
-        JsonNode notification = OBJECT_MAPPER.readTree("""
+        JsonNode notification = McpJson.parse("""
                 {
                   "jsonrpc": "2.0",
                   "method": "notifications/cancelled",

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
@@ -40,7 +40,8 @@ class McpOperationHandlerTest {
                 (id, reason) -> {
                     cancelledId.set(id);
                     cancelledReason.set(reason);
-                });
+                },
+                (id, message) -> {});
 
         JsonNode notification = McpJson.parse("""
                 {
@@ -90,7 +91,8 @@ class McpOperationHandlerTest {
                 (id, reason) -> {
                     cancelledId.set(id);
                     cancelledReason.set(reason);
-                });
+                },
+                (id, message) -> {});
 
         JsonNode notification = McpJson.parse("""
                 {
@@ -127,7 +129,8 @@ class McpOperationHandlerTest {
                 null,
                 () -> {},
                 () -> {},
-                (id, reason) -> cancelledId.set(id));
+                (id, reason) -> cancelledId.set(id),
+                (id, message) -> {});
 
         JsonNode notification = McpJson.parse("""
                 {
@@ -142,5 +145,83 @@ class McpOperationHandlerTest {
         assertThat(future).isNotCompleted();
         assertThat(pending).containsKey(99L);
         assertThat(cancelledId.get()).isNull();
+    }
+
+    @Test
+    void should_invoke_callback_on_subscription_acknowledged() throws JsonProcessingException {
+        AtomicReference<Long> acknowledgedId = new AtomicReference<>();
+        AtomicReference<Map<String, Object>> acknowledgedMessage = new AtomicReference<>();
+        McpOperationHandler handler = new McpOperationHandler(
+                new ConcurrentHashMap<>(),
+                java.util.Collections::emptyList,
+                Mockito.mock(McpTransport.class),
+                msg -> {},
+                () -> {},
+                () -> {},
+                () -> {},
+                uri -> {},
+                null,
+                () -> {},
+                () -> {},
+                (id, reason) -> {},
+                (id, message) -> {
+                    acknowledgedId.set(id);
+                    acknowledgedMessage.set(message);
+                });
+
+        String notification =
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "method": "notifications/subscriptions/acknowledged",
+                  "params": {
+                    "_meta": {
+                      "io.modelcontextprotocol/subscriptionId": 7
+                    },
+                    "notifications": {
+                      "resourceSubscriptions": ["file:///project/config.json"]
+                    }
+                  }
+                }
+                """;
+
+        handler.onMessage(notification);
+
+        assertThat(acknowledgedId.get()).isEqualTo(7L);
+        assertThat(acknowledgedMessage.get()).isEqualTo(McpJson.toValue(notification));
+    }
+
+    @Test
+    void should_ignore_subscription_acknowledged_notification_without_subscription_id() throws JsonProcessingException {
+        AtomicReference<Long> acknowledgedId = new AtomicReference<>();
+        McpOperationHandler handler = new McpOperationHandler(
+                new ConcurrentHashMap<>(),
+                java.util.Collections::emptyList,
+                Mockito.mock(McpTransport.class),
+                msg -> {},
+                () -> {},
+                () -> {},
+                () -> {},
+                uri -> {},
+                null,
+                () -> {},
+                () -> {},
+                (id, reason) -> {},
+                (id, message) -> acknowledgedId.set(id));
+
+        String notification =
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "method": "notifications/subscriptions/acknowledged",
+                  "params": {
+                    "notifications": {}
+                  }
+                }
+                """;
+
+        handler.onMessage(notification);
+
+        assertThat(acknowledgedId.get()).isNull();
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpPendingOperationTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpPendingOperationTest.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.mcp.client.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
+import dev.langchain4j.mcp.protocol.McpInitializationNotification;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Operations registered through the raw API must be visible to cancellation and to the client's
+ * cleanup, which both work off the shared pending-operations map.
+ */
+class McpPendingOperationTest {
+
+    private static McpOperationHandler handler(Map<Long, CompletableFuture<String>> pending) {
+        return new McpOperationHandler(
+                pending,
+                Collections::emptyList,
+                Mockito.mock(McpTransport.class),
+                msg -> {},
+                () -> {},
+                () -> {},
+                () -> {},
+                uri -> {},
+                null,
+                () -> {},
+                () -> {},
+                (id, reason) -> {});
+    }
+
+    @Test
+    void server_cancellation_should_fail_a_raw_operation() {
+        Map<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+        McpOperationHandler handler = handler(pending);
+        CompletableFuture<String> future = new CompletableFuture<>();
+        handler.expectResponse(5L, future);
+
+        handler.onMessage(
+                """
+                {"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":5,"reason":"stop"}}""");
+
+        assertThat(future).isCompletedExceptionally();
+        assertThat(future.handle((v, e) -> e).join()).isInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    void a_raw_operation_should_be_removable_through_the_shared_map() {
+        Map<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+        McpOperationHandler handler = handler(pending);
+        handler.expectResponse(7L, new CompletableFuture<>());
+
+        assertThat(pending).containsKey(7L);
+        pending.remove(7L);
+        assertThat(pending).isEmpty();
+    }
+
+    @Test
+    void transport_failure_should_fail_a_raw_operation() {
+        Map<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+        McpOperationHandler handler = handler(pending);
+        CompletableFuture<String> future = new CompletableFuture<>();
+        handler.expectResponse(9L, future);
+
+        handler.cancelAllPendingOperations("connection lost");
+
+        assertThat(future).isCompletedExceptionally();
+        assertThat(pending).isEmpty();
+    }
+
+    @Test
+    void the_deprecated_json_api_should_still_receive_its_response() {
+        Map<Long, CompletableFuture<String>> pending = new ConcurrentHashMap<>();
+        McpOperationHandler handler = handler(pending);
+        CompletableFuture<com.fasterxml.jackson.databind.JsonNode> future = new CompletableFuture<>();
+        handler.startOperation(11L, future);
+
+        handler.onMessage("""
+                {"jsonrpc":"2.0","id":11,"result":{"ok":true}}""");
+
+        assertThat(future.join().get("result").get("ok").asBoolean()).isTrue();
+        assertThat(pending).isEmpty();
+    }
+
+    @Test
+    void the_deprecated_no_reply_method_should_still_receive_messages() {
+        // sendMessage is the only bridge with no unit coverage; the client sends ping and
+        // roots/list replies through it, and a transport on the old API must still get them.
+        java.util.List<McpClientMessage> sent = new java.util.ArrayList<>();
+        McpTransport legacy = new McpTransport() {
+            public void start(McpOperationHandler h) {}
+            @Override
+            @SuppressWarnings("removal")
+            public void executeOperationWithoutResponse(McpClientMessage request) {
+                sent.add(request);
+            }
+            @Override
+            @SuppressWarnings("removal")
+            public void executeOperationWithoutResponse(McpCallContext context) {
+                sent.add(context.message());
+            }
+            public void checkHealth() {}
+            public void onFailure(Runnable r) {}
+            public void close() {}
+        };
+
+        legacy.sendMessage(new McpInitializationNotification());
+
+        assertThat(sent).hasSize(1);
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpPendingOperationTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpPendingOperationTest.java
@@ -32,7 +32,8 @@ class McpPendingOperationTest {
                 null,
                 () -> {},
                 () -> {},
-                (id, reason) -> {});
+                (id, reason) -> {},
+                (id, message) -> {});
     }
 
     @Test

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
@@ -1,0 +1,138 @@
+package dev.langchain4j.mcp.client.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.mcp.protocol.McpInitializeRequest;
+import dev.langchain4j.mcp.protocol.McpListToolsRequest;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers transparent reinitialization of an expired legacy-protocol session on 404: the retry is
+ * sent with the new session id, and a second 404 fails fast instead of hanging.
+ */
+class StreamableHttpMcpTransportSessionExpiryTest {
+
+    private static final String INITIALIZE_RESULT =
+            "{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"test-server\",\"version\":\"1.0\"}}}";
+    private static final String TOOLS_LIST_RESULT = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}";
+
+    private HttpServer server;
+    private StreamableHttpMcpTransport transport;
+    private final AtomicInteger sessionCounter = new AtomicInteger();
+    private final List<String> toolsListSessionIds = Collections.synchronizedList(new ArrayList<>());
+    private volatile boolean retrySucceeds;
+
+    private void startServer(boolean retrySucceeds) throws IOException {
+        this.retrySucceeds = retrySucceeds;
+        sessionCounter.set(0);
+        toolsListSessionIds.clear();
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/mcp", exchange -> {
+            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            String method = McpJson.parse(body).path("method").asText();
+            String sessionId = exchange.getRequestHeaders().getFirst("Mcp-Session-Id");
+            if ("initialize".equals(method)) {
+                exchange.getResponseHeaders().set("Mcp-Session-Id", "session-" + sessionCounter.incrementAndGet());
+                respond(exchange, 200, INITIALIZE_RESULT);
+            } else if ("notifications/initialized".equals(method)) {
+                respond(exchange, 200, "{}");
+            } else if ("tools/list".equals(method)) {
+                toolsListSessionIds.add(sessionId);
+                if (retrySucceeds && "session-2".equals(sessionId)) {
+                    respond(exchange, 200, TOOLS_LIST_RESULT);
+                } else {
+                    // simulate an expired session
+                    respond(
+                            exchange,
+                            404,
+                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"Session not found\"}}");
+                }
+            } else {
+                respond(exchange, 500, "{}");
+            }
+        });
+        server.start();
+        transport = StreamableHttpMcpTransport.builder()
+                .url("http://localhost:" + server.getAddress().getPort() + "/mcp")
+                .setHttpVersion1_1()
+                .build();
+        transport.start(new McpOperationHandler(
+                new ConcurrentHashMap<>(),
+                () -> Collections.emptyList(),
+                transport,
+                null,
+                () -> {},
+                null,
+                () -> {},
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+    }
+
+    private static void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (transport != null) {
+            transport.close();
+        }
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void shouldRetryWithTheNewSessionAfterReinitialization() throws Exception {
+        startServer(true);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        assertThat(response.get(5, TimeUnit.SECONDS)).contains("\"tools\":[]");
+        // the first attempt used the original session, the retry used the reinitialized one
+        assertThat(toolsListSessionIds).containsExactly("session-1", "session-2");
+    }
+
+    @Test
+    void shouldFailFastWhenTheRetriedRequestIsRejectedWith404Again() throws Exception {
+        startServer(false);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        // before the fix this future stayed pending forever; now it must fail fast
+        assertThatThrownBy(() -> response.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("after reinitialization");
+        assertThat(toolsListSessionIds).containsExactly("session-1", "session-2");
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/WebSocketMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/WebSocketMcpTransportTest.java
@@ -1,9 +1,19 @@
 package dev.langchain4j.mcp.client.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.mcp.client.transport.websocket.WebSocketMcpTransport;
+import dev.langchain4j.mcp.protocol.McpPingRequest;
 import java.lang.reflect.Field;
+import java.net.http.WebSocket;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import org.junit.jupiter.api.Test;
 
@@ -39,9 +49,53 @@ class WebSocketMcpTransportTest {
         assertThat(extractSslContext(transport)).isSameAs(reloadedContext);
     }
 
+    @Test
+    void shouldPropagateSendFailure() throws Exception {
+        RuntimeException sendFailure = new RuntimeException("send failed");
+        WebSocketMcpTransport transport = transportSending(CompletableFuture.failedFuture(sendFailure));
+
+        CompletableFuture<String> result = transport.sendRequest(new McpPingRequest(42L));
+
+        assertThat(result).isCompletedExceptionally();
+        assertThatThrownBy(result::get).isInstanceOf(ExecutionException.class).hasCause(sendFailure);
+    }
+
+    @Test
+    void shouldLeaveRequestPendingWhenSendSucceeds() throws Exception {
+        WebSocketMcpTransport transport = transportSending(CompletableFuture.completedFuture(mock(WebSocket.class)));
+
+        CompletableFuture<String> result = transport.sendRequest(new McpPingRequest(42L));
+
+        assertThat(result).isNotDone();
+    }
+
+    private static WebSocketMcpTransport transportSending(CompletableFuture<WebSocket> sendResult) throws Exception {
+        WebSocket webSocket = mock(WebSocket.class);
+        when(webSocket.sendText(anyString(), eq(true))).thenReturn(sendResult);
+        WebSocketMcpTransport transport =
+                WebSocketMcpTransport.builder().url("ws://localhost/mcp").build();
+        setField(transport, "operationHandler", mock(McpOperationHandler.class));
+        webSocketRef(transport).set(CompletableFuture.completedFuture(webSocket));
+        return transport;
+    }
+
     private static SSLContext extractSslContext(WebSocketMcpTransport transport) throws Exception {
         Field field = WebSocketMcpTransport.class.getDeclaredField("sslContext");
         field.setAccessible(true);
         return (SSLContext) field.get(transport);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static AtomicReference<CompletableFuture<WebSocket>> webSocketRef(WebSocketMcpTransport transport)
+            throws Exception {
+        Field field = WebSocketMcpTransport.class.getDeclaredField("webSocketRef");
+        field.setAccessible(true);
+        return (AtomicReference<CompletableFuture<WebSocket>>) field.get(transport);
+    }
+
+    private static void setField(WebSocketMcpTransport transport, String name, Object value) throws Exception {
+        Field field = WebSocketMcpTransport.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(transport, value);
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandlerTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.mcp.client.transport.stdio;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -31,6 +32,26 @@ class ProcessStderrHandlerTest {
 
             verify(logger).debug("[STDERR] {}", "server log");
             verify(logger, never()).debug("[ERROR] {}", "server log");
+        }
+    }
+
+    @Test
+    void shouldDecodeProcessStderrOutputAsUtf8() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            Logger logger = mock(Logger.class);
+            loggerFactory
+                    .when(() -> LoggerFactory.getLogger(ProcessStderrHandler.class))
+                    .thenReturn(logger);
+
+            Process process = mock(Process.class);
+            when(process.getErrorStream())
+                    .thenReturn(new ByteArrayInputStream(
+                            ("caf\u00e9 \ud55c\uae00 \ud83d\ude80" + System.lineSeparator()).getBytes(UTF_8)));
+            when(process.pid()).thenReturn(123L);
+
+            new ProcessStderrHandler(process).run();
+
+            verify(logger).debug("[STDERR] {}", "caf\u00e9 \ud55c\uae00 \ud83d\ude80");
         }
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolDtoTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolDtoTest.java
@@ -4,16 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.mcp.client.McpDiscoverResult;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import org.junit.jupiter.api.Test;
 
 class McpProtocolDtoTest {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
     void serverDiscoverRequestSerializes() throws Exception {
         McpServerDiscoverRequest request = new McpServerDiscoverRequest(1L);
-        String json = MAPPER.writeValueAsString(request);
+        String json = McpJson.serialize(request);
         assertThat(json).contains("\"method\":\"server/discover\"");
         assertThat(json).contains("\"id\":1");
     }
@@ -21,7 +21,7 @@ class McpProtocolDtoTest {
     @Test
     void subscriptionsListenRequestSerializes() throws Exception {
         McpSubscriptionsListenRequest request = new McpSubscriptionsListenRequest(2L);
-        String json = MAPPER.writeValueAsString(request);
+        String json = McpJson.serialize(request);
         assertThat(json).contains("\"method\":\"subscriptions/listen\"");
     }
 
@@ -35,7 +35,7 @@ class McpProtocolDtoTest {
                 "instructions": "Test server"
             }
             """;
-        McpDiscoverResult result = MAPPER.readValue(json, McpDiscoverResult.class);
+        McpDiscoverResult result = McpJson.deserialize(McpJson.parse(json), McpDiscoverResult.class);
         assertThat(result.supportedVersions()).containsExactly("2026-07-28", "2025-11-25");
         assertThat(result.resultType()).isEqualTo("complete");
         assertThat(result.instructions()).isEqualTo("Test server");

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolSerializationTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolSerializationTest.java
@@ -4,14 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.mcp.client.transport.McpJson;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class McpProtocolSerializationTest {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     void should_serialize_error_response_omitting_null_data() throws Exception {
@@ -20,7 +19,7 @@ class McpProtocolSerializationTest {
                 new McpErrorResponse(1L, new McpErrorResponse.Error(-32601, "Method not found", null));
 
         // when
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(response));
+        JsonNode json = McpJson.parse(McpJson.serialize(response));
 
         // then
         assertThat(json.get("jsonrpc").asText()).isEqualTo("2.0");
@@ -34,10 +33,10 @@ class McpProtocolSerializationTest {
     void should_serialize_call_tool_result_omitting_null_fields() throws Exception {
         // given
         McpCallToolResult response = new McpCallToolResult(
-                7L, new McpCallToolResult.Result(List.of(new McpCallToolResult.Content("text", "ok")), null, null));
+                7L, new McpCallToolResult.Result(List.of(Map.of("type", "text", "text", "ok")), null, null));
 
         // when
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(response));
+        JsonNode json = McpJson.parse(McpJson.serialize(response));
 
         // then
         assertThat(json.get("jsonrpc").asText()).isEqualTo("2.0");
@@ -58,7 +57,7 @@ class McpProtocolSerializationTest {
         params.setClientInfo(new McpImplementation("client", "1.0", "Client Title"));
 
         // when
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(params));
+        JsonNode json = McpJson.parse(McpJson.serialize(params));
 
         // then
         assertThat(json.get("protocolVersion").asText()).isEqualTo("2025-06-18");
@@ -69,11 +68,10 @@ class McpProtocolSerializationTest {
 
     @Test
     void should_serialize_call_tool_request() throws Exception {
-        ObjectNode args = OBJECT_MAPPER.createObjectNode();
-        args.put("location", "Prague");
+        Map<String, Object> args = Map.of("location", "Prague");
         McpCallToolRequest request = new McpCallToolRequest(1L, "get_weather", args);
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("jsonrpc").asText()).isEqualTo("2.0");
         assertThat(json.get("id").asLong()).isEqualTo(1L);
@@ -85,12 +83,11 @@ class McpProtocolSerializationTest {
 
     @Test
     void should_serialize_call_tool_request_with_meta() throws Exception {
-        ObjectNode args = OBJECT_MAPPER.createObjectNode();
-        args.put("location", "Prague");
+        Map<String, Object> args = Map.of("location", "Prague");
         McpCallToolRequest request = new McpCallToolRequest(2L, "get_weather", args);
         request.getParams().setMeta(Map.of("traceparent", "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01"));
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("params").get("_meta").get("traceparent").asText())
                 .isEqualTo("00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01");
@@ -101,7 +98,7 @@ class McpProtocolSerializationTest {
     void should_serialize_cancellation_notification() throws Exception {
         McpCancellationNotification notification = new McpCancellationNotification(42L, "Timeout");
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(notification));
+        JsonNode json = McpJson.parse(McpJson.serialize(notification));
 
         assertThat(json.has("id")).isFalse();
         assertThat(json.get("method").asText()).isEqualTo("notifications/cancelled");
@@ -113,7 +110,7 @@ class McpProtocolSerializationTest {
     void should_serialize_cancellation_notification_without_reason() throws Exception {
         McpCancellationNotification notification = new McpCancellationNotification(42L, null);
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(notification));
+        JsonNode json = McpJson.parse(McpJson.serialize(notification));
 
         assertThat(json.get("params").get("requestId").asLong()).isEqualTo(42L);
         assertThat(json.get("params").has("reason")).isFalse();
@@ -123,7 +120,7 @@ class McpProtocolSerializationTest {
     void should_serialize_get_prompt_request() throws Exception {
         McpGetPromptRequest request = new McpGetPromptRequest(3L, "summarize", Map.of("text", "hello"));
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("method").asText()).isEqualTo("prompts/get");
         assertThat(json.get("params").get("name").asText()).isEqualTo("summarize");
@@ -134,7 +131,7 @@ class McpProtocolSerializationTest {
     void should_serialize_read_resource_request() throws Exception {
         McpReadResourceRequest request = new McpReadResourceRequest(4L, "file:///tmp/test.txt");
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("method").asText()).isEqualTo("resources/read");
         assertThat(json.get("params").get("uri").asText()).isEqualTo("file:///tmp/test.txt");
@@ -144,7 +141,7 @@ class McpProtocolSerializationTest {
     void should_serialize_list_tools_request_without_cursor() throws Exception {
         McpListToolsRequest request = new McpListToolsRequest(5L, null);
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("method").asText()).isEqualTo("tools/list");
         assertThat(json.has("params")).isFalse();
@@ -154,7 +151,7 @@ class McpProtocolSerializationTest {
     void should_serialize_list_tools_request_with_cursor() throws Exception {
         McpListToolsRequest request = new McpListToolsRequest(5L, "next_page");
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("method").asText()).isEqualTo("tools/list");
         assertThat(json.get("params").get("cursor").asText()).isEqualTo("next_page");
@@ -164,7 +161,7 @@ class McpProtocolSerializationTest {
     void should_serialize_ping_request_without_params() throws Exception {
         McpPingRequest request = new McpPingRequest(6L);
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("method").asText()).isEqualTo("ping");
         assertThat(json.has("params")).isFalse();
@@ -178,7 +175,7 @@ class McpProtocolSerializationTest {
         params.setClientInfo(new McpImplementation("test", "1.0", null));
         request.setParams(params);
 
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+        JsonNode json = McpJson.parse(McpJson.serialize(request));
 
         assertThat(json.get("method").asText()).isEqualTo("initialize");
         assertThat(json.get("params").get("protocolVersion").asText()).isEqualTo("2025-06-18");
@@ -196,7 +193,7 @@ class McpProtocolSerializationTest {
         McpInitializeResult response = new McpInitializeResult(1L, result);
 
         // when
-        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(response));
+        JsonNode json = McpJson.parse(McpJson.serialize(response));
 
         // then
         assertThat(json.get("jsonrpc").asText()).isEqualTo("2.0");

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandlerTest.java
@@ -3,7 +3,6 @@ package dev.langchain4j.mcp.transport.stdio;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -17,12 +16,12 @@ import org.junit.jupiter.api.Test;
 class JsonRpcIoHandlerTest {
 
     @Test
-    void should_read_valid_json_lines_and_pass_to_handler() {
+    void should_read_lines_and_pass_them_to_the_handler() {
         // given
         String input = "{\"jsonrpc\":\"2.0\",\"id\":1}\n{\"jsonrpc\":\"2.0\",\"id\":2}\n";
         ByteArrayInputStream in = new ByteArrayInputStream(input.getBytes(UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        List<JsonNode> received = new ArrayList<>();
+        List<String> received = new ArrayList<>();
 
         JsonRpcIoHandler handler = new JsonRpcIoHandler(in, out, received::add, false);
 
@@ -30,27 +29,33 @@ class JsonRpcIoHandlerTest {
         handler.run();
 
         // then
-        assertThat(received).hasSize(2);
-        assertThat(received.get(0).get("id").asInt()).isEqualTo(1);
-        assertThat(received.get(1).get("id").asInt()).isEqualTo(2);
+        assertThat(received).containsExactly("{\"jsonrpc\":\"2.0\",\"id\":1}", "{\"jsonrpc\":\"2.0\",\"id\":2}");
     }
 
     @Test
-    void should_ignore_invalid_json_lines() {
-        // given
-        String input = "not json\n{\"jsonrpc\":\"2.0\",\"id\":1}\n{broken\n";
+    void a_handler_that_throws_should_not_stop_the_read_loop() {
+        // a message the handler cannot process must not strand the subprocess with a dead reader
+        String input = "boom\n{\"jsonrpc\":\"2.0\",\"id\":1}\n";
         ByteArrayInputStream in = new ByteArrayInputStream(input.getBytes(UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        List<JsonNode> received = new ArrayList<>();
+        List<String> received = new ArrayList<>();
 
-        JsonRpcIoHandler handler = new JsonRpcIoHandler(in, out, received::add, false);
+        JsonRpcIoHandler handler = new JsonRpcIoHandler(
+                in,
+                out,
+                line -> {
+                    if (line.equals("boom")) {
+                        throw new IllegalStateException("cannot handle this");
+                    }
+                    received.add(line);
+                },
+                false);
 
         // when
         handler.run();
 
         // then
-        assertThat(received).hasSize(1);
-        assertThat(received.get(0).get("id").asInt()).isEqualTo(1);
+        assertThat(received).containsExactly("{\"jsonrpc\":\"2.0\",\"id\":1}");
     }
 
     @Test

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandlerTest.java
@@ -73,6 +73,38 @@ class JsonRpcIoHandlerTest {
     }
 
     @Test
+    void should_read_multibyte_messages_as_utf8() {
+        // given
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"caf\u00e9 \ud55c\uae00 \ud83d\ude80\"}";
+        ByteArrayInputStream in = new ByteArrayInputStream((message + "\n").getBytes(UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        List<String> received = new ArrayList<>();
+
+        JsonRpcIoHandler handler = new JsonRpcIoHandler(in, out, received::add, false);
+
+        // when
+        handler.run();
+
+        // then
+        assertThat(received).containsExactly(message);
+    }
+
+    @Test
+    void should_write_multibyte_messages_as_utf8() throws Exception {
+        // given
+        String message = "{\"jsonrpc\":\"2.0\",\"id\":1,\"params\":\"caf\u00e9 \ud55c\uae00 \ud83d\ude80\"}";
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonRpcIoHandler handler = new JsonRpcIoHandler(in, out, ignored -> {}, false);
+
+        // when
+        handler.submit(message);
+
+        // then
+        assertThat(out.toByteArray()).isEqualTo((message + System.lineSeparator()).getBytes(UTF_8));
+    }
+
+    @Test
     void should_stop_reading_after_close() throws Exception {
         // given
         BlockingInputStream in = new BlockingInputStream();


### PR DESCRIPTION
Backport some MCP related fixes from main to 1.19
I only took fixes that are at least a week old (for bake time), more will be coming later

https://github.com/langchain4j/langchain4j/pull/6117 is a bit questionable but since it seems to be backward-compatible and since without backporting it, further backports would get a lot of git conflicts, I took that one too.