### PR TITLE
Return an independent copy from Utils.copy(List) and copyIfNotNull(List)

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -25,8 +25,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
@@ -414,7 +414,9 @@ public class Utils {
             return null;
         }
 
-        return unmodifiableList(list);
+        // Copy into a new list so the result is independent of the source; unmodifiableList(list)
+        // alone is only a live view and would reflect later mutations of the caller's list.
+        return unmodifiableList(new ArrayList<>(list));
     }
 
     /**
@@ -430,7 +432,9 @@ public class Utils {
             return List.of();
         }
 
-        return unmodifiableList(list);
+        // Copy into a new list so the result is independent of the source; unmodifiableList(list)
+        // alone is only a live view and would reflect later mutations of the caller's list.
+        return unmodifiableList(new ArrayList<>(list));
     }
 
     /**
@@ -586,8 +590,8 @@ public class Utils {
         }
     }
 
-    private static void collectInterfaceMethods(Class<?> clazz, Set<MethodSignature> seen,
-                                                List<Method> result, Set<Class<?>> visited) {
+    private static void collectInterfaceMethods(
+            Class<?> clazz, Set<MethodSignature> seen, List<Method> result, Set<Class<?>> visited) {
         if (clazz == null) {
             return;
         }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -328,6 +328,20 @@ class UtilsTest {
     }
 
     @Test
+    void copy_list_and_copyIfNotNull_areIndependentOfSource() {
+        List<String> source = new ArrayList<>(List.of("one"));
+        List<String> copy = Utils.copy(source);
+        source.add("two");
+        // A copy must not reflect later mutations of the source list.
+        assertThat(copy).containsExactly("one");
+
+        List<String> sourceIfNotNull = new ArrayList<>(List.of("one"));
+        List<String> copyIfNotNull = Utils.copyIfNotNull(sourceIfNotNull);
+        sourceIfNotNull.add("two");
+        assertThat(copyIfNotNull).containsExactly("one");
+    }
+
+    @Test
     void mutableCopy_list() {
         assertThat(Utils.mutableCopy((List<?>) null)).isEmpty();
         assertThat(Utils.mutableCopy(emptyList())).isEmpty();


### PR DESCRIPTION
### Problem

`Utils.copy(List)` and `Utils.copyIfNotNull(List)` are both documented to return an *(unmodifiable) copy* of the list, but returned `Collections.unmodifiableList(list)` — a live **view** of the caller's list, not an independent copy:

```java
public static <T> List<T> copy(List<? extends T> list) {
    if (list == null) return List.of();
    return unmodifiableList(list);   // view of the source, not a copy
}
```

So mutating the source list afterward mutates the returned "copy":

```java
List<String> source = new ArrayList<>(List.of("a"));
List<String> copy = Utils.copy(source);
source.add("b");
// copy is now [a, b] — a real copy would still be [a]
```

These calls back the immutable message value objects (`AiMessage`, `UserMessage`, `ToolExecutionResultMessage`), whose fields are `final` and whose `equals`/`hashCode` are computed over the list. A later change to the source list therefore silently alters a constructed message's contents and identity:

```java
List<ToolExecutionRequest> reqs = new ArrayList<>();
reqs.add(ToolExecutionRequest.builder().name("t").arguments("{}").build());
AiMessage msg = new AiMessage("hi", reqs);
int h = msg.hashCode();
reqs.add(ToolExecutionRequest.builder().name("t2").arguments("{}").build());
// msg.toolExecutionRequests() now has size 2 and msg.hashCode() != h — with no call on msg
```

The sibling overloads already return independent copies: `copy(Collection)` uses `List.copyOf`, and `mutableCopy(List)` uses `new ArrayList<>(list)` (its test asserts source-independence). These two `List` overloads were the outliers.

### Fix

Copy into a new list — `unmodifiableList(new ArrayList<>(list))` — which is independent and keeps the current tolerance of null elements (unlike `List.copyOf`, which rejects nulls; likely why the view form was used).

### Test

`copy_list_and_copyIfNotNull_areIndependentOfSource` mutates the source after copying and asserts the copy is unchanged, for both methods. It fails before this change (the copy reflects the mutation) and passes after; the existing `copy_list` test only checked content equality, never independence.

_Note: `spotless:apply` (run because the file was touched) also reordered one import and rewrapped an unrelated method signature — included to keep the file spotless-clean under the ratchet._
