### PR TITLE
fix: make watsonx and Gemini enum conversions locale-independent

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.Utils.mutableCopy;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -156,7 +157,7 @@ record GeminiContent(
 
                 @Override
                 public String toString() {
-                    return name().toLowerCase();
+                    return name().toLowerCase(Locale.ROOT);
                 }
             }
 
@@ -180,7 +181,7 @@ record GeminiContent(
 
                 @Override
                 public String toString() {
-                    return this.name().toLowerCase();
+                    return this.name().toLowerCase(Locale.ROOT);
                 }
             }
         }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiType.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiType.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.googleai;
 
+import java.util.Locale;
+
 enum GeminiType {
     STRING,
     NUMBER,
@@ -11,6 +13,6 @@ enum GeminiType {
 
     @Override
     public String toString() {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.ROOT);
     }
 }

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiEnumLocaleTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiEnumLocaleTest.java
@@ -1,0 +1,95 @@
+package dev.langchain4j.model.googleai;
+
+import static dev.langchain4j.spi.ServiceHelper.loadFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.internal.ProviderJson;
+import dev.langchain4j.internal.ProviderJsonSpec;
+import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiCodeExecutionResult;
+import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiCodeExecutionResult.GeminiOutcome;
+import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiExecutableCode;
+import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiExecutableCode.GeminiLanguage;
+import dev.langchain4j.spi.json.ProviderJsonCodecFactory;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Isolated // mutates the JVM-wide default locale
+class GeminiEnumLocaleTest {
+
+    private Locale defaultLocale;
+
+    @BeforeEach
+    void saveDefaultLocale() {
+        defaultLocale = Locale.getDefault();
+    }
+
+    @AfterEach
+    void restoreDefaultLocale() {
+        Locale.setDefault(defaultLocale);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en-US", "tr-TR", "az-AZ"})
+    void should_render_schema_types_independently_of_default_locale(String languageTag) {
+        Locale.setDefault(Locale.forLanguageTag(languageTag));
+
+        assertThat(GeminiType.values())
+                .extracting(GeminiType::toString)
+                .containsExactly("string", "number", "integer", "boolean", "array", "object", "null");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en-US", "tr-TR", "az-AZ"})
+    void should_render_languages_independently_of_default_locale(String languageTag) {
+        Locale.setDefault(Locale.forLanguageTag(languageTag));
+
+        assertThat(GeminiLanguage.values())
+                .extracting(GeminiLanguage::toString)
+                .containsExactly("python", "language_unspecified");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en-US", "tr-TR", "az-AZ"})
+    void should_render_outcomes_independently_of_default_locale(String languageTag) {
+        Locale.setDefault(Locale.forLanguageTag(languageTag));
+
+        assertThat(GeminiOutcome.values())
+                .extracting(GeminiOutcome::toString)
+                .containsExactly("outcome_unspecified", "outcome_ok", "outcome_failed", "outcome_deadline_exceeded");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en-US", "tr-TR", "az-AZ"})
+    void should_serialize_enums_independently_of_default_locale(String languageTag) {
+        Locale.setDefault(Locale.forLanguageTag(languageTag));
+
+        var spec = ProviderJsonSpec.builder()
+                .inclusion(ProviderJsonSpec.Inclusion.NON_NULL)
+                .prettyPrint(true)
+                .build();
+        // A fresh optional codec prevents enum strings cached under an earlier locale from masking the bug.
+        var factory = loadFactory(ProviderJsonCodecFactory.class);
+        var codec = factory == null ? ProviderJson.codec(spec) : factory.create(spec);
+        var schema = GeminiSchema.builder().type(GeminiType.INTEGER).build();
+        var code = new GeminiExecutableCode(GeminiLanguage.LANGUAGE_UNSPECIFIED, "print(1)");
+        var result = new GeminiCodeExecutionResult(GeminiOutcome.OUTCOME_FAILED, "failed");
+
+        // Jackson 2 uses enum names; the optional Jackson 3 codec uses toString().
+        assertThat(codec.fromJson(codec.toJson(schema), Map.class).get("type")).isIn("INTEGER", "integer");
+        assertThat(codec.fromJson(codec.toJson(code), Map.class).get("programmingLanguage"))
+                .isIn("LANGUAGE_UNSPECIFIED", "language_unspecified");
+        assertThat(codec.fromJson(codec.toJson(result), Map.class).get("outcome"))
+                .isIn("OUTCOME_FAILED", "outcome_failed");
+        assertThat(codec.fromJson(codec.toJson(GeminiType.INTEGER), GeminiType.class))
+                .isEqualTo(GeminiType.INTEGER);
+        assertThat(codec.fromJson(codec.toJson(code), GeminiExecutableCode.class))
+                .isEqualTo(code);
+        assertThat(codec.fromJson(codec.toJson(result), GeminiCodeExecutionResult.class))
+                .isEqualTo(result);
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapper.java
@@ -14,6 +14,7 @@ import dev.langchain4j.exception.RateLimitException;
 import dev.langchain4j.exception.TimeoutException;
 import dev.langchain4j.internal.ExceptionMapper;
 import java.net.http.HttpTimeoutException;
+import java.util.Locale;
 
 @Internal
 class WatsonxExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
@@ -33,7 +34,7 @@ class WatsonxExceptionMapper extends ExceptionMapper.DefaultExceptionMapper {
             WatsonxError.Error error = details.errors().get(0);
 
             try {
-                return switch (WatsonxError.Code.valueOf(error.code().toUpperCase())) {
+                return switch (WatsonxError.Code.valueOf(error.code().toUpperCase(Locale.ROOT))) {
                     case AUTHENTICATION_TOKEN_EXPIRED, AUTHORIZATION_REJECTED ->
                         new AuthenticationException(error.message(), watsonxException);
                     case INVALID_INPUT_ARGUMENT, INVALID_REQUEST_ENTITY, JSON_TYPE_ERROR, JSON_VALIDATION_ERROR ->

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapperLocaleTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxExceptionMapperLocaleTest.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.watsonx.ai.core.exception.WatsonxException;
+import com.ibm.watsonx.ai.core.exception.model.WatsonxError;
+import dev.langchain4j.exception.InternalServerException;
+import dev.langchain4j.exception.InvalidRequestException;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Isolated // mutates the JVM-wide default locale
+class WatsonxExceptionMapperLocaleTest {
+
+    private Locale defaultLocale;
+
+    @BeforeEach
+    void saveDefaultLocale() {
+        defaultLocale = Locale.getDefault();
+    }
+
+    @AfterEach
+    void restoreDefaultLocale() {
+        Locale.setDefault(defaultLocale);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en-US", "tr-TR", "az-AZ"})
+    void should_map_known_error_code_independently_of_default_locale(String languageTag) {
+        Locale.setDefault(Locale.forLanguageTag(languageTag));
+        // Deliberately use a status whose fallback differs from the known error-code mapping.
+        var details = new WatsonxError(
+                500,
+                "transaction-id",
+                List.of(new WatsonxError.Error("invalid_input_argument", "invalid input", null)));
+        var exception = new WatsonxException("invalid_input_argument", 500, details);
+
+        var mapped = WatsonxExceptionMapper.INSTANCE.mapException(exception);
+
+        assertThat(mapped)
+                .isExactlyInstanceOf(InvalidRequestException.class)
+                .hasMessage("invalid input")
+                .hasCause(exception);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"en-US", "tr-TR", "az-AZ"})
+    void should_preserve_unknown_error_code_fallback(String languageTag) {
+        Locale.setDefault(Locale.forLanguageTag(languageTag));
+        var details = new WatsonxError(
+                500, "transaction-id", List.of(new WatsonxError.Error("unknown_service_error", "service error", null)));
+        var exception = new WatsonxException("unknown_service_error", 500, details);
+
+        var mapped = WatsonxExceptionMapper.INSTANCE.mapException(exception);
+
+        assertThat(mapped)
+                .isExactlyInstanceOf(InternalServerException.class)
+                .hasMessage("service error")
+                .hasCause(exception);
+    }
+}


### PR DESCRIPTION

## Issue

Closes #6382

## Change

Use `Locale.ROOT` for all enum case conversions in the watsonx and Gemini modules:

- **watsonx:** preserve error-code classification under Turkish and Azerbaijani locales, instead of falling back to the HTTP status.
- **Gemini:** keep schema-type, language and outcome strings locale-independent, including JSON values with the optional Jackson 3 codec. Default Jackson 2 serialization is unchanged.
- **Gemini:** `GeminiRole` uses `Locale.ROOT` as well, for consistency. Its values (`user`, `model`) contain no `i`, so its output was not affected.

Add isolated regression tests for `en-US`, `tr-TR` and `az-AZ`, restoring the original locale after each test.

## Verification

- `langchain4j-watsonx` unit tests — 217 tests, all green.
- `langchain4j-google-ai-gemini` unit tests — 456 tests, all green.
- `langchain4j-google-ai-gemini` unit tests with `-Pjackson3` — 456 tests, all green.
- `git diff --check` — passed.
- The regression tests were confirmed to fail against the unfixed conversions and pass with the fix.
- The tests are deterministic and require no provider credentials

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x]  I have added unit and/or integration tests for my change
- [x]  The tests cover both positive and negative cases
- [ ]  I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ]  I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ]  I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (not applicable)
- [ ]  I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (not applicable)
- [ ]  I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (not applicable)
