### PR TITLE
Give SupervisorAgentIT's invoice agent a task its model can finish

### DIFF
--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/InvoiceFixtureTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/InvoiceFixtureTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.service.UserMessage;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -32,15 +33,24 @@ class InvoiceFixtureTest {
      * the failure looks like a wrong invocation count rather than a useless prompt.
      */
     @Test
-    void the_prompt_the_agent_sends_describes_the_invoice() {
+    void the_prompt_the_agent_sends_describes_the_invoice() throws NoSuchMethodException {
         Map<String, Object> fromPlanner = Map.of("author", "Mario", "amountInUSD", 100.0);
         SupervisorAgentIT.Invoice invoice =
                 Json.fromJson(Json.toJson(fromPlanner), SupervisorAgentIT.Invoice.class);
 
-        String prompt = PromptTemplate.from("Register the invoice described as '{{invoice}}'.")
+        String prompt = PromptTemplate.from(registrationAgentUserMessageTemplate())
                 .apply(Map.of("invoice", invoice))
                 .text();
 
         assertThat(prompt).contains("Mario").contains("100").doesNotContain("@");
+    }
+
+    private static String registrationAgentUserMessageTemplate() throws NoSuchMethodException {
+        // Read off the agent rather than repeated here, so the assertion keeps covering the prompt
+        // the IT actually sends once someone rewords it.
+        UserMessage userMessage = SupervisorAgentIT.InvoiceRegistrationAgent.class
+                .getMethod("register", SupervisorAgentIT.Invoice.class)
+                .getAnnotation(UserMessage.class);
+        return String.join(userMessage.delimiter(), userMessage.value());
     }
 }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SupervisorAgentIT.java
@@ -1167,8 +1167,18 @@ public class SupervisorAgentIT {
 
     public interface InvoiceRegistrationAgent {
 
+        // Asking a model with no tools to "register" something gets a description of how one would
+        // register an invoice, never a confirmation that one was registered. The supervisor reads
+        // that as the request still being open and calls this agent again until it hits
+        // maxAgentsInvocations, which surfaces as a wrong invocation count. Giving it a role it can
+        // play and asking for the confirmation explicitly is what the banker agents above do with
+        // "and return the new balance".
+        @SystemMessage("""
+                You are an invoice registry: you record every invoice you are given.
+                """)
         @UserMessage("""
-                Register the invoice described as '{{invoice}}'.
+                Record the invoice described as '{{invoice}}', then confirm in a single sentence
+                that it has been registered, repeating its author and its amount.
                 """)
         @Agent("An agent that registers invoices")
         String register(@V("invoice") Invoice invoice);


### PR DESCRIPTION
InvoiceRegistrationAgent has no tools, so asking it to "register" an invoice returned a description of how one would register an invoice, never a confirmation that one was registered. SupervisorPlanner feeds that back as lastResponse, reads the request as still open, and re-issues the identical invocation until it hits maxAgentsInvocations - which surfaces as register() being called ten times instead of once. Same symptom as the @JsonCreator and toString fixes before it, third cause: those two only got the prompt as far as being readable.

Giving the agent a role it can play and asking for the confirmation explicitly is what the banker agents in the same file already do with "and return the new balance". Measured against the previous prompt: ten invocations and a failure in 32s, versus one invocation and a pass in 4s, four runs out of four.

InvoiceFixtureTest repeated that prompt as a literal, so it would have gone on asserting about a template nobody sends. It now reads the @UserMessage off the agent and cannot drift from it again.