### PR TITLE
Add detailed Javadoc for Agent.typedOutputKey()

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/Agent.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/Agent.java
@@ -139,11 +139,6 @@ public @interface Agent {
      *     </li>
      * </ul>
      *
-     * <p>
-     * If no typed output key is configured, {@link NoTypedKey} is used as
-     * the default sentinel value, indicating that the agent does not declare
-     * its output through a typed key.
-     * </p>
      *
      * @return the {@link TypedKey} class identifying the strongly typed
      *         output variable where the result of this agent invocation

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/Agent.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/Agent.java
@@ -46,7 +46,7 @@ public @interface Agent {
 
     /**
      * Strongly typed key of the output variable that will be used to store
-     * the result of this agent's invocation in the {@link AgenticScope}.
+     * the result of this agent's invocation in the {@link dev.langchain4j.agentic.scope.AgenticScope}.
      * <p>
      * This attribute provides a type-safe alternative to {@link #outputKey()}.
      * Instead of identifying the output variable using a {@link String},

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/Agent.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/Agent.java
@@ -1,10 +1,9 @@
 package dev.langchain4j.agentic;
 
-import dev.langchain4j.agentic.declarative.TypedKey;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.declarative.TypedKey;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -45,6 +44,114 @@ public @interface Agent {
      */
     String outputKey() default "";
 
+    /**
+     * Strongly typed key of the output variable that will be used to store
+     * the result of this agent's invocation in the {@link AgenticScope}.
+     * <p>
+     * This attribute provides a type-safe alternative to {@link #outputKey()}.
+     * Instead of identifying the output variable using a {@link String},
+     * the output is identified by a class implementing {@link TypedKey}.
+     * </p>
+     *
+     * <p>
+     * The generic type declared by the {@link TypedKey} represents the type
+     * of value associated with the output variable.
+     * </p>
+     *
+     * <p>
+     * For example:
+     * </p>
+     *
+     * <pre>{@code
+     * public class Category implements TypedKey<RequestCategory> {
+     * }
+     *
+     * @Agent(
+     *         name = "categoryRouter",
+     *         typedOutputKey = Category.class
+     * )
+     * RequestCategory classify(String request);
+     * }</pre>
+     *
+     * <p>
+     * When the agent completes successfully, its returned
+     * {@code RequestCategory} value is stored in the agentic scope using
+     * {@code Category.class} as the typed state key.
+     * </p>
+     *
+     * <p>
+     * The value can later be retrieved without using a string key and
+     * without requiring an explicit type cast:
+     * </p>
+     *
+     * <pre>{@code
+     * RequestCategory category =
+     *         scope.readState(Category.class);
+     * }</pre>
+     *
+     * <p>
+     * This is particularly useful in multi-agent workflows where the output
+     * of one agent becomes the input of another agent. The typed key acts as
+     * both:
+     * </p>
+     *
+     * <ul>
+     *     <li>the identity of the state variable, and</li>
+     *     <li>the declaration of the Java type associated with that variable.</li>
+     * </ul>
+     *
+     * <p>
+     * Multiple typed keys may use the same Java value type while still
+     * representing different state variables. For example:
+     * </p>
+     *
+     * <pre>{@code
+     * public class InitialCategory
+     *         implements TypedKey<RequestCategory> {
+     * }
+     *
+     * public class ValidatedCategory
+     *         implements TypedKey<RequestCategory> {
+     * }
+     * }</pre>
+     *
+     * <p>
+     * Even though both keys contain {@code RequestCategory} values,
+     * {@code InitialCategory.class} and {@code ValidatedCategory.class}
+     * identify two independent variables in the agentic scope.
+     * </p>
+     *
+     * <p>
+     * {@code typedOutputKey} and {@link #outputKey()} are alternative ways
+     * of defining the output variable. Only one of them should be configured
+     * for an agent:
+     * </p>
+     *
+     * <ul>
+     *     <li>
+     *         {@link #outputKey()} identifies the output using a
+     *         {@link String}.
+     *     </li>
+     *     <li>
+     *         {@code typedOutputKey} identifies the output using a
+     *         {@link TypedKey} implementation and preserves its associated
+     *         Java type.
+     *     </li>
+     * </ul>
+     *
+     * <p>
+     * If no typed output key is configured, {@link NoTypedKey} is used as
+     * the default sentinel value, indicating that the agent does not declare
+     * its output through a typed key.
+     * </p>
+     *
+     * @return the {@link TypedKey} class identifying the strongly typed
+     *         output variable where the result of this agent invocation
+     *         will be stored
+     *
+     * @see TypedKey
+     * @see #outputKey()
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default NoTypedKey.class;
 
     /**
@@ -77,5 +184,5 @@ public @interface Agent {
      */
     String[] summarizedContext() default {};
 
-    class NoTypedKey implements TypedKey<Void> { }
+    class NoTypedKey implements TypedKey<Void> {}
 }


### PR DESCRIPTION
## Summary

Adds detailed Javadoc for `Agent.typedOutputKey()` to clearly explain how strongly typed agent outputs are stored and accessed through `TypedKey`.

## Changes

- Documented the purpose of `typedOutputKey`
- Explained how it differs from the string-based `outputKey`
- Added an example using `TypedKey<RequestCategory>`
- Documented how typed values can be retrieved from `AgenticScope`
- Clarified that different `TypedKey` implementations can use the same underlying Java type
- Documented the `NoTypedKey` default behavior
- Clarified that `outputKey` and `typedOutputKey` are alternative ways of defining an agent output key

## Example

```java
public class Category implements TypedKey<RequestCategory> {
}

@Agent(typedOutputKey = Category.class)
RequestCategory classify(String request);
```

The stored value can then be retrieved in a type-safe manner:

```java
RequestCategory category =
        scope.readState(Category.class);
```

## Testing

Documentation-only change. No functional behavior has been modified.