### PR TITLE
fix(mcp): reject a malformed prompts/get response instead of returning null

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/PromptsHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/PromptsHelper.java
@@ -3,7 +3,6 @@ package dev.langchain4j.mcp.client;
 import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.mcp.protocol.McpGetPromptResponse;
 import dev.langchain4j.mcp.protocol.McpListPromptsResult;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +26,16 @@ class PromptsHelper {
 
     static McpGetPromptResult parsePromptContents(String mcpMessage) {
         McpErrorHelper.checkForErrors(mcpMessage);
-        return McpJson.deserialize(mcpMessage, McpGetPromptResponse.class).getResult();
+        McpGetPromptResult result =
+                McpJson.deserialize(mcpMessage, McpGetPromptResponse.class).getResult();
+        if (result == null) {
+            log.warn("Result does not contain 'result' element: {}", mcpMessage);
+            throw new IllegalResponseException("Result does not contain 'result' element");
+        }
+        if (result.messages() == null) {
+            log.warn("Result does not contain 'messages' element: {}", mcpMessage);
+            throw new IllegalResponseException("Result does not contain 'messages' element");
+        }
+        return result;
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/PromptContentConversionTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/PromptContentConversionTest.java
@@ -1,10 +1,9 @@
 package dev.langchain4j.mcp.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import dev.langchain4j.mcp.client.transport.McpJson;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.Content;
@@ -19,13 +18,36 @@ import org.junit.jupiter.api.Test;
 class PromptContentConversionTest {
 
     @Test
+    void shouldRejectResponseWithoutResult() {
+        // language=JSON
+        String response = """
+                {"jsonrpc":"2.0","id":1}
+                """;
+
+        assertThatThrownBy(() -> PromptsHelper.parsePromptContents(response))
+                .isInstanceOf(IllegalResponseException.class)
+                .hasMessage("Result does not contain 'result' element");
+    }
+
+    @Test
+    void shouldRejectResponseWithoutMessages() {
+        // language=JSON
+        String response = """
+                {"jsonrpc":"2.0","id":1,"result":{}}
+                """;
+
+        assertThatThrownBy(() -> PromptsHelper.parsePromptContents(response))
+                .isInstanceOf(IllegalResponseException.class)
+                .hasMessage("Result does not contain 'messages' element");
+    }
+
+    @Test
     void userMessageWithText() throws JsonProcessingException {
         // language=JSON
-        String response =
-                """
+        String response = """
                 {"jsonrpc":"2.0","id":111,"result":{"messages":[{"role":"user","content":{"text":"Hello","type":"text"}}]}}
                 """;
-        
+
         McpGetPromptResult promptResponse = PromptsHelper.parsePromptContents(response);
 
         ChatMessage chatMessage = promptResponse.messages().get(0).toChatMessage();
@@ -36,11 +58,10 @@ class PromptContentConversionTest {
     @Test
     void aiMessageWithText() throws JsonProcessingException {
         // language=JSON
-        String response =
-                """
+        String response = """
                 {"jsonrpc":"2.0","id":123,"result":{"messages":[{"role":"assistant","content":{"text":"Hello","type":"text"}}]}}
                 """;
-        
+
         McpGetPromptResult promptResponse = PromptsHelper.parsePromptContents(response);
 
         ChatMessage chatMessage = promptResponse.messages().get(0).toChatMessage();
@@ -51,11 +72,10 @@ class PromptContentConversionTest {
     @Test
     void userMessageWithImage() throws JsonProcessingException {
         // language=JSON
-        String response =
-                """
+        String response = """
                 {"jsonrpc":"2.0","id":1,"result":{"messages":[{"role":"user","content":{"data":"aaa","mimeType":"image/png","type":"image"}}]}}
                 """;
-        
+
         McpGetPromptResult promptResponse = PromptsHelper.parsePromptContents(response);
 
         ChatMessage chatMessage = promptResponse.messages().get(0).toChatMessage();


### PR DESCRIPTION
## Issue
Closes #6366

## Change

`PromptsHelper.parsePromptContents` returned whatever `getResult()` produced without checking it. A `prompts/get` response carrying no `result` element deserializes to `null`, so `getPrompt(...)` returned null to the caller and passed that null to every listener through `afterPromptGet` (`DefaultMcpClient.java:958`); a response carrying a `result` but no `messages` element produced a result whose `messages()` is null, which the caller only discovers as a `NullPointerException`.

Both are now rejected where the response is parsed:

```java
McpGetPromptResult result =
        McpJson.deserialize(mcpMessage, McpGetPromptResponse.class).getResult();
if (result == null) {
    log.warn("Result does not contain 'result' element: {}", mcpMessage);
    throw new IllegalResponseException("Result does not contain 'result' element");
}
if (result.messages() == null) {
    log.warn("Result does not contain 'messages' element: {}", mcpMessage);
    throw new IllegalResponseException("Result does not contain 'messages' element");
}
```

The two guards are copied from `parsePromptRefs` in the same class, which already validates the same two elements with the same messages and the same warning; `ResourcesHelper` does it for all three of its parse methods through its `requireResult` and `require` helpers. I checked every parse entry point in the MCP client helpers and this was the only one without the check: `ToolExecutionHelper.extractResult` already throws on both a missing `result` and a missing `content`.

This is a behaviour change. A malformed response that previously produced a null return or a later `NullPointerException` now throws `IllegalResponseException`, which is the same type and the same message the list operations have always thrown, so the exception surface is not new. I left the guards inline rather than extracting helpers like `ResourcesHelper`, to keep the diff to the one method and match the class it lives in.

Most of the test diff is the Spotless ratchet: `PromptContentConversionTest` is not formatter-clean on `main`, so touching it reflows the three existing text blocks and drops two imports that were already unused. Only the two new tests are mine.

### Tests

- `PromptContentConversionTest.shouldRejectResponseWithoutResult` (new) proves a response with no `result` element is rejected instead of returning null.
- `PromptContentConversionTest.shouldRejectResponseWithoutMessages` (new) proves a `result` without `messages` is rejected instead of yielding a result with a null list.

Both fail on unmodified `main`, and reverting either guard on its own fails exactly the matching test. The three existing conversion tests in the class drive the same method on the success path and still pass, so the accepted responses are unchanged.

```
mvn -o -pl langchain4j-mcp test
Tests run: 249, Failures: 0, Errors: 0, Skipped: 0

mvn -o -pl langchain4j-core test
Tests run: 1378, Failures: 0, Errors: 0, Skipped: 3

mvn -pl langchain4j test
Tests run: 1713, Failures: 0, Errors: 0, Skipped: 19

mvn -o -pl langchain4j-mcp spotless:check
BUILD SUCCESS

mvn -pl langchain4j-mcp verify -DskipTests
API checks completed without failures.
```

The module's integration tests were not run: they start MCP servers through `jbang`, which is not available here.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

The first box is unchecked because a malformed response now throws where it previously returned null or failed later with a `NullPointerException`. The fourth is unchecked because the module's integration tests need `jbang` to start a server; the unit tests are green. The last three do not apply: this is an internal fix with no user-facing API, no new builder property and nothing to document.
