### PR TITLE
fix: map the m4a extension to audio/m4a instead of mpa

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
@@ -75,7 +75,7 @@ public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
         defaultMappings.put("wav", "audio/wav");
         defaultMappings.put("aac", "audio/aac");
         defaultMappings.put("flac", "audio/flac");
-        defaultMappings.put("mpa", "audio/m4a");
+        defaultMappings.put("m4a", "audio/m4a");
         defaultMappings.put("mpga", "audio/mpga");
         defaultMappings.put("opus", "audio/opus");
         defaultMappings.put("pcm", "audio/pcm");

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
@@ -76,6 +76,7 @@ public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
         defaultMappings.put("aac", "audio/aac");
         defaultMappings.put("flac", "audio/flac");
         defaultMappings.put("m4a", "audio/m4a");
+        defaultMappings.put("mpa", "audio/mpeg");
         defaultMappings.put("mpga", "audio/mpga");
         defaultMappings.put("opus", "audio/opus");
         defaultMappings.put("pcm", "audio/pcm");

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
@@ -389,6 +389,18 @@ class CustomMimeTypesFileTypeDetectorTest {
     }
 
     @Test
+    void should_return_a_mime_type_for_m4a() {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType(Path.of("/foo/bar/voice.m4a"));
+
+        // then
+        assertThat(mimeType).isEqualTo("audio/m4a");
+    }
+
+    @Test
     void should_return_empty_extension_for_path_without_file_name() {
         // when/then
         assertThat(CustomMimeTypesFileTypeDetector.extension(Path.of("/"))).isEmpty();

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
@@ -55,6 +55,30 @@ class CustomMimeTypesFileTypeDetectorTest {
     }
 
     @Test
+    void should_return_a_mime_type_for_m4a_from_default_mapping() {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType("voice.m4a");
+
+        // then
+        assertThat(mimeType).isEqualTo("audio/m4a");
+    }
+
+    @Test
+    void should_return_a_mime_type_for_mpa_from_default_mapping() {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType("song.mpa");
+
+        // then
+        assertThat(mimeType).isEqualTo("audio/mpeg");
+    }
+
+    @Test
     void should_return_a_mime_type_from_default_mapping_from_string() {
         // given
         CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
@@ -388,17 +412,6 @@ class CustomMimeTypesFileTypeDetectorTest {
         assertThat(mimeType).isEqualTo("audio/mp3");
     }
 
-    @Test
-    void should_return_a_mime_type_for_m4a() {
-        // given
-        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
-
-        // when
-        String mimeType = detector.probeContentType(Path.of("/foo/bar/voice.m4a"));
-
-        // then
-        assertThat(mimeType).isEqualTo("audio/m4a");
-    }
 
     @Test
     void should_return_empty_extension_for_path_without_file_name() {

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
@@ -66,6 +66,7 @@ class GoogleGenAiContentMapper {
         EXTENSION_TO_MIME_TYPE.put("aac", "audio/aac");
         EXTENSION_TO_MIME_TYPE.put("flac", "audio/flac");
         EXTENSION_TO_MIME_TYPE.put("m4a", "audio/m4a");
+        EXTENSION_TO_MIME_TYPE.put("mpa", "audio/mpeg");
         EXTENSION_TO_MIME_TYPE.put("mpga", "audio/mpga");
         EXTENSION_TO_MIME_TYPE.put("opus", "audio/opus");
         EXTENSION_TO_MIME_TYPE.put("pcm", "audio/pcm");

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
@@ -487,6 +487,10 @@ class GoogleGenAiContentMapperTest {
                 .isEqualTo("audio/mp3");
         assertThat(GoogleGenAiContentMapper.detectMimeType(URI.create("file:///test.wav")))
                 .isEqualTo("audio/wav");
+        assertThat(GoogleGenAiContentMapper.detectMimeType(URI.create("file:///test.m4a")))
+                .isEqualTo("audio/m4a");
+        assertThat(GoogleGenAiContentMapper.detectMimeType(URI.create("file:///test.mpa")))
+                .isEqualTo("audio/mpeg");
     }
 
     @Test

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
@@ -61,7 +61,7 @@ class PartsMapper {
         EXTENSION_TO_MIME_TYPE.put("wav", "audio/wav");
         EXTENSION_TO_MIME_TYPE.put("aac", "audio/aac");
         EXTENSION_TO_MIME_TYPE.put("flac", "audio/flac");
-        EXTENSION_TO_MIME_TYPE.put("mpa", "audio/m4a");
+        EXTENSION_TO_MIME_TYPE.put("m4a", "audio/m4a");
         EXTENSION_TO_MIME_TYPE.put("mpga", "audio/mpga");
         EXTENSION_TO_MIME_TYPE.put("opus", "audio/opus");
         EXTENSION_TO_MIME_TYPE.put("pcm", "audio/pcm");

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
@@ -62,6 +62,7 @@ class PartsMapper {
         EXTENSION_TO_MIME_TYPE.put("aac", "audio/aac");
         EXTENSION_TO_MIME_TYPE.put("flac", "audio/flac");
         EXTENSION_TO_MIME_TYPE.put("m4a", "audio/m4a");
+        EXTENSION_TO_MIME_TYPE.put("mpa", "audio/mpeg");
         EXTENSION_TO_MIME_TYPE.put("mpga", "audio/mpga");
         EXTENSION_TO_MIME_TYPE.put("opus", "audio/opus");
         EXTENSION_TO_MIME_TYPE.put("pcm", "audio/pcm");
@@ -76,7 +77,7 @@ class PartsMapper {
         EXTENSION_TO_MIME_TYPE.put("avi", "video/avi");
         EXTENSION_TO_MIME_TYPE.put("flv", "video/x-flv");
         EXTENSION_TO_MIME_TYPE.put("webm", "video/webm");
-        EXTENSION_TO_MIME_TYPE.put("mmv", "video/wmv");
+        EXTENSION_TO_MIME_TYPE.put("wmv", "video/wmv");
         EXTENSION_TO_MIME_TYPE.put("3gpp", "video/3gpp");
 
         // see document understanding:

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/PartsMapperTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/PartsMapperTest.java
@@ -101,6 +101,18 @@ class PartsMapperTest {
                 Arguments.of("http://example.org/cat.MP4", "video/mp4"),
                 Arguments.of("http://example.org/cat.mp4?query=dog.png", "video/mp4"),
 
+                Arguments.of("http://example.org/cat.m4a", "audio/m4a"),
+                Arguments.of("http://example.org/cat.M4A", "audio/m4a"),
+                Arguments.of("http://example.org/cat.m4a?query=dog.png", "audio/m4a"),
+
+                Arguments.of("http://example.org/cat.mpa", "audio/mpeg"),
+                Arguments.of("http://example.org/cat.MPA", "audio/mpeg"),
+                Arguments.of("http://example.org/cat.mpa?query=dog.png", "audio/mpeg"),
+
+                Arguments.of("http://example.org/cat.wmv", "video/wmv"),
+                Arguments.of("http://example.org/cat.WMV", "video/wmv"),
+                Arguments.of("http://example.org/cat.wmv?query=dog.png", "video/wmv"),
+
                 Arguments.of("https://storage.googleapis.com/cloud-samples-data/generative-ai/audio/pixel.mp3", "audio/mp3"),
                 Arguments.of("gs://cloud-samples-data/generative-ai/audio/pixel.mp3", "audio/mp3"),
 


### PR DESCRIPTION
## Issue
Closes #6341

## Change
`.m4a` doesn't get `audio/m4a`, because the mapping key is `mpa`:

```java
defaultMappings.put("mpa", "audio/m4a");
```

`.mpa` is MPEG-1 audio, and `audio/m4a` goes with `.m4a`, so this looks like a typo — the intended entry is missing and a bogus one is there instead.

The repo already answers which way it should go. `GoogleGenAiContentMapper` has the same table, in the same order, and differs from `PartsMapper` at exactly this one line:

```java
// langchain4j-google-genai/.../GoogleGenAiContentMapper.java
EXTENSION_TO_MIME_TYPE.put("m4a", "audio/m4a");

// langchain4j-vertex-ai-gemini/.../PartsMapper.java
EXTENSION_TO_MIME_TYPE.put("mpa", "audio/m4a");
```

`AudioFile` maps the other direction and agrees: `case "audio/m4a" -> ".m4a"`. The Vertex audio-understanding page linked in the comment above the block lists `audio/m4a` and no `.mpa`.

What you get today, from `CustomMimeTypesFileTypeDetector`:

```
voice.m4a    audio/x-m4a     <- falls through to the JDK table
song.mpa     audio/m4a
```

So `.m4a` ends up as `audio/x-m4a`, which isn't one of the accepted audio types, and it comes from the OS mime table so it isn't even stable across machines. `.m4a` is what iPhone voice memos and anything out of Apple's stack produce, so it's a common thing to hand to a multimodal model.

Changed the key in `CustomMimeTypesFileTypeDetector` and `PartsMapper`, which brings both in line with the google-genai module. Left the rest of the tables alone.

One thing I didn't do: `.mpa` now has no mapping at all. Adding `mpa -> audio/mpeg` would be correct for MPEG-1 audio, but it isn't in the Vertex list and google-genai doesn't carry it, so I left it out rather than guess. Happy to add it if you'd rather keep the extension covered.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Notes on the unticked boxes: no docs change since the mapping table isn't documented under `docs/docs`, and this isn't a "big" feature or a starter-facing change.

The new test fails before the change with `expected: "audio/m4a" but was: "audio/x-m4a"`.

```
mvn -pl langchain4j-core,langchain4j test
  Tests run: 1705, Failures: 0, Errors: 0, Skipped: 19
  BUILD SUCCESS
```

`spotless:check` is clean on both changed modules.
