### PR TITLE
fix(infinispan): widen Float literals in IN/NOT IN to double

### DIFF
--- a/langchain4j-infinispan/src/main/java/dev/langchain4j/store/embedding/infinispan/InfinispanMetadataFilterMapper.java
+++ b/langchain4j-infinispan/src/main/java/dev/langchain4j/store/embedding/infinispan/InfinispanMetadataFilterMapper.java
@@ -204,7 +204,9 @@ class InfinispanMetadataFilterMapper {
         if (!(value instanceof Number)) {
             return "'" + escape(String.valueOf(value)) + "'";
         }
-        if (asFloat && (value instanceof Integer || value instanceof Long)) {
+        if (asFloat) {
+            // widen every numeric literal to double so it matches what
+            // LangChainMetadataMarshaller.writeTo() stores in value_float
             return String.valueOf(((Number) value).doubleValue());
         }
         return value.toString();

--- a/langchain4j-infinispan/src/test/java/dev/langchain4j/store/embedding/infinispan/InfinispanMetadataFilterMapperTest.java
+++ b/langchain4j-infinispan/src/test/java/dev/langchain4j/store/embedding/infinispan/InfinispanMetadataFilterMapperTest.java
@@ -133,10 +133,10 @@ class InfinispanMetadataFilterMapperTest {
                         new IsIn("status", Arrays.asList(1, 2, 3)),
                         "m0.name='status' and m0.value_int IN (1, 2, 3)",
                         " join i.metadata m0"),
-                // Float IsIn
+                // Float IsIn - literals are widened to double, matching the value_float column
                 Arguments.of(
                         new IsIn("scores", Arrays.asList(1.1f, 2.2f, 3.3f)),
-                        "m0.name='scores' and m0.value_float IN (3.3, 1.1, 2.2)",
+                        "m0.name='scores' and m0.value_float IN (3.299999952316284, 1.100000023841858, 2.200000047683716)",
                         " join i.metadata m0"));
     }
 
@@ -365,6 +365,22 @@ class InfinispanMetadataFilterMapperTest {
 
         // then
         assertThat(result.query).isEqualTo("m0.name='score' and m0.value_float = " + Double.MIN_VALUE);
+    }
+
+    @Test
+    void should_render_float_in_literals_as_doubles_matching_the_equal_filter() {
+        // given - 1.1f is not exactly representable as a double
+        Filter in = new IsIn("score", Arrays.asList(1.1f));
+        Filter eq = new IsEqualTo("score", 1.1f);
+
+        // when - a fresh mapper per mapping: the mapper's join alias counter is stateful
+        InfinispanMetadataFilterMapper.FilterResult inResult = new InfinispanMetadataFilterMapper().map(in);
+        InfinispanMetadataFilterMapper.FilterResult eqResult = new InfinispanMetadataFilterMapper().map(eq);
+
+        // then - the IN literal must equal the = literal, which stores the Float as a double
+        String doubleLiteral = String.valueOf(((Float) 1.1f).doubleValue());
+        assertThat(inResult.query).isEqualTo("m0.name='score' and m0.value_float IN (" + doubleLiteral + ")");
+        assertThat(eqResult.query).isEqualTo("m0.name='score' and m0.value_float = " + doubleLiteral);
     }
 
     @Test


### PR DESCRIPTION
## Issue
Fixes #5952

## Change

`InfinispanMetadataFilterMapper` renders `Float` metadata values inconsistently:

- `=`, `>`, `<` (via `computeFilter`) build the literal with `getDoubleValue()` → `((Float) value).doubleValue()`
- `IN` / `NOT IN` (via `formattedComparisonValue`) only widened `Integer` / `Long`; a `Float` fell through to `value.toString()`

Both target the `value_float` column (`Type.Scalar.DOUBLE`), and `LangChainMetadataMarshaller.writeTo()` stores a `Float` as `((Float) value).doubleValue()`. For floats that are not exactly representable as doubles (e.g. `1.1f`), the `IN` literal (`1.1`) no longer equals the stored value (`1.100000023841858`), so filtering silently misses rows.

`formattedComparisonValue` now widens **every** numeric literal to double when the `value_float` column is selected, matching the `=` path and the marshaller.

## Test

- Updated the pinned expectation in `inFilters()`: `IN (3.3, 1.1, 2.2)` → `IN (3.299999952316284, 1.100000023841858, 2.200000047683716)`
- Added `should_render_float_in_literals_as_doubles_matching_the_equal_filter`: asserts the `IN` literal for `1.1f` is byte-for-byte the same literal the `=` filter produces

`mvn -pl langchain4j-infinispan -am test`: 67 tests, 0 failures.