### PR TITLE
fix: make Workers AI role and Gemini thinking level mapping locale-independent

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Locale;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record GeminiThinkingConfig(
@@ -41,7 +42,7 @@ public record GeminiThinkingConfig(
         }
 
         public Builder thinkingLevel(GeminiThinkingLevel thinkingLevel) {
-            this.thinkingLevel = thinkingLevel.toString().toLowerCase();
+            this.thinkingLevel = thinkingLevel.name().toLowerCase(Locale.ROOT);
             return this;
         }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiThinkingConfigTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiThinkingConfigTest.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.googleai.GeminiThinkingConfig.GeminiThinkingLevel;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@Isolated // mutates the JVM-wide default locale
+class GeminiThinkingConfigTest {
+
+    private Locale defaultLocale;
+
+    @BeforeEach
+    void setTurkishLocale() {
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+    }
+
+    @AfterEach
+    void restoreDefaultLocale() {
+        Locale.setDefault(defaultLocale);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"MINIMAL,minimal", "LOW,low", "MEDIUM,medium", "HIGH,high"})
+    void should_map_thinking_level_independently_of_default_locale(
+            GeminiThinkingLevel thinkingLevel, String expectedThinkingLevel) {
+
+        GeminiThinkingConfig thinkingConfig =
+                GeminiThinkingConfig.builder().thinkingLevel(thinkingLevel).build();
+
+        assertThat(thinkingConfig.thinkingLevel()).isEqualTo(expectedThinkingLevel);
+    }
+}

--- a/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiChatModel.java
+++ b/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiChatModel.java
@@ -171,7 +171,7 @@ public class WorkersAiChatModel extends AbstractWorkersAIModel implements ChatMo
     private Response<AiMessage> generate(List<ChatMessage> messages) {
         WorkersAiChatCompletionRequest req = new WorkersAiChatCompletionRequest();
         req.setMessages(messages.stream()
-                .map(this::toMessage)
+                .map(WorkersAiChatModel::toMessage)
                 .collect(Collectors.toList()));
         return new Response<>(new AiMessage(generate(req)), null, FinishReason.STOP);
     }

--- a/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiChatModel.java
+++ b/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiChatModel.java
@@ -21,6 +21,7 @@ import dev.langchain4j.model.workersai.spi.WorkersAiChatModelBuilderFactory;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
@@ -181,9 +182,9 @@ public class WorkersAiChatModel extends AbstractWorkersAIModel implements ChatMo
      * @param message inbound message
      * @return message for request
      */
-    private WorkersAiChatCompletionRequest.Message toMessage(ChatMessage message) {
+    static WorkersAiChatCompletionRequest.Message toMessage(ChatMessage message) {
         return new WorkersAiChatCompletionRequest.Message(
-                WorkersAiChatCompletionRequest.MessageRole.valueOf(message.type().name().toLowerCase()),
+                WorkersAiChatCompletionRequest.MessageRole.valueOf(message.type().name().toLowerCase(Locale.ROOT)),
                 toText(message)
         );
     }

--- a/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiChatModelLocaleTest.java
+++ b/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiChatModelLocaleTest.java
@@ -6,7 +6,9 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.workersai.client.WorkersAiChatCompletionRequest.MessageRole;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
+@Isolated // mutates the JVM-wide default locale
 class WorkersAiChatModelLocaleTest {
 
     @Test

--- a/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiChatModelLocaleTest.java
+++ b/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiChatModelLocaleTest.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.model.workersai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.workersai.client.WorkersAiChatCompletionRequest.MessageRole;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class WorkersAiChatModelLocaleTest {
+
+    @Test
+    void should_map_ai_message_role_independently_of_default_locale() {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        try {
+            assertThat(WorkersAiChatModel.toMessage(AiMessage.from("previous response")).getRole())
+                    .isEqualTo(MessageRole.ai);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+}


### PR DESCRIPTION

## Issue
Fixes #6347

## Change
Two provider integrations derived a wire value by lowercasing an enum constant with the JVM default locale. Under Turkish-like locales (`tr`, `az`, `lt`) `I` lowercases to the dotless `ı`, so the resulting value is not what the provider expects.

**Workers AI** — `WorkersAiChatModel` resolved the request role with `message.type().name().toLowerCase()`. `ChatMessageType.AI` became `aı` instead of `ai`, so every conversation containing an earlier assistant message failed with `IllegalArgumentException: No enum constant ...MessageRole.aı` before the HTTP request was even sent.

**Google AI Gemini** — `GeminiThinkingConfig.Builder#thinkingLevel(GeminiThinkingLevel)` lowercased the level the same way, putting `mınımal`, `medıum` and `hıgh` on the wire, which the API rejects. Only `LOW` was unaffected.

Both now lowercase with `Locale.ROOT`.

In Workers AI, `toMessage` was additionally made package-visible and `static` (it has no instance state), which keeps the regression test small and network-free. It is a private implementation detail, so this is not an API change.

## Verification
- `./mvnw -pl langchain4j-workers-ai test` — 74 tests, all green
- `./mvnw -pl langchain4j-workers-ai -Pjackson3 test` — 74 tests, all green
- `./mvnw -pl langchain4j-google-ai-gemini test` — 435 tests, all green
- `./mvnw -pl langchain4j-workers-ai -pl langchain4j-google-ai-gemini revapi:check` — no API problems
- Both new tests were confirmed to fail against the unfixed mappings (`No enum constant ...MessageRole.aı`, and `mınımal`/`medıum`/`hıgh`) and to pass with the fix.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit tests for both affected mappings
- [X] The tests are deterministic and require no provider credentials
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation (not required)
- [ ] I have added an example in the examples repo (not required)
- [ ] I have added/updated Spring Boot starter(s) (not applicable)
