### PR TITLE
Guard the release pipeline against releasing from the wrong branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -424,3 +424,38 @@ jobs:
               | head -50
             echo '```'
           } >> $GITHUB_STEP_SUMMARY
+
+  # revapi binds to the verify phase, which no other CI job reaches - they stop at test. An
+  # unusable API baseline therefore stays invisible until a release build fails on it.
+  # Only on main: on a release branch revapi compares against the release directly below the one
+  # being built, which for release/1.19.x is the erroneous 1.19.1 and can never pass.
+  revapi:
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up JDK 17
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Revapi API Check
+        run: |
+          set -o pipefail
+          mvn -B -U -T8C -DskipTests -DskipITs -DembeddingsSkipDownload \
+            -Dmaven.javadoc.skip=true -Dmaven.source.skip=true \
+            verify 2>&1 | tee maven-output.log
+
+      - name: Surface build errors
+        if: failure()
+        run: |
+          {
+            echo '## API Errors (revapi)'
+            echo ''
+            echo '```'
+            grep '^\[ERROR\]' maven-output.log \
+              | grep -vE '^\[ERROR\]( +"|[[:space:]]*(Stub|DEBUG:)|[[:space:]]*$)' \
+              | head -50
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,23 @@ jobs:
           echo "Branch to release from: $BRANCH"
           echo "Start from phase: $START_FROM"
 
+      # Guards against releasing from the wrong branch, which is how 1.19.1 was cut from main on
+      # top of 1.20.0. The version being released must be newer than every release already
+      # reachable from the chosen branch.
+      - name: Verify the version is newer than the branch's latest release
+        run: |
+          LATEST=$(git tag --merged HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+          if [ -z "$LATEST" ]; then
+            echo "No release tags reachable from $BRANCH; nothing to compare against."
+            exit 0
+          fi
+          NEWEST=$(printf '%s\n%s\n' "$LATEST" "$STABLE_VERSION" | sort -V | tail -1)
+          if [ "$STABLE_VERSION" = "$LATEST" ] || [ "$NEWEST" != "$STABLE_VERSION" ]; then
+            echo "::error::Refusing to release $STABLE_VERSION from $BRANCH: $LATEST is already released and reachable from this branch. A patch must be cut from its release/x.y.x branch, not from a branch that has moved past it."
+            exit 1
+          fi
+          echo "OK: $STABLE_VERSION is newer than $LATEST, the latest release reachable from $BRANCH."
+
       - name: Compute start phase number
         id: phase
         run: |
@@ -176,6 +193,27 @@ jobs:
         run: |
           git tag "$STABLE_VERSION"
           git push origin "$STABLE_VERSION"
+
+      # A minor release is the point where its maintenance line starts, so create the branch now
+      # rather than scrambling for one when a patch is needed.
+      - name: Create the maintenance branch for a minor release
+        if: ${{ fromJSON(steps.phase.outputs.num) <= 4 }}
+        run: |
+          case "$STABLE_VERSION" in
+            *.0)
+              MAINTENANCE_BRANCH="release/${STABLE_VERSION%.*}.x"
+              if git ls-remote --exit-code --heads origin "$MAINTENANCE_BRANCH" >/dev/null 2>&1; then
+                echo "$MAINTENANCE_BRANCH already exists."
+              else
+                git branch "$MAINTENANCE_BRANCH" HEAD
+                git push origin "$MAINTENANCE_BRANCH"
+                echo "Created $MAINTENANCE_BRANCH."
+              fi
+              ;;
+            *)
+              echo "$STABLE_VERSION is a patch release; its maintenance branch already exists."
+              ;;
+          esac
 
       - name: Trigger release in the langchain4j/langchain4j-spring repo
         env:

--- a/.github/workflows/snapshot_release.yaml
+++ b/.github/workflows/snapshot_release.yaml
@@ -33,7 +33,26 @@ jobs:
           server-username: MAVEN_CENTRAL_USERNAME
           server-password: MAVEN_CENTRAL_PASSWORD
 
+      # Every push to main runs this, including the "Release versions x.y.z" commits, where the
+      # version is not a SNAPSHOT. Deploying those re-publishes a release: it normally fails on
+      # "already exists", but would push an unsigned release if a release ever died before deploying.
+      - name: Check the version is a SNAPSHOT
+        id: snapshot-check
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          case "$VERSION" in
+            *-SNAPSHOT)
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              echo "Version is $VERSION."
+              ;;
+            *)
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::Version is $VERSION, not a SNAPSHOT; skipping the snapshot deploy. If main is meant to be in development, run 'Update versions for next dev iteration'."
+              ;;
+          esac
+
       - name: snapshot_release
+        if: steps.snapshot-check.outputs.proceed == 'true'
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
1.19.1 was released from main on top of 1.20.0: release.yaml takes its branch from "Use workflow from", and nothing checked that the version matched the branch. Maven Central is immutable, so 1.19.1 permanently contains all of 1.20.0 and cannot be withdrawn.

- release.yaml: refuse to release a version that is not newer than every release already reachable from the chosen branch. Blocks 1.19.1 from main (1.19.1 < 1.20.0) while allowing a patch from release/1.19.x and a minor from main.
- release.yaml: create release/x.y.x when a minor is released, so a patch always has a branch to be cut from. There is no release/1.20.x today.
- snapshot_release.yaml: skip the deploy when the version is not a SNAPSHOT. Every "Release versions x.y.z" commit currently triggers a snapshot deploy that re-publishes a release. It fails on "already exists", but would push an unsigned release if a release ever died between its version commit and its deploy step.
- main.yaml: run revapi in CI on main. revapi binds to verify, which no CI job reaches, so an unusable API baseline only surfaces when a release build fails on it. Restricted to main: on a release branch revapi compares against the release directly below the one being built, which for release/1.19.x is the erroneous 1.19.1 and can never pass.