### PR TITLE
fix(mcp): reject malformed tools/list responses

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -1386,6 +1386,12 @@ public class DefaultMcpClient implements McpClient {
                     result -> {
                         McpListToolsResult.Result parsed = McpJson.deserialize(result, McpListToolsResult.class)
                                 .getResult();
+                        if (parsed == null) {
+                            throw new IllegalResponseException("Result does not contain 'result' element");
+                        }
+                        if (parsed.getTools() == null) {
+                            throw new IllegalResponseException("Result does not contain 'tools' element");
+                        }
                         return new McpPage<>(
                                 ToolSpecificationHelper.toolSpecificationListFromMcpResponse(parsed.getTools()),
                                 parsed.getNextCursor());

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -219,6 +219,36 @@ public class DefaultMcpClientTest {
     }
 
     @Test
+    public void should_reject_tool_list_response_without_result() throws Exception {
+        McpTransport transport = getMinimalMcpTransportMock();
+        DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+        ObjectNode response = JsonNodeFactory.instance.objectNode();
+        response.put("jsonrpc", "2.0").put("id", 1);
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertThatThrownBy(client::listTools)
+                .isInstanceOf(IllegalResponseException.class)
+                .hasMessage("Result does not contain 'result' element");
+    }
+
+    @Test
+    public void should_reject_tool_list_response_without_tools() throws Exception {
+        McpTransport transport = getMinimalMcpTransportMock();
+        DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+        ObjectNode response = JsonNodeFactory.instance.objectNode();
+        response.put("jsonrpc", "2.0").put("id", 1).putObject("result");
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        assertThatThrownBy(client::listTools)
+                .isInstanceOf(IllegalResponseException.class)
+                .hasMessage("Result does not contain 'tools' element");
+    }
+
+    @Test
     public void should_preserve_error_data_when_tool_list_is_refused() throws Exception {
         final McpTransport transport = getMinimalMcpTransportMock();
         final DefaultMcpClient client =


### PR DESCRIPTION
Fixes #6368

`DefaultMcpClient.listTools()` previously dereferenced a missing `result` or `tools` element and surfaced a NullPointerException. This now follows the existing MCP list parsers and raises `IllegalResponseException` with the missing element named.

Added regression coverage for both malformed response shapes.

Verification:
- `./mvnw -pl langchain4j-mcp -Dtest=DefaultMcpClientTest -DfailIfNoTests=false -Dspotless.check.skip=false test`
- `git diff --check`

Signed-off-by: Yohanes <CryoThrust@users.noreply.github.com>