### PR TITLE
fix(vertex-ai-gemini, core): correct WMV and M4A extension-to-MIME mappings

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
@@ -75,7 +75,7 @@ public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
         defaultMappings.put("wav", "audio/wav");
         defaultMappings.put("aac", "audio/aac");
         defaultMappings.put("flac", "audio/flac");
-        defaultMappings.put("mpa", "audio/m4a");
+        defaultMappings.put("m4a", "audio/m4a");
         defaultMappings.put("mpga", "audio/mpga");
         defaultMappings.put("opus", "audio/opus");
         defaultMappings.put("pcm", "audio/pcm");

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
@@ -55,6 +55,18 @@ class CustomMimeTypesFileTypeDetectorTest {
     }
 
     @Test
+    void should_return_a_mime_type_for_m4a_from_default_mapping() {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType("audio.m4a");
+
+        // then
+        assertThat(mimeType).isEqualTo("audio/m4a");
+    }
+
+    @Test
     void should_return_a_mime_type_from_default_mapping_from_string() {
         // given
         CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
@@ -76,7 +76,7 @@ class PartsMapper {
         EXTENSION_TO_MIME_TYPE.put("avi", "video/avi");
         EXTENSION_TO_MIME_TYPE.put("flv", "video/x-flv");
         EXTENSION_TO_MIME_TYPE.put("webm", "video/webm");
-        EXTENSION_TO_MIME_TYPE.put("mmv", "video/wmv");
+        EXTENSION_TO_MIME_TYPE.put("wmv", "video/wmv");
         EXTENSION_TO_MIME_TYPE.put("3gpp", "video/3gpp");
 
         // see document understanding:

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
@@ -61,7 +61,7 @@ class PartsMapper {
         EXTENSION_TO_MIME_TYPE.put("wav", "audio/wav");
         EXTENSION_TO_MIME_TYPE.put("aac", "audio/aac");
         EXTENSION_TO_MIME_TYPE.put("flac", "audio/flac");
-        EXTENSION_TO_MIME_TYPE.put("mpa", "audio/m4a");
+        EXTENSION_TO_MIME_TYPE.put("m4a", "audio/m4a");
         EXTENSION_TO_MIME_TYPE.put("mpga", "audio/mpga");
         EXTENSION_TO_MIME_TYPE.put("opus", "audio/opus");
         EXTENSION_TO_MIME_TYPE.put("pcm", "audio/pcm");

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/PartsMapperTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/PartsMapperTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.net.URI;
@@ -19,6 +20,7 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PartsMapperTest {
 
@@ -97,6 +99,10 @@ class PartsMapperTest {
                 Arguments.of("http://example.org/cat.MP3", "audio/mp3"),
                 Arguments.of("http://example.org/cat.mp3?query=dog.png", "audio/mp3"),
 
+                Arguments.of("http://example.org/cat.m4a", "audio/m4a"),
+                Arguments.of("http://example.org/cat.M4A", "audio/m4a"),
+                Arguments.of("http://example.org/cat.m4a?query=dog.png", "audio/m4a"),
+
                 Arguments.of("http://example.org/cat.mp4", "video/mp4"),
                 Arguments.of("http://example.org/cat.MP4", "video/mp4"),
                 Arguments.of("http://example.org/cat.mp4?query=dog.png", "video/mp4"),
@@ -111,6 +117,24 @@ class PartsMapperTest {
                 Arguments.of("https://storage.googleapis.com/cloud-samples-data/video/animals.mp4", "video/mp4"),
                 Arguments.of("gs://cloud-samples-data/video/animals.mp4", "video/mp4")
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://example.org/cat.banana",
+            "http://example.org/cat.mmv",
+            "http://example.org/cat.mpa",
+            "http://example.org/cat"
+    })
+    void should_fail_to_detect_mime_type_of_unsupported_extension(String url) {
+
+        // given
+        URI uri = URI.create(url);
+
+        // when-then
+        assertThatThrownBy(() -> PartsMapper.detectMimeType(uri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to detect the MIME type");
     }
 
     @Test

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/PartsMapperTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/PartsMapperTest.java
@@ -101,6 +101,10 @@ class PartsMapperTest {
                 Arguments.of("http://example.org/cat.MP4", "video/mp4"),
                 Arguments.of("http://example.org/cat.mp4?query=dog.png", "video/mp4"),
 
+                Arguments.of("http://example.org/cat.wmv", "video/wmv"),
+                Arguments.of("http://example.org/cat.WMV", "video/wmv"),
+                Arguments.of("http://example.org/cat.wmv?query=dog.png", "video/wmv"),
+
                 Arguments.of("https://storage.googleapis.com/cloud-samples-data/generative-ai/audio/pixel.mp3", "audio/mp3"),
                 Arguments.of("gs://cloud-samples-data/generative-ai/audio/pixel.mp3", "audio/mp3"),
 


### PR DESCRIPTION

## Issue

Fixes #6343

## Change

`PartsMapper` in `langchain4j-vertex-ai-gemini` mapped two extensions with a one-character typo, so ordinary media URIs without an explicitly supplied MIME type could not be used as `VideoContent`, `AudioContent` or `FileContent`:

| Mapped key | Mapped to | Correct key |
|---|---|---|
| `mmv` | `video/wmv` | `wmv` |
| `mpa` | `audio/m4a` | `m4a` |

The `mpa` typo is also present in `CustomMimeTypesFileTypeDetector` in `langchain4j-core`, so it is corrected there too. `GoogleGenAiContentMapper` already used the correct keys, so all three tables now agree.

Before:

```java
PartsMapper.detectMimeType(URI.create("https://example.org/video.wmv"));
// IllegalArgumentException: Unable to detect the MIME type of 'https://example.org/video.wmv'.
```

After:

```java
PartsMapper.detectMimeType(URI.create("https://example.org/video.wmv"));
// "video/wmv"
```

Test coverage added:

- lowercase, uppercase and query-string URIs for `.wmv` and `.m4a` in `PartsMapperTest`
- a negative case in `PartsMapperTest` asserting that unsupported (`.banana`, `.mmv`, `.mpa`) and missing extensions are rejected with `IllegalArgumentException`
- `.m4a` in `CustomMimeTypesFileTypeDetectorTest`, alongside the existing `.wmv` case

## Breaking Changes

The two incorrect keys are removed rather than kept alongside the correct ones, so `.mmv` and `.mpa` URIs no longer resolve:

- `.mmv` previously resolved to `video/wmv` and now throws `IllegalArgumentException`. `.mmv` is not a Windows Media Video extension, so this mapping never matched a real file.
- `.mpa` previously resolved to `audio/m4a`. It now throws `IllegalArgumentException` in the Vertex mapper, and falls through to the JDK's own detection in `CustomMimeTypesFileTypeDetector`. `.mpa` is MPEG audio, not MPEG-4 audio, so the old mapping sent the wrong MIME type to the model.

If you relied on either extension, pass the MIME type explicitly:

```java
Video video = Video.builder()
        .url("https://example.org/clip.mmv")
        .mimeType("video/wmv")
        .build();

VideoContent content = VideoContent.from(video);
```

## Verification

- `./mvnw -pl langchain4j-core,langchain4j-vertex-ai-gemini test` — 1372 and 103 tests, all green
- `./mvnw -pl langchain4j test` — 1705 tests, all green
- `./mvnw -pl langchain4j-core,langchain4j-vertex-ai-gemini revapi:check` — no API breakage
- Every new assertion was confirmed to fail against the unfixed mappings and pass with them
- `git diff --check`

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation (not required)
- [ ] I have added an example in the examples repo (not required)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)
