### PR TITLE
fix(bedrock): make image format lookup locale-independent

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/Utils.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/Utils.java
@@ -7,6 +7,7 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import java.net.URI;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -80,7 +81,7 @@ class Utils {
 
         // First try to extract from mime type
         if (image.mimeType() != null && !image.mimeType().isBlank()) {
-            ImageFormat format = MIME_TYPE_MAPPING.get(image.mimeType().toLowerCase());
+            ImageFormat format = MIME_TYPE_MAPPING.get(image.mimeType().toLowerCase(Locale.ROOT));
             if (format != null) {
                 return format.toString();
             }
@@ -88,7 +89,7 @@ class Utils {
 
         // If mime type fails, try to extract from URI
         if (image.url() != null) {
-            String extension = Utils.extractExtension(image.url()).toLowerCase();
+            String extension = Utils.extractExtension(image.url()).toLowerCase(Locale.ROOT);
             ImageFormat format = EXTENSION_MAPPING.get(extension);
             if (format != null) {
                 return format.toString();

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/UtilsLocaleTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/UtilsLocaleTest.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import java.net.URI;
+import java.util.Locale;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * These tests mutate the JVM default {@link Locale}, so the whole class runs {@link Isolated}
+ * and single-threaded, which keeps them deterministic even if this module ever enables
+ * parallel test execution.
+ * <p>
+ * {@code tr} and {@code az} lowercase {@code 'I'} to the dotless {@code 'ı'} (U+0131),
+ * {@code lt} applies its own dot rules, and {@code en-US} is the baseline.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class UtilsLocaleTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ", "lt-LT", "en-US"})
+    void uppercase_extension_should_resolve_locale_independently(String languageTag) {
+        // "gif" is the only extension mapping containing an 'i': without Locale.ROOT,
+        // "GIF".toLowerCase() yields "gıf" under tr/az and the lookup misses.
+        withDefaultLocale(
+                languageTag,
+                () -> assertThat(Utils.extractAndValidateFormat(
+                                Image.builder().url(URI.create("file:///image.GIF")).build()))
+                        .isEqualTo("gif"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "tr-TR, IMAGE/GIF, gif",
+        "tr-TR, IMAGE/PNG, png",
+        "az-AZ, IMAGE/GIF, gif",
+        "az-AZ, IMAGE/PNG, png",
+        "lt-LT, IMAGE/GIF, gif",
+        "lt-LT, IMAGE/PNG, png",
+        "en-US, IMAGE/GIF, gif",
+        "en-US, IMAGE/PNG, png"
+    })
+    void uppercase_mime_type_should_resolve_locale_independently(String languageTag, String mimeType, String expected) {
+        // Every MIME mapping starts with "image/", so under tr/az any uppercase 'I' misses,
+        // not only the gif entry. The URI carries no extension, isolating the MIME path.
+        withDefaultLocale(
+                languageTag,
+                () -> assertThat(Utils.extractAndValidateFormat(Image.builder()
+                                .mimeType(mimeType)
+                                .url(URI.create("file:///image"))
+                                .build()))
+                        .isEqualTo(expected));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"tr-TR", "az-AZ", "lt-LT", "en-US"})
+    void dotless_extension_should_not_resolve(String languageTag) {
+        // The mirror image: a dotless "gıf" must never fold onto the "gif" mapping.
+        withDefaultLocale(
+                languageTag,
+                () -> assertThatExceptionOfType(UnsupportedFeatureException.class)
+                        .isThrownBy(() -> Utils.extractAndValidateFormat(Image.builder()
+                                .mimeType("ımage/gıf")
+                                .build())));
+    }
+
+    private static void withDefaultLocale(String languageTag, Runnable action) {
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
+            action.run();
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
+    }
+}

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/UtilsTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/UtilsTest.java
@@ -7,7 +7,6 @@ import dev.langchain4j.data.image.Image;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 class UtilsTest {
@@ -156,24 +155,6 @@ class UtilsTest {
         assertThat(Utils.extractAndValidateFormat(
                         Image.builder().url(new URI("file:///image.webp")).build()))
                 .isEqualTo("webp");
-    }
-
-    @Test
-    void should_extract_format_independently_of_default_locale() throws Exception {
-        Locale defaultLocale = Locale.getDefault();
-        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
-        try {
-            assertThat(Utils.extractAndValidateFormat(
-                            Image.builder().url(new URI("file:///image.GIF")).build()))
-                    .isEqualTo("gif");
-            assertThat(Utils.extractAndValidateFormat(Image.builder()
-                            .mimeType("IMAGE/GIF")
-                            .url(new URI("file:///image"))
-                            .build()))
-                    .isEqualTo("gif");
-        } finally {
-            Locale.setDefault(defaultLocale);
-        }
     }
 
     @Test

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/UtilsTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/UtilsTest.java
@@ -7,6 +7,7 @@ import dev.langchain4j.data.image.Image;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 class UtilsTest {
@@ -155,6 +156,24 @@ class UtilsTest {
         assertThat(Utils.extractAndValidateFormat(
                         Image.builder().url(new URI("file:///image.webp")).build()))
                 .isEqualTo("webp");
+    }
+
+    @Test
+    void should_extract_format_independently_of_default_locale() throws Exception {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        try {
+            assertThat(Utils.extractAndValidateFormat(
+                            Image.builder().url(new URI("file:///image.GIF")).build()))
+                    .isEqualTo("gif");
+            assertThat(Utils.extractAndValidateFormat(Image.builder()
+                            .mimeType("IMAGE/GIF")
+                            .url(new URI("file:///image"))
+                            .build()))
+                    .isEqualTo("gif");
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Test


### PR DESCRIPTION

## Issue

Fixes #6345

## Change

`Utils#extractAndValidateFormat` lowercased the image MIME type and the filename extension with `String#toLowerCase()` (no `Locale`) before looking them up in fixed lowercase maps, so the lookup depended on the JVM default locale. Under `tr`/`az`, `'I'` lowercases to the dotless `'ı'` (U+0131) and the lookup misses, so a perfectly valid image is rejected with `UnsupportedFeatureException` before the request ever reaches Bedrock:

```java
// on a JVM defaulting to tr-TR
Image.builder().url(URI.create("file:///photo.GIF")).build();       // UnsupportedFeatureException
Image.builder().mimeType("IMAGE/PNG").url(...).build();             // UnsupportedFeatureException
```

Both call sites now normalize with `Locale.ROOT`.

Scope of the bug, which is wider on the MIME side than the issue first described:

- **Extensions**: only `gif` contains an `i`, so `.GIF` is the single affected extension. `png`, `jpg`, `jpeg` and `webp` were already locale-proof.
- **MIME types**: every key in `MIME_TYPE_MAPPING` starts with `image/`, so **any** uppercase `I` misses — `IMAGE/PNG` and `Image/Jpeg` fail just as `IMAGE/GIF` does, not only the gif entry.

This is the same class of locale-dependent lookup fixed in #6147, which covered `langchain4j-core` and the two Gemini mappers but not `langchain4j-bedrock`.

## Tests

`UtilsLocaleTest` mirrors the `*LocaleTest` shape introduced in #6147: `@Isolated` + `@Execution(SAME_THREAD)`, because the tests mutate the JVM-wide default locale. `langchain4j-bedrock` currently runs tests serially (`junit.jupiter.execution.parallel.enabled=false`), so this is insurance rather than a present-day requirement, but it keeps the regression deterministic if the module ever switches to parallel execution.

Each case is parameterized over `tr-TR`, `az-AZ`, `lt-LT` and `en-US`, with the last two acting as controls, and the MIME and extension paths are asserted separately so a failure names the path that broke:

- uppercase extension `.GIF` resolves to `gif`
- uppercase MIME `IMAGE/GIF` and `IMAGE/PNG` resolve to `gif` and `png` (the URI carries no extension, isolating the MIME path)
- the negative case: a dotless `ımage/gıf` must never fold onto the `image/gif` mapping

Reverting the two `Locale.ROOT` calls fails exactly 6 of the 16 cases — the `tr-TR` and `az-AZ` rows of both positive tests — while `lt-LT` and `en-US` stay green.

## Verification

Run against `main` at e506490 (the branch merges cleanly with it; no shared files):

- `./mvnw -pl langchain4j-bedrock test` → 294 tests, 0 failures, 8 skipped, BUILD SUCCESS (JDK 25)
- `./mvnw -pl langchain4j-core,langchain4j test` → 1380 and 1713 tests, 0 failures, BUILD SUCCESS
- `./mvnw -pl langchain4j-bedrock revapi:check` → API checks completed without failures
- No `*IT` ran: they require AWS credentials.

## General checklist

- [X] There are no breaking changes (API, behaviour)
    - No signature change. Under `tr`/`az` more inputs now resolve, which is the fix itself.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
    - Positive: uppercase extension and uppercase MIME types across four locales. Negative: a dotless `ımage/gıf` must not resolve.
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
    - N/A — behaviour fix, no documented API changed.
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
    - N/A — not a feature.
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
    - N/A — no configuration surface changed.
