### PR TITLE
fix(kotlin): match pathMatcher against paths relative to the traversed directory

### DIFF
--- a/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
@@ -64,7 +64,9 @@ public suspend fun loadDocuments(
                 fileStream.use { stream ->
                     stream
                         .filter { file ->
-                            Files.isRegularFile(file) && matcher.matches(file)
+                            // matching is done on paths relative to the traversed directory,
+                            // so patterns like "glob:*.txt" behave like FileSystemDocumentLoader
+                            Files.isRegularFile(file) && matcher.matches(path.relativize(file))
                         }.forEach { file ->
                             files.add(file)
                         }

--- a/langchain4j-kotlin/src/test/kotlin/dev/langchain4j/kotlin/data/document/loader/AsyncDocumentLoaderTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/dev/langchain4j/kotlin/data/document/loader/AsyncDocumentLoaderTest.kt
@@ -16,6 +16,7 @@ import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -73,5 +74,24 @@ internal class AsyncDocumentLoaderTest {
                         "test-file-3.banana",
                         "test-file-4.banana"
                     )
+        }
+
+    @Test
+    fun `Should loadDocuments with a relative pathMatcher`() =
+        runTest {
+            val documents =
+                loadDocuments(
+                    recursive = true,
+                    documentParser = parser,
+                    directoryPaths = listOf(Path.of("./src/test/resources/asyncDocumentLoaderTest")),
+                    pathMatcher = FileSystems.getDefault().getPathMatcher("glob:*.txt")
+                )
+
+            // relative matching: only the top-level file1.txt matches "glob:*.txt",
+            // mirroring FileSystemDocumentLoader; absolute matching would match nothing
+            documents shouldHaveSize 1
+
+            val documentNames = documents.map { it.metadata().getString("file_name") }
+            documentNames shouldContainExactly listOf("file1.txt")
         }
 }


### PR DESCRIPTION
## Issue
Fixes #6074

## Change

The Kotlin `loadDocuments` extension matched the paths emitted by `Files.walk` directly against the `pathMatcher`. Those paths are absolute (rooted at the configured directory), so relative globs such as `glob:*.txt` never matched anything and the call silently returned an empty list.

This diverges from `FileSystemDocumentLoader`, which documents (on three public overloads) that each file path is converted from absolute to relative — relative to `directoryPath` — before being matched, and which relativizes in `loadDocuments(Stream, PathMatcher, Path, DocumentParser)`.

The Kotlin extension now calls `path.relativize(file)` before matching (paths are still passed to `FileSystemSource` in absolute form, so loading is unchanged).

## Test

Added `Should loadDocuments with a relative pathMatcher` to `AsyncDocumentLoaderTest`: recursive load of the existing `asyncDocumentLoaderTest` resources with `glob:*.txt` now returns exactly the top-level `file1.txt` (previously: empty list).

`mvn -pl langchain4j-kotlin -am test`: all module tests pass.