### PR TITLE
fix(anthropic): mark only the last system message with cache_control when duplicates exist

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -67,11 +67,11 @@ import dev.langchain4j.model.output.TokenUsage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.stream.IntStream;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 @Internal
 public class AnthropicMapper {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -67,6 +67,7 @@ import dev.langchain4j.model.output.TokenUsage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.stream.IntStream;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -301,11 +302,10 @@ public class AnthropicMapper {
             }
         }
 
-        SystemMessage lastSystemMessage =
-                systemMessages.isEmpty() ? null : systemMessages.get(systemMessages.size() - 1);
-        return systemMessages.stream()
-                .map(message -> {
-                    boolean isLastItem = message.equals(lastSystemMessage);
+        return IntStream.range(0, systemMessages.size())
+                .mapToObj(i -> {
+                    SystemMessage message = systemMessages.get(i);
+                    boolean isLastItem = i == systemMessages.size() - 1;
                     if (isLastItem && cacheType != AnthropicCacheType.NO_CACHE) {
                         return new AnthropicTextContent(message.text(), cacheType.cacheControl());
                     }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -786,6 +786,26 @@ class AnthropicMapperTest {
     }
 
     @Test
+    void should_mark_only_last_system_message_with_cache_control_when_duplicate_system_messages_exist() {
+        // given - value-equal duplicate system messages (see issue #6051)
+        List<ChatMessage> messages = asList(
+                SystemMessage.from("same"),
+                SystemMessage.from("same"),
+                UserMessage.from("hi"));
+
+        // when
+        List<AnthropicTextContent> systemPrompt =
+                toAnthropicSystemPrompt(messages, AnthropicCacheType.EPHEMERAL, false);
+
+        // then - only the last occurrence carries cache_control, so only one cache breakpoint is spent
+        assertThat(systemPrompt).hasSize(2);
+        assertThat(systemPrompt.get(0).text).isEqualTo("same");
+        assertThat(systemPrompt.get(0).cacheControl).isNull();
+        assertThat(systemPrompt.get(1).text).isEqualTo("same");
+        assertThat(systemPrompt.get(1).cacheControl.getType()).isEqualTo("ephemeral");
+    }
+
+    @Test
     void mid_conversation_system_messages_enabled_keeps_only_leading_system_messages_in_top_level_system_prompt() {
         // given
         List<ChatMessage> messages = asList(

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -20,7 +20,6 @@ import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.langchain4j.model.anthropic.internal.client.Json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -48,6 +47,7 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicTool;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolResultContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolSchema;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent;
+import dev.langchain4j.model.anthropic.internal.client.Json;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
@@ -788,10 +788,8 @@ class AnthropicMapperTest {
     @Test
     void should_mark_only_last_system_message_with_cache_control_when_duplicate_system_messages_exist() {
         // given - value-equal duplicate system messages (see issue #6051)
-        List<ChatMessage> messages = asList(
-                SystemMessage.from("same"),
-                SystemMessage.from("same"),
-                UserMessage.from("hi"));
+        List<ChatMessage> messages =
+                asList(SystemMessage.from("same"), SystemMessage.from("same"), UserMessage.from("hi"));
 
         // when
         List<AnthropicTextContent> systemPrompt =


### PR DESCRIPTION
## Issue
Fixes #6051

## Change

`AnthropicMapper.toAnthropicSystemPrompt(...)` identified the last system message by **value** (`message.equals(lastSystemMessage)`), but `SystemMessage.equals()` compares `text` only. When two system messages have the same text, both were treated as "the last item" and both received a `cache_control` block.

This wastes Anthropic's limited cache breakpoints (max 4) on a single system prompt, and with enough duplicates the request is rejected with `A maximum of 4 blocks with cache_control may be provided.`

The last system message is now identified **by position** (`IntStream.range(0, size)` + index check), so exactly one `cache_control` block is emitted regardless of duplicate texts.

## Test

Added `should_mark_only_last_system_message_with_cache_control_when_duplicate_system_messages_exist` to `AnthropicMapperTest`: two value-equal system messages + `EPHEMERAL` cache type produce exactly one `cache_control` block, on the last message only.

`mvn -pl langchain4j-anthropic -am test`: 244 tests, 0 failures.