### PR TITLE
fix(open-ai): surface refusal in streaming responses as ContentFilter…

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.model.ModelProvider.OPEN_AI;
 import static dev.langchain4j.model.openai.internal.ChatCompletionEventDispatcher.handle;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_OPENAI_URL;
@@ -19,6 +20,7 @@ import static java.util.Arrays.asList;
 
 import dev.langchain4j.Experimental;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.internal.ExceptionMapper;
 import dev.langchain4j.internal.MappingTrackingStreamingChatResponseHandler;
@@ -166,6 +168,14 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
                 .onComplete(() -> {
                     if (toolCallBuilder.hasRequests()) {
                         onCompleteToolCall(trackingHandler, toolCallBuilder.buildAndReset());
+                    }
+
+                    // checked explicitly here, since an exception thrown from this callback
+                    // may be swallowed by the SSE parser instead of reaching onError
+                    String refusal = openAiResponseBuilder.refusal();
+                    if (isNotNullOrBlank(refusal)) {
+                        withLoggingExceptions(() -> handler.onError(new ContentFilteredException(refusal)));
+                        return;
                     }
 
                     ChatResponse completeResponse = openAiResponseBuilder.build();

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.openai;
 
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.finishReasonFrom;
@@ -10,6 +11,7 @@ import static java.util.stream.Collectors.toList;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -59,6 +61,7 @@ public class OpenAiStreamingResponseBuilder {
     private final AtomicReference<String> model = new AtomicReference<>();
     private final AtomicReference<String> serviceTier = new AtomicReference<>();
     private final AtomicReference<String> systemFingerprint = new AtomicReference<>();
+    private final AtomicReference<String> refusal = new AtomicReference<>();
     private final AtomicReference<TokenUsage> tokenUsage = new AtomicReference<>();
     private final AtomicReference<FinishReason> finishReason = new AtomicReference<>();
     private final AtomicReference<SuccessfulHttpResponse> rawHttpResponse = new AtomicReference<>();
@@ -155,6 +158,10 @@ public class OpenAiStreamingResponseBuilder {
             this.contentBuilder.append(content);
         }
 
+        if (!isNullOrBlank(delta.refusal())) {
+            this.refusal.set(delta.refusal());
+        }
+
         String reasoningContent = delta.reasoningContent();
         if (returnThinking && !isNullOrEmpty(reasoningContent)) {
             this.reasoningContentBuilder.append(reasoningContent);
@@ -246,7 +253,22 @@ public class OpenAiStreamingResponseBuilder {
         }
     }
 
+    /**
+     * Returns the refusal text accumulated from the streamed chunks, or {@code null} if the model did not refuse.
+     */
+    public String refusal() {
+        return refusal.get();
+    }
+
+    /**
+     * @throws ContentFilteredException if the model refused to answer (consistent with the non-streaming behavior)
+     */
     public ChatResponse build() {
+        String refusal = this.refusal.get();
+        if (isNotNullOrBlank(refusal)) {
+            throw new ContentFilteredException(refusal);
+        }
+
         return ChatResponse.builder()
                 .aiMessage(buildAiMessage())
                 .metadata(buildMetadata())

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
@@ -2,9 +2,9 @@ package dev.langchain4j.model.openai.internal.chat;
 
 import static java.util.Collections.unmodifiableList;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,6 +25,9 @@ public final class Delta {
     private final String content;
 
     @JsonProperty
+    private final String refusal;
+
+    @JsonProperty
     private final String reasoningContent;
 
     @JsonProperty
@@ -38,6 +41,7 @@ public final class Delta {
     public Delta(Builder builder) {
         this.role = builder.role;
         this.content = builder.content;
+        this.refusal = builder.refusal;
         this.reasoningContent = builder.reasoningContent;
         this.toolCalls = builder.toolCalls == null ? null : unmodifiableList(builder.toolCalls);
         this.functionCall = builder.functionCall;
@@ -49,6 +53,10 @@ public final class Delta {
 
     public String content() {
         return content;
+    }
+
+    public String refusal() {
+        return refusal;
     }
 
     public String reasoningContent() {
@@ -75,6 +83,7 @@ public final class Delta {
     private boolean equalTo(Delta another) {
         return Objects.equals(role, another.role)
                 && Objects.equals(content, another.content)
+                && Objects.equals(refusal, another.refusal)
                 && Objects.equals(reasoningContent, another.reasoningContent)
                 && Objects.equals(toolCalls, another.toolCalls)
                 && Objects.equals(functionCall, another.functionCall);
@@ -86,6 +95,7 @@ public final class Delta {
         int h = 5381;
         h += (h << 5) + Objects.hashCode(role);
         h += (h << 5) + Objects.hashCode(content);
+        h += (h << 5) + Objects.hashCode(refusal);
         h += (h << 5) + Objects.hashCode(reasoningContent);
         h += (h << 5) + Objects.hashCode(toolCalls);
         h += (h << 5) + Objects.hashCode(functionCall);
@@ -98,6 +108,7 @@ public final class Delta {
         return "Delta{"
                 + "role=" + role
                 + ", content=" + content
+                + ", refusal=" + refusal
                 + ", reasoningContent=" + reasoningContent
                 + ", toolCalls=" + toolCalls
                 + ", functionCall=" + functionCall
@@ -115,8 +126,11 @@ public final class Delta {
 
         private String role;
         private String content;
+        private String refusal;
+
         @JsonAlias("reasoning")
         private String reasoningContent;
+
         private List<ToolCall> toolCalls;
 
         @Deprecated
@@ -129,6 +143,11 @@ public final class Delta {
 
         public Builder content(String content) {
             this.content = content;
+            return this;
+        }
+
+        public Builder refusal(String refusal) {
+            this.refusal = refusal;
             return this;
         }
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.model.openai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.internal.chat.*;
 import java.util.List;
@@ -310,6 +312,44 @@ class OpenAiStreamingResponseBuilderTest {
         // Then: logProbs stays null (backward compatible)
         OpenAiChatResponseMetadata metadata = (OpenAiChatResponseMetadata) chatResponse.metadata();
         assertThat(metadata.logProbs()).isNull();
+    }
+
+    @Test
+    void should_throw_content_filter_exception_when_model_refuses() {
+        // Given: OpenAI streams a chunk whose delta carries a refusal instead of content
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+        builder.append(chatCompletionResponseWithRefusal("I'm sorry, I cannot assist with that request."));
+
+        // When / Then: building the response throws, consistent with the non-streaming behavior
+        assertThatThrownBy(builder::build)
+                .isExactlyInstanceOf(ContentFilteredException.class)
+                .hasMessageContaining("I'm sorry, I cannot assist with that request.");
+        assertThat(builder.refusal()).isEqualTo("I'm sorry, I cannot assist with that request.");
+    }
+
+    @Test
+    void should_not_throw_when_no_refusal_received() {
+        // Given: a regular stream without a refusal
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+        builder.append(chatCompletionResponseWithRefusal(null));
+
+        // When
+        ChatResponse chatResponse = builder.build();
+
+        // Then
+        assertThat(builder.refusal()).isNull();
+        assertThat(chatResponse.aiMessage().text()).isNull();
+    }
+
+    private static ChatCompletionResponse chatCompletionResponseWithRefusal(String refusal) {
+        return ChatCompletionResponse.builder()
+                .id("resp_1")
+                .model("gpt-4o")
+                .choices(List.of(ChatCompletionChoice.builder()
+                        .index(0)
+                        .delta(Delta.builder().refusal(refusal).build())
+                        .build()))
+                .build();
     }
 
     private static ChatCompletionResponse chatCompletionResponseWithLogProb(

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/ChatCompletionResponseDeserializeTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/ChatCompletionResponseDeserializeTest.java
@@ -189,6 +189,39 @@ class ChatCompletionResponseDeserializeTest {
     }
 
     @Test
+    void should_deserialize_delta_with_refusal() {
+
+        // given
+        String json = """
+                {
+                    "id": "chatcmpl-123",
+                    "object": "chat.completion.chunk",
+                    "created": 1742268380,
+                    "model": "gpt-4o",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "content": null,
+                                "refusal": "I'm sorry, I cannot assist with that request."
+                            },
+                            "finish_reason": "stop"
+                        }
+                    ]
+                }
+                """;
+
+        // when
+        ChatCompletionResponse response = Json.fromJson(json, ChatCompletionResponse.class);
+
+        // then
+        Delta delta = response.choices().get(0).delta();
+        assertThat(delta.content()).isNull();
+        assertThat(delta.refusal()).isEqualTo("I'm sorry, I cannot assist with that request.");
+    }
+
+    @Test
     void should_deserialize_message_without_reasoning_fields() {
 
         // given


### PR DESCRIPTION
## Issue
Closes #5813

## Change
OpenAI streams refusals as a `refusal` field on the message delta. `Delta` had no such field, so Jackson silently discarded it (`@JsonIgnoreProperties(ignoreUnknown = true)`), and a refused streaming call produced an empty `ChatResponse` instead of surfacing the refusal. Non-streaming chat already throws `ContentFilteredException` in this case (`OpenAiUtils#chatResponseFrom`), so the two code paths disagreed.

This PR makes streaming consistent with non-streaming:

- Added the `refusal` field (JSON `refusal`) to `Delta`, so it is no longer dropped during deserialization.
- `OpenAiStreamingResponseBuilder` now accumulates the refusal (exposed via the new `refusal()` accessor) and `build()` throws `ContentFilteredException(refusal)`, mirroring the non-streaming behavior. On the reactive/publisher path, the existing `try/catch` around `build()` routes this to `onError` (`ChatCompletionEventSink`).
- `OpenAiStreamingChatModel` checks the accumulated refusal explicitly in the completion callback and calls `handler.onError(new ContentFilteredException(refusal))` — needed because on the callback/executor path, exceptions thrown from SSE listener callbacks can be swallowed by the SSE parser (`ServerSentEventListenerUtils.ignoringExceptions`) instead of reaching `onError`.

No API removals or signature changes; for previously-silently-swallowed refusals, users now get `onError(ContentFilteredException)` instead of a blank message, which matches the documented non-streaming behavior.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (langchain4j-open-ai: 404 tests, 0 failures)
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation — N/A: bug fix, no documented behavior change
- [ ] I have added an example in the examples repo (only for "big" features) — N/A
- [ ] I have added/updated Spring Boot starter(s) (if applicable) — N/A