### PR TITLE
fix: preserve embedding direction when normalizing large finite values

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/Embedding.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/Embedding.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.data.embedding;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * Represents a dense vector embedding of a text.
@@ -52,7 +52,7 @@ public class Embedding {
     public double[] vectorAsDoubleArray() {
         double[] doubles = new double[vector.length];
 
-        for(int i = 0; i < vector.length; i++) {
+        for (int i = 0; i < vector.length; i++) {
             doubles[i] = vector[i];
         }
 
@@ -65,14 +65,15 @@ public class Embedding {
     public void normalize() {
         double norm = 0.0;
         for (float f : vector) {
-            norm += f * f;
+            double d = f;
+            norm += d * d;
         }
         norm = Math.sqrt(norm);
         if (Math.abs(norm) < 1e-10) {
             return;
         }
         for (int i = 0; i < vector.length; i++) {
-            vector[i] /= (float) norm;
+            vector[i] = (float) (vector[i] / norm);
         }
     }
 
@@ -99,9 +100,7 @@ public class Embedding {
 
     @Override
     public String toString() {
-        return "Embedding {" +
-                " vector = " + Arrays.toString(vector) +
-                " }";
+        return "Embedding {" + " vector = " + Arrays.toString(vector) + " }";
     }
 
     /**

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/embedding/EmbeddingTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/embedding/EmbeddingTest.java
@@ -62,4 +62,22 @@ class EmbeddingTest implements WithAssertions {
         Embedding expect = new Embedding(new float[] {0f, 0f});
         assertThat(embedding).isEqualTo(expect);
     }
+
+    @Test
+    void normalize_large_finite_values() {
+        Embedding embedding = new Embedding(new float[] {6e20f, -8e20f});
+        embedding.normalize();
+
+        assertThat(embedding.vector()[0]).isCloseTo(0.6f, org.assertj.core.data.Offset.offset(1e-6f));
+        assertThat(embedding.vector()[1]).isCloseTo(-0.8f, org.assertj.core.data.Offset.offset(1e-6f));
+    }
+
+    @Test
+    void normalize_float_max_value() {
+        Embedding embedding = new Embedding(new float[] {Float.MAX_VALUE, Float.MAX_VALUE});
+        embedding.normalize();
+
+        assertThat(embedding.vector()[0]).isCloseTo(0.70710677f, org.assertj.core.data.Offset.offset(1e-6f));
+        assertThat(embedding.vector()[1]).isCloseTo(0.70710677f, org.assertj.core.data.Offset.offset(1e-6f));
+    }
 }


### PR DESCRIPTION
## Issue
Closes #6338

## Change

`Embedding.normalize()` squared each `float` component in `float` precision before adding it to the `double` accumulator, so a component like `6e20f` overflowed to `Infinity` even though the true Euclidean norm fits comfortably in a `double`. The norm was then cast back to `float` before dividing, so a finite `double` norm above `Float.MAX_VALUE` also became `Infinity`. Both paths turned a valid direction into an all-zero vector.

Fixed by squaring in `double` precision and dividing by the `double` norm before the final cast back to `float`, matching the fix proposed in the issue. Added the two reproduction cases from the issue (`{6e20f, -8e20f}` and `{Float.MAX_VALUE, Float.MAX_VALUE}`) as regression tests.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
