### PR TITLE
Give each Summarizer its own ContextSummarizer instead of a shared static one

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/Context.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/Context.java
@@ -1,16 +1,15 @@
 package dev.langchain4j.agentic.internal;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.UserMessage;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-
 public class Context {
-
-    private static ContextSummarizer SUMMARIZER_INSTANCE;
 
     public interface ContextSummarizer {
 
@@ -33,15 +32,6 @@ public class Context {
         public void setSummary(final String summary) {
             this.summary = summary;
         }
-    }
-
-    private static ContextSummarizer initSummarizer(ChatModel chatModel) {
-        if (SUMMARIZER_INSTANCE == null) {
-            SUMMARIZER_INSTANCE = AiServices.builder(ContextSummarizer.class)
-                    .chatModel(chatModel)
-                    .build();
-        }
-        return SUMMARIZER_INSTANCE;
     }
 
     public static class AgenticScopeContextGenerator implements UserMessageTransformer {
@@ -68,10 +58,26 @@ public class Context {
 
     public static class Summarizer extends AgenticScopeContextGenerator {
         public Summarizer(AgenticScope agenticScope, ChatModel chatModel, String... agentNames) {
-            super(agenticScope, c -> {
+            super(agenticScope, summarizingContextProvider(chatModel, agentNames));
+        }
+
+        private static Function<AgenticScope, String> summarizingContextProvider(
+                ChatModel chatModel, String... agentNames) {
+            AtomicReference<ContextSummarizer> summarizer = new AtomicReference<>();
+            return c -> {
                 String context = c.contextAsConversation(agentNames);
-                return context.isBlank() ? context : initSummarizer(chatModel).summarize(context).getSummary();
-            });
+                if (context.isBlank()) {
+                    return context;
+                }
+                return summarizer
+                        .updateAndGet(current -> current != null
+                                ? current
+                                : AiServices.builder(ContextSummarizer.class)
+                                        .chatModel(chatModel)
+                                        .build())
+                        .summarize(context)
+                        .getSummary();
+            };
         }
     }
 }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/ContextSummarizerTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/ContextSummarizerTest.java
@@ -1,0 +1,70 @@
+package dev.langchain4j.agentic.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Test;
+
+class ContextSummarizerTest {
+
+    @Test
+    void each_summarizer_uses_its_own_chat_model() {
+        RecordingChatModel firstModel = new RecordingChatModel("first summary");
+        RecordingChatModel secondModel = new RecordingChatModel("second summary");
+
+        AgenticScope agenticScope = mock(AgenticScope.class);
+        when(agenticScope.contextAsConversation()).thenReturn("a conversation to summarize");
+
+        Context.Summarizer firstSummarizer = new Context.Summarizer(agenticScope, firstModel);
+        Context.Summarizer secondSummarizer = new Context.Summarizer(agenticScope, secondModel);
+
+        assertThat(firstSummarizer.transformUserMessage("user message", "memoryId"))
+                .contains("first summary");
+        assertThat(secondSummarizer.transformUserMessage("user message", "memoryId"))
+                .contains("second summary");
+
+        assertThat(firstModel.invocations()).isEqualTo(1);
+        assertThat(secondModel.invocations()).isEqualTo(1);
+    }
+
+    @Test
+    void summarizer_is_not_created_when_there_is_no_context_to_summarize() {
+        RecordingChatModel model = new RecordingChatModel("unused summary");
+
+        AgenticScope agenticScope = mock(AgenticScope.class);
+        when(agenticScope.contextAsConversation()).thenReturn("");
+
+        Context.Summarizer summarizer = new Context.Summarizer(agenticScope, model);
+
+        assertThat(summarizer.transformUserMessage("user message", "memoryId")).isEqualTo("user message");
+        assertThat(model.invocations()).isZero();
+    }
+
+    static class RecordingChatModel implements ChatModel {
+
+        private final String summary;
+        private int invocations;
+
+        RecordingChatModel(String summary) {
+            this.summary = summary;
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            invocations++;
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("{\"summary\": \"" + summary + "\"}"))
+                    .build();
+        }
+
+        int invocations() {
+            return invocations;
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6245

## Change

`Context.Summarizer` cached its `ContextSummarizer` AI service in a JVM-wide static field, and `initSummarizer(chatModel)` only used its `chatModel` argument on the very first call:

```java
private static ContextSummarizer SUMMARIZER_INSTANCE;

private static ContextSummarizer initSummarizer(ChatModel chatModel) {
    if (SUMMARIZER_INSTANCE == null) {
        SUMMARIZER_INSTANCE = AiServices.builder(ContextSummarizer.class)
                .chatModel(chatModel)
                .build();
    }
    return SUMMARIZER_INSTANCE;
}
```

Every `Summarizer` created afterwards - from any agent, agentic system or supervisor in the same JVM - reused the service built with the first caller's model. An agent declaring `summarizedContext` therefore summarized through whichever `ChatModel` happened to win the race, which contradicts `docs/docs/tutorials/agents.md`, where `summarizedContext` is documented to run "with the same chat model of the agent where it has been defined". Nothing fails; the requests just go to the wrong provider until the JVM restarts. The lazy static was also racy, so concurrent first calls could build the service twice.

All four construction sites (`AgentBuilder` and the three in `SupervisorPlanner`) already pass the model they want, so the fix is entirely inside `Context.Summarizer`: the summarizer is now created per instance, in a static factory that hands the constructor a closure over its own `AtomicReference`.

The summarizer is still built lazily, on the first non-blank context, rather than in the constructor. That is deliberate: `summarizerModel` is `null` for an agent configured with `streamingChatModel` or `streamingChatModelProvider` (`AgentBuilder#build`), and `AiServices.build()` rejects a null model, so building eagerly would turn agent construction into a hard failure for those agents.

### One behaviour change worth flagging

An agent configured with a streaming model plus `summarizedContext` has no usable `ChatModel` for summarization at all - `summarizerModel` is `null` for it. Previously the shared static hid this: such an agent silently borrowed a different agent's model and appeared to work. With the summarizer built per instance there is nothing to borrow, so the first summarization now fails with `IllegalConfigurationException: Please specify either chatModel or streamingChatModel`.

That is the same misconfiguration surfacing instead of being masked, but it is a visible change for anyone relying on the old accidental behaviour. It could be caught earlier and more clearly in `AgentBuilder#validateChatModel`, or `summarizedContext` could be given a real streaming path - both felt like your call rather than something to decide inside a bug fix, so this PR leaves that path alone. Happy to follow up in either direction.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Notes on the checklist:

- The removed members were both private, so there is no API change. The behaviour change is the fix itself, plus the streaming-model case described above.
- Tests: `ContextSummarizerTest` covers two summarizers with different models each using their own (this fails on `main`), and the negative case where a blank context builds no summarizer at all.
- The 144 unit tests in `langchain4j-agentic` are green, as are the `langchain4j-core` and `langchain4j` module suites. The integration tests in that module need provider API keys I do not have, so I have not run them locally.
- No documentation change: `docs/docs/tutorials/agents.md` already describes the intended behaviour, which this PR makes true.
