### PR TITLE
fix(azure-open-ai): support GPT-5 model names in AzureOpenAiTokenCountEstimator

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiTokenCountEstimator.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiTokenCountEstimator.java
@@ -60,7 +60,7 @@ public class AzureOpenAiTokenCountEstimator implements TokenCountEstimator {
      */
     public AzureOpenAiTokenCountEstimator(String modelName) {
         this.modelName = ensureNotBlank(modelName, "modelName");
-        if (modelName.startsWith("o") || modelName.startsWith("gpt-4.")) {
+        if (modelName.startsWith("o") || modelName.startsWith("gpt-4.") || modelName.startsWith("gpt-5")) {
             // temporary fix until https://github.com/knuddelsgmbh/jtokkit/pull/118 is released
             this.encoding = ENCODING_REGISTRY.getEncoding(O200K_BASE);
         } else {

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiTokenCountEstimatorTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiTokenCountEstimatorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 class AzureOpenAiTokenCountEstimatorTest {
@@ -102,5 +103,13 @@ class AzureOpenAiTokenCountEstimatorTest {
             result.add(strings);
         }
         return result;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-chat", "gpt-5.1"})
+    void should_support_gpt_5_model_names(String modelName) {
+        TokenCountEstimator tokenCountEstimator = new AzureOpenAiTokenCountEstimator(modelName);
+
+        assertThat(tokenCountEstimator.estimateTokenCountInText("Hello")).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## Issue
Fixes #5918

## Change

`new AzureOpenAiTokenCountEstimator("gpt-5")` throws:

```
java.lang.IllegalArgumentException: Model 'gpt-5' is unknown to jtokkit
```

The `String` constructor selects `O200K_BASE` only for names starting with `o` or `gpt-4.`, so GPT-5 names (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `gpt-5.1`) fall through to `ENCODING_REGISTRY.getEncodingForModel(...)`, which jtokkit 1.1.0 cannot resolve. `AzureOpenAiChatModelName` has no GPT-5 constant, so the `String` constructor is the only way to use such a deployment — and since a `TokenCountEstimator` is typically created at startup (e.g. injected into `TokenWindowChatMemory`), the application fails to start.

This mirrors `OpenAiTokenCountEstimator`, which already handles `gpt-5` on the same line.

## Test

Added `should_support_gpt_5_model_names` to `AzureOpenAiTokenCountEstimatorTest` — parameterized over `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `gpt-5.1`, asserting the estimator initializes and counts with the o200k encoding.

`mvn -pl langchain4j-azure-open-ai -am test`: BUILD SUCCESS (module: 72 tests, 0 failures).