### PR TITLE
Return an unmodifiable list from `AgenticScope.agentInvocations()`

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
@@ -354,7 +354,7 @@ public class DefaultAgenticScope implements AgenticScope {
 
     @Override
     public List<AgentInvocation> agentInvocations() {
-        return agentInvocations;
+        return Collections.unmodifiableList(agentInvocations);
     }
 
     @Override

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgentInvocationsTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgentInvocationsTest.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.agentic.scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AgentInvocationsTest {
+
+    @Test
+    void should_not_allow_modifying_agent_invocations() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        AgentInvocation invocation = new AgentInvocation(Object.class, "agent", "agent-id", Map.of(), null);
+        scope.registerAgentInvocation(invocation, null);
+
+        List<AgentInvocation> invocations = scope.agentInvocations();
+
+        assertThat(invocations).containsExactly(invocation);
+        assertThatThrownBy(invocations::clear).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(scope.agentInvocations()).containsExactly(invocation);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #6363

## Change

`AgenticScope.agentInvocations()` documents its return value as "an unmodifiable list of all agent invocations", but `DefaultAgenticScope` returned the internal list field, so `agenticScope().agentInvocations().clear()` silently erased the scope's execution history and `add(...)` could insert entries that no agent produced.

```java
return Collections.unmodifiableList(agentInvocations);
```

`AgentsRegistry.allAgents()` carries the same contract and already enforces it this way, so this is the pattern the module already uses rather than a new one. The distinction is deliberate elsewhere in this interface: `state()` documents "a live view" and "the mutable state map", and the two filtered overloads `agentInvocations(String)` and `agentInvocations(Class<?>)` are already unmodifiable because they collect with `Stream.toList()`. This one method was the exception.

Reads are unaffected: the wrapper is a view over the same list, so invocations recorded after the call are still visible through it. Nothing inside the module reads through this accessor, every writer uses the field directly, and no caller anywhere in the repository mutates the returned list, so the only behaviour that changes is that a mutation attempt now throws `UnsupportedOperationException` instead of corrupting the history.

### Tests

- `AgentInvocationsTest.should_not_allow_modifying_agent_invocations` (new) records one invocation, asserts it is readable, asserts `clear()` throws `UnsupportedOperationException`, and asserts the history is still intact afterwards.

It fails on unmodified `main`. The rest of the module's suite covers the read paths and is unchanged.

```
mvn -o -pl langchain4j-agentic clean test
Tests run: 158, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-agentic-mcp clean test
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1378, Failures: 0, Errors: 0, Skipped: 3

mvn -pl langchain4j test
Tests run: 1713, Failures: 0, Errors: 0, Skipped: 19

mvn -o -pl langchain4j-agentic spotless:check
BUILD SUCCESS

mvn -pl langchain4j-agentic verify -DskipTests
API checks completed without failures.
```

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

The first box is unchecked because code that mutated the returned list now throws instead of succeeding, even though the Javadoc never allowed it. The fourth is unchecked because the module's integration tests need model API keys; the unit tests are green. The last three do not apply: this changes no public signature, adds no builder property and documents nothing new.
