### PR TITLE
MCP: honor refs in allOf schemas, log a warning on scalars and unresolved refs

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -78,6 +78,16 @@ class ToolSpecificationHelper {
      * to a JsonSchemaElement object that describes the tool's arguments.
      */
     static JsonSchemaElement jsonNodeToJsonSchemaElement(Map<String, Object> node) {
+        return jsonNodeToJsonSchemaElement(node, Map.of(), new HashSet<>());
+    }
+
+    /**
+     * @param definitions   the '$defs'/'definitions' collected from this node and all of its ancestors,
+     *                       keyed by name, used to resolve a '$ref' that appears inside an 'allOf'
+     * @param resolvingRefs the definition keys currently being resolved, used to break reference cycles
+     */
+    private static JsonSchemaElement jsonNodeToJsonSchemaElement(
+            Map<String, Object> node, Map<String, Object> definitions, Set<String> resolvingRefs) {
         // MCP SEP-2106 allows composition keywords such as anyOf alongside type "object", and the tool
         // inputSchema root is always type "object". JsonObjectSchema cannot represent a schema-level anyOf,
         // so an object-typed node is parsed as an object (its anyOf constraint is not carried over) rather
@@ -85,7 +95,7 @@ class ToolSpecificationHelper {
         if (node.containsKey("anyOf") && !isObjectType(node)) {
             JsonAnyOfSchema.Builder anyOf = JsonAnyOfSchema.builder();
             JsonSchemaElement[] types = array(node.get("anyOf")).stream()
-                    .map(item -> jsonNodeToJsonSchemaElement(object(item)))
+                    .map(item -> jsonNodeToJsonSchemaElement(object(item), definitions, resolvingRefs))
                     .toArray(JsonSchemaElement[]::new);
             anyOf.anyOf(types);
             if (node.containsKey("description")) {
@@ -106,29 +116,42 @@ class ToolSpecificationHelper {
             if (node.containsKey("description")) {
                 builder.description(string(node.get("description")));
             }
+            // Definitions ('$defs' in draft 2019-09+, 'definitions' in draft-07) declared on this node are
+            // added to those inherited from ancestor schemas and threaded further down, so a '$ref' (e.g.
+            // one appearing inside 'allOf') resolves even when its definition lives on an outer schema.
+            Object defsNode = node.containsKey("$defs") ? node.get("$defs") : node.get("definitions");
+            Map<String, Object> availableDefinitions = definitions;
+            if (!object(defsNode).isEmpty()) {
+                availableDefinitions = new LinkedHashMap<>(definitions);
+                availableDefinitions.putAll(object(defsNode));
+            }
             // MCP servers commonly compose object schemas with 'allOf' (e.g. one object schema per
-            // capability). JsonObjectSchema cannot represent 'allOf' itself, so object-typed
-            // sub-schemas are merged into this one: union of properties, union of required and
-            // collected definitions, with the node's own members taking precedence on conflicts.
-            // Entries that do not convert to an object (e.g. a $ref or a scalar constraint) are
-            // ignored, as they were before.
+            // capability). JsonObjectSchema cannot represent 'allOf' itself, so object-typed sub-schemas
+            // (including those reached through a '$ref') are merged into this one: union of properties,
+            // union of required and collected definitions, with the node's own members taking precedence
+            // on conflicts. An 'allOf' entry that does not resolve to an object (a scalar sub-schema, or a
+            // '$ref' that cannot be resolved or points at a non-object) is skipped with a warning.
             Map<String, JsonSchemaElement> mergedProperties = new LinkedHashMap<>();
             Set<String> mergedRequired = new LinkedHashSet<>();
             Map<String, JsonSchemaElement> mergedDefinitions = new LinkedHashMap<>();
             if (node.containsKey("allOf")) {
                 for (Object allOfEntry : array(node.get("allOf"))) {
-                    JsonSchemaElement element = jsonNodeToJsonSchemaElement(object(allOfEntry));
-                    if (element instanceof JsonObjectSchema subSchema) {
-                        mergedProperties.putAll(subSchema.properties());
-                        mergedRequired.addAll(subSchema.required());
-                        mergedDefinitions.putAll(subSchema.definitions());
-                    }
+                    mergeAllOfSubSchema(
+                            object(allOfEntry),
+                            availableDefinitions,
+                            resolvingRefs,
+                            mergedProperties,
+                            mergedRequired,
+                            mergedDefinitions);
                 }
             }
             if (node.containsKey("properties")) {
                 for (Map.Entry<String, Object> property :
                         object(node.get("properties")).entrySet()) {
-                    mergedProperties.put(property.getKey(), jsonNodeToJsonSchemaElement(object(property.getValue())));
+                    mergedProperties.put(
+                            property.getKey(),
+                            jsonNodeToJsonSchemaElement(
+                                    object(property.getValue()), availableDefinitions, resolvingRefs));
                 }
             }
             if (!mergedProperties.isEmpty()) {
@@ -153,11 +176,13 @@ class ToolSpecificationHelper {
                     builder.additionalProperties(bool(additionalProperties));
                 }
             }
-            // Handle $defs (draft 2019-09+) and definitions (draft-07)
-            Object defsNode = node.containsKey("$defs") ? node.get("$defs") : node.get("definitions");
+            // Convert the definitions collected above (draft 2019-09+ '$defs', draft-07 'definitions')
+            // into the schema's own 'definitions' map.
             if (defsNode != null) {
                 for (Map.Entry<String, Object> entry : object(defsNode).entrySet()) {
-                    mergedDefinitions.put(entry.getKey(), jsonNodeToJsonSchemaElement(object(entry.getValue())));
+                    mergedDefinitions.put(
+                            entry.getKey(),
+                            jsonNodeToJsonSchemaElement(object(entry.getValue()), availableDefinitions, resolvingRefs));
                 }
             }
             if (!mergedDefinitions.isEmpty()) {
@@ -211,7 +236,7 @@ class ToolSpecificationHelper {
                     // which means "any value"
                     Object items = node.get("items");
                     if (!(items instanceof List) || !((List<?>) items).isEmpty()) {
-                        builder.items(jsonNodeToJsonSchemaElement(object(items)));
+                        builder.items(jsonNodeToJsonSchemaElement(object(items), definitions, resolvingRefs));
                     }
                 }
                 return builder.build();
@@ -254,6 +279,75 @@ class ToolSpecificationHelper {
             }
             return anyOf.build();
         }
+    }
+
+    /**
+     * Merges a single 'allOf' sub-schema into the accumulators of the containing object schema.
+     * A '$ref' entry is resolved against {@code definitions} (guarding against reference cycles);
+     * any entry that does not resolve to a {@link JsonObjectSchema} cannot be merged and is skipped
+     * with a warning, since JsonObjectSchema can only absorb object-typed sub-schemas.
+     */
+    private static void mergeAllOfSubSchema(
+            Map<String, Object> entry,
+            Map<String, Object> definitions,
+            Set<String> resolvingRefs,
+            Map<String, JsonSchemaElement> mergedProperties,
+            Set<String> mergedRequired,
+            Map<String, JsonSchemaElement> mergedDefinitions) {
+        if (entry.containsKey("$ref")) {
+            String ref = string(entry.get("$ref"));
+            String refKey = extractReferenceKey(ref);
+            if (refKey == null || !definitions.containsKey(refKey)) {
+                log.warn(
+                        "Ignoring 'allOf' entry with unresolvable $ref '{}' while converting a tool input schema:"
+                                + " no matching definition was found",
+                        ref);
+                return;
+            }
+            if (!resolvingRefs.add(refKey)) {
+                // This $ref is already being resolved higher up the stack (a cyclic definition); its
+                // members are merged at that outer level, so the repeat is skipped to avoid looping.
+                return;
+            }
+            try {
+                JsonSchemaElement resolved =
+                        jsonNodeToJsonSchemaElement(object(definitions.get(refKey)), definitions, resolvingRefs);
+                if (!mergeObjectSchema(resolved, mergedProperties, mergedRequired, mergedDefinitions)) {
+                    log.warn(
+                            "Ignoring 'allOf' $ref '{}' while converting a tool input schema: it resolves to a"
+                                    + " non-object schema, which cannot be merged into the containing object",
+                            ref);
+                }
+            } finally {
+                resolvingRefs.remove(refKey);
+            }
+        } else {
+            JsonSchemaElement element = jsonNodeToJsonSchemaElement(entry, definitions, resolvingRefs);
+            if (!mergeObjectSchema(element, mergedProperties, mergedRequired, mergedDefinitions)) {
+                log.warn(
+                        "Ignoring non-object 'allOf' entry (declared type: {}) while converting a tool input schema:"
+                                + " only object sub-schemas can be merged into the containing object",
+                        entry.get("type"));
+            }
+        }
+    }
+
+    /**
+     * Merges an object sub-schema (its properties, required and definitions) into the given accumulators.
+     * Returns {@code false} without touching them when the element is not a {@link JsonObjectSchema}.
+     */
+    private static boolean mergeObjectSchema(
+            JsonSchemaElement element,
+            Map<String, JsonSchemaElement> mergedProperties,
+            Set<String> mergedRequired,
+            Map<String, JsonSchemaElement> mergedDefinitions) {
+        if (element instanceof JsonObjectSchema subSchema) {
+            mergedProperties.putAll(subSchema.properties());
+            mergedRequired.addAll(subSchema.required());
+            mergedDefinitions.putAll(subSchema.definitions());
+            return true;
+        }
+        return false;
     }
 
     private static boolean isObjectType(Map<String, Object> node) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -1522,4 +1522,200 @@ class ToolSpecificationHelperTest {
                 (JsonArraySchema) parameters.properties().get("rules");
         assertThat(rulesProperty.items()).isNull();
     }
+
+    @Test
+    void allOfRefIsResolvedAndMergedViaDefs() throws JsonProcessingException {
+        // An allOf entry that is a $ref into $defs is resolved and the target object is merged,
+        // rather than being dropped as an unmergeable JsonReferenceSchema.
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "allOf" : [ {
+                          "$ref" : "#/$defs/Base"
+                        }, {
+                          "type" : "object",
+                          "properties" : {
+                            "title" : {
+                              "type" : "string"
+                            }
+                          }
+                        } ],
+                        "$defs" : {
+                          "Base" : {
+                            "type" : "object",
+                            "properties" : {
+                              "identifier" : {
+                                "type" : "string"
+                              }
+                            },
+                            "required" : [ "identifier" ]
+                          }
+                        }
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        assertThat(parameters.properties()).containsOnlyKeys("identifier", "title");
+        assertThat(parameters.properties().get("identifier")).isInstanceOf(JsonStringSchema.class);
+        assertThat(parameters.properties().get("title")).isInstanceOf(JsonStringSchema.class);
+        assertThat(parameters.required()).containsExactly("identifier");
+    }
+
+    @Test
+    void allOfRefIsResolvedAndMergedViaDefinitions() throws JsonProcessingException {
+        // Same as above, but using draft-07 'definitions' and a '#/definitions/...' pointer.
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "allOf" : [ {
+                          "$ref" : "#/definitions/Base"
+                        } ],
+                        "definitions" : {
+                          "Base" : {
+                            "type" : "object",
+                            "properties" : {
+                              "identifier" : {
+                                "type" : "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        assertThat(parameters.properties()).containsOnlyKeys("identifier");
+        assertThat(parameters.properties().get("identifier")).isInstanceOf(JsonStringSchema.class);
+    }
+
+    @Test
+    void allOfRefResolvesAgainstRootDefinitionsWhenNested() throws JsonProcessingException {
+        // The $defs live on the root inputSchema, but the allOf that references them is nested
+        // inside a property. Definitions are threaded through the recursion so the ref resolves.
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "properties" : {
+                          "config" : {
+                            "type" : "object",
+                            "allOf" : [ {
+                              "$ref" : "#/$defs/Base"
+                            } ]
+                          }
+                        },
+                        "$defs" : {
+                          "Base" : {
+                            "type" : "object",
+                            "properties" : {
+                              "identifier" : {
+                                "type" : "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        assertThat(parameters.properties().get("config")).isInstanceOf(JsonObjectSchema.class);
+        JsonObjectSchema config =
+                (JsonObjectSchema) parameters.properties().get("config");
+        assertThat(config.properties()).containsOnlyKeys("identifier");
+        assertThat(config.properties().get("identifier")).isInstanceOf(JsonStringSchema.class);
+    }
+
+    @Test
+    void allOfRefCycleTerminates() throws JsonProcessingException {
+        // A self-referential definition (its own allOf points back at itself) must not loop
+        // forever: the cycle guard stops re-resolving a ref already on the stack, and the
+        // definition's own members are still merged.
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "allOf" : [ {
+                          "$ref" : "#/$defs/Node"
+                        } ],
+                        "$defs" : {
+                          "Node" : {
+                            "type" : "object",
+                            "allOf" : [ {
+                              "$ref" : "#/$defs/Node"
+                            } ],
+                            "properties" : {
+                              "value" : {
+                                "type" : "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        assertThat(parameters.properties()).containsOnlyKeys("value");
+        assertThat(parameters.properties().get("value")).isInstanceOf(JsonStringSchema.class);
+    }
+
+    @Test
+    void allOfRefToUnknownDefinitionIsIgnored() throws JsonProcessingException {
+        // A $ref that cannot be resolved (no such definition) contributes nothing and does not
+        // fail; the node's own members are unaffected.
+        String text =
+                // language=json
+                """
+                [ {
+                      "name" : "create_action",
+                      "inputSchema" : {
+                        "type" : "object",
+                        "allOf" : [ {
+                          "$ref" : "#/$defs/DoesNotExist"
+                        } ],
+                        "properties" : {
+                          "title" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                } ]
+                """;
+        List<Map<String, Object>> json = toolList(text);
+        ToolSpecification toolSpecification = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0);
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        assertThat(parameters.properties()).containsOnlyKeys("title");
+        assertThat(parameters.properties().get("title")).isInstanceOf(JsonStringSchema.class);
+    }
 }


### PR DESCRIPTION
Support for references inside `allOf` in MCP tool definitions, for example:

```
                    {
                      "name" : "create_action",
                      "inputSchema" : {
                        "type" : "object",
                        "allOf" : [ {
                          "$ref" : "#/$defs/Base"
                        }, {
                          "type" : "object",
                          "properties" : {
                            "title" : {
                              "type" : "string"
                            }
                          }
                        } ],
                        "$defs" : {
                          "Base" : {
                            "type" : "object",
                            "properties" : {
                              "identifier" : {
                                "type" : "string"
                              }
                            },
                            "required" : [ "identifier" ]
                          }
                        }
                      }
                }
```