### PR TITLE
fix: prevent float overflow in embedding normalization and cosine similarity

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/Embedding.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/Embedding.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.data.embedding;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * Represents a dense vector embedding of a text.
@@ -52,7 +52,7 @@ public class Embedding {
     public double[] vectorAsDoubleArray() {
         double[] doubles = new double[vector.length];
 
-        for(int i = 0; i < vector.length; i++) {
+        for (int i = 0; i < vector.length; i++) {
             doubles[i] = vector[i];
         }
 
@@ -65,14 +65,14 @@ public class Embedding {
     public void normalize() {
         double norm = 0.0;
         for (float f : vector) {
-            norm += f * f;
+            norm += (double) f * f;
         }
         norm = Math.sqrt(norm);
         if (Math.abs(norm) < 1e-10) {
             return;
         }
         for (int i = 0; i < vector.length; i++) {
-            vector[i] /= (float) norm;
+            vector[i] = (float) (vector[i] / norm);
         }
     }
 
@@ -99,9 +99,7 @@ public class Embedding {
 
     @Override
     public String toString() {
-        return "Embedding {" +
-                " vector = " + Arrays.toString(vector) +
-                " }";
+        return "Embedding {" + " vector = " + Arrays.toString(vector) + " }";
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/CosineSimilarity.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/CosineSimilarity.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.store.embedding;
 
-import dev.langchain4j.data.embedding.Embedding;
-
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.embedding.Embedding;
 
 /**
  * Utility class for calculating cosine similarity between two vectors.
@@ -45,7 +45,8 @@ public class CosineSimilarity {
         float[] vectorB = embeddingB.vector();
 
         if (vectorA.length != vectorB.length) {
-            throw illegalArgument("Length of vector a (%s) must be equal to the length of vector b (%s)",
+            throw illegalArgument(
+                    "Length of vector a (%s) must be equal to the length of vector b (%s)",
                     vectorA.length, vectorB.length);
         }
 
@@ -54,9 +55,9 @@ public class CosineSimilarity {
         double normB = 0.0;
 
         for (int i = 0; i < vectorA.length; i++) {
-            dotProduct += vectorA[i] * vectorB[i];
-            normA += vectorA[i] * vectorA[i];
-            normB += vectorB[i] * vectorB[i];
+            dotProduct += (double) vectorA[i] * vectorB[i];
+            normA += (double) vectorA[i] * vectorA[i];
+            normB += (double) vectorB[i] * vectorB[i];
         }
 
         // Avoid division by zero.

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/embedding/EmbeddingTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/embedding/EmbeddingTest.java
@@ -55,6 +55,27 @@ class EmbeddingTest implements WithAssertions {
     }
 
     @Test
+    void normalize_large_finite_values() {
+        Embedding embedding = new Embedding(new float[] {6e20f, -8e20f});
+
+        embedding.normalize();
+
+        assertThat(embedding.vector()[0]).isCloseTo(0.6f, within(1e-6f));
+        assertThat(embedding.vector()[1]).isCloseTo(-0.8f, within(1e-6f));
+    }
+
+    @Test
+    void normalize_when_norm_exceeds_float_range() {
+        Embedding embedding = new Embedding(new float[] {Float.MAX_VALUE, Float.MAX_VALUE});
+
+        embedding.normalize();
+
+        float expected = (float) (1 / Math.sqrt(2));
+        assertThat(embedding.vector()[0]).isCloseTo(expected, within(1e-6f));
+        assertThat(embedding.vector()[1]).isCloseTo(expected, within(1e-6f));
+    }
+
+    @Test
     void normalize_zero() {
         Embedding embedding = new Embedding(new float[] {0f, 0f});
         embedding.normalize();

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/CosineSimilarityTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/CosineSimilarityTest.java
@@ -35,6 +35,23 @@ class CosineSimilarityTest implements WithAssertions {
     }
 
     @Test
+    void should_calculate_cosine_similarity_for_large_finite_values() {
+        Embedding embeddingA = Embedding.from(new float[] {6e20f, -8e20f});
+        Embedding embeddingB = Embedding.from(new float[] {-6e20f, 8e20f});
+
+        assertThat(CosineSimilarity.between(embeddingA, embeddingA)).isCloseTo(1, withPercentage(1));
+        assertThat(CosineSimilarity.between(embeddingA, embeddingB)).isCloseTo(-1, withPercentage(1));
+    }
+
+    @Test
+    void should_calculate_cosine_similarity_for_orthogonal_vectors_with_large_finite_values() {
+        Embedding embeddingA = Embedding.from(new float[] {Float.MAX_VALUE, Float.MAX_VALUE});
+        Embedding embeddingB = Embedding.from(new float[] {Float.MAX_VALUE, -Float.MAX_VALUE});
+
+        assertThat(CosineSimilarity.between(embeddingA, embeddingB)).isCloseTo(0, withPercentage(1));
+    }
+
+    @Test
     void should_convert_relevance_score_into_cosine_similarity() {
         assertThat(CosineSimilarity.fromRelevanceScore(0)).isEqualTo(-1);
         assertThat(CosineSimilarity.fromRelevanceScore(0.5)).isEqualTo(0);


### PR DESCRIPTION

## Issue

Closes #6338

## Change

`Embedding.normalize()` and `CosineSimilarity.between()` both accumulate into `double` variables, but the products themselves were evaluated in `float` arithmetic and only widened afterwards. A component whose magnitude exceeds `sqrt(Float.MAX_VALUE)` (~1.8e19) therefore squares to infinity before it ever reaches the accumulator.

- `Embedding.normalize()`: perform the sum-of-squares multiplication in `double` arithmetic, so large finite components do not overflow while the norm is accumulated.
- `Embedding.normalize()`: divide each component by the `double` norm and convert the result back to `float` afterwards, instead of casting the norm down to `float` first — a finite norm above `Float.MAX_VALUE` became infinity. Either bug turned a non-zero embedding into a zero vector.
- `CosineSimilarity.between()`: multiply in `double` arithmetic for the dot product and for both norms. The same overflow made the method return `NaN` for large finite vectors. This function backs `InMemoryEmbeddingStore`, `EmbeddingModelTextClassifier` and the relevance scores of the Qdrant, Pinecone and Couchbase stores, so it is fixed alongside `normalize()` rather than leaving core half-fixed.
- Add regression tests for each of the three defects. Every new test was confirmed to fail against the unfixed code.

### A note on precision

Both methods now round once rather than twice, so they are correctly rounded where they previously were not. Results for ordinary embeddings are consequently slightly *more* accurate, but no longer bit-identical to earlier releases: measured over 20,000 random 1536-dimension vectors, about 21% of normalized components shift by one ULP, the largest observed absolute difference being 1.5e-8. Similarity scores move by a comparable amount, well below anything that can affect ranking. The API itself is unchanged and `revapi` reports no differences.

Two hunks in `CosineSimilarity.java` outside the fix itself (import order, and one call that had to be re-wrapped) are formatting-only: spotless is ratcheted to `origin/main`, so editing the file brings its pre-existing violations into scope.

No documentation update is needed, as this corrects existing behaviour without changing the API.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for big features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

## Verification

- `./mvnw -pl langchain4j-core test` — 1375 tests, 0 failures, 5 skipped
- `./mvnw -pl langchain4j -am test` — 1705 tests, 0 failures, 19 skipped
- `./mvnw -pl langchain4j-core revapi:check` — API checks completed without failures
