### PR TITLE
fix(http-client-okhttp): stop double-terminating SSE listener on mid-stream error

### DIFF
--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.http.client.okhttp;
 
 import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
+import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.terminateOnce;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.TimeoutException;
@@ -15,6 +17,15 @@ import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.http.client.sse.ServerSentEventContext;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketTimeoutException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
 import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;
 import mutiny.zero.ZeroPublisher;
@@ -25,18 +36,6 @@ import okhttp3.MultipartBody;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.SocketTimeoutException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Flow;
-import java.util.concurrent.TimeUnit;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 
 public class OkHttpClient implements HttpClient {
 
@@ -177,9 +176,10 @@ public class OkHttpClient implements HttpClient {
     }
 
     private Call enqueueServerSentEvents(
-            HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+            HttpRequest request, ServerSentEventParser parser, ServerSentEventListener rawListener) {
         Request okRequest = toOkHttpRequest(request);
         Call call = client.newCall(okRequest);
+        ServerSentEventListener listener = terminateOnce(rawListener);
         call.enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) {

--- a/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientDoubleTerminationTest.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientDoubleTerminationTest.java
@@ -1,0 +1,107 @@
+package dev.langchain4j.http.client.okhttp;
+
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Fault;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.DefaultServerSentEventParser;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import okhttp3.Dispatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OkHttpClientDoubleTerminationTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void beforeEach() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void should_call_onError_but_not_onClose_when_stream_is_truncated_mid_body() throws Exception {
+
+        // given: a response that starts successfully (status 200, valid headers) but whose body
+        // is corrupted mid-transfer, so the SSE parser reports an IOException via onError and returns
+        // normally rather than throwing it back to the caller.
+        wireMockServer.stubFor(WireMock.get("/endpoint")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody("data: hello\n\n")
+                        .withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+        List<String> calls = new CopyOnWriteArrayList<>();
+        CountDownLatch terminated = new CountDownLatch(1);
+        Dispatcher dispatcher = new Dispatcher();
+
+        HttpRequest request = HttpRequest.builder()
+                .method(GET)
+                .url("http://localhost:" + wireMockServer.port() + "/endpoint")
+                .build();
+
+        // when
+        OkHttpClient.builder()
+                .okHttpClientBuilder(new okhttp3.OkHttpClient.Builder().dispatcher(dispatcher))
+                .build()
+                .execute(request, new DefaultServerSentEventParser(), new ServerSentEventListener() {
+
+                    @Override
+                    public void onOpen(SuccessfulHttpResponse response) {
+                        calls.add("onOpen");
+                    }
+
+                    @Override
+                    public void onEvent(ServerSentEvent event) {
+                        calls.add("onEvent");
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        calls.add("onError");
+                        terminated.countDown();
+                    }
+
+                    @Override
+                    public void onClose() {
+                        calls.add("onClose");
+                        terminated.countDown();
+                    }
+                });
+
+        // then
+        assertThat(terminated.await(10, SECONDS)).isTrue();
+        awaitDispatcherIdle(dispatcher);
+        assertThat(calls).containsExactly("onOpen", "onError");
+    }
+
+    private static void awaitDispatcherIdle(Dispatcher dispatcher) throws InterruptedException {
+        long deadline = System.nanoTime() + SECONDS.toNanos(10);
+        while (dispatcher.runningCallsCount() > 0) {
+            if (System.nanoTime() > deadline) {
+                throw new AssertionError("OkHttp dispatcher did not go idle in time");
+            }
+            Thread.sleep(10);
+        }
+    }
+}

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventListenerUtils.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventListenerUtils.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.http.client.sse;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,5 +20,51 @@ public class ServerSentEventListenerUtils {
                             + "This exception has been ignored.",
                     e);
         }
+    }
+
+    /**
+     * Wraps {@code listener} so that at most one of {@link ServerSentEventListener#onClose()} and
+     * {@link ServerSentEventListener#onError(Throwable)} is ever delivered to it. {@link ServerSentEventParser#parse}
+     * reports a mid-stream failure by calling {@code onError} itself and then returning normally rather than
+     * throwing, so an HTTP client that unconditionally calls {@code onClose} right after {@code parse()} returns
+     * would otherwise terminate the same request twice.
+     */
+    public static ServerSentEventListener terminateOnce(ServerSentEventListener listener) {
+        AtomicBoolean terminated = new AtomicBoolean(false);
+        return new ServerSentEventListener() {
+
+            @Override
+            public void onOpen(SuccessfulHttpResponse response) {
+                listener.onOpen(response);
+            }
+
+            @Override
+            public void onEvent(ServerSentEvent event) {
+                listener.onEvent(event);
+            }
+
+            @Override
+            public void onEvent(ServerSentEvent event, ServerSentEventContext context) {
+                listener.onEvent(event, context);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                if (terminated.compareAndSet(false, true)) {
+                    listener.onError(throwable);
+                } else {
+                    log.warn("Ignoring onError() after the SSE listener was already terminated.", throwable);
+                }
+            }
+
+            @Override
+            public void onClose() {
+                if (terminated.compareAndSet(false, true)) {
+                    listener.onClose();
+                } else {
+                    log.warn("Ignoring onClose() after the SSE listener was already terminated.");
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
## Issue
Relates to #2988 (does not close it — see scope note below)

## Change
`DefaultServerSentEventParser.parse()` catches `IOException` internally, notifies the listener via `onError`, and returns normally instead of throwing. `OkHttpClient`'s `enqueueServerSentEvents()` called `listener::onClose` unconditionally right after `parse()` returned, assuming a normal return meant success. A mid-stream failure (a truncated or malformed chunk) therefore delivered `onError` immediately followed by `onClose` for the same request — the exact double-termination described in #2988.

Fix: wrap the listener in a one-shot `terminateOnce()` guard (added to the shared `ServerSentEventListenerUtils`) so only the first of `onClose`/`onError` ever reaches the caller. The suppressed second call is logged at `WARN` rather than silently dropped, matching the existing `ignoringExceptions()` convention in the same class.

**Scope note:** `JdkHttpClient` has the identical pattern and is affected the same way, but it's already tracked by the open #5178, so I left it untouched here to avoid duplicating that work. `ApacheHttpClient` has the same-looking code, but its response is fully buffered into a `ByteArrayInputStream` before parsing starts, which the JDK documents as never throwing `IOException` — I could not reproduce the double-dispatch there with two different WireMock fault types, so I'm not claiming a bug in that client.

## Verification
- Reproduced against a real `WireMockServer` returning a 200 response with a `Fault.MALFORMED_RESPONSE_CHUNK` mid-body: unfixed code delivers `[onOpen, onError, onClose]`; with the fix, `[onOpen, onError]`, and the suppressed second call is visible in the log (`WARN: Ignoring onClose() after the SSE listener was already terminated.`).
- `OkHttpClientDoubleTerminationTest` added; confirmed red against the unfixed code, green with the fix. The test waits for OkHttp's own dispatcher to go idle (rather than a fixed sleep) before asserting, so it deterministically observes the full callback method, including any would-be second terminal call.
- `./mvnw -pl langchain4j-http-client test` — 152 tests, all green.
- `./mvnw -pl http-clients/langchain4j-http-client-okhttp test` — 7 tests, all green.
- `./mvnw spotless:check` clean on both modules.
- `./mvnw -pl langchain4j-core test` — 1387 tests, all green.
- `./mvnw -pl langchain4j test` — 1713 tests, all green.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
