### PR TITLE
fix(workers-ai): pass source image and mask to executeQuery in the correct order

### DIFF
--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -52,6 +52,15 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client</artifactId>
+            <version>1.21.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiImageModel.java
+++ b/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiImageModel.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.model.workersai;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.image.ImageModel;
@@ -8,18 +12,13 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.workersai.client.AbstractWorkersAIModel;
 import dev.langchain4j.model.workersai.client.WorkersAiImageGenerationRequest;
 import dev.langchain4j.model.workersai.spi.WorkersAiImageModelBuilderFactory;
-
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Base64;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+import javax.imageio.ImageIO;
 
 /**
  * WorkerAI Image model.
@@ -93,8 +92,7 @@ public class WorkersAiImageModel extends AbstractWorkersAIModel implements Image
         /**
          * Simple constructor.
          */
-        public Builder() {
-        }
+        public Builder() {}
 
         /**
          * Simple constructor.
@@ -283,7 +281,4 @@ public class WorkersAiImageModel extends AbstractWorkersAIModel implements Image
                 .mimeType(MIME_TYPE)
                 .build();
     }
-
 }
-
-

--- a/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiImageModel.java
+++ b/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiImageModel.java
@@ -162,7 +162,7 @@ public class WorkersAiImageModel extends AbstractWorkersAIModel implements Image
     public Response<Image> edit(Image image, String prompt) {
         ensureNotBlank(prompt, "Prompt");
         ensureNotNull(image, "Image");
-        return new Response<>(convertAsImage(executeQuery(prompt, null, image)), null, FinishReason.STOP);
+        return new Response<>(convertAsImage(executeQuery(prompt, image, null)), null, FinishReason.STOP);
     }
 
     /** {@inheritDoc} */
@@ -170,7 +170,7 @@ public class WorkersAiImageModel extends AbstractWorkersAIModel implements Image
         ensureNotBlank(prompt, "Prompt");
         ensureNotNull(image, "Image");
         ensureNotNull(mask, "Mask");
-        return new Response<>(convertAsImage(executeQuery(prompt, mask, image)), null, FinishReason.STOP);
+        return new Response<>(convertAsImage(executeQuery(prompt, image, mask)), null, FinishReason.STOP);
     }
 
     /**

--- a/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiImageModelTest.java
+++ b/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiImageModelTest.java
@@ -1,0 +1,105 @@
+package dev.langchain4j.model.workersai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkersAiImageModelTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void should_send_image_in_image_field_when_editing() throws Exception {
+        File sourceImage = writePng("source");
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(new byte[] {1, 2, 3}).build());
+        WorkersAiImageModel model = imageModel(mockHttpClient);
+
+        model.edit(Image.builder().url(sourceImage.toURI()).build(), "make it blue");
+
+        JsonNode body = objectMapper.readTree(mockHttpClient.request().body());
+        assertThat(body.get("prompt").asText()).isEqualTo("make it blue");
+        assertThat(body.get("image")).isNotNull();
+        assertThat(body.get("image").isArray()).isTrue();
+        assertThat(body.get("image").size()).isPositive();
+        assertThat(body.get("mask").isNull()).isTrue();
+    }
+
+    @Test
+    void should_send_image_and_mask_in_distinct_fields_when_editing_with_mask() throws Exception {
+        File sourceImage = writePng("source");
+        File maskImage = writePng("mask");
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(new byte[] {1, 2, 3}).build());
+        WorkersAiImageModel model = imageModel(mockHttpClient);
+
+        model.edit(
+                Image.builder().url(sourceImage.toURI()).build(),
+                Image.builder().url(maskImage.toURI()).build(),
+                "make it blue");
+
+        JsonNode body = objectMapper.readTree(mockHttpClient.request().body());
+        assertThat(body.get("prompt").asText()).isEqualTo("make it blue");
+        assertThat(body.get("image")).isNotNull();
+        assertThat(body.get("image").isArray()).isTrue();
+        assertThat(body.get("mask")).isNotNull();
+        assertThat(body.get("mask").isArray()).isTrue();
+        assertThat(body.get("image")).isNotEqualTo(body.get("mask"));
+    }
+
+    @Test
+    void should_send_no_image_nor_mask_when_generating() throws Exception {
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body(new byte[] {1, 2, 3}).build());
+        WorkersAiImageModel model = imageModel(mockHttpClient);
+
+        model.generate("a blue bird");
+
+        JsonNode body = objectMapper.readTree(mockHttpClient.request().body());
+        assertThat(body.get("prompt").asText()).isEqualTo("a blue bird");
+        assertThat(body.get("image").isNull()).isTrue();
+        assertThat(body.get("mask").isNull()).isTrue();
+    }
+
+    private WorkersAiImageModel imageModel(MockHttpClient mockHttpClient) {
+        return WorkersAiImageModel.builder()
+                .accountId("account-id")
+                .apiToken("api-token")
+                .modelName("test-model")
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .build();
+    }
+
+    private File writePng(String name) throws Exception {
+        BufferedImage bufferedImage = new BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB);
+        if (name.equals("mask")) {
+            bufferedImage.setRGB(0, 0, 0xFFFFFF);
+            bufferedImage.setRGB(1, 0, 0xFFFFFF);
+            bufferedImage.setRGB(0, 1, 0x000000);
+            bufferedImage.setRGB(1, 1, 0x000000);
+        } else {
+            bufferedImage.setRGB(0, 0, 0xFF0000);
+            bufferedImage.setRGB(1, 0, 0x00FF00);
+            bufferedImage.setRGB(0, 1, 0x0000FF);
+            bufferedImage.setRGB(1, 1, 0x000000);
+        }
+        File file = tempDir.resolve(name + ".png").toFile();
+        ImageIO.write(bufferedImage, "png", file);
+        return file;
+    }
+}

--- a/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiImageModelTest.java
+++ b/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiImageModelTest.java
@@ -1,20 +1,19 @@
 package dev.langchain4j.model.workersai;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.http.client.MockHttpClient;
 import dev.langchain4j.http.client.MockHttpClientBuilder;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class WorkersAiImageModelTest {
 
@@ -26,8 +25,10 @@ class WorkersAiImageModelTest {
     @Test
     void should_send_image_in_image_field_when_editing() throws Exception {
         File sourceImage = writePng("source");
-        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
-                SuccessfulHttpResponse.builder().statusCode(200).body(new byte[] {1, 2, 3}).build());
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new byte[] {1, 2, 3})
+                .build());
         WorkersAiImageModel model = imageModel(mockHttpClient);
 
         model.edit(Image.builder().url(sourceImage.toURI()).build(), "make it blue");
@@ -44,8 +45,10 @@ class WorkersAiImageModelTest {
     void should_send_image_and_mask_in_distinct_fields_when_editing_with_mask() throws Exception {
         File sourceImage = writePng("source");
         File maskImage = writePng("mask");
-        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
-                SuccessfulHttpResponse.builder().statusCode(200).body(new byte[] {1, 2, 3}).build());
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new byte[] {1, 2, 3})
+                .build());
         WorkersAiImageModel model = imageModel(mockHttpClient);
 
         model.edit(
@@ -64,8 +67,10 @@ class WorkersAiImageModelTest {
 
     @Test
     void should_send_no_image_nor_mask_when_generating() throws Exception {
-        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
-                SuccessfulHttpResponse.builder().statusCode(200).body(new byte[] {1, 2, 3}).build());
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(new byte[] {1, 2, 3})
+                .build());
         WorkersAiImageModel model = imageModel(mockHttpClient);
 
         model.generate("a blue bird");


### PR DESCRIPTION
## Issue
Fixes #6149

## Change

`WorkersAiImageModel` builds its request through `executeQuery(String prompt, Image image, Image mask)`, but both `edit()` overloads passed the arguments in the opposite order:

- `edit(image, prompt)` called `executeQuery(prompt, null, image)` — the source pixels were sent in the `mask` field and `image` was `null`, so the image to edit was never sent as the image.
- `edit(image, mask, prompt)` called `executeQuery(prompt, mask, image)` — the two fields were exchanged.

Both overloads now call `executeQuery(prompt, image, mask)` as declared. The `generate()` overloads are unaffected (they pass `null, null`).

## Test

Added `WorkersAiImageModelTest` using `MockHttpClient` (requires the `langchain4j-http-client` test-jar in the module):

- `edit(image, prompt)` serializes the source pixels under `"image"` and leaves `"mask"` null
- `edit(image, mask, prompt)` serializes the source and mask pixels under the correct, distinct fields
- `generate(prompt)` leaves both null (regression)

`mvn -pl langchain4j-workers-ai test`: 77 tests, 0 failures.