### PR TITLE
fix(gemini): make thinking level mapping locale-independent

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Locale;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record GeminiThinkingConfig(
@@ -41,7 +42,7 @@ public record GeminiThinkingConfig(
         }
 
         public Builder thinkingLevel(GeminiThinkingLevel thinkingLevel) {
-            this.thinkingLevel = thinkingLevel.toString().toLowerCase();
+            this.thinkingLevel = thinkingLevel.toString().toLowerCase(Locale.ROOT);
             return this;
         }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiThinkingConfigTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiThinkingConfigTest.java
@@ -1,0 +1,50 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.googleai.GeminiThinkingConfig.GeminiThinkingLevel;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class GeminiThinkingConfigTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "tr-TR, MINIMAL, minimal", "tr-TR, LOW, low", "tr-TR, MEDIUM, medium", "tr-TR, HIGH, high",
+        "az-AZ, MINIMAL, minimal", "az-AZ, LOW, low", "az-AZ, MEDIUM, medium", "az-AZ, HIGH, high",
+        "en-US, MINIMAL, minimal", "en-US, LOW, low", "en-US, MEDIUM, medium", "en-US, HIGH, high"
+    })
+    void should_serialize_thinking_level_independently_of_default_locale(
+            String languageTag, GeminiThinkingLevel level, String expected) {
+        Locale previous = Locale.getDefault();
+        Locale previousDisplay = Locale.getDefault(Locale.Category.DISPLAY);
+        Locale previousFormat = Locale.getDefault(Locale.Category.FORMAT);
+        try {
+            Locale.setDefault(Locale.forLanguageTag(languageTag));
+
+            GeminiThinkingConfig config =
+                    GeminiThinkingConfig.builder().thinkingLevel(level).build();
+
+            assertThat(Json.toJsonWithoutIndent(config)).isEqualTo("{\"thinkingLevel\":\"" + expected + "\"}");
+        } finally {
+            Locale.setDefault(previous);
+            Locale.setDefault(Locale.Category.DISPLAY, previousDisplay);
+            Locale.setDefault(Locale.Category.FORMAT, previousFormat);
+        }
+    }
+
+    @Test
+    void should_preserve_explicit_string_thinking_level() {
+        GeminiThinkingConfig config =
+                GeminiThinkingConfig.builder().thinkingLevel("CUSTOM_LEVEL").build();
+
+        assertThat(config.thinkingLevel()).isEqualTo("CUSTOM_LEVEL");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #6354.

## Change

With a Turkish or Azerbaijani default locale, the enum overload of `thinkingLevel` produces values such as `hıgh` and `medıum`, which are then written into the Gemini request JSON. Use `Locale.ROOT` so these protocol values stay independent of the host locale. The string overload is unchanged.

The regression checks all four enum values under `tr-TR`, `az-AZ`, and `en-US`, as well as the explicit string overload. It restores the default locale and both locale categories, and is isolated from parallel tests.

Validation on OpenJDK 26.0.1, with Java 17 compilation target:

```sh
./mvnw -B -ntp -f langchain4j-google-ai-gemini/pom.xml spotless:apply test
./mvnw -B -ntp -f langchain4j-google-ai-gemini/pom.xml -Pjackson3 \
  -Dtest=GeminiThinkingConfigTest,GeminiWireFormatTest spotless:check test
```

The new test had 6 failures before the fix. Afterward, all 453 module unit tests passed, plus 16 locale/wire-format tests with Jackson 3. Local execution used a temporary Maven mirror configuration to bypass an unavailable third-party public mirror. Validation used current module sources with resolved SNAPSHOT dependencies; the full repository reactor and live Gemini integration tests were not run.

Developed with Codex assistance; the diff and regression results were reviewed.

## General checklist

- [x] There are no breaking API changes
- [x] I have added unit tests for my change
- [x] The tests cover both affected and unaffected cases
- [ ] I have manually run all unit and integration tests in the changed module (unit tests passed; live provider integration tests not run)
- [ ] I have manually run all unit and integration tests in the core and main modules
- [ ] I have added/updated documentation (not needed for this internal conversion fix)
- [ ] I have added an example (not applicable)
- [ ] I have added/updated Spring Boot starters (not applicable)

The new-module and embedding-store checklists do not apply.
