### PR TITLE
fix(mcp): restore the interrupt status in DefaultMcpClient

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -242,6 +242,7 @@ public class DefaultMcpClient implements McpClient {
                     try {
                         TimeUnit.MILLISECONDS.sleep(reconnectInterval.toMillis());
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
                     }
                     log.info("Trying to reconnect...");
@@ -1000,7 +1001,12 @@ public class DefaultMcpClient implements McpClient {
             CompletableFuture<String> resultFuture = executeViaTransport(context);
             resultFuture.get(pingTimeout.toMillis(), TimeUnit.MILLISECONDS);
             notifyListeners(l -> l.afterPing(context));
-        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            RuntimeException re = new RuntimeException(e);
+            notifyListeners(l -> l.onPingError(context, re));
+            throw re;
+        } catch (ExecutionException | TimeoutException e) {
             RuntimeException re = new RuntimeException(e);
             notifyListeners(l -> l.onPingError(context, re));
             throw re;
@@ -1019,7 +1025,12 @@ public class DefaultMcpClient implements McpClient {
             CompletableFuture<String> resultFuture = executeViaTransport(context);
             resultFuture.get(pingTimeout.toMillis(), TimeUnit.MILLISECONDS);
             notifyListeners(l -> l.afterPing(context));
-        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            RuntimeException re = new RuntimeException(e);
+            notifyListeners(l -> l.onPingError(context, re));
+            throw re;
+        } catch (ExecutionException | TimeoutException e) {
             RuntimeException re = new RuntimeException(e);
             notifyListeners(l -> l.onPingError(context, re));
             throw re;
@@ -1496,7 +1507,10 @@ public class DefaultMcpClient implements McpClient {
             } catch (TimeoutException e) {
                 cancelTimedOutOperation(e, operation.getId(), resultFuture);
                 throw new RuntimeException(e);
-            } catch (ExecutionException | InterruptedException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
                 throw new RuntimeException(e);
             } finally {
                 pendingOperations.remove(operation.getId());

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -35,9 +35,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1050,6 +1052,85 @@ public class DefaultMcpClientTest {
         assertThat(client.isModernProtocol()).isFalse();
         verify(transport).initialize(any());
         verify(transport, never()).executeOperationWithResponse(any(McpCallContext.class));
+    }
+
+    @Test
+    public void legacy_health_check_restores_interrupt_status() throws Exception {
+        McpTransport transport = getMinimalMcpTransportMock();
+        CountDownLatch pingSent = new CountDownLatch(1);
+        when(transport.sendRequest(any(McpCallContext.class))).thenAnswer(invocation -> {
+            pingSent.countDown();
+            return new CompletableFuture<>();
+        });
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .pingTimeout(java.time.Duration.ofSeconds(30))
+                .build();
+
+        assertInterruptStatusRestored(client::checkHealth, pingSent);
+    }
+
+    @Test
+    public void modern_health_check_restores_interrupt_status() throws Exception {
+        McpTransport transport = getModernStdioTransportMock();
+        CountDownLatch pingSent = new CountDownLatch(1);
+        when(transport.sendRequest(any(McpCallContext.class)))
+                .thenReturn(
+                        CompletableFuture.completedFuture(getDiscoverResult().toString()))
+                .thenAnswer(invocation -> {
+                    pingSent.countDown();
+                    return new CompletableFuture<>();
+                });
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2026-07-28")
+                .pingTimeout(java.time.Duration.ofSeconds(30))
+                .subscribeToToolListChanges(false)
+                .subscribeToPromptListChanges(false)
+                .subscribeToResourceListChanges(false)
+                .build();
+
+        assertInterruptStatusRestored(client::checkHealth, pingSent);
+    }
+
+    @Test
+    public void paginated_list_restores_interrupt_status() throws Exception {
+        McpTransport transport = getMinimalMcpTransportMock();
+        CountDownLatch listSent = new CountDownLatch(1);
+        when(transport.sendRequest(any(McpCallContext.class))).thenAnswer(invocation -> {
+            listSent.countDown();
+            return new CompletableFuture<>();
+        });
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .protocolVersion("2025-11-25")
+                .toolExecutionTimeout(java.time.Duration.ofSeconds(30))
+                .build();
+
+        assertInterruptStatusRestored(() -> client.listTools(), listSent);
+    }
+
+    private static void assertInterruptStatusRestored(Runnable operation, CountDownLatch requestSent) throws Exception {
+        CompletableFuture<Boolean> interruptStatus = new CompletableFuture<>();
+        Thread thread = new Thread(() -> {
+            try {
+                operation.run();
+                interruptStatus.completeExceptionally(new AssertionError("operation unexpectedly completed"));
+            } catch (RuntimeException expected) {
+                interruptStatus.complete(Thread.currentThread().isInterrupted());
+            }
+        });
+
+        thread.start();
+        try {
+            assertThat(requestSent.await(5, TimeUnit.SECONDS)).isTrue();
+            thread.interrupt();
+            assertThat(interruptStatus.get(5, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            thread.interrupt();
+            thread.join(TimeUnit.SECONDS.toMillis(5));
+        }
     }
 
     private static McpTransport getMinimalMcpTransportMock() {


### PR DESCRIPTION
## Issue
Closes #6361

## Change

`DefaultMcpClient` caught `InterruptedException` in four blocking paths and rethrew it wrapped in a `RuntimeException` without re-asserting the thread's interrupt status: `checkHealthModern` and `checkHealthLegacy` (both reached from `checkHealth()`), `fetchPaginatedList` (reached from `listTools()`, `listResources()`, `listResourceTemplates()` and `listPrompts()`), and the reconnect delay in the `transport.onFailure(...)` callback installed by the constructor. `Future.get(...)` and `Thread.sleep(...)` clear the flag when they throw, so a caller that had interrupted the operation saw the exception but found `Thread.currentThread().isInterrupted()` returning `false`.

Each of the four now handles it separately, for example in the health checks:

```java
} catch (InterruptedException e) {
    Thread.currentThread().interrupt();
    RuntimeException re = new RuntimeException(e);
    notifyListeners(l -> l.onPingError(context, re));
    throw re;
} catch (ExecutionException | TimeoutException e) {
    RuntimeException re = new RuntimeException(e);
    notifyListeners(l -> l.onPingError(context, re));
    throw re;
}
```

Everything else is unchanged: the same `RuntimeException` wrapping the same cause, the same listener callbacks, and the same `pendingOperations` cleanup in the `finally` block. `ExecutionException` and `TimeoutException` behave exactly as before.

This follows #6242, which restored the same invariant in `readResource` and `getPrompt` in this class. Six handlers here already call `Thread.currentThread().interrupt()`, as do the three in `WebSocketMcpTransport`; these four were the remainder, so no handler in `langchain4j-mcp` drops the flag any more. `DockerMcpTransport` in `langchain4j-mcp-docker` has the same gap in one place, on the image pull in `start()`; I kept this PR to one module and will send that separately, but I am happy to fold it in if you would rather have both at once.

### Tests

- `DefaultMcpClientTest.modern_health_check_restores_interrupt_status` (new) proves `checkHealth()` leaves the flag set on the `2026-07-28` protocol path.
- `DefaultMcpClientTest.legacy_health_check_restores_interrupt_status` (new) proves the same on the `2025-11-25` path.
- `DefaultMcpClientTest.paginated_list_restores_interrupt_status` (new) proves the same for `listTools()` while a page request is in flight.

Each test blocks the transport on a future that never completes, interrupts the calling thread once the request has been sent, and asserts `Thread.currentThread().isInterrupted()` inside the caller's catch block. All three fail on unmodified `main`, and reverting the three production sites one at a time fails exactly the matching test. They exercise the interrupted path only; there is no positive case, which is why that checklist box is unticked.

The reconnect delay is a one-line change with no test: it runs on the transport's failure callback rather than on a caller's thread, and the class exposes no offline seam to drive it. It matches the other three and the handlers already in the class.

```
mvn -o -pl langchain4j-mcp test
Tests run: 250, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1378, Failures: 0, Errors: 0, Skipped: 3

mvn -pl langchain4j test
Tests run: 1713, Failures: 0, Errors: 0, Skipped: 19

mvn -o -pl langchain4j-mcp spotless:check
BUILD SUCCESS

mvn -pl langchain4j-mcp verify -DskipTests
API checks completed without failures.
```

The module's integration tests were not run: they start MCP servers through `jbang`, which is not available here.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

The first box is unchecked because the interrupt status is now set where it previously was not, which is an observable change for a caller that polls the flag after catching the exception. The third and fourth are unchecked because the new tests cover only the interrupted path, and because the module's integration tests need `jbang` to start a server. The last three do not apply: this is an internal fix with no user-facing API, no new builder property and nothing to document.
