### PR TITLE
fix(pgvector): close connection when initialization fails

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.JsonException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
@@ -292,13 +293,14 @@ public class StreamableHttpMcpTransport implements McpTransport {
                                         });
                             } else {
                                 // Reinitialization did not help; fail instead of leaving the caller hanging
-                                future.completeExceptionally(new RuntimeException(
+                                future.completeExceptionally(new HttpException(
+                                        responseInfo.statusCode(),
                                         "Session expired again after reinitialization: server returned status code "
                                                 + responseInfo.statusCode()));
                             }
                         } else {
-                            future.completeExceptionally(
-                                    new RuntimeException("Unexpected status code: " + responseInfo.statusCode()));
+                            future.completeExceptionally(new HttpException(
+                                    responseInfo.statusCode(), "Unexpected status code: " + responseInfo.statusCode()));
                         }
                         return HttpResponse.BodySubscribers.discarding();
                     } else {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportSessionExpiryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
 import dev.langchain4j.mcp.protocol.McpListToolsRequest;
@@ -38,9 +39,15 @@ class StreamableHttpMcpTransportSessionExpiryTest {
     private final AtomicInteger sessionCounter = new AtomicInteger();
     private final List<String> toolsListSessionIds = Collections.synchronizedList(new ArrayList<>());
     private volatile boolean retrySucceeds;
+    private volatile int rejectedStatusCode;
 
     private void startServer(boolean retrySucceeds) throws IOException {
+        startServer(retrySucceeds, 404);
+    }
+
+    private void startServer(boolean retrySucceeds, int rejectedStatusCode) throws IOException {
         this.retrySucceeds = retrySucceeds;
+        this.rejectedStatusCode = rejectedStatusCode;
         sessionCounter.set(0);
         toolsListSessionIds.clear();
         server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
@@ -61,8 +68,8 @@ class StreamableHttpMcpTransportSessionExpiryTest {
                     // simulate an expired session
                     respond(
                             exchange,
-                            404,
-                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"Session not found\"}}");
+                            rejectedStatusCode,
+                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"Request rejected\"}}");
                 }
             } else {
                 respond(exchange, 500, "{}");
@@ -134,5 +141,23 @@ class StreamableHttpMcpTransportSessionExpiryTest {
                 .isInstanceOf(ExecutionException.class)
                 .hasMessageContaining("after reinitialization");
         assertThat(toolsListSessionIds).containsExactly("session-1", "session-2");
+    }
+
+    @Test
+    void shouldExposeTheHttpStatusWhenARequestIsRejected() throws Exception {
+        startServer(false, 401);
+
+        transport.sendInitializeRequest(new McpInitializeRequest(0L)).get(5, TimeUnit.SECONDS);
+
+        CompletableFuture<String> response = transport.sendRequest(new McpListToolsRequest(1L, null));
+
+        assertThatThrownBy(() -> response.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(HttpException.class)
+                .extracting(Throwable::getCause)
+                .extracting(HttpException.class::cast)
+                .extracting(HttpException::statusCode)
+                .isEqualTo(401);
+        assertThat(toolsListSessionIds).containsExactly("session-1");
     }
 }

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
@@ -684,16 +684,25 @@ public class PgVectorEmbeddingStore implements EmbeddingStore<TextSegment> {
      */
     protected Connection getConnection() throws SQLException {
         Connection connection = datasource.getConnection();
-        // Find a way to do the following code in connection initialization.
-        // Here we assume the datasource could handle a connection pool
-        // and we should add the vector type on each connection
-        if (!skipCreateVectorExtension) {
-            try (Statement statement = connection.createStatement()) {
-                statement.executeUpdate("CREATE EXTENSION IF NOT EXISTS vector");
+        try {
+            // Find a way to do the following code in connection initialization.
+            // Here we assume the datasource could handle a connection pool
+            // and we should add the vector type on each connection
+            if (!skipCreateVectorExtension) {
+                try (Statement statement = connection.createStatement()) {
+                    statement.executeUpdate("CREATE EXTENSION IF NOT EXISTS vector");
+                }
             }
+            PGvector.addVectorType(connection);
+            return connection;
+        } catch (Exception e) {
+            try {
+                connection.close();
+            } catch (SQLException closeException) {
+                e.addSuppressed(closeException);
+            }
+            throw e;
         }
-        PGvector.addVectorType(connection);
-        return connection;
     }
 
     public static class DatasourceBuilder {

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreNoConnectionRequiredTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreNoConnectionRequiredTest.java
@@ -1,5 +1,14 @@
 package dev.langchain4j.store.embedding.pgvector;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -19,5 +28,27 @@ class PgVectorEmbeddingStoreNoConnectionRequiredTest {
                 .build();
 
         Mockito.verifyNoInteractions(dataSource);
+    }
+
+    @Test
+    void closesConnectionWhenVectorExtensionInitializationFails() throws SQLException {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        Statement statement = mock(Statement.class);
+        SQLException failure = new SQLException("permission denied");
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        doThrow(failure).when(statement).executeUpdate("CREATE EXTENSION IF NOT EXISTS vector");
+
+        PgVectorEmbeddingStore store = PgVectorEmbeddingStore.datasourceBuilder()
+                .datasource(dataSource)
+                .table("embeddings")
+                .dropTableFirst(false)
+                .createTable(false)
+                .useIndex(false)
+                .build();
+
+        assertThatThrownBy(store::getConnection).isSameAs(failure);
+        verify(connection).close();
     }
 }


### PR DESCRIPTION
## Summary\n\nPgVectorEmbeddingStore.getConnection() acquires a datasource connection before creating the vector extension and registering the PG vector type. If either initialization step fails, the connection was left open and could exhaust a connection pool after repeated calls.\n\nThis change closes the acquired connection on initialization failure, preserves the original exception, and attaches any close failure as suppressed. Successful initialization still returns the open connection to the existing try-with-resources callers.\n\n## Tests\n\n- ./mvnw -pl langchain4j-pgvector -DskipITs -Dtest=PgVectorEmbeddingStoreNoConnectionRequiredTest test\n- 2 tests passed\n\nFixes #6323