### PR TITLE
Fix containsString LIKE wildcard escaping in Milvus stores

### DIFF
--- a/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapper.java
+++ b/langchain4j-milvus-v2/src/main/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapper.java
@@ -46,10 +46,33 @@ class MilvusV2MetadataFilterMapper {
     }
 
     private static String mapContains(ContainsString containsString, String metadataFieldName) {
+        // ContainsString is a literal substring match (see Filter / ContainsString#test, which uses
+        // String#contains). Milvus LIKE treats % and _ as wildcards, so any % or _ in the user-supplied
+        // value must be escaped to be matched literally; only the surrounding % we add are real wildcards.
         return format(
                 "%s LIKE %s",
                 formatKey(containsString.key(), metadataFieldName),
-                formatValue("%" + containsString.comparisonValue() + "%"));
+                formatLikePattern(containsString.comparisonValue()));
+    }
+
+    /**
+     * Builds a quoted Milvus LIKE pattern that matches the given value as a literal substring. The value's
+     * own LIKE wildcards ({@code %} and {@code _}) are escaped so they are matched literally, while the
+     * surrounding {@code %} characters remain wildcards for the "contains" semantics.
+     *
+     * <p>Milvus resolves backslash escapes twice: once when reading the string literal out of the filter
+     * expression, and again when interpreting the LIKE pattern. A wildcard therefore needs two backslashes
+     * in the expression we send so that a single one reaches the pattern; a single backslash makes the
+     * server reject the whole expression with a parse error.
+     *
+     * <p>Two inputs are known not to work, because Milvus itself mis-parses them: a value ending with
+     * {@code %}, and a value containing a backslash immediately before a {@code %} or {@code _}.
+     */
+    private static String formatLikePattern(String value) {
+        // escape() covers the string literal layer. A wildcard has to survive the LIKE pattern layer as
+        // well, so it gets two backslashes here and reaches the pattern with one.
+        String escaped = escape(value).replace("%", "\\\\%").replace("_", "\\\\_");
+        return "\"%" + escaped + "%\"";
     }
 
     private static String mapEqual(IsEqualTo isEqualTo, String metadataFieldName) {

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2ContainsStringIT.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2ContainsStringIT.java
@@ -1,0 +1,108 @@
+package dev.langchain4j.store.embedding.milvus.v2;
+
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.Filter;
+import io.milvus.v2.common.ConsistencyLevel;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+/**
+ * Verifies {@code containsString} against a real Milvus server. Asserting the generated LIKE expression
+ * is not enough: a wildcard escaped with a single backslash produces an expression the server rejects
+ * outright, which a string assertion cannot see.
+ */
+@Testcontainers
+class MilvusV2ContainsStringIT {
+
+    private static final String COLLECTION_NAME = "contains_string_test";
+
+    @Container
+    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.6.11")
+            .withEnv("DEPLOY_MODE", "STANDALONE")
+            .withEnv("MILVUS_MODE", "standalone")
+            .withEnv("ETCD_USE_EMBED", "true")
+            .withEnv("COMMON_STORAGETYPE", "local")
+            .withCommand("milvus", "run", "standalone");
+
+    private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    private MilvusV2EmbeddingStore embeddingStore;
+
+    @BeforeEach
+    void beforeEach() {
+        embeddingStore = MilvusV2EmbeddingStore.builder()
+                .uri(milvus.getEndpoint())
+                .collectionName(COLLECTION_NAME)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .dimension(384)
+                .build();
+
+        for (String tag : List.of("50%off", "50XXoff", "a_b", "axb", "back\\slash", "plain")) {
+            TextSegment segment = TextSegment.from(tag, new Metadata().put("tag", tag));
+            embeddingStore.add(embeddingModel.embed(segment).content(), segment);
+        }
+        awaitUntilAsserted(() -> assertThat(tagsMatching(metadataKey("tag").containsString("plain")))
+                .containsExactly("plain"));
+    }
+
+    @AfterEach
+    void afterEach() {
+        embeddingStore.dropCollection(COLLECTION_NAME);
+    }
+
+    @Test
+    void percent_in_value_should_be_matched_literally_and_not_as_a_wildcard() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("50%off"))).containsExactly("50%off");
+    }
+
+    @Test
+    void underscore_in_value_should_be_matched_literally_and_not_as_a_wildcard() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("a_b"))).containsExactly("a_b");
+    }
+
+    @Test
+    void underscore_should_match_every_value_that_contains_it() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("_"))).containsExactly("a_b");
+    }
+
+    @Test
+    void backslash_in_value_should_be_matched_literally() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("back\\slash")))
+                .containsExactly("back\\slash");
+    }
+
+    @Test
+    void value_without_wildcards_should_match_as_a_substring() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("off")))
+                .containsExactlyInAnyOrder("50%off", "50XXoff");
+    }
+
+    private List<String> tagsMatching(Filter filter) {
+        return embeddingStore
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(embeddingModel.embed("tag").content())
+                        .filter(filter)
+                        .maxResults(100)
+                        .build())
+                .matches()
+                .stream()
+                .map(EmbeddingMatch::embedded)
+                .map(segment -> segment.metadata().getString("tag"))
+                .sorted()
+                .toList();
+    }
+}

--- a/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapperTest.java
+++ b/langchain4j-milvus-v2/src/test/java/dev/langchain4j/store/embedding/milvus/v2/MilvusV2MetadataFilterMapperTest.java
@@ -92,4 +92,43 @@ class MilvusV2MetadataFilterMapperTest {
 
         assertThat(expr).isEqualTo("metadata[\"user.email 1\"] == \"foo\"");
     }
+
+    @Test
+    void contains_should_wrap_plain_value_in_like_wildcards() {
+        Filter filter = metadataKey("key").containsString("foo");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%foo%\"");
+    }
+
+    @Test
+    void contains_should_escape_percent_wildcard_in_value() {
+        // "50%" must be matched as a literal substring; the user's '%' must NOT act as a LIKE wildcard.
+        // Two backslashes reach Milvus so that one survives into the LIKE pattern.
+        Filter filter = metadataKey("key").containsString("50%");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%50\\\\%%\"");
+    }
+
+    @Test
+    void contains_should_escape_underscore_wildcard_in_value() {
+        // "a_b" must be matched literally; the user's '_' must NOT act as a single-character wildcard.
+        Filter filter = metadataKey("key").containsString("a_b");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%a\\\\_b%\"");
+    }
+
+    @Test
+    void contains_should_escape_backslash_percent_and_underscore_together() {
+        Filter filter = metadataKey("key").containsString("a\\b100%_done");
+
+        String expr = MilvusV2MetadataFilterMapper.map(filter, "metadata");
+
+        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%a\\\\b100\\\\%\\\\_done%\"");
+    }
 }

--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapper.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapper.java
@@ -57,17 +57,21 @@ class MilvusMetadataFilterMapper {
 
     /**
      * Builds a quoted Milvus LIKE pattern that matches the given value as a literal substring. The value's
-     * own LIKE wildcards ({@code %} and {@code _}) are escaped with a backslash so they are matched
-     * literally, while the surrounding {@code %} characters remain wildcards for the "contains" semantics.
-     * Backslash and double quote are escaped as in {@link #formatValue(Object)} so the value stays inside
-     * the string literal.
+     * own LIKE wildcards ({@code %} and {@code _}) are escaped so they are matched literally, while the
+     * surrounding {@code %} characters remain wildcards for the "contains" semantics.
+     *
+     * <p>Milvus resolves backslash escapes twice: once when reading the string literal out of the filter
+     * expression, and again when interpreting the LIKE pattern. A wildcard therefore needs two backslashes
+     * in the expression we send so that a single one reaches the pattern; a single backslash makes the
+     * server reject the whole expression with a parse error.
+     *
+     * <p>Two inputs are known not to work, because Milvus itself mis-parses them: a value ending with
+     * {@code %}, and a value containing a backslash immediately before a {@code %} or {@code _}.
      */
     private static String formatLikePattern(String value) {
-        // Escape backslash first, then the LIKE wildcards % and _, then the string-literal double quote.
-        String escaped = value.replace("\\", "\\\\")
-                .replace("%", "\\%")
-                .replace("_", "\\_")
-                .replace("\"", "\\\"");
+        // escape() covers the string literal layer. A wildcard has to survive the LIKE pattern layer as
+        // well, so it gets two backslashes here and reaches the pattern with one.
+        String escaped = escape(value).replace("%", "\\\\%").replace("_", "\\\\_");
         return "\"%" + escaped + "%\"";
     }
 

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusContainsStringIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusContainsStringIT.java
@@ -1,0 +1,103 @@
+package dev.langchain4j.store.embedding.milvus;
+
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static io.milvus.common.clientenum.ConsistencyLevelEnum.STRONG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+/**
+ * Verifies {@code containsString} against a real Milvus server. Asserting the generated LIKE expression
+ * is not enough: a wildcard escaped with a single backslash produces an expression the server rejects
+ * outright, which a string assertion cannot see.
+ */
+@Testcontainers
+class MilvusContainsStringIT {
+
+    private static final String COLLECTION_NAME = "contains_string_test";
+
+    @Container
+    private static final MilvusContainer milvus = new MilvusContainer(MilvusEmbeddingStoreIT.MILVUS_DOCKER_IMAGE);
+
+    private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    private MilvusEmbeddingStore embeddingStore;
+
+    @BeforeEach
+    void beforeEach() {
+        embeddingStore = MilvusEmbeddingStore.builder()
+                .uri(milvus.getEndpoint())
+                .collectionName(COLLECTION_NAME)
+                .consistencyLevel(STRONG)
+                .dimension(384)
+                .build();
+
+        for (String tag : List.of("50%off", "50XXoff", "a_b", "axb", "back\\slash", "plain")) {
+            TextSegment segment = TextSegment.from(tag, new Metadata().put("tag", tag));
+            embeddingStore.add(embeddingModel.embed(segment).content(), segment);
+        }
+        awaitUntilAsserted(() -> assertThat(tagsMatching(metadataKey("tag").containsString("plain")))
+                .containsExactly("plain"));
+    }
+
+    @AfterEach
+    void afterEach() {
+        embeddingStore.dropCollection(COLLECTION_NAME);
+    }
+
+    @Test
+    void percent_in_value_should_be_matched_literally_and_not_as_a_wildcard() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("50%off"))).containsExactly("50%off");
+    }
+
+    @Test
+    void underscore_in_value_should_be_matched_literally_and_not_as_a_wildcard() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("a_b"))).containsExactly("a_b");
+    }
+
+    @Test
+    void underscore_should_match_every_value_that_contains_it() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("_"))).containsExactly("a_b");
+    }
+
+    @Test
+    void backslash_in_value_should_be_matched_literally() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("back\\slash")))
+                .containsExactly("back\\slash");
+    }
+
+    @Test
+    void value_without_wildcards_should_match_as_a_substring() {
+        assertThat(tagsMatching(metadataKey("tag").containsString("off")))
+                .containsExactlyInAnyOrder("50%off", "50XXoff");
+    }
+
+    private List<String> tagsMatching(Filter filter) {
+        return embeddingStore
+                .search(EmbeddingSearchRequest.builder()
+                        .queryEmbedding(embeddingModel.embed("tag").content())
+                        .filter(filter)
+                        .maxResults(100)
+                        .build())
+                .matches()
+                .stream()
+                .map(EmbeddingMatch::embedded)
+                .map(segment -> segment.metadata().getString("tag"))
+                .sorted()
+                .toList();
+    }
+}

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapperTest.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusMetadataFilterMapperTest.java
@@ -56,11 +56,12 @@ class MilvusMetadataFilterMapperTest {
     @Test
     void contains_should_escape_percent_wildcard_in_value() {
         // "50%" must be matched as a literal substring; the user's '%' must NOT act as a LIKE wildcard.
+        // Two backslashes reach Milvus so that one survives into the LIKE pattern.
         Filter filter = metadataKey("key").containsString("50%");
 
         String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
 
-        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%50\\%%\"");
+        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%50\\\\%%\"");
     }
 
     @Test
@@ -70,7 +71,7 @@ class MilvusMetadataFilterMapperTest {
 
         String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
 
-        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%a\\_b%\"");
+        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%a\\\\_b%\"");
     }
 
     @Test
@@ -79,7 +80,7 @@ class MilvusMetadataFilterMapperTest {
 
         String expr = MilvusMetadataFilterMapper.map(filter, "metadata");
 
-        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%a\\\\b100\\%\\_done%\"");
+        assertThat(expr).isEqualTo("metadata[\"key\"] LIKE \"%a\\\\b100\\\\%\\\\_done%\"");
     }
 
     @Test


### PR DESCRIPTION
## Issue
N/A — regression introduced by #5600. Branched on top of #6333 in `langchain4j-milvus`, plus the corresponding gap in `langchain4j-milvus-v2`, which never received #5600.

## Change

#5600 escaped the LIKE wildcards `%` and `_` with a single backslash, matching what #5522 and #5553 did for Hibernate and MongoDB. Milvus needs two.

Milvus resolves backslash escapes **twice**: once when reading the string literal out of the filter expression, and again when interpreting the LIKE pattern. A single backslash never reaches the pattern, and the server rejects the whole expression:

```
metadata["tag"] LIKE "%50\%off%"
  -> failed to create query plan: cannot parse expression:
     line 1:31 token recognition error at: '"': invalid parameter
```

So since #5600, any `containsString` value containing `%` or `_` fails server-side in `langchain4j-milvus` instead of matching. Underscores in tag and filename values are not exotic, so this is reachable in ordinary use.

Escaping the wildcards with two backslashes lets one survive into the pattern, and Milvus then matches the value literally, as #5600 intended.

| `containsString` value | `\%` (#5600) | `\\%` (this PR) |
| --- | --- | --- |
| `50%off` | parse error | matches `50%off`, not `50XXoff` |
| `a_b` | parse error | matches `a_b`, not `axb` |
| `back\slash` | no match | matches `back\slash` |

`langchain4j-milvus-v2` never received #5600 and was over-matching instead — a `%` or `_` in the value acted as a wildcard. It now uses the same escaping, and reuses the `escape()` helper added in #6333 rather than repeating that escaping, so the two mappers are byte-identical again (modulo package and class name). In both modules a value containing a backslash is now matched literally; previously it matched nothing.

### Known limitations

Two inputs remain broken because Milvus itself mis-parses them, and are documented on `formatLikePattern`:

- a value **ending** with `%` — `containsString("50%")` matches nothing, and `containsString("%")` matches values containing a backslash;
- a value with a backslash immediately before a `%` or `_`.

Both are improvements on the current state (a hard parse error in v1, silent over-matching in v2), but they are real and worth knowing about.

## Testing

New `MilvusContainsStringIT` / `MilvusV2ContainsStringIT` assert the behaviour **against a real Milvus server**. This matters here: the four existing `contains_should_*` unit tests asserted an expression string the server rejects outright, and `EmbeddingStoreWithFilteringIT` only ever passes plain `containsString` values (`"value"`, `"contains"`), so nothing in CI could catch it. Those four unit tests are corrected in this PR.

| Module | Unit | Integration | revapi |
|---|---|---|---|
| `langchain4j-milvus` | 26 green | 134 green | green |
| `langchain4j-milvus-v2` | 45 green | 137 green | green |

Run against Milvus 2.5.10 (v1) and 2.6.11 (v2).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `MilvusEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

<sub>Last box left unchecked deliberately: no cross-version check was run. The change touches only filter-expression generation, not the write path, so nothing about the persisted format changes.</sub>
