### PR TITLE
Fix filter expression injection via metadata keys in Milvus embedding stores

### DIFF
--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapper.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapper.java
@@ -111,13 +111,23 @@ class MilvusV2MetadataFilterMapper {
     }
 
     private static String formatKey(String key, String metadataFieldName) {
-        return metadataFieldName + "[\"" + key + "\"]";
+        return metadataFieldName + "[\"" + escape(key) + "\"]";
+    }
+
+    /**
+     * Escapes a string that is embedded into a double-quoted Milvus string literal. This applies both to
+     * metadata keys, which are embedded into the {@code metadata["..."]} accessor, and to string values.
+     * Without it, a key or value containing a double quote could break out of the literal and inject
+     * arbitrary Milvus filter expression syntax.
+     */
+    private static String escape(String value) {
+        // Escape backslashes first, then double quotes (Milvus treats backslash as the escape character)
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     private static String formatValue(Object value) {
         if (value instanceof String stringValue) {
-            final String escapedValue = stringValue.replace("\\", "\\\\").replace("\"", "\\\"");
-            return "\"" + escapedValue + "\"";
+            return "\"" + escape(stringValue) + "\"";
         } else if (value instanceof UUID) {
             return "\"" + value + "\"";
         } else {

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapperTest.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapperTest.java
@@ -43,4 +43,53 @@ class MilvusV2MetadataFilterMapperTest {
 
         assertThat(expr).isEqualTo("metadata[\"key\"] == \"foo\"");
     }
+
+    @Test
+    void should_escape_double_quote_in_key() {
+        // An unescaped key would break out of the metadata["..."] accessor and inject
+        // arbitrary Milvus filter expression syntax (here: an "or" term the caller never wrote).
+        Filter filter = metadataKey("tenant\"] != \"\" or metadata[\"x").isEqualTo("acme");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"tenant\\\"] != \\\"\\\" or metadata[\\\"x\"] == \"acme\"");
+    }
+
+    @Test
+    void should_escape_backslash_in_key() {
+        Filter filter = metadataKey("a\\b").isEqualTo("foo");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"a\\\\b\"] == \"foo\"");
+    }
+
+    @Test
+    void should_escape_key_in_collection_filter() {
+        Filter filter = metadataKey("a\"b").isIn("foo");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"a\\\"b\"] in [\"foo\"]");
+    }
+
+    @Test
+    void should_escape_key_in_contains_filter() {
+        Filter filter = metadataKey("a\"b").containsString("foo");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"a\\\"b\"] LIKE \"%foo%\"");
+    }
+
+    @Test
+    void should_not_change_key_without_special_characters() {
+        // Metadata keys are not restricted to SQL-style identifiers, so dots, spaces and
+        // non-ASCII characters must keep working exactly as before.
+        Filter filter = metadataKey("user.email 1").isEqualTo("foo");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"user.email 1\"] == \"foo\"");
+    }
 }

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataKeyEscapingIT.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataKeyEscapingIT.java
@@ -1,0 +1,116 @@
+package dev.langchain4j.store.embedding.milvus.v2;
+
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.Filter;
+import io.milvus.v2.common.ConsistencyLevel;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+/**
+ * Verifies on a real Milvus server that a metadata filter key is escaped rather than interpreted as
+ * filter expression syntax. Asserting only the generated expression string is not enough: it does not
+ * prove the server accepts the expression, nor that a crafted key cannot widen the filter.
+ */
+@Testcontainers
+class MilvusV2MetadataKeyEscapingIT {
+
+    private static final String COLLECTION_NAME = "key_escaping_test";
+
+    /** A key that closes the metadata accessor and appends a self-true term. */
+    private static final String INJECTED_KEY = "tenant\"] != \"\" or metadata_field[\"x";
+
+    @Container
+    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.6.11")
+            .withEnv("DEPLOY_MODE", "STANDALONE")
+            .withEnv("MILVUS_MODE", "standalone")
+            .withEnv("ETCD_USE_EMBED", "true")
+            .withEnv("COMMON_STORAGETYPE", "local")
+            .withCommand("milvus", "run", "standalone");
+
+    private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    private MilvusV2EmbeddingStore embeddingStore;
+
+    @BeforeEach
+    void beforeEach() {
+        embeddingStore = MilvusV2EmbeddingStore.builder()
+                .uri(milvus.getEndpoint())
+                .collectionName(COLLECTION_NAME)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .dimension(384)
+                .metadataFieldName("metadata_field")
+                .build();
+
+        add("acme doc", new Metadata().put("tenant", "acme"));
+        add("globex doc", new Metadata().put("tenant", "globex"));
+        add("quoted key doc", new Metadata().put("a\"b", "v"));
+        add("backslash key doc", new Metadata().put("a\\b", "v"));
+
+        awaitUntilAsserted(() ->
+                assertThat(search(metadataKey("tenant").isEqualTo("acme"))).hasSize(1));
+    }
+
+    @AfterEach
+    void afterEach() {
+        embeddingStore.dropCollection(COLLECTION_NAME);
+    }
+
+    @Test
+    void should_match_only_the_intended_tenant() {
+        assertThat(search(metadataKey("tenant").isEqualTo("acme"))).hasSize(1);
+    }
+
+    @Test
+    void should_round_trip_a_key_containing_a_double_quote() {
+        assertThat(search(metadataKey("a\"b").isEqualTo("v"))).hasSize(1);
+    }
+
+    @Test
+    void should_round_trip_a_key_containing_a_backslash() {
+        assertThat(search(metadataKey("a\\b").isEqualTo("v"))).hasSize(1);
+    }
+
+    @Test
+    void should_not_widen_the_filter_when_key_contains_expression_syntax() {
+        // The injected term must be treated as part of the key, not as an "or" branch,
+        // so the search matches nothing instead of returning the whole collection.
+        assertThat(search(metadataKey(INJECTED_KEY).isEqualTo("irrelevant"))).isEmpty();
+    }
+
+    @Test
+    void should_not_remove_anything_when_key_contains_expression_syntax() {
+        embeddingStore.removeAll(metadataKey(INJECTED_KEY).isEqualTo("irrelevant"));
+
+        awaitUntilAsserted(() ->
+                assertThat(search(metadataKey("tenant").isEqualTo("acme"))).hasSize(1));
+        assertThat(search(metadataKey("tenant").isEqualTo("globex"))).hasSize(1);
+    }
+
+    private void add(String text, Metadata metadata) {
+        TextSegment segment = TextSegment.from(text, metadata);
+        embeddingStore.add(embeddingModel.embed(segment).content(), segment);
+    }
+
+    private List<?> search(Filter filter) {
+        return embeddingStore
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(embeddingModel.embed("doc").content())
+                        .filter(filter)
+                        .maxResults(100)
+                        .build())
+                .matches();
+    }
+}

--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapper.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapper.java
@@ -130,14 +130,23 @@ class MilvusMetadataFilterMapper {
     }
 
     private static String formatKey(String key, String metadataFieldName) {
-        return metadataFieldName + "[\"" + key + "\"]";
+        return metadataFieldName + "[\"" + escape(key) + "\"]";
+    }
+
+    /**
+     * Escapes a string that is embedded into a double-quoted Milvus string literal. This applies both to
+     * metadata keys, which are embedded into the {@code metadata["..."]} accessor, and to string values.
+     * Without it, a key or value containing a double quote could break out of the literal and inject
+     * arbitrary Milvus filter expression syntax.
+     */
+    private static String escape(String value) {
+        // Escape backslashes first, then double quotes (Milvus treats backslash as the escape character)
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     private static String formatValue(Object value) {
         if (value instanceof String stringValue) {
-            // Escape backslashes first, then double quotes (Milvus treats backslash as the escape character)
-            final String escapedValue = stringValue.replace("\\", "\\\\").replace("\"", "\\\"");
-            return "\"" + escapedValue + "\"";
+            return "\"" + escape(stringValue) + "\"";
         } else if (value instanceof UUID) {
             return "\"" + value + "\"";
         } else {

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapperTest.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapperTest.java
@@ -81,4 +81,53 @@ class MilvusMetadataFilterMapperTest {
 
         assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%a\\\\b100\\%\\_done%\"");
     }
+
+    @Test
+    void should_escape_double_quote_in_key() {
+        // An unescaped key would break out of the metadata["..."] accessor and inject
+        // arbitrary Milvus filter expression syntax (here: an "or" term the caller never wrote).
+        Filter filter = metadataKey("tenant\"] != \"\" or metadata[\"x").isEqualTo("acme");
+
+        String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"tenant\\\"] != \\\"\\\" or metadata[\\\"x\"] == \"acme\"");
+    }
+
+    @Test
+    void should_escape_backslash_in_key() {
+        Filter filter = metadataKey("a\\b").isEqualTo("foo");
+
+        String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"a\\\\b\"] == \"foo\"");
+    }
+
+    @Test
+    void should_escape_key_in_collection_filter() {
+        Filter filter = metadataKey("a\"b").isIn("foo");
+
+        String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"a\\\"b\"] in [\"foo\"]");
+    }
+
+    @Test
+    void should_escape_key_in_contains_filter() {
+        Filter filter = metadataKey("a\"b").containsString("foo");
+
+        String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"a\\\"b\"] LIKE \"%foo%\"");
+    }
+
+    @Test
+    void should_not_change_key_without_special_characters() {
+        // Metadata keys are not restricted to SQL-style identifiers, so dots, spaces and
+        // non-ASCII characters must keep working exactly as before.
+        Filter filter = metadataKey("user.email 1").isEqualTo("foo");
+
+        String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"user.email 1\"] == \"foo\"");
+    }
 }

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataKeyEscapingIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataKeyEscapingIT.java
@@ -1,0 +1,111 @@
+package dev.langchain4j.store.embedding.milvus;
+
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static io.milvus.common.clientenum.ConsistencyLevelEnum.STRONG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+/**
+ * Verifies on a real Milvus server that a metadata filter key is escaped rather than interpreted as
+ * filter expression syntax. Asserting only the generated expression string is not enough: it does not
+ * prove the server accepts the expression, nor that a crafted key cannot widen the filter.
+ */
+@Testcontainers
+class MilvusMetadataKeyEscapingIT {
+
+    private static final String COLLECTION_NAME = "key_escaping_test";
+
+    /** A key that closes the metadata accessor and appends a self-true term. */
+    private static final String INJECTED_KEY = "tenant\"] != \"\" or metadata_field[\"x";
+
+    @Container
+    private static final MilvusContainer milvus = new MilvusContainer(MilvusEmbeddingStoreIT.MILVUS_DOCKER_IMAGE);
+
+    private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    private MilvusEmbeddingStore embeddingStore;
+
+    @BeforeEach
+    void beforeEach() {
+        embeddingStore = MilvusEmbeddingStore.builder()
+                .uri(milvus.getEndpoint())
+                .collectionName(COLLECTION_NAME)
+                .consistencyLevel(STRONG)
+                .dimension(384)
+                .metadataFieldName("metadata_field")
+                .build();
+
+        add("acme doc", new Metadata().put("tenant", "acme"));
+        add("globex doc", new Metadata().put("tenant", "globex"));
+        add("quoted key doc", new Metadata().put("a\"b", "v"));
+        add("backslash key doc", new Metadata().put("a\\b", "v"));
+
+        awaitUntilAsserted(() ->
+                assertThat(search(metadataKey("tenant").isEqualTo("acme"))).hasSize(1));
+    }
+
+    @AfterEach
+    void afterEach() {
+        embeddingStore.dropCollection(COLLECTION_NAME);
+    }
+
+    @Test
+    void should_match_only_the_intended_tenant() {
+        assertThat(search(metadataKey("tenant").isEqualTo("acme"))).hasSize(1);
+    }
+
+    @Test
+    void should_round_trip_a_key_containing_a_double_quote() {
+        assertThat(search(metadataKey("a\"b").isEqualTo("v"))).hasSize(1);
+    }
+
+    @Test
+    void should_round_trip_a_key_containing_a_backslash() {
+        assertThat(search(metadataKey("a\\b").isEqualTo("v"))).hasSize(1);
+    }
+
+    @Test
+    void should_not_widen_the_filter_when_key_contains_expression_syntax() {
+        // The injected term must be treated as part of the key, not as an "or" branch,
+        // so the search matches nothing instead of returning the whole collection.
+        assertThat(search(metadataKey(INJECTED_KEY).isEqualTo("irrelevant"))).isEmpty();
+    }
+
+    @Test
+    void should_not_remove_anything_when_key_contains_expression_syntax() {
+        embeddingStore.removeAll(metadataKey(INJECTED_KEY).isEqualTo("irrelevant"));
+
+        awaitUntilAsserted(() ->
+                assertThat(search(metadataKey("tenant").isEqualTo("acme"))).hasSize(1));
+        assertThat(search(metadataKey("tenant").isEqualTo("globex"))).hasSize(1);
+    }
+
+    private void add(String text, Metadata metadata) {
+        TextSegment segment = TextSegment.from(text, metadata);
+        embeddingStore.add(embeddingModel.embed(segment).content(), segment);
+    }
+
+    private List<?> search(Filter filter) {
+        return embeddingStore
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(embeddingModel.embed("doc").content())
+                        .filter(filter)
+                        .maxResults(100)
+                        .build())
+                .matches();
+    }
+}


### PR DESCRIPTION
## Issue
N/A — reported privately as a security advisory. Same defect class as CVE-2026-55405 (GHSA-2mfg-cc43-9pcj), which was fixed for `langchain4j-mariadb` and `langchain4j-pgvector` in ce96291df; neither Milvus module was in scope of that change.

## Change

**The problem.** `MilvusMetadataFilterMapper#formatKey` and `MilvusV2MetadataFilterMapper#formatKey` concatenated the metadata filter key into the Milvus boolean expression without escaping, while `formatValue` immediately below escapes correctly:

```java
private static String formatKey(String key, String metadataFieldName) {
    return metadataFieldName + "[\"" + key + "\"]";   // no escaping
}
```

Nothing upstream constrains the key — `MetadataFilterBuilder` and every `filter.comparison.*` class apply only `ensureNotBlank(key, "key")`. An application in which untrusted input reaches a filter *key* (a request-supplied facet or field name, a per-request tenant/ACL field, or an LLM-derived key from `LanguageModelSqlFilterBuilder`) can therefore inject arbitrary Milvus expression syntax. Given the key `tenant"] != "" or metadata["x`, a caller asking for a single equality got:

```
before:  metadata["tenant"] != "" or metadata["x"] == "acme"
after:   metadata["tenant\"] != \"\" or metadata[\"x"] == "acme"
```

The injected `or` term is self-true, so the metadata filter is bypassed — every entity in the collection is returned by a search, and deleted by `removeAll(Filter)`. Both sinks are affected: `CollectionRequestBuilder` (search) and `MilvusEmbeddingStore#removeAll` / `MilvusV2EmbeddingStore#removeAll` (delete).

`mapAnd` also emits `A and B` unparenthesised, so an injected `or` term escapes a server-side tenant/ACL clause that an application ANDs onto the user's filter. With keys escaped this is no longer reachable, so `mapAnd` is left alone.

**The fix.** Both mappers now run the key through the same escaping already applied to values, extracted into a shared `escape()`. An injected key becomes a literal JSON key that matches nothing, so the filter fails closed.

Escaping was preferred over restricting keys to plain identifiers, the way `pgvector`'s `ColumnFilterMapper` does. Here the key is not an identifier but a JSON key inside the `metadata["..."]` accessor, and `Metadata` permits any non-blank key — `user.email` and the like are legal today, so a `SAFE_IDENTIFIER`-style restriction would be a breaking change. This matches `pgvector`'s `JSONFilterMapper`, which escapes for the same reason.

Keys containing no `"` or `\` produce exactly the same expression as before, and only the query path is touched — nothing about how data is persisted changes.

## Testing

Five key-escaping unit tests per module, including one pinning that keys such as `user.email 1` keep working unchanged.

More importantly, a new `MilvusMetadataKeyEscapingIT` / `MilvusV2MetadataKeyEscapingIT` per module asserts the behaviour **against a real Milvus server** rather than against a generated string: an injected key matches nothing and removes nothing, and keys containing `"` or `\` round-trip. Asserting the expression string alone would not prove the server even accepts it.

| Module | Unit | Integration | revapi |
|---|---|---|---|
| `langchain4j-milvus` | 27 green | 129 green | green |
| `langchain4j-milvus-v2` | 42 green | 132 green | green |

Integration runs cover `EmbeddingStoreWithFilteringIT` (~115 parameterized metadata-filter cases per module), `EmbeddingStoreWithRemovalIT`, and the new key-escaping ITs, against Milvus 2.5.10 (v1) and 2.6.11 (v2).

## Not included

`langchain4j-milvus-v2` still lacks the `containsString` LIKE wildcard escaping that `langchain4j-milvus` received in #5600. That is deliberate: #5600's `formatLikePattern` emits `\%` and `\_`, which Milvus's expression parser rejects outright (`failed to create query plan: ... token recognition error`), reproduced on both 2.5.10 and 2.6.11. Porting it would turn a wrong result into a thrown exception for v2 users. #5600 needs its own fix in `langchain4j-milvus` first, with an integration test — filed separately.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `MilvusEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

<sub>Last box left unchecked deliberately: no cross-version check was run. The change touches only filter-expression generation, not the write path, so nothing about the persisted format changes.</sub>

## Credits

Reported by Thai Son Dinh (@sondt99) of VinSOC Labs (R&D).